### PR TITLE
(feat) export to pdf/html feature alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markpad",
-  "version": "2.4.5",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markpad",
-      "version": "2.4.5",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -834,6 +834,81 @@
 		return false;
 	}
 
+	async function exportAsHtml() {
+		if (!htmlContent) return;
+
+		const tab = tabManager.activeTab;
+		const defaultName = tab?.path ? tab.path.replace(/\.[^.]+$/, '.html') : 'export.html';
+
+		const selected = await save({
+			filters: [{ name: 'HTML', extensions: ['html', 'htm'] }],
+			defaultPath: defaultName,
+		});
+		if (!selected) return;
+
+		// gather styles from the app
+		let styles = '';
+		for (const sheet of document.styleSheets) {
+			try {
+				for (const rule of sheet.cssRules) {
+					styles += rule.cssText + '\n';
+				}
+			} catch {
+				// cross-origin sheets
+			}
+		}
+
+		const fullHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>${tab?.title || 'Export'}</title>
+<style>
+${styles}
+html, body {
+	overflow: auto !important;
+	height: auto !important;
+	min-height: 100vh;
+	background-color: var(--color-canvas-default, #ffffff);
+	margin: 0;
+	padding: 0;
+}
+.markdown-body {
+	padding: 40px !important;
+	max-width: 900px;
+	margin: 0 auto;
+	height: auto !important;
+	overflow: visible !important;
+	min-height: 100%;
+}
+.lang-label {
+	display: none !important;
+}
+.markdown-body pre {
+	white-space: pre-wrap !important;
+	word-break: break-word !important;
+}
+</style>
+</head>
+<body>
+<article class="markdown-body">
+${markdownBody?.innerHTML || htmlContent}
+</article>
+</body>
+</html>`;
+
+		try {
+			await invoke('save_file_content', { path: selected, content: fullHtml });
+		} catch (e) {
+			console.error('Failed to export HTML', e);
+		}
+	}
+
+	function exportAsPdf() {
+		window.print();
+	}
+
 	function handleNewFile() {
 		tabManager.addNewTab();
 		showHome = false;
@@ -1392,6 +1467,8 @@
 		onopenFile={selectFile}
 		onsaveFile={saveContent}
 		onsaveFileAs={saveContentAs}
+		onexportHtml={exportAsHtml}
+		onexportPdf={exportAsPdf}
 		onexit={() => {
 			appWindow.close();
 		}}
@@ -1437,6 +1514,8 @@
 		onopenFile={selectFile}
 		onsaveFile={saveContent}
 		onsaveFileAs={saveContentAs}
+		onexportHtml={exportAsHtml}
+		onexportPdf={exportAsPdf}
 		onexit={() => {
 			appWindow.close();
 		}}
@@ -1586,6 +1665,14 @@
 		height: 100%;
 		overflow-y: auto;
 		transform: translate3d(0, 0, 0);
+	}
+
+	@media print {
+		.markdown-body {
+			height: auto !important;
+			overflow: visible !important;
+			padding: 0 !important;
+		}
 	}
 
 	.markdown-container :global(.markdown-body pre),

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -125,6 +125,7 @@
 			fontFamily: settings.editorFont,
 			wordBasedSuggestions: 'off',
 			quickSuggestions: false,
+			renderWhitespace: settings.showWhitespace ? 'trailing' : 'none',
 		});
 
 		if (tabManager.activeTab?.editorViewState) {
@@ -209,6 +210,14 @@
 			label: 'Toggle Occurrences Highlight',
 			run: () => {
 				settings.toggleOccurrencesHighlight();
+			},
+		});
+
+		editor.addAction({
+			id: 'toggle-whitespace',
+			label: 'Toggle Show Whitespace',
+			run: () => {
+				settings.toggleShowWhitespace();
 			},
 		});
 
@@ -563,6 +572,7 @@
 				occurrencesHighlight: settings.occurrencesHighlight ? 'singleFile' : 'off',
 				fontSize: settings.editorFontSize * (zoomLevel / 100),
 				fontFamily: settings.editorFont,
+				renderWhitespace: settings.showWhitespace ? 'trailing' : 'none',
 			});
 		}
 	});

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -299,6 +299,14 @@
 									<span class="toggle-slider"></span>
 								</label>
 							</div>
+
+							<div class="setting-item">
+								<label for="editor-show-whitespace">Show Whitespace</label>
+								<label class="toggle">
+									<input id="editor-show-whitespace" type="checkbox" checked={settings.showWhitespace} onchange={() => settings.toggleShowWhitespace()} />
+									<span class="toggle-slider"></span>
+								</label>
+							</div>
 						</div>
 					{:else if activeCategory === 'preview'}
 						<div class="settings-group">

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -22,6 +22,8 @@
 		onopenFile,
 		onsaveFile,
 		onsaveFileAs,
+		onexportHtml,
+		onexportPdf,
 		onexit,
 		ontoggleHome,
 		ononpenFileLocation,
@@ -55,6 +57,8 @@
 		onopenFile?: () => void;
 		onsaveFile?: () => void;
 		onsaveFileAs?: () => void;
+		onexportHtml?: () => void;
+		onexportPdf?: () => void;
 		onexit?: () => void;
 		ontoggleHome: () => void;
 		ononpenFileLocation: () => void;
@@ -353,6 +357,29 @@
 								></svg>
 							Save As...
 							<span class="menu-shortcut">{modifier}+Shift+S</span>
+						</button>
+					{/if}
+					{#if currentFile !== '' || (tabManager.activeTab && tabManager.activeTab.content)}
+						<div class="home-menu-divider"></div>
+						<button
+							class="home-menu-item"
+							onclick={() => {
+								homeMenuOpen = false;
+								onexportHtml?.();
+							}}>
+							<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+								><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+							Export as HTML
+						</button>
+						<button
+							class="home-menu-item"
+							onclick={() => {
+								homeMenuOpen = false;
+								onexportPdf?.();
+							}}>
+							<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+								><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="9" y1="15" x2="15" y2="15"></line></svg>
+							Export as PDF
 						</button>
 					{/if}
 					<div class="home-menu-divider"></div>

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -49,6 +49,7 @@ export class SettingsStore {
 		lineNumbers: string;
 	} | null>(null);
 	occurrencesHighlight = $state(false);
+	showWhitespace = $state(false);
 	osType = $state<OSType>('unknown');
 
 	editorFont = $state('Consolas');
@@ -72,6 +73,7 @@ export class SettingsStore {
 			const savedZenMode = localStorage.getItem('editor.zenMode');
 			const savedPreZenState = localStorage.getItem('editor.preZenState');
 			const savedOccurrencesHighlight = localStorage.getItem('editor.occurrencesHighlight');
+			const savedShowWhitespace = localStorage.getItem('editor.showWhitespace');
 
 			const savedEditorFont = localStorage.getItem('editor.font');
 			const savedEditorFontSize = localStorage.getItem('editor.fontSize');
@@ -98,6 +100,7 @@ export class SettingsStore {
 			if (savedShowTabs !== null) this.showTabs = savedShowTabs === 'true';
 			if (savedZenMode !== null) this.zenMode = savedZenMode === 'true';
 			if (savedOccurrencesHighlight !== null) this.occurrencesHighlight = savedOccurrencesHighlight === 'true';
+			if (savedShowWhitespace !== null) this.showWhitespace = savedShowWhitespace === 'true';
 			if (savedPreZenState !== null) {
 				try {
 					this.preZenState = JSON.parse(savedPreZenState);
@@ -145,6 +148,7 @@ export class SettingsStore {
 					localStorage.setItem('editor.showTabs', String(this.showTabs));
 					localStorage.setItem('editor.zenMode', String(this.zenMode));
 					localStorage.setItem('editor.occurrencesHighlight', String(this.occurrencesHighlight));
+					localStorage.setItem('editor.showWhitespace', String(this.showWhitespace));
 					localStorage.setItem('editor.font', this.editorFont);
 					localStorage.setItem('editor.fontSize', String(this.editorFontSize));
 					localStorage.setItem('preview.font', this.previewFont);
@@ -222,6 +226,10 @@ export class SettingsStore {
 
 	toggleOccurrencesHighlight() {
 		this.occurrencesHighlight = !this.occurrencesHighlight;
+	}
+
+	toggleShowWhitespace() {
+		this.showWhitespace = !this.showWhitespace;
 	}
 
 	async initOSType() {

--- a/src/styles.css
+++ b/src/styles.css
@@ -353,6 +353,7 @@ body {
 .markdown-body [type="reset"],
 .markdown-body [type="submit"] {
 	-webkit-appearance: button;
+	appearance: button;
 }
 
 .markdown-body [type="button"]::-moz-focus-inner,
@@ -381,6 +382,7 @@ body {
 
 .markdown-body [type="search"] {
 	-webkit-appearance: textfield;
+	appearance: textfield;
 	outline-offset: -2px;
 }
 
@@ -960,4 +962,70 @@ body {
 .split-bar:hover,
 .split-bar:active {
 	background-color: var(--color-accent-fg);
+}
+
+/* print styles for pdf export */
+@media print {
+	@page {
+		margin: 0.75in;
+		size: auto;
+	}
+
+	.custom-title-bar,
+	.tab-area,
+	.window-controls-left,
+	.window-controls-right,
+	.title-actions-container,
+	.tooltip,
+	.custom-tooltip,
+	.drag-overlay,
+	.pane.editor-pane,
+	.split-bar,
+	.home-menu-container,
+	.kebab-btn,
+	.title-action-btn,
+	.theme-dropdown-container,
+	.control-btn,
+	.lang-label {
+		display: none !important;
+	}
+
+	html,
+	body,
+	#app,
+	.markdown-container,
+	.layout-container,
+	.pane.viewer-pane {
+		background: white !important;
+		overflow: visible !important;
+		height: auto !important;
+		min-height: auto !important;
+		position: static !important;
+		margin: 0 !important;
+		padding: 0 !important;
+		width: 100% !important;
+		border-radius: 0 !important;
+	}
+
+	.markdown-body {
+		padding: 0 !important;
+		margin: 0 !important;
+		overflow: visible !important;
+		height: auto !important;
+		min-height: auto !important;
+		max-width: 100% !important;
+		color: #000 !important;
+		background: white !important;
+		position: static !important;
+	}
+
+	.markdown-body pre {
+		white-space: pre-wrap !important;
+		word-break: break-word !important;
+		overflow-x: visible !important;
+	}
+
+	.markdown-container {
+		zoom: 1 !important;
+	}
 }


### PR DESCRIPTION
## Changes
- added file actions to export as html or pdf. (alpha implementation, needs testing)
- fixed whitespace, added option to toggle whitespace visibility

<img width="270" height="362" alt="image" src="https://github.com/user-attachments/assets/31b4c7b7-4877-436b-81f0-1b90bfc81e76" />

<img width="971" height="669" alt="image" src="https://github.com/user-attachments/assets/4f17cad3-8a12-4eca-9c97-759f7e64dec5" />
