### PR TITLE
Add Windows ARM64 build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,13 +49,24 @@ jobs:
         include:
           - platform: windows-latest
             os: windows
-            target: '' 
+            arch: x64
+            target: ''
+            rust_target: ''
+          - platform: windows-latest
+            os: windows
+            arch: arm64
+            target: 'aarch64-pc-windows-msvc'
+            rust_target: 'aarch64-pc-windows-msvc'
           - platform: ubuntu-22.04
             os: linux
+            arch: x64
             target: ''
+            rust_target: ''
           - platform: macos-latest
             os: macos
+            arch: universal
             target: 'universal-apple-darwin'
+            rust_target: 'aarch64-apple-darwin,x86_64-apple-darwin'
 
     runs-on: ${{ matrix.platform }}
 
@@ -70,9 +81,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          # macos: install targets for universal build
-          # windows/linux: standard
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ matrix.rust_target }}
 
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-22.04'
@@ -83,20 +92,35 @@ jobs:
       - name: Install Frontend Dependencies
         run: npm install
 
-      # --- Windows Build ---
-      - name: Build Windows
-        if: matrix.platform == 'windows-latest'
+      # --- Windows Build (x64) ---
+      - name: Build Windows x64
+        if: matrix.platform == 'windows-latest' && matrix.arch == 'x64'
         run: npm run tauri build
 
-      - name: Upload Windows Artifacts
-        if: matrix.platform == 'windows-latest'
+      - name: Upload Windows x64 Artifacts
+        if: matrix.platform == 'windows-latest' && matrix.arch == 'x64'
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cp src-tauri/target/release/Markpad.exe Markpad.exe
-          cp Markpad.exe MarkpadInstaller.exe
-          gh release upload v${{ needs.create-release.outputs.version }} Markpad.exe MarkpadInstaller.exe --clobber
+          cp src-tauri/target/release/Markpad.exe Markpad-x64.exe
+          cp Markpad-x64.exe MarkpadInstaller-x64.exe
+          gh release upload v${{ needs.create-release.outputs.version }} Markpad-x64.exe MarkpadInstaller-x64.exe --clobber
+
+      # --- Windows Build (ARM64) ---
+      - name: Build Windows ARM64
+        if: matrix.platform == 'windows-latest' && matrix.arch == 'arm64'
+        run: npm run tauri build -- --target aarch64-pc-windows-msvc
+
+      - name: Upload Windows ARM64 Artifacts
+        if: matrix.platform == 'windows-latest' && matrix.arch == 'arm64'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cp src-tauri/target/aarch64-pc-windows-msvc/release/Markpad.exe Markpad-arm64.exe
+          cp Markpad-arm64.exe MarkpadInstaller-arm64.exe
+          gh release upload v${{ needs.create-release.outputs.version }} Markpad-arm64.exe MarkpadInstaller-arm64.exe --clobber
 
       # --- Linux Build ---
       - name: Build Linux

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "markdown-viewer",
-  "version": "2.0.0",
+  "name": "markpad",
+  "version": "2.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "markdown-viewer",
-      "version": "2.0.0",
+      "name": "markpad",
+      "version": "2.3.5",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",
@@ -909,6 +909,7 @@
       "integrity": "sha512-JFtOqDoU0DI/+QSG8qnq5bKcehVb3tCHhOG4amsSYth5/KgO4EkJvi42xSAiyKmXAAULW1/Zdb6lkgGEgSxdZg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
@@ -952,6 +953,7 @@
       "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
         "debug": "^4.4.1",
@@ -1258,6 +1260,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1609,6 +1612,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1755,6 +1759,7 @@
       "integrity": "sha512-Y5juST3x+/ySty5tYJCVWa6Corkxpt25bUZQHqOceg9xfMUtDsFx6rCsG6cYf1cA6vzDi66HIvaki0byZZX95A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1833,6 +1838,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1847,6 +1853,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",


### PR DESCRIPTION
## Summary
This PR adds Windows ARM64 (aarch64) build support to the release workflow, enabling native builds for ARM-based Windows devices like Surface Pro X and other Snapdragon-powered PCs.

## Changes
- Added new build matrix entry for `windows-latest` with `aarch64-pc-windows-msvc` target
- Separated Windows builds by architecture (x64 and arm64)
- Updated artifact naming to differentiate architectures:
  - `Markpad-x64.exe` / `MarkpadInstaller-x64.exe`
  - `Markpad-arm64.exe` / `MarkpadInstaller-arm64.exe`
- Refactored Rust target configuration in the workflow matrix for cleaner handling

## Release Artifacts
After this change, the following Windows artifacts will be included in releases:

| Architecture | Files |
|--------------|-------|
| x64 | `Markpad-x64.exe`, `MarkpadInstaller-x64.exe` |
| ARM64 | `Markpad-arm64.exe`, `MarkpadInstaller-arm64.exe` |

## Breaking Changes
⚠️ Windows artifact filenames have changed (added architecture suffix). Direct links to `Markpad.exe` or `MarkpadInstaller.exe` will need to be updated.