### PR TITLE
Fix macOS markdown file associations

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -40,17 +40,22 @@
     "fileAssociations": [
       {
         "ext": ["md", "markdown"],
+        "contentTypes": [
+          "net.daringfireball.markdown",
+          "public.markdown"
+        ],
         "mimeType": "text/markdown",
         "name": "Markdown File",
         "description": "Opens Markdown files with Markpad",
-        "role": "Viewer"
+        "role": "Editor"
       },
       {
         "ext": ["txt"],
+        "contentTypes": ["public.plain-text"],
         "mimeType": "text/plain",
         "name": "Text File",
         "description": "Opens Text files with Markpad",
-        "role": "Viewer"
+        "role": "Editor"
       }
     ],
     "windows": {


### PR DESCRIPTION
## Summary

Adds macOS content type declarations for Markpad's Markdown and plain text file associations.

## Why

The app already declares `.md`, `.markdown`, and `.txt` extensions, but macOS Launch Services works more reliably when document handlers also declare the corresponding UTI/content types. Without those, Markpad may not reliably appear as a recommended/default app in Finder's Open With flow on some macOS installations.

This also changes the document role from `Viewer` to `Editor`, which matches Markpad's actual behavior as both a Markdown viewer and editor.

## Validation

- `cargo check` from `src-tauri/`
- `npm run check` (existing warnings only, no errors)
- `npm run build` (existing warnings only)
- `npm run tauri build -- --bundles app`
- Verified the generated `Markpad.app/Contents/Info.plist` includes:
  - `LSItemContentTypes = [net.daringfireball.markdown, public.markdown]`
  - `LSItemContentTypes = [public.plain-text]`
  - `CFBundleTypeRole = Editor`
