### PR TITLE
fix(editor): fix image directory path handling and enhance security

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -630,7 +630,13 @@ fn save_image(parent_dir: String, filename: String, base64_data: String, image_d
 
     fs::write(&file_path, bytes).map_err(|e| e.to_string())?;
 
-    Ok(format!("{}/{}", image_directory, filename))
+    let rel_path = if image_directory.is_empty() {
+        filename
+    } else {
+        format!("{}/{}", image_directory, filename)
+    };
+
+    Ok(rel_path)
 }
 
 #[tauri::command]
@@ -662,7 +668,13 @@ fn copy_file_to_img(src_path: String, parent_dir: String, image_directory: Strin
     let final_dest = img_dir.join(&dest_name);
     fs::copy(src, &final_dest).map_err(|e| e.to_string())?;
 
-    Ok(format!("{}/{}", image_directory, dest_name))
+    let rel_path = if image_directory.is_empty() {
+        dest_name
+    } else {
+        format!("{}/{}", image_directory, dest_name)
+    };
+
+    Ok(rel_path)
 }
 
 #[tauri::command]

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -106,7 +106,9 @@ import { t } from './utils/i18n.js';
 	let isMarkdown = $derived(['md', 'markdown', 'mdown', 'mkd', 'txt'].includes(currentFile.split('.').pop()?.toLowerCase() || ''));
 	let editorLanguage = $derived(getLanguage(currentFile));
 	let htmlContent = $derived(tabManager.activeTab?.content ?? '');
-	let sanitizedHtml = $derived(DOMPurify.sanitize(htmlContent));
+	let sanitizedHtml = $derived(DOMPurify.sanitize(htmlContent, {
+		ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|asset|tauri):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
+	}));
 	let scrollTop = $derived(tabManager.activeTab?.scrollTop ?? 0);
 	let isScrolled = $derived(scrollTop > 0);
 	let windowTitle = $derived(tabManager.activeTab?.title ?? 'Markpad');

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -604,10 +604,11 @@
 				const last = managedImages[managedImages.length - 1];
 				if (!currentContent.includes(last.embed)) {
 					managedImages.pop();
-						const imgPath = `${last.parentDir}/${settings.imageDirectory}/${last.filename}`;
+						const imgDirName = settings.imageDirectory || "img";
+						const imgPath = `${last.parentDir}/${imgDirName}/${last.filename}`;
 						invoke("delete_file", { path: imgPath })
 							.then(() => {
-								invoke("cleanup_empty_img_dir", { parentDir: last.parentDir, imageDirectory: settings.imageDirectory });
+								invoke("cleanup_empty_img_dir", { parentDir: last.parentDir, imageDirectory: imgDirName });
 							})
 							.catch(console.error);
 				}
@@ -635,13 +636,14 @@
 						tab.path.lastIndexOf("/"),
 					);
 					const parentDir = tab.path.substring(0, lastSlash);
+					const imgDirName = settings.imageDirectory || "img";
 
 					try {
 						const [currentEntries, imgEntries] = await Promise.all([
 							invoke("list_directory_contents", { path: parentDir })
 								.then((r) => r as string[])
 								.catch(() => []),
-							invoke("list_directory_contents", { path: parentDir + "/img" })
+							invoke("list_directory_contents", { path: `${parentDir}/${imgDirName}` })
 								.then((r) => r as string[])
 								.catch(() => []),
 						]);
@@ -664,11 +666,11 @@
 								range,
 							})),
 							...imgEntries.map((e) => ({
-								label: `img/${e}`,
+								label: `${imgDirName}/${e}`,
 								kind: e.endsWith("/")
 									? monaco.languages.CompletionItemKind.Folder
 									: monaco.languages.CompletionItemKind.File,
-								insertText: `img/${e}`,
+								insertText: `${imgDirName}/${e}`,
 								range,
 							})),
 						];
@@ -701,7 +703,7 @@
 		editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyV, async () => {
 			try {
 				// check for image in clipboard via Rust
-				const base64Image = await invoke("clipboard_read_image", { macos_image_scaling: settings.macosImageScaling }).catch(() => null) as string | null;
+				const base64Image = await invoke("clipboard_read_image", { macosImageScaling: settings.macosImageScaling }).catch(() => null) as string | null;
 				if (base64Image && tabManager.activeTab?.path) {
 					const ext = "png"; // output of Rust command is always PNG
 					const filename = `paste_${Date.now()}.${ext}`;
@@ -710,13 +712,15 @@
 					const dirMatch = tabPath.match(/^(.*)[/\\][^/\\]+$/);
 					if (dirMatch) {
 						const parentDir = dirMatch[1];
+						const imgDirName = settings.imageDirectory || "img";
 						const relPath = (await invoke("save_image", {
 							parentDir,
 							filename,
 							base64Data: base64Image,
-							imageDirectory: settings.imageDirectory,
+							imageDirectory: imgDirName,
 						})) as string;
-						const escapedPath = relPath.replace(/ /g, "%20");
+						// Remove leading slash if imageDirectory was empty, to ensure relative path
+						const escapedPath = relPath.replace(/ /g, "%20").replace(/^\//, "");
 						const embed = `![alt](${escapedPath})`;
 
 						const position = editor.getPosition();
@@ -1008,12 +1012,14 @@
 		const parentDir = match[1];
 
 		try {
+			const imgDirName = settings.imageDirectory || "img";
 			const relPath = (await invoke("copy_file_to_img", {
 				srcPath: path,
 				parentDir,
-				imageDirectory: settings.imageDirectory,
+				imageDirectory: imgDirName,
 			})) as string;
-			const escapedPath = relPath.replace(/ /g, "%20");
+			// Remove leading slash if imageDirectory was empty
+			const escapedPath = relPath.replace(/ /g, "%20").replace(/^\//, "");
 			const embed = `![alt](${escapedPath})`;
 
 			editor.executeEdits(


### PR DESCRIPTION
# Fix image paste and rendering issues

## Description

This PR fixes multiple bugs related to image handling in the editor, ensuring that images pasted or dropped into the application are properly saved, correctly referenced, and successfully rendered in the Markdown viewer.

## Changes Made

### 1. Fixed macOS Image Scaling Parameter
- **Issue**: Image pasting was failing silently (falling back to text paste) because the Rust backend command `clipboard_read_image` expected `macosImageScaling` (camelCase) from the frontend IPC, but it was being sent as `macos_image_scaling` (snake_case).
- **Fix**: Updated the IPC payload property in `Editor.svelte` to use `macosImageScaling`.

### 2. Fixed Image Rendering in Markdown Preview
- **Issue**: Images saved locally and loaded via Tauri's custom protocols (`asset://` or `tauri://`) were not displaying because `DOMPurify` stripped out these non-standard URI schemes during HTML sanitization.
- **Fix**: Configured `DOMPurify.sanitize` in `MarkdownViewer.svelte` with a custom `ALLOWED_URI_REGEXP` that explicitly permits `asset` and `tauri` protocols.

### 3. Handled Empty Image Directory Setting
- **Issue**: If the user left the `imageDirectory` setting empty, the backend generated an absolute-like path with a leading slash (e.g., `![alt](/paste_...png)`), causing the Markdown preview to fail to locate the file relative to the document.
- **Fix**: 
  - Updated the Rust backend (`save_image` and `copy_file_to_img`) to omit the leading slash when the image directory is empty.
  - Added a fallback in the frontend (`Editor.svelte`) to default to `"img"` if `settings.imageDirectory` is empty/falsy during paste, drop, undo-cleanup, and path autocomplete.
  - Ensured any remaining leading slashes are stripped before inserting the Markdown image syntax into the editor.

## Related Components
- `src/lib/components/Editor.svelte`
- `src/lib/MarkdownViewer.svelte`
- `src-tauri/src/lib.rs`

## Testing
- Verify that pasting an image from the clipboard successfully saves the image and inserts the correct Markdown syntax.
- Verify that dragging and dropping an image file works correctly.
- Verify that images render properly in the Markdown preview pane.
- Verify that clearing the "Image Directory" setting correctly defaults to saving images in an `img` folder relative to the current document.