### PR TITLE
fix(i18n): Mainly for zh-CN and zh-TW, making supplements and corrections

### DIFF
--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -2240,12 +2240,12 @@ import { t } from './utils/i18n.js';
 							class:on-right={settings.tocSide === 'right'}
 							class:in-edit-mode={isEditing && !settings.showToc}
 							onclick={() => settings.toggleToc()}
-							aria-label="{settings.showToc ? 'Hide' : 'Show'} Table of Contents"
+							aria-label={settings.showToc ? t('tooltip.hideTableOfContents', settings.language) : t('tooltip.showTableOfContents', settings.language)}
 							onmouseenter={(e) => {
 								const rect = e.currentTarget.getBoundingClientRect();
 								tooltip = { 
 									show: true, 
-									text: (settings.showToc ? 'Hide' : 'Show') + ' Table of Contents', 
+									text: settings.showToc ? t('tooltip.hideTableOfContents', settings.language) : t('tooltip.showTableOfContents', settings.language), 
 									shortcut: '',
 									html: '', 
 									isFootnote: false, 

--- a/src/lib/components/Tab.svelte
+++ b/src/lib/components/Tab.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import type { Tab } from '../stores/tabs.svelte.js';
-import ContextMenu, { type ContextMenuItem } from './ContextMenu.svelte';
-import { emit } from '@tauri-apps/api/event';
-import { t } from '../utils/i18n.js';
-import { settings } from '../stores/settings.svelte.js';
+	import ContextMenu, { type ContextMenuItem } from './ContextMenu.svelte';
+	import { emit } from '@tauri-apps/api/event';
+	import { t } from '../utils/i18n.js';
+	import { settings } from '../stores/settings.svelte.js';
 
 	let { tab, isActive, isLast, onclick, onclose } = $props<{
 		tab: Tab;
@@ -78,7 +78,7 @@ import { settings } from '../stores/settings.svelte.js';
 		<button class="tab-close" class:dirty={tab.isDirty} onclick={handleClose} onmousedown={(e) => {
 			e.stopPropagation();
 			e.preventDefault();
-		}} title="Close (Ctrl+W)">
+		}} title={`${t('tooltip.close', settings.language)} (Ctrl+W)`}>
 			{#if tab.isDirty}
 				<span class="dirty-dot"></span>
 			{/if}

--- a/src/lib/components/TabList.svelte
+++ b/src/lib/components/TabList.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import { type Tab as TabData, tabManager } from '../stores/tabs.svelte.js';
-import Tab from './Tab.svelte';
-import ContextMenu, { type ContextMenuItem } from './ContextMenu.svelte';
-import { t } from '../utils/i18n.js';
-import { settings } from '../stores/settings.svelte.js';
-import { emit } from '@tauri-apps/api/event';
+	import Tab from './Tab.svelte';
+	import ContextMenu, { type ContextMenuItem } from './ContextMenu.svelte';
+	import { t } from '../utils/i18n.js';
+	import { settings } from '../stores/settings.svelte.js';
+	import { emit } from '@tauri-apps/api/event';
 
-import { flip } from 'svelte/animate';
-import { tick } from 'svelte';
+	import { flip } from 'svelte/animate';
+	import { tick } from 'svelte';
 
 	let {
 		onnewTab,
@@ -222,7 +222,7 @@ import { tick } from 'svelte';
 		<div class="scroll-shadow right" class:visible={showRightArrow}></div>
 	</div>
 
-	<button class="new-tab-btn" onclick={onnewTab} onmousedown={(e) => e.preventDefault()} title="New tab (Ctrl+T)">
+	<button class="new-tab-btn" onclick={onnewTab} onmousedown={(e) => e.preventDefault()} title={`${t('tooltip.newTab', settings.language)} (Ctrl+T)`}>
 		<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
 			><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
 	</button>

--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -257,7 +257,11 @@ export const translations: Record<LanguageCode, Translation> = {
             switchSide: 'Switch side',
             toggleFold: 'Toggle fold',
             undockToc: 'Undock Table of Contents',
-            dockToc: 'Dock Table of Contents'
+            dockToc: 'Dock Table of Contents',
+            showTableOfContents: 'Show Table of Contents',
+            hideTableOfContents: 'Hide Table of Contents',
+            newTab: 'New Tab',
+            close: 'Close'
         },
         toc: {
             noHeadingsFound: 'No headings found'
@@ -508,7 +512,11 @@ export const translations: Record<LanguageCode, Translation> = {
             switchSide: '切换侧边',
             toggleFold: '切换折叠',
             undockToc: '取消固定目录',
-            dockToc: '固定目录'
+            dockToc: '固定目录',
+            showTableOfContents: '显示目录',
+            hideTableOfContents: '隐藏目录',
+            newTab: '新标签页',
+            close: '关闭'
         },
         toc: {
             noHeadingsFound: '未找到标题'
@@ -758,7 +766,11 @@ export const translations: Record<LanguageCode, Translation> = {
             switchSide: '側を切り替え',
             toggleFold: '折りたたみを切り替え',
             undockToc: '目次の固定を解除',
-            dockToc: '目次を固定'
+            dockToc: '目次を固定',
+            showTableOfContents: '目次を表示',
+            hideTableOfContents: '目次を隠す',
+            newTab: '新しいタブ',
+            close: '閉じる'
         },
         toc: {
             noHeadingsFound: '見出しが見つかりません'
@@ -1001,7 +1013,22 @@ export const translations: Record<LanguageCode, Translation> = {
             editFile: '編輯文件',
             changeTheme: '更改主題',
             zoomIn: '放大',
-            zoomOut: '縮小'
+            zoomOut: '縮小',
+            toggleZenMode: '切換禪模式',
+            toggleSplitView: '切換分割視圖',
+            toggleScrollSync: '切換同步滾動',
+            toggleFullWidth: '切換全寬',
+            toggleAutoReload: '切換自動重載',
+            undock: '取消固定',
+            dock: '固定',
+            switchSide: '切換側邊',
+            toggleFold: '切換摺疊',
+            undockToc: '取消固定目錄',
+            dockToc: '固定目錄',
+            showTableOfContents: '顯示目錄',
+            hideTableOfContents: '隱藏目錄',
+            newTab: '新標籤頁',
+            close: '關閉'
         },
         uninstaller: {
             uninstallMarkpad: '您想要卸載 Markpad 嗎？',
@@ -1018,7 +1045,10 @@ export const translations: Record<LanguageCode, Translation> = {
             close: '關閉',
             minimize: '最小化',
             maximize: '最大化'
-        }
+        },
+        toc: {
+            noHeadingsFound: '未找到標題'
+        },
     },
     ko: {
         settings: {
@@ -4106,7 +4136,10 @@ export const translations: Record<LanguageCode, Translation> = {
             editFile: 'Upravit soubor',
             changeTheme: 'Změnit motiv',
             zoomIn: 'Přiblížit',
-            zoomOut: 'Oddálit'
+            zoomOut: 'Oddálit',
+            dock: 'pevný',
+            undock: 'zrušit pevné',
+            switchSide: 'Switch side',
         },
         uninstaller: {
             uninstallMarkpad: 'Chcete odinstalovat Markpad?',
@@ -4123,7 +4156,10 @@ export const translations: Record<LanguageCode, Translation> = {
             close: 'Zavřít',
             minimize: 'Minimalizovat',
             maximize: 'Maximalizovat'
-        }
+        },
+        toc: {
+            noHeadingsFound: 'Nenalezen název'
+        },
     },
     sk: {
         settings: {


### PR DESCRIPTION
1. Add i18n support for '+' button tooltip (new tab)
2. Add i18n support for 'x' button tooltip (close tab)
3. Add i18n support for table of contents toggle button (show/hide)
4. Add tooltip translations for zh-CN, zh-TW:
   - tooltip.newTab
   - tooltip.close
   - tooltip.showTableOfContents
   - tooltip.hideTableOfContents
   
  
![PixPin_2026-04-01_13-32-05](https://github.com/user-attachments/assets/59d7da18-691f-4c3b-8ab0-9cbe222a72f6)
