### PR TITLE
[codex] Close window after final tab closes

### DIFF
--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -1279,12 +1279,30 @@ import { t } from './utils/i18n.js';
 	}
 
 	async function closeFile() {
-		if (tabManager.activeTabId) {
-			if (await canCloseTab(tabManager.activeTabId)) {
-				tabManager.closeTab(tabManager.activeTabId);
-			}
+		if (!tabManager.activeTabId) {
+			await destroyWindowAfterTabsClosed();
+			return;
 		}
-		if (liveMode && tabManager.tabs.length === 0) invoke('unwatch_file').catch(console.error);
+
+		await closeTabAndWindowIfLast(tabManager.activeTabId);
+	}
+
+	async function closeTabAndWindowIfLast(tabId: string) {
+		if (!(await canCloseTab(tabId))) return;
+
+		tabManager.closeTab(tabId);
+		if (tabManager.tabs.length > 0) return;
+
+		if (liveMode) invoke('unwatch_file').catch(console.error);
+		await destroyWindowAfterTabsClosed();
+	}
+
+	async function destroyWindowAfterTabsClosed() {
+		if (settings.restoreStateOnReopen) {
+			localStorage.setItem('savedTabsData', tabManager.serializeState());
+		}
+
+		await appWindow.destroy();
 	}
 
 	async function openFileLocation() {
@@ -1913,9 +1931,7 @@ import { t } from './utils/i18n.js';
 			unlisteners.push(
 				await listen('menu-tab-close', async (event) => {
 					const tabId = event.payload as string;
-					if (await canCloseTab(tabId)) {
-						tabManager.closeTab(tabId);
-					}
+					await closeTabAndWindowIfLast(tabId);
 				}),
 			);
 			unlisteners.push(
@@ -2104,11 +2120,7 @@ import { t } from './utils/i18n.js';
 		{theme}
 		onSetTheme={(t) => (theme = t)}
 		onopenSettings={() => (showSettings = true)}
-		oncloseTab={(id) => {
-			canCloseTab(id).then((can) => {
-				if (can) tabManager.closeTab(id);
-			});
-		}} />
+		oncloseTab={closeTabAndWindowIfLast} />
 	<div class="loading-screen">
 		<svg class="spinner" viewBox="0 0 50 50">
 			<circle class="path" cx="25" cy="25" r="20" fill="none" stroke-width="4"></circle>
@@ -2151,11 +2163,7 @@ import { t } from './utils/i18n.js';
 		{theme}
 		onSetTheme={(t) => (theme = t)}
 		onopenSettings={() => (showSettings = true)}
-		oncloseTab={(id) => {
-			canCloseTab(id).then((can) => {
-				if (can) tabManager.closeTab(id);
-			});
-		}} />
+		oncloseTab={closeTabAndWindowIfLast} />
 
 	<Settings show={showSettings} {theme} onSetTheme={(t) => (theme = t)} onclose={() => (showSettings = false)} />
 


### PR DESCRIPTION
## Summary

- Route close-file and close-tab actions through one final-tab close helper.
- When the last tab closes, save restore-state tab data if needed and destroy the current Tauri window.
- Preserve the existing unsaved-changes prompt before the final tab is removed.

## Root cause

`Cmd+W` and close-tab actions only removed the active tab. When the last tab was removed, the app stayed open and rendered the home screen because no code reliably closed the window after the tab list became empty.

I originally tried `appWindow.close()`, but rechecking showed that it can leave the window visible in the local Tauri runtime because `close()` goes through the close-request flow. After the final tab has already passed `canCloseTab()`, `appWindow.destroy()` is the correct force-close API for this clean window state.

## Validation

- `npm run check` completed with 0 errors. Existing warnings remain in unrelated components.
- `npm run build` completed successfully. Existing Svelte/chunk warnings remain unchanged.
- `cargo test` completed successfully. The existing `APP_NAME` dead-code warning remains unchanged.
- Runtime smoke on macOS: launched `cargo run -- /tmp/markpad-close-window-smoke.md`, sent `Cmd+W`, then verified via CoreGraphics that visible Markpad windows dropped from 1 to 0.