### PR TITLE
Fix markdown preview wrapping and Windows open-with registration

### DIFF
--- a/src-tauri/hooks.nsi
+++ b/src-tauri/hooks.nsi
@@ -1,18 +1,18 @@
 !macro MARKPAD_REGISTER_OPEN_WITH EXTENSION
-  WriteRegStr HKCU "Software\Classes\.${EXTENSION}\shell\Open with MarkPad" "" "Open with MarkPad"
-  WriteRegStr HKCU "Software\Classes\.${EXTENSION}\shell\Open with MarkPad" "Icon" "$INSTDIR\Markpad.exe"
-  WriteRegStr HKCU "Software\Classes\.${EXTENSION}\shell\Open with MarkPad\command" "" "$\"$INSTDIR\Markpad.exe$\" $\"%1$\""
+  WriteRegStr HKCU "Software\Classes\.${EXTENSION}\shell\Open with Markpad" "" "Open with Markpad"
+  WriteRegStr HKCU "Software\Classes\.${EXTENSION}\shell\Open with Markpad" "Icon" "$INSTDIR\Markpad.exe"
+  WriteRegStr HKCU "Software\Classes\.${EXTENSION}\shell\Open with Markpad\command" "" "$\"$INSTDIR\Markpad.exe$\" $\"%1$\""
 
-  WriteRegStr HKCU "Software\Classes\SystemFileAssociations\.${EXTENSION}\shell\Open with MarkPad" "" "Open with MarkPad"
-  WriteRegStr HKCU "Software\Classes\SystemFileAssociations\.${EXTENSION}\shell\Open with MarkPad" "Icon" "$INSTDIR\Markpad.exe"
-  WriteRegStr HKCU "Software\Classes\SystemFileAssociations\.${EXTENSION}\shell\Open with MarkPad\command" "" "$\"$INSTDIR\Markpad.exe$\" $\"%1$\""
+  WriteRegStr HKCU "Software\Classes\SystemFileAssociations\.${EXTENSION}\shell\Open with Markpad" "" "Open with Markpad"
+  WriteRegStr HKCU "Software\Classes\SystemFileAssociations\.${EXTENSION}\shell\Open with Markpad" "Icon" "$INSTDIR\Markpad.exe"
+  WriteRegStr HKCU "Software\Classes\SystemFileAssociations\.${EXTENSION}\shell\Open with Markpad\command" "" "$\"$INSTDIR\Markpad.exe$\" $\"%1$\""
 
   WriteRegStr HKCU "Software\Classes\.${EXTENSION}\OpenWithList\Markpad.exe" "" ""
 !macroend
 
 !macro MARKPAD_UNREGISTER_OPEN_WITH EXTENSION
-  DeleteRegKey HKCU "Software\Classes\.${EXTENSION}\shell\Open with MarkPad"
-  DeleteRegKey HKCU "Software\Classes\SystemFileAssociations\.${EXTENSION}\shell\Open with MarkPad"
+  DeleteRegKey HKCU "Software\Classes\.${EXTENSION}\shell\Open with Markpad"
+  DeleteRegKey HKCU "Software\Classes\SystemFileAssociations\.${EXTENSION}\shell\Open with Markpad"
   DeleteRegKey HKCU "Software\Classes\.${EXTENSION}\OpenWithList\Markpad.exe"
 !macroend
 

--- a/src-tauri/hooks.nsi
+++ b/src-tauri/hooks.nsi
@@ -1,7 +1,37 @@
+!macro MARKPAD_REGISTER_OPEN_WITH EXTENSION
+  WriteRegStr HKCU "Software\Classes\.${EXTENSION}\shell\Open with MarkPad" "" "Open with MarkPad"
+  WriteRegStr HKCU "Software\Classes\.${EXTENSION}\shell\Open with MarkPad" "Icon" "$INSTDIR\Markpad.exe"
+  WriteRegStr HKCU "Software\Classes\.${EXTENSION}\shell\Open with MarkPad\command" "" "$\"$INSTDIR\Markpad.exe$\" $\"%1$\""
+
+  WriteRegStr HKCU "Software\Classes\SystemFileAssociations\.${EXTENSION}\shell\Open with MarkPad" "" "Open with MarkPad"
+  WriteRegStr HKCU "Software\Classes\SystemFileAssociations\.${EXTENSION}\shell\Open with MarkPad" "Icon" "$INSTDIR\Markpad.exe"
+  WriteRegStr HKCU "Software\Classes\SystemFileAssociations\.${EXTENSION}\shell\Open with MarkPad\command" "" "$\"$INSTDIR\Markpad.exe$\" $\"%1$\""
+
+  WriteRegStr HKCU "Software\Classes\.${EXTENSION}\OpenWithList\Markpad.exe" "" ""
+!macroend
+
+!macro MARKPAD_UNREGISTER_OPEN_WITH EXTENSION
+  DeleteRegKey HKCU "Software\Classes\.${EXTENSION}\shell\Open with MarkPad"
+  DeleteRegKey HKCU "Software\Classes\SystemFileAssociations\.${EXTENSION}\shell\Open with MarkPad"
+  DeleteRegKey HKCU "Software\Classes\.${EXTENSION}\OpenWithList\Markpad.exe"
+!macroend
+
 !macro NSIS_HOOK_POST_INSTALL
-  CreateShortcut "$DESKTOP\Markpad.lnk" "$INSTDIR\markdown-viewer-v2.exe" "" "$INSTDIR\markdown-viewer-v2.exe" 0
+  CreateShortcut "$DESKTOP\Markpad.lnk" "$INSTDIR\Markpad.exe" "" "$INSTDIR\Markpad.exe" 0
+
+  WriteRegStr HKCU "Software\Classes\Applications\Markpad.exe\shell\open\command" "" "$\"$INSTDIR\Markpad.exe$\" $\"%1$\""
+  !insertmacro MARKPAD_REGISTER_OPEN_WITH "md"
+  !insertmacro MARKPAD_REGISTER_OPEN_WITH "markdown"
+
+  System::Call 'shell32::SHChangeNotify(i 0x08000000, i 0, p 0, p 0)'
 !macroend
 
 !macro NSIS_HOOK_POST_UNINSTALL
   Delete "$DESKTOP\Markpad.lnk"
+
+  DeleteRegKey HKCU "Software\Classes\Applications\Markpad.exe"
+  !insertmacro MARKPAD_UNREGISTER_OPEN_WITH "md"
+  !insertmacro MARKPAD_UNREGISTER_OPEN_WITH "markdown"
+
+  System::Call 'shell32::SHChangeNotify(i 0x08000000, i 0, p 0, p 0)'
 !macroend

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -2415,11 +2415,14 @@ import { t } from './utils/i18n.js';
 		box-sizing: border-box;
 		min-width: 200px;
 		margin: 0;
-		padding: 50px clamp(calc(calc(50% - 390px)), 5vw, 50px);
+		padding: 50px clamp(24px, 5vw, 50px);
 		height: 100%;
 		overflow-y: auto;
 		overflow-x: hidden;
 		transform: translate3d(0, 0, 0);
+		max-width: 100%;
+		text-align: left;
+		overflow-wrap: anywhere;
 	}
 
 	.loading-chip {
@@ -2473,7 +2476,7 @@ import { t } from './utils/i18n.js';
 	}
 
 	.markdown-body.full-width {
-		padding: 50px;
+		padding: 50px clamp(24px, 5vw, 50px);
 		max-width: 100%;
 	}
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -221,6 +221,8 @@ body {
 	font-size: 16px;
 	line-height: 1.5;
 	word-wrap: break-word;
+	overflow-wrap: anywhere;
+	text-align: left;
 	user-select: text;
 	-webkit-user-select: text;
 }
@@ -428,10 +430,11 @@ body {
 .markdown-body table {
 	border-spacing: 0;
 	border-collapse: collapse;
-	display: block;
-	width: max-content;
+	display: table;
+	table-layout: fixed;
+	width: 100%;
 	max-width: 100%;
-	overflow: auto;
+	overflow: visible;
 	margin-top: 0;
 	margin-bottom: 16px;
 }
@@ -444,6 +447,9 @@ body {
 .markdown-body table th {
 	padding: 6px 13px;
 	border: 1px solid var(--color-border-default);
+	white-space: normal;
+	overflow-wrap: anywhere;
+	word-break: normal;
 }
 
 .markdown-body table tr {
@@ -606,6 +612,8 @@ body {
 .markdown-body p {
 	margin-top: 0;
 	margin-bottom: 10px;
+	white-space: normal;
+	overflow-wrap: anywhere;
 }
 
 .markdown-body blockquote {
@@ -635,7 +643,9 @@ body {
 }
 
 .markdown-body li {
-	word-wrap: break-all;
+	word-wrap: break-word;
+	overflow-wrap: anywhere;
+	word-break: normal;
 }
 
 .markdown-body li>p {
@@ -668,6 +678,8 @@ body {
 	margin: 0;
 	font-size: 85%;
 	white-space: break-spaces;
+	overflow-wrap: anywhere;
+	word-break: break-word;
 	background-color: var(--color-neutral-muted);
 	border-radius: 6px;
 }
@@ -684,14 +696,15 @@ body {
 		Liberation Mono,
 		monospace;
 	font-size: 12px;
-	word-wrap: normal;
+	word-wrap: break-word;
+	white-space: pre-wrap;
 }
 
 .markdown-body pre>code {
 	padding: 0;
 	margin: 0;
-	word-break: normal;
-	white-space: pre;
+	word-break: break-word;
+	white-space: pre-wrap;
 	background: transparent;
 	border: 0;
 }
@@ -702,13 +715,13 @@ body {
 
 .markdown-body .highlight pre {
 	margin-bottom: 0;
-	word-break: normal;
+	word-break: break-word;
 }
 
 .markdown-body .highlight pre,
 .markdown-body pre {
 	padding: 18px 16px;
-	overflow-x: auto;
+	overflow-x: hidden;
 	overflow-y: hidden;
 	font-size: 85%;
 	line-height: 1.45;
@@ -750,7 +763,9 @@ body {
 	margin: 0;
 	overflow: visible;
 	line-height: inherit;
-	word-wrap: normal;
+	word-wrap: break-word;
+	overflow-wrap: anywhere;
+	white-space: pre-wrap;
 	background-color: transparent;
 	border: 0;
 }


### PR DESCRIPTION
## Summary
- Left-align markdown preview content instead of centering it.
- Improve wrapping for paragraphs, lists, inline code, code blocks, and tables so content stays visible in the window.
- Register "Open with MarkPad" for .md and .markdown files during Windows NSIS installation.
- Remove those registry entries on uninstall.

## Verification
- npm run check
- npm run build
- npm run tauri -- build --target x86_64-pc-windows-msvc --bundles nsis --ci

Notes:
- Existing Svelte accessibility warnings remain unchanged.
- Windows NSIS build completed successfully.