### PR TITLE
Add configurable auto-save with atomic writes

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -43,9 +43,13 @@ fn atomic_write(target: &Path, bytes: &[u8]) -> std::io::Result<()> {
     };
     let target = resolved.as_path();
 
+    // For a relative path with no leading directory (e.g. just "foo.md"),
+    // `target.parent()` returns Some("") which is unusable for the temp
+    // file. Treat that as the current directory so we can still place the
+    // temp alongside the target and keep the rename atomic.
     let parent_path: PathBuf = match target.parent() {
         Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
-        _ => return fs::write(target, bytes),
+        _ => PathBuf::from("."),
     };
 
     // Snapshot existing permissions so we can re-apply them after rename.
@@ -83,16 +87,29 @@ fn atomic_write(target: &Path, bytes: &[u8]) -> std::io::Result<()> {
     }
 
     // Try rename; on Windows std::fs::rename refuses to replace an existing
-    // destination, so on the first error retry with a remove+rename. Unix
-    // hits the success branch on the first try.
+    // destination, so on the first error retry with a remove+rename — but
+    // ONLY when the destination actually exists. Otherwise the rename
+    // failed for some other reason (permissions, AV lock, missing temp)
+    // and removing the target would risk leaving the user with no file.
     if let Err(e) = fs::rename(&temp_path, target) {
         #[cfg(windows)]
         {
-            // Best-effort: drop the existing destination, then retry.
-            let _ = fs::remove_file(target);
-            if let Err(e2) = fs::rename(&temp_path, target) {
+            if target.exists() {
+                let _ = fs::remove_file(target);
+                if let Err(e2) = fs::rename(&temp_path, target) {
+                    // Both attempts failed: clean up the temp and surface
+                    // the second error. The original target may already
+                    // be gone here, but that is the worst case for any
+                    // non-MoveFileExW recovery without `windows-sys`.
+                    let _ = fs::remove_file(&temp_path);
+                    return Err(e2);
+                }
+            } else {
+                // The rename failed but the target doesn't exist: the
+                // problem isn't "destination exists". Don't risk removing
+                // anything, just clean up the temp and surface the error.
                 let _ = fs::remove_file(&temp_path);
-                return Err(e2);
+                return Err(e);
             }
         }
         #[cfg(not(windows))]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,22 +9,12 @@ use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, Manager, State};
 
-/// Write `bytes` to `target` durably and as atomically as the platform allows:
-/// write to a sibling temp file, fsync it, then rename over the target. Falls
-/// back to a plain `fs::write` only if the target has no parent directory
-/// (a path like "foo.md" with no leading dir), which `fs::rename` would not
-/// be able to handle safely anyway.
-///
-/// **Atomicity guarantees:**
-/// - **Unix:** fully atomic. `fs::rename` is a single `rename(2)` syscall and
-///   the parent directory is fsync'd afterwards so the rename survives a
-///   crash.
-/// - **Windows:** near-atomic. `std::fs::rename` does NOT replace an existing
-///   destination on Windows, so we fall back to `remove + rename` if the
-///   first rename fails. There is a very short window where `target` is
-///   briefly absent. A truly atomic Windows replace would need a
-///   `MoveFileExW(MOVEFILE_REPLACE_EXISTING)` call, which would require
-///   pulling in `windows-sys` as a dep.
+/// Write `bytes` to `target` durably and atomically: write to a sibling temp
+/// file, fsync it, then rename over the target. Atomic on both Unix and
+/// modern Windows — `std::fs::rename` calls `MoveFileExW` with
+/// `MOVEFILE_REPLACE_EXISTING` on Windows since Rust 1.35, so an existing
+/// destination is replaced atomically without a dedicated fallback path.
+/// Markpad targets Tauri v2 (Rust 1.70+), so we can rely on this everywhere.
 ///
 /// **Other correctness preservations vs. plain `fs::write`:**
 /// - **Symlinks:** if `target` is a symlink, follow it to the real file so we
@@ -32,6 +22,9 @@ use tauri::{AppHandle, Emitter, Manager, State};
 /// - **Permissions:** on overwrite, restore the destination's original mode
 ///   bits after the rename; the temp file otherwise inherits the process
 ///   umask.
+/// - **POSIX durability:** on Unix, fsync the parent directory after the
+///   rename so the directory entry update survives a crash. Windows NTFS
+///   journals this on its own, so no extra step is needed there.
 fn atomic_write(target: &Path, bytes: &[u8]) -> std::io::Result<()> {
     // Resolve symlinks so we update the real file. `symlink_metadata` does NOT
     // follow links (unlike `metadata`); if target is a symlink, canonicalize
@@ -86,37 +79,16 @@ fn atomic_write(target: &Path, bytes: &[u8]) -> std::io::Result<()> {
         return Err(e);
     }
 
-    // Try rename; on Windows std::fs::rename refuses to replace an existing
-    // destination, so on the first error retry with a remove+rename — but
-    // ONLY when the destination actually exists. Otherwise the rename
-    // failed for some other reason (permissions, AV lock, missing temp)
-    // and removing the target would risk leaving the user with no file.
+    // Atomic on both Unix and modern Windows: std::fs::rename uses
+    // `rename(2)` (POSIX) or `MoveFileExW(MOVEFILE_REPLACE_EXISTING)`
+    // (Windows since Rust 1.35). The destination is either fully replaced
+    // or left untouched — never partially overwritten or missing. If the
+    // rename fails (e.g. target locked by another process on Windows),
+    // we clean up the temp file and surface the original error without
+    // touching the target.
     if let Err(e) = fs::rename(&temp_path, target) {
-        #[cfg(windows)]
-        {
-            if target.exists() {
-                let _ = fs::remove_file(target);
-                if let Err(e2) = fs::rename(&temp_path, target) {
-                    // Both attempts failed: clean up the temp and surface
-                    // the second error. The original target may already
-                    // be gone here, but that is the worst case for any
-                    // non-MoveFileExW recovery without `windows-sys`.
-                    let _ = fs::remove_file(&temp_path);
-                    return Err(e2);
-                }
-            } else {
-                // The rename failed but the target doesn't exist: the
-                // problem isn't "destination exists". Don't risk removing
-                // anything, just clean up the temp and surface the error.
-                let _ = fs::remove_file(&temp_path);
-                return Err(e);
-            }
-        }
-        #[cfg(not(windows))]
-        {
-            let _ = fs::remove_file(&temp_path);
-            return Err(e);
-        }
+        let _ = fs::remove_file(&temp_path);
+        return Err(e);
     }
 
     // Best-effort restore of the original mode bits. If this fails (e.g. the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,11 +17,34 @@ use tauri::{AppHandle, Emitter, Manager, State};
 /// On both Unix and Windows `fs::rename` is atomic when source and destination
 /// live on the same filesystem; placing the temp next to the target guarantees
 /// that. On crash mid-write the original file is left intact.
+///
+/// Two correctness preservations vs. `fs::write`:
+/// - **Symlinks:** if `target` is a symbolic link, follow it to the real file
+///   so the rename replaces the actual content rather than the link itself.
+/// - **Permissions:** when overwriting an existing file, restore its original
+///   mode bits after the rename, since the temp file is created with the
+///   process default umask.
 fn atomic_write(target: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    // Resolve symlinks so we update the real file. `symlink_metadata` does NOT
+    // follow links (unlike `metadata`); if target is a symlink, canonicalize
+    // returns the real path it points to. For a non-existent target or a
+    // regular file, we keep the original path.
+    let resolved: PathBuf = match fs::symlink_metadata(target) {
+        Ok(m) if m.file_type().is_symlink() => target.canonicalize()?,
+        _ => target.to_path_buf(),
+    };
+    let target = resolved.as_path();
+
     let parent = match target.parent() {
         Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
         _ => return fs::write(target, bytes),
     };
+
+    // Snapshot existing permissions so we can re-apply them after rename.
+    // `fs::rename` brings over the temp file's permissions, dropping mode
+    // bits / ACLs that the destination had. `None` means "target didn't
+    // exist", in which case there's nothing to restore.
+    let existing_perms = fs::metadata(target).ok().map(|m| m.permissions());
 
     let file_name = target
         .file_name()
@@ -54,6 +77,13 @@ fn atomic_write(target: &Path, bytes: &[u8]) -> std::io::Result<()> {
     if let Err(e) = fs::rename(&temp_path, target) {
         let _ = fs::remove_file(&temp_path);
         return Err(e);
+    }
+
+    // Best-effort restore of the original mode bits. If this fails (e.g. the
+    // filesystem doesn't support it, or the user lacks privileges), the file
+    // contents are still correctly written, so we don't surface the error.
+    if let Some(perms) = existing_perms {
+        let _ = fs::set_permissions(target, perms);
     }
 
     Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,21 +9,29 @@ use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, Manager, State};
 
-/// Write `bytes` to `target` atomically: write to a sibling temp file, fsync it,
-/// then rename over the target. Falls back to a plain `fs::write` only if the
-/// target has no parent directory (a path like "foo.md" with no leading dir),
-/// which `fs::rename` would not be able to handle safely anyway.
+/// Write `bytes` to `target` durably and as atomically as the platform allows:
+/// write to a sibling temp file, fsync it, then rename over the target. Falls
+/// back to a plain `fs::write` only if the target has no parent directory
+/// (a path like "foo.md" with no leading dir), which `fs::rename` would not
+/// be able to handle safely anyway.
 ///
-/// On both Unix and Windows `fs::rename` is atomic when source and destination
-/// live on the same filesystem; placing the temp next to the target guarantees
-/// that. On crash mid-write the original file is left intact.
+/// **Atomicity guarantees:**
+/// - **Unix:** fully atomic. `fs::rename` is a single `rename(2)` syscall and
+///   the parent directory is fsync'd afterwards so the rename survives a
+///   crash.
+/// - **Windows:** near-atomic. `std::fs::rename` does NOT replace an existing
+///   destination on Windows, so we fall back to `remove + rename` if the
+///   first rename fails. There is a very short window where `target` is
+///   briefly absent. A truly atomic Windows replace would need a
+///   `MoveFileExW(MOVEFILE_REPLACE_EXISTING)` call, which would require
+///   pulling in `windows-sys` as a dep.
 ///
-/// Two correctness preservations vs. `fs::write`:
-/// - **Symlinks:** if `target` is a symbolic link, follow it to the real file
-///   so the rename replaces the actual content rather than the link itself.
-/// - **Permissions:** when overwriting an existing file, restore its original
-///   mode bits after the rename, since the temp file is created with the
-///   process default umask.
+/// **Other correctness preservations vs. plain `fs::write`:**
+/// - **Symlinks:** if `target` is a symlink, follow it to the real file so we
+///   replace the linked content rather than the link itself.
+/// - **Permissions:** on overwrite, restore the destination's original mode
+///   bits after the rename; the temp file otherwise inherits the process
+///   umask.
 fn atomic_write(target: &Path, bytes: &[u8]) -> std::io::Result<()> {
     // Resolve symlinks so we update the real file. `symlink_metadata` does NOT
     // follow links (unlike `metadata`); if target is a symlink, canonicalize
@@ -35,7 +43,7 @@ fn atomic_write(target: &Path, bytes: &[u8]) -> std::io::Result<()> {
     };
     let target = resolved.as_path();
 
-    let parent = match target.parent() {
+    let parent_path: PathBuf = match target.parent() {
         Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
         _ => return fs::write(target, bytes),
     };
@@ -56,7 +64,7 @@ fn atomic_write(target: &Path, bytes: &[u8]) -> std::io::Result<()> {
         .unwrap_or(0);
     let pid = std::process::id();
     let temp_name = format!(".{}.markpad-tmp-{}-{}", file_name, pid, nanos);
-    let mut temp_path: PathBuf = parent;
+    let mut temp_path = parent_path.clone();
     temp_path.push(temp_name);
 
     let write_result = (|| -> std::io::Result<()> {
@@ -74,9 +82,24 @@ fn atomic_write(target: &Path, bytes: &[u8]) -> std::io::Result<()> {
         return Err(e);
     }
 
+    // Try rename; on Windows std::fs::rename refuses to replace an existing
+    // destination, so on the first error retry with a remove+rename. Unix
+    // hits the success branch on the first try.
     if let Err(e) = fs::rename(&temp_path, target) {
-        let _ = fs::remove_file(&temp_path);
-        return Err(e);
+        #[cfg(windows)]
+        {
+            // Best-effort: drop the existing destination, then retry.
+            let _ = fs::remove_file(target);
+            if let Err(e2) = fs::rename(&temp_path, target) {
+                let _ = fs::remove_file(&temp_path);
+                return Err(e2);
+            }
+        }
+        #[cfg(not(windows))]
+        {
+            let _ = fs::remove_file(&temp_path);
+            return Err(e);
+        }
     }
 
     // Best-effort restore of the original mode bits. If this fails (e.g. the
@@ -84,6 +107,18 @@ fn atomic_write(target: &Path, bytes: &[u8]) -> std::io::Result<()> {
     // contents are still correctly written, so we don't surface the error.
     if let Some(perms) = existing_perms {
         let _ = fs::set_permissions(target, perms);
+    }
+
+    // POSIX durability: a rename is not durable until the parent directory's
+    // metadata is also flushed to disk. Without this, a crash right after
+    // rename could leave the target missing or pointing at the old inode.
+    // Windows doesn't expose directory fsync semantics — its NTFS journal
+    // already handles this, so we skip the call there.
+    #[cfg(unix)]
+    {
+        if let Ok(dir) = fs::File::open(&parent_path) {
+            let _ = dir.sync_all();
+        }
     }
 
     Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,9 +3,61 @@ use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
 use regex::{Captures, Regex};
 use std::borrow::Cow;
 use std::fs;
-use std::path::Path;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, Manager, State};
+
+/// Write `bytes` to `target` atomically: write to a sibling temp file, fsync it,
+/// then rename over the target. Falls back to a plain `fs::write` only if the
+/// target has no parent directory (a path like "foo.md" with no leading dir),
+/// which `fs::rename` would not be able to handle safely anyway.
+///
+/// On both Unix and Windows `fs::rename` is atomic when source and destination
+/// live on the same filesystem; placing the temp next to the target guarantees
+/// that. On crash mid-write the original file is left intact.
+fn atomic_write(target: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let parent = match target.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+        _ => return fs::write(target, bytes),
+    };
+
+    let file_name = target
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "markpad".to_string());
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let pid = std::process::id();
+    let temp_name = format!(".{}.markpad-tmp-{}-{}", file_name, pid, nanos);
+    let mut temp_path: PathBuf = parent;
+    temp_path.push(temp_name);
+
+    let write_result = (|| -> std::io::Result<()> {
+        let mut f = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_path)?;
+        f.write_all(bytes)?;
+        f.sync_all()?;
+        Ok(())
+    })();
+
+    if let Err(e) = write_result {
+        let _ = fs::remove_file(&temp_path);
+        return Err(e);
+    }
+
+    if let Err(e) = fs::rename(&temp_path, target) {
+        let _ = fs::remove_file(&temp_path);
+        return Err(e);
+    }
+
+    Ok(())
+}
 
 struct WatcherState {
     watcher: Mutex<Option<RecommendedWatcher>>,
@@ -210,12 +262,12 @@ fn read_file_content(path: String) -> Result<String, String> {
 
 #[tauri::command]
 fn save_file_content(path: String, content: String) -> Result<(), String> {
-    fs::write(path, content).map_err(|e| e.to_string())
+    atomic_write(Path::new(&path), content.as_bytes()).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 fn save_file_binary(path: String, data: Vec<u8>) -> Result<(), String> {
-    fs::write(path, data).map_err(|e| e.to_string())
+    atomic_write(Path::new(&path), &data).map_err(|e| e.to_string())
 }
 
 #[tauri::command]

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -92,11 +92,29 @@ import { t } from './utils/i18n.js';
 	// --- Auto-save bookkeeping (see saveContent + auto-save $effect below) ---
 	// Per-tab debounce timers so switching tabs cannot kill another tab's pending save.
 	const autoSaveTimers = new Map<string, ReturnType<typeof setTimeout>>();
+	// Per-tab last-seen rawContent length, used by the auto-save effect to
+	// detect which tab actually changed in this run. Without this, every
+	// keystroke in any tab restarts every other dirty tab's timer too,
+	// indefinitely postponing background saves.
+	const lastContentTickByTab = new Map<string, number>();
 	// Suppress the file-watcher reload that fires when we ourselves write the file.
 	// Maps absolute path -> wall-clock ms after which an event for that path is real again.
 	const selfWriteUntilByPath = new Map<string, number>();
 	const SELF_WRITE_GRACE_MS = 400;
 	const AUTO_SAVE_DEBOUNCE_MS = 1500;
+
+	// Cancel a pending auto-save for a tab. Call this only on paths that
+	// COMMIT to a save or discard outcome — never before showing a modal,
+	// because if the user picks Cancel, the timer is gone forever and
+	// background auto-save is silently disabled for that tab until the
+	// next keystroke.
+	function cancelPendingAutoSave(tabId: string) {
+		const t = autoSaveTimers.get(tabId);
+		if (t) {
+			clearTimeout(t);
+			autoSaveTimers.delete(tabId);
+		}
+	}
 
 	// in-page scroll position history for mouse 4/5 nav
 	let scrollHistory: number[] = [];
@@ -1130,18 +1148,13 @@ import { t } from './utils/i18n.js';
 
 		if (!tab.isDirty) return true;
 
-		// Cancel any pending auto-save timer — we're handling this tab now,
-		// either by saving immediately or by surrendering to the user's choice.
-		const pendingTimer = autoSaveTimers.get(tabId);
-		if (pendingTimer) {
-			clearTimeout(pendingTimer);
-			autoSaveTimers.delete(tabId);
-		}
-
-		// Silent save path: only when auto-save is on, the user did NOT ask for
-		// confirmation, and the tab has a real path. Untitled tabs always need
-		// a save dialog, which means the modal flow is the right place for them.
+		// Silent save path: only when auto-save is on, the user did NOT ask
+		// for confirmation, and the tab has a real path. Untitled tabs always
+		// need a save dialog, which means the modal flow is the right place
+		// for them. We cancel the pending timer right before the manual save
+		// to avoid a duplicate write from a timer that fires concurrently.
 		if (settings.autoSave && !settings.confirmBeforeSave && tab.path !== '') {
+			cancelPendingAutoSave(tabId);
 			const success = await saveContent(tabId);
 			if (success) return true;
 			// Silent save failed — fall through to the modal so the user can
@@ -1155,12 +1168,20 @@ import { t } from './utils/i18n.js';
 			showSave: true,
 		});
 
+		// Important: do NOT cancel the pending auto-save timer before this
+		// modal. If the user clicks Cancel, the tab remains dirty and we
+		// want background auto-save to keep firing on the existing schedule.
 		if (response === 'cancel') return false;
 		if (response === 'save') {
+			cancelPendingAutoSave(tabId);
 			return await saveContent(tabId);
 		}
 
-		return true; // discard
+		// Discard: drop pending save so we don't write what the user just
+		// threw away. The effect will re-arm a timer if the tab gets edited
+		// again.
+		cancelPendingAutoSave(tabId);
+		return true;
 	}
 
 	async function toggleEdit(silentSave = false) {
@@ -1170,50 +1191,53 @@ import { t } from './utils/i18n.js';
 		if (isEditing) {
 			// Switch back to view
 			if (tab.isDirty && tab.path !== '') {
-				// Cancel pending auto-save timer for this tab — we're flushing now.
-				const pendingTimer = autoSaveTimers.get(tab.id);
-				if (pendingTimer) {
-					clearTimeout(pendingTimer);
-					autoSaveTimers.delete(tab.id);
-				}
-
-				// Silent save when caller asked for it (hotkey path) OR when the
-				// user enabled auto-save without confirmation in settings.
 				const shouldSilent =
 					silentSave || (settings.autoSave && !settings.confirmBeforeSave);
 				if (shouldSilent) {
-				const success = await saveContent(tab.id);
-				if (!success) {
-					addToast(t('toast.autoSaveFailed', settings.language), 'error');
-					return; // If save fails, stay in edit mode
-				}
-			} else {
-				const response = await askCustom(t('modal.unsavedChanges.viewMode.message'), {
-					title: t('modal.unsavedChanges.title'),
-					kind: 'warning',
-					showSave: true,
-				});
+					cancelPendingAutoSave(tab.id);
+					const success = await saveContent(tab.id);
+					if (!success) {
+						addToast(t('toast.autoSaveFailed', settings.language), 'error');
+						return; // If save fails, stay in edit mode
+					}
+				} else {
+					const response = await askCustom(t('modal.unsavedChanges.viewMode.message'), {
+						title: t('modal.unsavedChanges.title'),
+						kind: 'warning',
+						showSave: true,
+					});
 
+					// Cancel only happens on save / discard. If user picks
+					// Cancel, the pending auto-save timer keeps running.
 					if (response === 'cancel') return;
 					if (response === 'save') {
+						cancelPendingAutoSave(tab.id);
 						const success = await saveContent(tab.id);
 						if (!success) return;
 					} else if (response === 'discard') {
+						cancelPendingAutoSave(tab.id);
 						tab.rawContent = tab.originalContent;
+						tab.isDirty = false;
 					}
 				}
 			}
 			tab.isEditing = false;
-			if (tab.path !== '') {
-				tab.isDirty = false;
+			// `saveContent` now correctly leaves `isDirty=true` if the user
+			// kept typing during the in-flight save (TOCTOU fix). Don't
+			// force it back to false here — and don't reload from disk in
+			// that case, because the on-disk snapshot is older than the
+			// current rawContent buffer.
+			if (tab.path !== '' && !tab.isDirty) {
 				await loadMarkdown(tab.path, { preserveEditState: true });
 			} else {
+				// Untitled OR rawContent is fresher than disk: render the
+				// in-memory buffer for the preview instead of reloading.
 				try {
 					const html = (await invoke('render_markdown', { content: tab.rawContent })) as string;
 					const processedInfo = processMarkdownHtml(html, '', collapsedHeaders);
 					tabManager.updateTabContent(tab.id, processedInfo);
 				} catch (e) {
-					console.error('Failed to render markdown for unsaved file', e);
+					console.error('Failed to render markdown', e);
 				}
 			}
 		} else {
@@ -1342,23 +1366,31 @@ import { t } from './utils/i18n.js';
 	 * cancelled and a manual Cmd+S becomes the only path again.
 	 */
 	$effect(() => {
-		if (!settings.autoSave) {
+		// Disable background auto-save in two cases:
+		//   1. The user turned `autoSave` off entirely.
+		//   2. The user enabled `confirmBeforeSave` — the Settings UI label
+		//      promises confirmation before each save, so silent debounced
+		//      writes contradict that contract. With this flag on, saves
+		//      happen only via Cmd+S or via the close/toggle modals.
+		if (!settings.autoSave || settings.confirmBeforeSave) {
 			untrack(() => {
 				for (const t of autoSaveTimers.values()) clearTimeout(t);
 				autoSaveTimers.clear();
+				lastContentTickByTab.clear();
 			});
 			return;
 		}
 
 		// Reactive reads — every keystroke flows through updateTabRawContent,
-		// which mutates rawContent and isDirty in the tab object. Reading both
-		// here ensures Svelte 5 re-runs this effect on each change.
+		// which mutates rawContent and isDirty. We touch every tab's
+		// rawContent so the effect re-runs on any keystroke.
 		const snapshot = tabManager.tabs.map((tab) => ({
 			id: tab.id,
 			path: tab.path,
 			isDirty: tab.isDirty,
 			editable: tab.isEditing || tab.isSplit,
-			contentTick: tab.rawContent.length, // touch rawContent so we track it
+			// `.length` is enough to detect changes without copying the buffer.
+			contentTick: tab.rawContent.length,
 		}));
 
 		untrack(() => {
@@ -1366,27 +1398,68 @@ import { t } from './utils/i18n.js';
 			for (const s of snapshot) {
 				seenIds.add(s.id);
 				const eligible = s.isDirty && s.path !== '' && s.editable;
-				const existing = autoSaveTimers.get(s.id);
-				if (eligible) {
-					if (existing) clearTimeout(existing);
-					const timer = setTimeout(() => {
+				const prevTick = lastContentTickByTab.get(s.id);
+				const tickChanged = prevTick !== s.contentTick;
+
+				if (!eligible) {
+					// Tab is no longer dirty / editable / has a path — drop
+					// any pending timer and forget its tick.
+					const existing = autoSaveTimers.get(s.id);
+					if (existing) {
+						clearTimeout(existing);
 						autoSaveTimers.delete(s.id);
-						saveContent(s.id).catch((e) =>
-							console.error('Auto-save failed', e),
-						);
-					}, AUTO_SAVE_DEBOUNCE_MS);
-					autoSaveTimers.set(s.id, timer);
-				} else if (existing) {
-					clearTimeout(existing);
-					autoSaveTimers.delete(s.id);
+					}
+					lastContentTickByTab.delete(s.id);
+					continue;
 				}
+
+				if (!tickChanged && autoSaveTimers.has(s.id)) {
+					// Eligible but no new edit AND a timer is already armed —
+					// leave it alone so background tabs don't get their
+					// debounce reset by foreground typing.
+					continue;
+				}
+
+				// Either content changed, or the tab just became eligible
+				// (e.g. user pressed Save As). (Re)arm the debounce.
+				const existing = autoSaveTimers.get(s.id);
+				if (existing) clearTimeout(existing);
+				lastContentTickByTab.set(s.id, s.contentTick);
+				const timer = setTimeout(() => {
+					autoSaveTimers.delete(s.id);
+					// `saveContent` resolves with a boolean; it does not
+					// reject on save failure, so `.catch` alone hid errors.
+					// Surface failures via toast + console.
+					saveContent(s.id).then(
+						(ok) => {
+							if (!ok) {
+								console.error('Auto-save failed for tab', s.id);
+								addToast(
+									t('toast.autoSaveFailed', settings.language),
+									'error',
+								);
+							}
+						},
+						(e) => {
+							console.error('Auto-save threw for tab', s.id, e);
+							addToast(
+								t('toast.autoSaveFailed', settings.language),
+								'error',
+							);
+						},
+					);
+				}, AUTO_SAVE_DEBOUNCE_MS);
+				autoSaveTimers.set(s.id, timer);
 			}
-			// Tabs that were closed: drop their timers.
+			// Tabs that were closed: drop their timers and tick records.
 			for (const id of [...autoSaveTimers.keys()]) {
 				if (!seenIds.has(id)) {
 					clearTimeout(autoSaveTimers.get(id)!);
 					autoSaveTimers.delete(id);
 				}
+			}
+			for (const id of [...lastContentTickByTab.keys()]) {
+				if (!seenIds.has(id)) lastContentTickByTab.delete(id);
 			}
 		});
 	});
@@ -1746,15 +1819,10 @@ import { t } from './utils/i18n.js';
 			if (liveMode) toggleLiveMode();
 		} else {
 			if (tab.isDirty && tab.path !== '') {
-				const pendingTimer = autoSaveTimers.get(tab.id);
-				if (pendingTimer) {
-					clearTimeout(pendingTimer);
-					autoSaveTimers.delete(tab.id);
-				}
-
 				const shouldSilent =
 					silentSave || (settings.autoSave && !settings.confirmBeforeSave);
 				if (shouldSilent) {
+					cancelPendingAutoSave(tab.id);
 					const success = await saveContent(tab.id);
 					if (!success) {
 						addToast(t('toast.autoSaveFailed', settings.language), 'error');
@@ -1767,20 +1835,25 @@ import { t } from './utils/i18n.js';
 						showSave: true,
 					});
 
+					// Cancel keeps the pending auto-save timer alive.
 					if (response === 'cancel') return;
 					if (response === 'save') {
+						cancelPendingAutoSave(tab.id);
 						const success = await saveContent(tab.id);
 						if (!success) return;
 					} else if (response === 'discard') {
+						cancelPendingAutoSave(tab.id);
 						tab.rawContent = tab.originalContent;
+						tab.isDirty = false;
 					}
 				}
 			}
 			tabManager.setSplitEnabled(tab.id, false);
-			if (tab.path !== '') {
-				tab.isDirty = false;
+			// Same TOCTOU guard as in toggleEdit: if the user typed during
+			// the save, leave the buffer alone instead of reloading from
+			// disk and losing those keystrokes.
+			if (tab.path !== '' && !tab.isDirty) {
 				await loadMarkdown(tab.path);
-			} else {
 			}
 		}
 	}
@@ -2151,31 +2224,31 @@ import { t } from './utils/i18n.js';
 						console.log('Preventing default close');
 				event.preventDefault();
 
-				// Cancel any pending auto-save timers — we own these saves now.
-				for (const t of autoSaveTimers.values()) clearTimeout(t);
-				autoSaveTimers.clear();
-
 				// Auto-save without confirmation: try silently saving every dirty
-				// tab that has a real path. If any fails, OR there are untitled
-				// tabs (which would need a Save dialog), fall through to the
-				// modal so the user is in control.
+				// tab that has a real path. If untitled tabs exist they need a
+				// Save dialog, so we just fall through to the modal — that is
+				// NOT a failure case and shouldn't show an error toast. We
+				// also DON'T clear pending timers up front: if the user picks
+				// Cancel in the modal below, we want the timers to keep
+				// running for tabs that are still dirty.
 				if (settings.autoSave && !settings.confirmBeforeSave) {
 					const tabsWithPath = dirtyTabs.filter((t) => t.path !== '');
-					const untitled = dirtyTabs.filter((t) => t.path === '');
-					let allOk = untitled.length === 0;
-					if (allOk) {
-						allOk = true;
+					const hasUntitled = dirtyTabs.some((t) => t.path === '');
+					if (!hasUntitled) {
+						let allOk = true;
 						for (const tab of tabsWithPath) {
+							cancelPendingAutoSave(tab.id);
 							const ok = await saveContent(tab.id);
 							if (!ok) { allOk = false; break; }
 						}
+						if (allOk) {
+							appWindow.close();
+							return;
+						}
+						// A real save failure happened — surface it.
+						addToast(t('toast.autoSaveFailed', settings.language), 'error');
 					}
-					if (allOk) {
-						appWindow.close();
-						return;
-					}
-					addToast(t('toast.autoSaveFailed', settings.language), 'error');
-					// fall through to modal
+					// hasUntitled: skip toast, just fall through to the modal.
 				}
 
 				const response = await askCustom(t('modal.youHaveUnsavedFiles', settings.language).replace('{{count}}', dirtyTabs.length.toString()), {
@@ -2189,6 +2262,7 @@ import { t } from './utils/i18n.js';
 							for (const tab of dirtyTabs) {
 								tabManager.setActive(tab.id);
 								await tick();
+								cancelPendingAutoSave(tab.id);
 								const saved = await saveContent(tab.id);
 								if (!saved) return; // Cancelled or failed
 							}

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -92,11 +92,11 @@ import { t } from './utils/i18n.js';
 	// --- Auto-save bookkeeping (see saveContent + auto-save $effect below) ---
 	// Per-tab debounce timers so switching tabs cannot kill another tab's pending save.
 	const autoSaveTimers = new Map<string, ReturnType<typeof setTimeout>>();
-	// Per-tab last-seen rawContent reference, used by the auto-save effect
-	// to detect which tab actually changed in this run. Strings in JS are
-	// immutable, so a `===` compare on the reference catches all edits —
-	// including same-length ones (overwriting characters, formatting
-	// toggles) that a length-based tick would miss.
+	// Per-tab last-seen rawContent value, used by the auto-save effect to
+	// detect which tab actually changed in this run. JS string `===` is a
+	// value compare, so any edit yields a different value — including
+	// same-length ones (overwriting characters, formatting toggles) that
+	// a length-based tick would miss.
 	const lastContentRefByTab = new Map<string, string>();
 	// Suppress the file-watcher reload that fires when we ourselves write the file.
 	// Maps absolute path -> wall-clock ms after which an event for that path is real again.
@@ -1157,10 +1157,19 @@ import { t } from './utils/i18n.js';
 		if (settings.autoSave && !settings.confirmBeforeSave && tab.path !== '') {
 			cancelPendingAutoSave(tabId);
 			const success = await saveContent(tabId);
-			if (success) return true;
-			// Silent save failed — fall through to the modal so the user can
-			// pick Discard / Cancel rather than silently losing data.
-			addToast(t('toast.autoSaveFailed', settings.language), 'error');
+			// Only allow the close if the tab is fully clean afterwards.
+			// `saveContent` resolves true even when post-save `isDirty=true`
+			// (the user typed during the await — TOCTOU) — closing here
+			// would silently drop those new keystrokes.
+			if (success && !tab.isDirty) return true;
+			if (success) {
+				// Save succeeded but the tab is dirty again — let the user
+				// decide via the modal whether to save again, discard, or cancel.
+				addToast(t('toast.savedNewerEdits', settings.language), 'info');
+			} else {
+				// Silent save failed — surface and fall through to the modal.
+				addToast(t('toast.autoSaveFailed', settings.language), 'error');
+			}
 		}
 
 		const response = await askCustom(t('modal.youHaveUnsavedChanges', settings.language).replace('{title}', tab.title), {
@@ -1192,8 +1201,11 @@ import { t } from './utils/i18n.js';
 		if (isEditing) {
 			// Switch back to view
 			if (tab.isDirty && tab.path !== '') {
+				// `confirmBeforeSave` always wins: when the user has asked
+				// for confirmation, every dirty toggle must show the modal,
+				// even if the caller passed `silentSave=true` (hotkey path).
 				const shouldSilent =
-					silentSave || (settings.autoSave && !settings.confirmBeforeSave);
+					!settings.confirmBeforeSave && (silentSave || settings.autoSave);
 				if (shouldSilent) {
 					cancelPendingAutoSave(tab.id);
 					const success = await saveContent(tab.id);
@@ -1288,12 +1300,12 @@ import { t } from './utils/i18n.js';
 			? tabManager.tabs.find((t) => t.id === tabId)
 			: tabManager.activeTab;
 		if (!tab) return false;
-
-		// Untitled tabs need an interactive Save dialog, which only makes
-		// sense from edit/split context. Tabs with a real path can be saved
-		// at any time — including the post-TOCTOU case where the user typed
-		// during a save and the tab moved out of edit mode while still dirty.
-		if (tab.path === '' && !tab.isEditing && !tab.isSplit) return false;
+		// No further gating: explicit user-initiated saves should always
+		// work. Auto-save filters by `path !== '' && (isEditing || isSplit)`
+		// in the effect itself, so untitled or view-mode tabs can only
+		// reach this function through a modal "Save" choice or a hotkey,
+		// both of which are legitimate save triggers — including for
+		// untitled tabs in view mode (e.g. unsaved-changes modal at close).
 
 		let targetPath = tab.path;
 
@@ -1838,8 +1850,11 @@ import { t } from './utils/i18n.js';
 			if (liveMode) toggleLiveMode();
 		} else {
 			if (tab.isDirty && tab.path !== '') {
+				// `confirmBeforeSave` always wins: when the user has asked
+				// for confirmation, every dirty toggle must show the modal,
+				// even if the caller passed `silentSave=true` (hotkey path).
 				const shouldSilent =
-					silentSave || (settings.autoSave && !settings.confirmBeforeSave);
+					!settings.confirmBeforeSave && (silentSave || settings.autoSave);
 				if (shouldSilent) {
 					cancelPendingAutoSave(tab.id);
 					const success = await saveContent(tab.id);

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -92,11 +92,12 @@ import { t } from './utils/i18n.js';
 	// --- Auto-save bookkeeping (see saveContent + auto-save $effect below) ---
 	// Per-tab debounce timers so switching tabs cannot kill another tab's pending save.
 	const autoSaveTimers = new Map<string, ReturnType<typeof setTimeout>>();
-	// Per-tab last-seen rawContent length, used by the auto-save effect to
-	// detect which tab actually changed in this run. Without this, every
-	// keystroke in any tab restarts every other dirty tab's timer too,
-	// indefinitely postponing background saves.
-	const lastContentTickByTab = new Map<string, number>();
+	// Per-tab last-seen rawContent reference, used by the auto-save effect
+	// to detect which tab actually changed in this run. Strings in JS are
+	// immutable, so a `===` compare on the reference catches all edits —
+	// including same-length ones (overwriting characters, formatting
+	// toggles) that a length-based tick would miss.
+	const lastContentRefByTab = new Map<string, string>();
 	// Suppress the file-watcher reload that fires when we ourselves write the file.
 	// Maps absolute path -> wall-clock ms after which an event for that path is real again.
 	const selfWriteUntilByPath = new Map<string, number>();
@@ -1221,17 +1222,21 @@ import { t } from './utils/i18n.js';
 					}
 				}
 			}
+			// If `saveContent` left `tab.isDirty=true` (TOCTOU — user typed
+			// during the await), staying in edit mode is the safe default:
+			// a non-editable dirty tab disables auto-save, blocks Cmd+S,
+			// and risks getting clobbered by the next disk reload. Surface
+			// a hint and keep the tab editable.
+			if (tab.path !== '' && tab.isDirty) {
+				addToast(t('toast.savedNewerEdits', settings.language), 'info');
+				return;
+			}
+
 			tab.isEditing = false;
-			// `saveContent` now correctly leaves `isDirty=true` if the user
-			// kept typing during the in-flight save (TOCTOU fix). Don't
-			// force it back to false here — and don't reload from disk in
-			// that case, because the on-disk snapshot is older than the
-			// current rawContent buffer.
-			if (tab.path !== '' && !tab.isDirty) {
+			if (tab.path !== '') {
 				await loadMarkdown(tab.path, { preserveEditState: true });
 			} else {
-				// Untitled OR rawContent is fresher than disk: render the
-				// in-memory buffer for the preview instead of reloading.
+				// Untitled: render the in-memory buffer for the preview.
 				try {
 					const html = (await invoke('render_markdown', { content: tab.rawContent })) as string;
 					const processedInfo = processMarkdownHtml(html, '', collapsedHeaders);
@@ -1243,13 +1248,21 @@ import { t } from './utils/i18n.js';
 		} else {
 			// Switch to edit
 			if (tab.path !== '') {
-				try {
-					const content = (await invoke('read_file_content', { path: tab.path })) as string;
-					tab.rawContent = content;
+				if (tab.isDirty) {
+					// Already have unsaved in-memory edits (e.g. from an
+					// earlier session restored from localStorage, or from
+					// post-save TOCTOU). Reading from disk would clobber
+					// them, so just flip into edit mode without a reload.
 					tab.isEditing = true;
-					tab.isDirty = false;
-				} catch (e) {
-					console.error('Failed to read file for editing', e);
+				} else {
+					try {
+						const content = (await invoke('read_file_content', { path: tab.path })) as string;
+						tab.rawContent = content;
+						tab.isEditing = true;
+						tab.isDirty = false;
+					} catch (e) {
+						console.error('Failed to read file for editing', e);
+					}
 				}
 			} else {
 				tab.isEditing = true;
@@ -1274,7 +1287,13 @@ import { t } from './utils/i18n.js';
 		const tab = tabId
 			? tabManager.tabs.find((t) => t.id === tabId)
 			: tabManager.activeTab;
-		if (!tab || (!tab.isEditing && !tab.isSplit)) return false;
+		if (!tab) return false;
+
+		// Untitled tabs need an interactive Save dialog, which only makes
+		// sense from edit/split context. Tabs with a real path can be saved
+		// at any time — including the post-TOCTOU case where the user typed
+		// during a save and the tab moved out of edit mode while still dirty.
+		if (tab.path === '' && !tab.isEditing && !tab.isSplit) return false;
 
 		let targetPath = tab.path;
 
@@ -1376,21 +1395,21 @@ import { t } from './utils/i18n.js';
 			untrack(() => {
 				for (const t of autoSaveTimers.values()) clearTimeout(t);
 				autoSaveTimers.clear();
-				lastContentTickByTab.clear();
+				lastContentRefByTab.clear();
 			});
 			return;
 		}
 
 		// Reactive reads — every keystroke flows through updateTabRawContent,
-		// which mutates rawContent and isDirty. We touch every tab's
-		// rawContent so the effect re-runs on any keystroke.
+		// which assigns a new immutable string to `tab.rawContent`. Capturing
+		// the reference here triggers re-runs on any edit (including
+		// same-length ones like overwrite or formatting toggles).
 		const snapshot = tabManager.tabs.map((tab) => ({
 			id: tab.id,
 			path: tab.path,
 			isDirty: tab.isDirty,
 			editable: tab.isEditing || tab.isSplit,
-			// `.length` is enough to detect changes without copying the buffer.
-			contentTick: tab.rawContent.length,
+			contentRef: tab.rawContent,
 		}));
 
 		untrack(() => {
@@ -1398,8 +1417,8 @@ import { t } from './utils/i18n.js';
 			for (const s of snapshot) {
 				seenIds.add(s.id);
 				const eligible = s.isDirty && s.path !== '' && s.editable;
-				const prevTick = lastContentTickByTab.get(s.id);
-				const tickChanged = prevTick !== s.contentTick;
+				const prevRef = lastContentRefByTab.get(s.id);
+				const refChanged = prevRef !== s.contentRef;
 
 				if (!eligible) {
 					// Tab is no longer dirty / editable / has a path — drop
@@ -1409,11 +1428,11 @@ import { t } from './utils/i18n.js';
 						clearTimeout(existing);
 						autoSaveTimers.delete(s.id);
 					}
-					lastContentTickByTab.delete(s.id);
+					lastContentRefByTab.delete(s.id);
 					continue;
 				}
 
-				if (!tickChanged && autoSaveTimers.has(s.id)) {
+				if (!refChanged && autoSaveTimers.has(s.id)) {
 					// Eligible but no new edit AND a timer is already armed —
 					// leave it alone so background tabs don't get their
 					// debounce reset by foreground typing.
@@ -1424,7 +1443,7 @@ import { t } from './utils/i18n.js';
 				// (e.g. user pressed Save As). (Re)arm the debounce.
 				const existing = autoSaveTimers.get(s.id);
 				if (existing) clearTimeout(existing);
-				lastContentTickByTab.set(s.id, s.contentTick);
+				lastContentRefByTab.set(s.id, s.contentRef);
 				const timer = setTimeout(() => {
 					autoSaveTimers.delete(s.id);
 					// `saveContent` resolves with a boolean; it does not
@@ -1458,8 +1477,8 @@ import { t } from './utils/i18n.js';
 					autoSaveTimers.delete(id);
 				}
 			}
-			for (const id of [...lastContentTickByTab.keys()]) {
-				if (!seenIds.has(id)) lastContentTickByTab.delete(id);
+			for (const id of [...lastContentRefByTab.keys()]) {
+				if (!seenIds.has(id)) lastContentRefByTab.delete(id);
 			}
 		});
 	});
@@ -1848,11 +1867,17 @@ import { t } from './utils/i18n.js';
 					}
 				}
 			}
+			// Same TOCTOU guard as toggleEdit: if the user typed during
+			// the save, the tab is still dirty. Keep it in split mode so
+			// auto-save keeps firing and Cmd+S still works on it; flipping
+			// it out would make a non-editable dirty tab.
+			if (tab.path !== '' && tab.isDirty) {
+				addToast(t('toast.savedNewerEdits', settings.language), 'info');
+				return;
+			}
+
 			tabManager.setSplitEnabled(tab.id, false);
-			// Same TOCTOU guard as in toggleEdit: if the user typed during
-			// the save, leave the buffer alone instead of reloading from
-			// disk and losing those keystrokes.
-			if (tab.path !== '' && !tab.isDirty) {
+			if (tab.path !== '') {
 				await loadMarkdown(tab.path);
 			}
 		}

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -89,6 +89,15 @@ import { t } from './utils/i18n.js';
 		toasts.push({ id, message, type });
 	}
 
+	// --- Auto-save bookkeeping (see saveContent + auto-save $effect below) ---
+	// Per-tab debounce timers so switching tabs cannot kill another tab's pending save.
+	const autoSaveTimers = new Map<string, ReturnType<typeof setTimeout>>();
+	// Suppress the file-watcher reload that fires when we ourselves write the file.
+	// Maps absolute path -> wall-clock ms after which an event for that path is real again.
+	const selfWriteUntilByPath = new Map<string, number>();
+	const SELF_WRITE_GRACE_MS = 400;
+	const AUTO_SAVE_DEBOUNCE_MS = 1500;
+
 	// in-page scroll position history for mouse 4/5 nav
 	let scrollHistory: number[] = [];
 	let scrollFuture: number[] = [];
@@ -1121,6 +1130,25 @@ import { t } from './utils/i18n.js';
 
 		if (!tab.isDirty) return true;
 
+		// Cancel any pending auto-save timer — we're handling this tab now,
+		// either by saving immediately or by surrendering to the user's choice.
+		const pendingTimer = autoSaveTimers.get(tabId);
+		if (pendingTimer) {
+			clearTimeout(pendingTimer);
+			autoSaveTimers.delete(tabId);
+		}
+
+		// Silent save path: only when auto-save is on, the user did NOT ask for
+		// confirmation, and the tab has a real path. Untitled tabs always need
+		// a save dialog, which means the modal flow is the right place for them.
+		if (settings.autoSave && !settings.confirmBeforeSave && tab.path !== '') {
+			const success = await saveContent(tabId);
+			if (success) return true;
+			// Silent save failed — fall through to the modal so the user can
+			// pick Discard / Cancel rather than silently losing data.
+			addToast(t('toast.autoSaveFailed', settings.language), 'error');
+		}
+
 		const response = await askCustom(t('modal.youHaveUnsavedChanges', settings.language).replace('{title}', tab.title), {
 			title: t('modal.unsavedChanges.title'),
 			kind: 'warning',
@@ -1129,22 +1157,36 @@ import { t } from './utils/i18n.js';
 
 		if (response === 'cancel') return false;
 		if (response === 'save') {
-			return await saveContent();
+			return await saveContent(tabId);
 		}
 
 		return true; // discard
 	}
 
-	async function toggleEdit(autoSave = false) {
+	async function toggleEdit(silentSave = false) {
 		const tab = tabManager.activeTab;
 		if (!tab || tab.path === undefined) return;
 
 		if (isEditing) {
 			// Switch back to view
 			if (tab.isDirty && tab.path !== '') {
-				if (autoSave) {
-				const success = await saveContent();
-				if (!success) return; // If save fails, stay in edit mode?
+				// Cancel pending auto-save timer for this tab — we're flushing now.
+				const pendingTimer = autoSaveTimers.get(tab.id);
+				if (pendingTimer) {
+					clearTimeout(pendingTimer);
+					autoSaveTimers.delete(tab.id);
+				}
+
+				// Silent save when caller asked for it (hotkey path) OR when the
+				// user enabled auto-save without confirmation in settings.
+				const shouldSilent =
+					silentSave || (settings.autoSave && !settings.confirmBeforeSave);
+				if (shouldSilent) {
+				const success = await saveContent(tab.id);
+				if (!success) {
+					addToast(t('toast.autoSaveFailed', settings.language), 'error');
+					return; // If save fails, stay in edit mode
+				}
 			} else {
 				const response = await askCustom(t('modal.unsavedChanges.viewMode.message'), {
 					title: t('modal.unsavedChanges.title'),
@@ -1154,7 +1196,7 @@ import { t } from './utils/i18n.js';
 
 					if (response === 'cancel') return;
 					if (response === 'save') {
-						const success = await saveContent();
+						const success = await saveContent(tab.id);
 						if (!success) return;
 					} else if (response === 'discard') {
 						tab.rawContent = tab.originalContent;
@@ -1191,8 +1233,23 @@ import { t } from './utils/i18n.js';
 		}
 	}
 
-	async function saveContent(): Promise<boolean> {
-		const tab = tabManager.activeTab;
+	/**
+	 * Save the given (or active) tab to disk. Returns true on success.
+	 *
+	 * Important details:
+	 * - Operates on a snapshot of `rawContent` taken BEFORE the await, so further
+	 *   keystrokes during the in-flight invoke are not mistakenly marked clean
+	 *   (TOCTOU fix). The dirty flag is recomputed against the snapshot, not
+	 *   forced to false.
+	 * - Marks the destination path as a "self write" so the file-watcher does
+	 *   not bounce the change back into the editor and clobber unsaved input.
+	 * - Untitled tabs (empty path) are NOT silently auto-saved; they require an
+	 *   interactive save dialog (caller must come from a user gesture).
+	 */
+	async function saveContent(tabId?: string): Promise<boolean> {
+		const tab = tabId
+			? tabManager.tabs.find((t) => t.id === tabId)
+			: tabManager.activeTab;
 		if (!tab || (!tab.isEditing && !tab.isSplit)) return false;
 
 		let targetPath = tab.path;
@@ -1212,17 +1269,25 @@ import { t } from './utils/i18n.js';
 			}
 		}
 
+		const snapshot = tab.rawContent;
+		selfWriteUntilByPath.set(targetPath, Date.now() + SELF_WRITE_GRACE_MS);
+
 		try {
-			await invoke('save_file_content', { path: targetPath, content: tab.rawContent });
+			await invoke('save_file_content', { path: targetPath, content: snapshot });
+			// Refresh the grace window — the watcher event arrives after the write
+			// completes, not when it started.
+			selfWriteUntilByPath.set(targetPath, Date.now() + SELF_WRITE_GRACE_MS);
 			if (tab.path === '') {
 				// We just saved an untitled tab for the first time
 				tabManager.updateTabPath(tab.id, targetPath);
 				saveRecentFile(targetPath);
 			}
-			tab.isDirty = false;
-			tab.originalContent = tab.rawContent;
+			tab.originalContent = snapshot;
+			// If the user kept typing during the await, the buffer is still dirty.
+			tab.isDirty = tab.rawContent !== snapshot;
 			return true;
 		} catch (e) {
+			selfWriteUntilByPath.delete(targetPath);
 			console.error('Failed to save file', e);
 			return false;
 		}
@@ -1241,20 +1306,90 @@ import { t } from './utils/i18n.js';
 		});
 
 		if (selected) {
+			const snapshot = tab.rawContent;
+			selfWriteUntilByPath.set(selected, Date.now() + SELF_WRITE_GRACE_MS);
 			try {
-				await invoke('save_file_content', { path: selected, content: tab.rawContent });
+				await invoke('save_file_content', { path: selected, content: snapshot });
+				selfWriteUntilByPath.set(selected, Date.now() + SELF_WRITE_GRACE_MS);
 				tabManager.updateTabPath(tab.id, selected);
 				saveRecentFile(selected);
-				tab.isDirty = false;
-				tab.originalContent = tab.rawContent;
+				tab.originalContent = snapshot;
+				tab.isDirty = tab.rawContent !== snapshot;
 				return true;
 			} catch (e) {
+				selfWriteUntilByPath.delete(selected);
 				console.error('Failed to save file as', e);
 				return false;
 			}
 		}
 		return false;
 	}
+
+	/**
+	 * Auto-save effect.
+	 *
+	 * Watches every tab in the tab manager. For each tab that is dirty, has a
+	 * non-empty path (untitled files require an explicit Save dialog), and is
+	 * currently editable (edit-mode or split-mode), arms a per-tab debounce
+	 * timer that calls saveContent(tabId) when the typing pause exceeds
+	 * AUTO_SAVE_DEBOUNCE_MS.
+	 *
+	 * Per-tab timers (instead of a single timer keyed off the active tab) mean
+	 * a dirty background tab can still be flushed without the user revisiting
+	 * it — typical scenario when you switch tabs mid-edit.
+	 *
+	 * If `settings.autoSave` flips to false at runtime, all pending timers are
+	 * cancelled and a manual Cmd+S becomes the only path again.
+	 */
+	$effect(() => {
+		if (!settings.autoSave) {
+			untrack(() => {
+				for (const t of autoSaveTimers.values()) clearTimeout(t);
+				autoSaveTimers.clear();
+			});
+			return;
+		}
+
+		// Reactive reads — every keystroke flows through updateTabRawContent,
+		// which mutates rawContent and isDirty in the tab object. Reading both
+		// here ensures Svelte 5 re-runs this effect on each change.
+		const snapshot = tabManager.tabs.map((tab) => ({
+			id: tab.id,
+			path: tab.path,
+			isDirty: tab.isDirty,
+			editable: tab.isEditing || tab.isSplit,
+			contentTick: tab.rawContent.length, // touch rawContent so we track it
+		}));
+
+		untrack(() => {
+			const seenIds = new Set<string>();
+			for (const s of snapshot) {
+				seenIds.add(s.id);
+				const eligible = s.isDirty && s.path !== '' && s.editable;
+				const existing = autoSaveTimers.get(s.id);
+				if (eligible) {
+					if (existing) clearTimeout(existing);
+					const timer = setTimeout(() => {
+						autoSaveTimers.delete(s.id);
+						saveContent(s.id).catch((e) =>
+							console.error('Auto-save failed', e),
+						);
+					}, AUTO_SAVE_DEBOUNCE_MS);
+					autoSaveTimers.set(s.id, timer);
+				} else if (existing) {
+					clearTimeout(existing);
+					autoSaveTimers.delete(s.id);
+				}
+			}
+			// Tabs that were closed: drop their timers.
+			for (const id of [...autoSaveTimers.keys()]) {
+				if (!seenIds.has(id)) {
+					clearTimeout(autoSaveTimers.get(id)!);
+					autoSaveTimers.delete(id);
+				}
+			}
+		});
+	});
 
 	async function exportAsHtml() {
 		const tab = tabManager.activeTab;
@@ -1593,7 +1728,7 @@ import { t } from './utils/i18n.js';
 		}
 	});
 
-	async function toggleSplitView(tabId: string, autoSave = false) {
+	async function toggleSplitView(tabId: string, silentSave = false) {
 		const tab = tabManager.tabs.find((t) => t.id === tabId);
 		if (!tab) return;
 
@@ -1611,9 +1746,20 @@ import { t } from './utils/i18n.js';
 			if (liveMode) toggleLiveMode();
 		} else {
 			if (tab.isDirty && tab.path !== '') {
-				if (autoSave) {
-					const success = await saveContent();
-					if (!success) return;
+				const pendingTimer = autoSaveTimers.get(tab.id);
+				if (pendingTimer) {
+					clearTimeout(pendingTimer);
+					autoSaveTimers.delete(tab.id);
+				}
+
+				const shouldSilent =
+					silentSave || (settings.autoSave && !settings.confirmBeforeSave);
+				if (shouldSilent) {
+					const success = await saveContent(tab.id);
+					if (!success) {
+						addToast(t('toast.autoSaveFailed', settings.language), 'error');
+						return;
+					}
 				} else {
 					const response = await askCustom(t('modal.unsavedChanges.splitView.message'), {
 						title: t('modal.unsavedChanges.title'),
@@ -1623,7 +1769,7 @@ import { t } from './utils/i18n.js';
 
 					if (response === 'cancel') return;
 					if (response === 'save') {
-						const success = await saveContent();
+						const success = await saveContent(tab.id);
 						if (!success) return;
 					} else if (response === 'discard') {
 						tab.rawContent = tab.originalContent;
@@ -1898,7 +2044,16 @@ import { t } from './utils/i18n.js';
 			);
 			unlisteners.push(
 				await listen('file-changed', () => {
-					if (liveMode && currentFile) loadMarkdown(currentFile);
+					if (!liveMode || !currentFile) return;
+					// Skip events caused by our own auto-save / save invocations,
+					// otherwise the reload would clobber any keystrokes that landed
+					// between fs::write and this listener firing.
+					const until = selfWriteUntilByPath.get(currentFile);
+					if (until !== undefined) {
+						if (Date.now() < until) return;
+						selfWriteUntilByPath.delete(currentFile);
+					}
+					loadMarkdown(currentFile);
 				}),
 			);
 
@@ -1995,6 +2150,34 @@ import { t } from './utils/i18n.js';
 					if (dirtyTabs.length > 0) {
 						console.log('Preventing default close');
 				event.preventDefault();
+
+				// Cancel any pending auto-save timers — we own these saves now.
+				for (const t of autoSaveTimers.values()) clearTimeout(t);
+				autoSaveTimers.clear();
+
+				// Auto-save without confirmation: try silently saving every dirty
+				// tab that has a real path. If any fails, OR there are untitled
+				// tabs (which would need a Save dialog), fall through to the
+				// modal so the user is in control.
+				if (settings.autoSave && !settings.confirmBeforeSave) {
+					const tabsWithPath = dirtyTabs.filter((t) => t.path !== '');
+					const untitled = dirtyTabs.filter((t) => t.path === '');
+					let allOk = untitled.length === 0;
+					if (allOk) {
+						allOk = true;
+						for (const tab of tabsWithPath) {
+							const ok = await saveContent(tab.id);
+							if (!ok) { allOk = false; break; }
+						}
+					}
+					if (allOk) {
+						appWindow.close();
+						return;
+					}
+					addToast(t('toast.autoSaveFailed', settings.language), 'error');
+					// fall through to modal
+				}
+
 				const response = await askCustom(t('modal.youHaveUnsavedFiles', settings.language).replace('{{count}}', dirtyTabs.length.toString()), {
 											title: t('modal.unsavedChanges', settings.language),
 					kind: 'warning',
@@ -2006,7 +2189,7 @@ import { t } from './utils/i18n.js';
 							for (const tab of dirtyTabs) {
 								tabManager.setActive(tab.id);
 								await tick();
-								const saved = await saveContent();
+								const saved = await saveContent(tab.id);
 								if (!saved) return; // Cancelled or failed
 							}
 							// If all saved successfully, close the app

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -277,8 +277,8 @@ import { t } from './utils/i18n.js';
 		if (settings.restoreStateOnReopen) {
 			const hasUnsaved = tabManager.tabs.some((t) => t.isDirty || (t.path === '' && t.rawContent.trim() !== ''));
 			if (hasUnsaved) {
-				const response = await askCustom(t('modal.exit.unsaved.message'), {
-					title: t('modal.exit.unsaved.title'),
+				const response = await askCustom(t('modal.areYouSureYouWantToExit', settings.language), {
+					title: t('modal.confirmExit', settings.language),
 					kind: 'warning',
 					showSave: false,
 				});
@@ -1163,7 +1163,7 @@ import { t } from './utils/i18n.js';
 		}
 
 		const response = await askCustom(t('modal.youHaveUnsavedChanges', settings.language).replace('{title}', tab.title), {
-			title: t('modal.unsavedChanges.title'),
+			title: t('modal.unsavedChanges', settings.language),
 			kind: 'warning',
 			showSave: true,
 		});
@@ -1201,8 +1201,8 @@ import { t } from './utils/i18n.js';
 						return; // If save fails, stay in edit mode
 					}
 				} else {
-					const response = await askCustom(t('modal.unsavedChanges.viewMode.message'), {
-						title: t('modal.unsavedChanges.title'),
+					const response = await askCustom(t('modal.youHaveUnsavedChangesBeforeReturning', settings.language), {
+						title: t('modal.unsavedChanges', settings.language),
 						kind: 'warning',
 						showSave: true,
 					});
@@ -1829,8 +1829,8 @@ import { t } from './utils/i18n.js';
 						return;
 					}
 				} else {
-					const response = await askCustom(t('modal.unsavedChanges.splitView.message'), {
-						title: t('modal.unsavedChanges.title'),
+					const response = await askCustom(t('modal.youHaveUnsavedChangesBeforeClosingSplitView', settings.language), {
+						title: t('modal.unsavedChanges', settings.language),
 						kind: 'warning',
 						showSave: true,
 					});
@@ -2207,6 +2207,26 @@ import { t } from './utils/i18n.js';
 				await appWindow.onCloseRequested(async (event) => {
 					console.log('onCloseRequested triggered');
 					if (isForceExiting) return;
+
+					// CRITICAL: before serializing tab state to localStorage
+					// (the restore-on-reopen path), make sure all pending
+					// auto-save edits are actually flushed to disk. Without
+					// this, closing the window with auto-save on but
+					// confirmBeforeSave off would silently put unsaved edits
+					// in localStorage only and never persist them to file.
+					if (settings.autoSave && !settings.confirmBeforeSave) {
+						const dirtyWithPath = tabManager.tabs.filter(
+							(t) => t.isDirty && t.path !== '',
+						);
+						for (const tab of dirtyWithPath) {
+							cancelPendingAutoSave(tab.id);
+							try {
+								await saveContent(tab.id);
+							} catch (e) {
+								console.error('Flush-on-close save failed for tab', tab.id, e);
+							}
+						}
+					}
 
 					if (settings.restoreStateOnReopen) {
 						try {

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -13,7 +13,7 @@
 		onclose,
 	} = $props<{ show?: boolean; theme?: string; onSetTheme?: (t: string) => void; onclose: () => void }>();
 
-	let activeCategory = $state<'editor' | 'preview' | 'appearance'>('editor');
+	let activeCategory = $state<'editor' | 'preview' | 'appearance' | 'files'>('editor');
 	let highlightMenuOpen = $state(false);
 	const highlightColors = [
 		{ value: 'default', color: 'var(--color-accent-fg)' },
@@ -229,6 +229,24 @@
 								></path>
 							</svg>
 							{t('settings.appearance', settings.language)}
+					</button>
+					<button class="nav-item" class:active={activeCategory === 'files'} onclick={() => (activeCategory = 'files')}>
+						<svg
+								xmlns="http://www.w3.org/2000/svg"
+								width="16"
+								height="16"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+								stroke-linecap="round"
+								stroke-linejoin="round">
+								<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+								<polyline points="14 2 14 8 20 8"></polyline>
+								<line x1="9" y1="13" x2="15" y2="13"></line>
+								<line x1="9" y1="17" x2="13" y2="17"></line>
+							</svg>
+							{t('settings.files', settings.language)}
 					</button>
 
 					<div class="nav-footer">
@@ -665,6 +683,28 @@
 							<span class="toggle-slider"></span>
 						</label>
 					</div>
+					</div>
+					{:else if activeCategory === 'files'}
+					<div class="settings-group">
+						<div class="settings-group-header">
+							<h2>{t('settings.fileSettings', settings.language)}</h2>
+						</div>
+
+						<div class="setting-item">
+							<label for="files-auto-save">{t('settings.autoSave', settings.language)}</label>
+							<label class="toggle">
+								<input id="files-auto-save" type="checkbox" checked={settings.autoSave} onchange={() => settings.toggleAutoSave()} />
+								<span class="toggle-slider"></span>
+							</label>
+						</div>
+
+						<div class="setting-item">
+							<label for="files-confirm-before-save">{t('settings.confirmBeforeSave', settings.language)}</label>
+							<label class="toggle">
+								<input id="files-confirm-before-save" type="checkbox" checked={settings.confirmBeforeSave} onchange={() => settings.toggleConfirmBeforeSave()} />
+								<span class="toggle-slider"></span>
+							</label>
+						</div>
 					</div>
 					{/if}
 				</div>

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -162,6 +162,12 @@ export class SettingsStore {
 	codeFont = $state('Consolas');
 	codeFontSize = $state(14);
 
+	// File-save behavior. autoSave = silently persist edits without Cmd+S.
+	// confirmBeforeSave = if true, keep the unsaved-changes modals on close/toggle
+	// (i.e. ask for confirmation) even when autoSave is on.
+	autoSave = $state(true);
+	confirmBeforeSave = $state(false);
+
 	constructor() {
 		if (typeof localStorage !== 'undefined') {
 			const savedMinimap = localStorage.getItem('editor.minimap');
@@ -194,6 +200,11 @@ export class SettingsStore {
 			const savedPreviewFontSize = localStorage.getItem('preview.fontSize');
 			const savedCodeFont = localStorage.getItem('preview.codeFont');
 			const savedCodeFontSize = localStorage.getItem('preview.codeFontSize');
+
+			const savedAutoSave = localStorage.getItem('editor.autoSave');
+			const savedConfirmBeforeSave = localStorage.getItem('editor.confirmBeforeSave');
+			if (savedAutoSave !== null) this.autoSave = savedAutoSave === 'true';
+			if (savedConfirmBeforeSave !== null) this.confirmBeforeSave = savedConfirmBeforeSave === 'true';
 
 			const parseFontSize = (value: string | null, fallback: number, min: number, max: number) => {
 				if (value === null) return fallback;
@@ -295,6 +306,8 @@ export class SettingsStore {
 					localStorage.setItem('preview.fontSize', String(this.previewFontSize));
 					localStorage.setItem('preview.codeFont', this.codeFont);
 					localStorage.setItem('preview.codeFontSize', String(this.codeFontSize));
+					localStorage.setItem('editor.autoSave', String(this.autoSave));
+					localStorage.setItem('editor.confirmBeforeSave', String(this.confirmBeforeSave));
 					if (this.preZenState) {
 						localStorage.setItem('editor.preZenState', JSON.stringify(this.preZenState));
 					} else {
@@ -403,6 +416,14 @@ export class SettingsStore {
 
 	toggleMacosImageScaling() {
 		this.macosImageScaling = !this.macosImageScaling;
+	}
+
+	toggleAutoSave() {
+		this.autoSave = !this.autoSave;
+	}
+
+	toggleConfirmBeforeSave() {
+		this.confirmBeforeSave = !this.confirmBeforeSave;
 	}
 
 	setLanguage(lang: LanguageCode) {

--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -369,7 +369,11 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefault: '默认',
             themeDefaultLight: '默认浅色',
             themeDefaultDark: '默认深色',
-            themeFollowSystem: '跟随系统'
+            themeFollowSystem: '跟随系统',
+            files: '文件',
+            fileSettings: '文件设置',
+            autoSave: '自动保存编辑',
+            confirmBeforeSave: '保存前进行确认'
         },
         colors: {
             default: '默认',
@@ -461,7 +465,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: '图表已保存为SVG',
             failedToSaveDiagram: '保存图表失败',
             failedToCopyCode: '复制代码失败',
-            unsupportedFile: '不支持的文件类型: {{filename}}'
+            unsupportedFile: '不支持的文件类型: {{filename}}',
+            autoSaveFailed: '自动保存失败 — 未保存的更改仍在内存中',
+            savedNewerEdits: '已保存 — 因为存在更新的编辑,继续保持编辑模式'
         },
         modal: {
             confirmExit: '确认退出',
@@ -623,7 +629,11 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefault: 'デフォルト',
             themeDefaultLight: 'デフォルトの明るい',
             themeDefaultDark: 'デフォルトの暗い',
-            themeFollowSystem: 'システムに従う'
+            themeFollowSystem: 'システムに従う',
+            files: 'ファイル',
+            fileSettings: 'ファイル設定',
+            autoSave: '編集を自動保存',
+            confirmBeforeSave: '保存前に確認する'
         },
         colors: {
             default: 'デフォルト',
@@ -715,7 +725,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: '図がSVGとして保存されました',
             failedToSaveDiagram: '図の保存に失敗しました',
             failedToCopyCode: 'コードのコピーに失敗しました',
-            unsupportedFile: 'サポートされていないファイル形式: {{filename}}'
+            unsupportedFile: 'サポートされていないファイル形式: {{filename}}',
+            autoSaveFailed: '自動保存に失敗しました — 未保存の変更はメモリ内に残っています',
+            savedNewerEdits: '保存しました — 新しい編集があるため編集モードを継続します'
         },
         modal: {
             confirmExit: '終了を確認',
@@ -888,7 +900,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: '藍色',
                 cyan: '青色',
                 green: '綠色'
-            }
+            },
+            files: '檔案',
+            fileSettings: '檔案設定',
+            autoSave: '自動儲存編輯',
+            confirmBeforeSave: '儲存前先確認'
         },
         menu: {
             file: '文件',
@@ -969,7 +985,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: '圖表已保存為SVG',
             failedToSaveDiagram: '保存圖表失敗',
             failedToCopyCode: '複製代碼失敗',
-            unsupportedFile: '不支持的文件類型: {{filename}}'
+            unsupportedFile: '不支持的文件類型: {{filename}}',
+            autoSaveFailed: '自動儲存失敗 — 未儲存的變更仍在記憶體中',
+            savedNewerEdits: '已儲存 — 因有較新的編輯,繼續保持編輯模式'
         },
         modal: {
             confirmExit: '確認退出',
@@ -1113,7 +1131,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: '파란색',
                 cyan: '청록색',
                 green: '초록색'
-            }
+            },
+            files: '파일',
+            fileSettings: '파일 설정',
+            autoSave: '편집 내용 자동 저장',
+            confirmBeforeSave: '저장 전 확인'
         },
         menu: {
             file: '파일',
@@ -1194,7 +1216,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: '다이어그램이 SVG로 저장되었습니다',
             failedToSaveDiagram: '다이어그램 저장 실패',
             failedToCopyCode: '코드 복사 실패',
-            unsupportedFile: '지원되지 않는 파일 형식: {{filename}}'
+            unsupportedFile: '지원되지 않는 파일 형식: {{filename}}',
+            autoSaveFailed: '자동 저장 실패 — 저장되지 않은 변경 사항은 메모리에 남아 있습니다',
+            savedNewerEdits: '저장됨 — 새로운 편집이 있어 편집 모드를 유지합니다'
         },
         modal: {
             confirmExit: '종료 확인',
@@ -1533,7 +1557,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: 'Azul',
                 cyan: 'Cian',
                 green: 'Verde'
-            }
+            },
+            files: 'Archivos',
+            fileSettings: 'Configuración de archivos',
+            autoSave: 'Guardar cambios automáticamente',
+            confirmBeforeSave: 'Pedir confirmación antes de guardar'
         },
         menu: {
             file: 'Archivo',
@@ -1614,7 +1642,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Diagrama guardado como SVG',
             failedToSaveDiagram: 'Error al guardar diagrama',
             failedToCopyCode: 'Error al copiar código',
-            unsupportedFile: 'Tipo de archivo no compatible: {{filename}}'
+            unsupportedFile: 'Tipo de archivo no compatible: {{filename}}',
+            autoSaveFailed: 'Error de autoguardado — los cambios no guardados siguen en memoria',
+            savedNewerEdits: 'Guardado — se mantiene el modo de edición porque hay cambios más recientes'
         },
         modal: {
             confirmExit: 'Confirmar salida',
@@ -1740,7 +1770,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: 'Bleu',
                 cyan: 'Cyan',
                 green: 'Vert'
-            }
+            },
+            files: 'Fichiers',
+            fileSettings: 'Paramètres des fichiers',
+            autoSave: 'Enregistrement automatique des modifications',
+            confirmBeforeSave: 'Demander confirmation avant d\'enregistrer'
         },
         menu: {
             file: 'Fichier',
@@ -1821,7 +1855,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Diagramme enregistré en SVG',
             failedToSaveDiagram: 'Échec de l\'enregistrement du diagramme',
             failedToCopyCode: 'Échec de la copie du code',
-            unsupportedFile: 'Type de fichier non pris en charge : {{filename}}'
+            unsupportedFile: 'Type de fichier non pris en charge : {{filename}}',
+            autoSaveFailed: 'Échec de l\'enregistrement automatique — les modifications non enregistrées restent en mémoire',
+            savedNewerEdits: 'Enregistré — maintien du mode édition car des modifications plus récentes existent'
         },
         modal: {
             confirmExit: 'Confirmer la sortie',
@@ -1947,7 +1983,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: 'Blau',
                 cyan: 'Cyan',
                 green: 'Grün'
-            }
+            },
+            files: 'Dateien',
+            fileSettings: 'Datei-Einstellungen',
+            autoSave: 'Änderungen automatisch speichern',
+            confirmBeforeSave: 'Vor dem Speichern bestätigen'
         },
         menu: {
             file: 'Datei',
@@ -2028,7 +2068,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Diagramm als SVG gespeichert',
             failedToSaveDiagram: 'Diagramm speichern fehlgeschlagen',
             failedToCopyCode: 'Code kopieren fehlgeschlagen',
-            unsupportedFile: 'Nicht unterstützter Dateityp: {{filename}}'
+            unsupportedFile: 'Nicht unterstützter Dateityp: {{filename}}',
+            autoSaveFailed: 'Automatisches Speichern fehlgeschlagen — nicht gespeicherte Änderungen bleiben im Speicher',
+            savedNewerEdits: 'Gespeichert — Bearbeitungsmodus bleibt aktiv, da neuere Änderungen vorliegen'
         },
         modal: {
             confirmExit: 'Beenden bestätigen',
@@ -2154,7 +2196,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: 'Azul',
                 cyan: 'Ciano',
                 green: 'Verde'
-            }
+            },
+            files: 'Arquivos',
+            fileSettings: 'Configurações de arquivos',
+            autoSave: 'Salvar edições automaticamente',
+            confirmBeforeSave: 'Pedir confirmação antes de salvar'
         },
         menu: {
             file: 'Arquivo',
@@ -2235,7 +2281,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Diagrama salvo como SVG',
             failedToSaveDiagram: 'Falha ao salvar diagrama',
             failedToCopyCode: 'Falha ao copiar código',
-            unsupportedFile: 'Tipo de arquivo não suportado: {{filename}}'
+            unsupportedFile: 'Tipo de arquivo não suportado: {{filename}}',
+            autoSaveFailed: 'Falha ao salvar automaticamente — alterações não salvas ainda estão na memória',
+            savedNewerEdits: 'Salvo — mantendo o modo de edição porque há edições mais recentes'
         },
         modal: {
             confirmExit: 'Confirmar saída',
@@ -2361,7 +2409,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: 'Blu',
                 cyan: 'Ciano',
                 green: 'Verde'
-            }
+            },
+            files: 'File',
+            fileSettings: 'Impostazioni file',
+            autoSave: 'Salvataggio automatico delle modifiche',
+            confirmBeforeSave: 'Chiedi conferma prima di salvare'
         },
         menu: {
             file: 'File',
@@ -2442,7 +2494,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Diagramma salvato come SVG',
             failedToSaveDiagram: 'Impossibile salvare diagramma',
             failedToCopyCode: 'Impossibile copiare codice',
-            unsupportedFile: 'Tipo file non supportato: {{filename}}'
+            unsupportedFile: 'Tipo file non supportato: {{filename}}',
+            autoSaveFailed: 'Salvataggio automatico non riuscito — le modifiche non salvate sono ancora in memoria',
+            savedNewerEdits: 'Salvato — mantengo la modalità modifica perché ci sono modifiche più recenti'
         },
         modal: {
             confirmExit: 'Conferma uscita',
@@ -2568,7 +2622,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: 'Niebieski',
                 cyan: 'Cyjan',
                 green: 'Zielony'
-            }
+            },
+            files: 'Pliki',
+            fileSettings: 'Ustawienia plików',
+            autoSave: 'Autozapis zmian',
+            confirmBeforeSave: 'Pytaj o potwierdzenie przed zapisem'
         },
         menu: {
             file: 'Plik',
@@ -2649,7 +2707,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Diagram zapisany jako SVG',
             failedToSaveDiagram: 'Nie udało się zapisać diagramu',
             failedToCopyCode: 'Nie udało się skopiować kodu',
-            unsupportedFile: 'Nieobsługiwany typ pliku: {{filename}}'
+            unsupportedFile: 'Nieobsługiwany typ pliku: {{filename}}',
+            autoSaveFailed: 'Autozapis nie powiódł się — niezapisane zmiany pozostają w pamięci',
+            savedNewerEdits: 'Zapisano — pozostaję w trybie edycji, ponieważ są nowsze zmiany'
         },
         modal: {
             confirmExit: 'Potwierdź wyjście',
@@ -2775,7 +2835,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: 'Blauw',
                 cyan: 'Cyaan',
                 green: 'Groen'
-            }
+            },
+            files: 'Bestanden',
+            fileSettings: 'Bestandsinstellingen',
+            autoSave: 'Wijzigingen automatisch opslaan',
+            confirmBeforeSave: 'Bevestiging vragen voor opslaan'
         },
         menu: {
             file: 'Bestand',
@@ -2856,7 +2920,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Diagram opgeslagen als SVG',
             failedToSaveDiagram: 'Kan diagram niet opslaan',
             failedToCopyCode: 'Kan code niet kopiëren',
-            unsupportedFile: 'Niet-ondersteund bestandstype: {{filename}}'
+            unsupportedFile: 'Niet-ondersteund bestandstype: {{filename}}',
+            autoSaveFailed: 'Automatisch opslaan mislukt — niet-opgeslagen wijzigingen staan nog in het geheugen',
+            savedNewerEdits: 'Opgeslagen — bewerkmodus blijft actief omdat er nieuwere wijzigingen zijn'
         },
         modal: {
             confirmExit: 'Bevestig afsluiten',
@@ -2982,7 +3048,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: 'Blå',
                 cyan: 'Cyan',
                 green: 'Grön'
-            }
+            },
+            files: 'Filer',
+            fileSettings: 'Filinställningar',
+            autoSave: 'Spara ändringar automatiskt',
+            confirmBeforeSave: 'Fråga om bekräftelse innan sparande'
         },
         menu: {
             file: 'Arkiv',
@@ -3063,7 +3133,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Diagram sparat som SVG',
             failedToSaveDiagram: 'Kunde inte spara diagram',
             failedToCopyCode: 'Kunde inte kopiera kod',
-            unsupportedFile: 'Filtyp stöds inte: {{filename}}'
+            unsupportedFile: 'Filtyp stöds inte: {{filename}}',
+            autoSaveFailed: 'Automatisk sparning misslyckades — osparade ändringar finns kvar i minnet',
+            savedNewerEdits: 'Sparat — stannar i redigeringsläge eftersom det finns nyare ändringar'
         },
         modal: {
             confirmExit: 'Bekräfta avslut',
@@ -3189,7 +3261,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: 'Xanh dương',
                 cyan: 'Xanh lam',
                 green: 'Xanh lá'
-            }
+            },
+            files: 'Tệp',
+            fileSettings: 'Cài đặt tệp',
+            autoSave: 'Tự động lưu chỉnh sửa',
+            confirmBeforeSave: 'Hỏi xác nhận trước khi lưu'
         },
         menu: {
             file: 'Tệp',
@@ -3270,7 +3346,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Đã lưu sơ đồ dưới dạng SVG',
             failedToSaveDiagram: 'Không thể lưu sơ đồ',
             failedToCopyCode: 'Không thể sao chép mã',
-            unsupportedFile: 'Loại tệp không được hỗ trợ: {{filename}}'
+            unsupportedFile: 'Loại tệp không được hỗ trợ: {{filename}}',
+            autoSaveFailed: 'Tự động lưu thất bại — các thay đổi chưa lưu vẫn còn trong bộ nhớ',
+            savedNewerEdits: 'Đã lưu — vẫn ở chế độ chỉnh sửa vì bạn có chỉnh sửa mới hơn'
         },
         modal: {
             confirmExit: 'Xác nhận thoát',
@@ -3396,7 +3474,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: 'Azul',
                 cyan: 'Ciano',
                 green: 'Verde'
-            }
+            },
+            files: 'Ficheiros',
+            fileSettings: 'Definições de ficheiros',
+            autoSave: 'Guardar edições automaticamente',
+            confirmBeforeSave: 'Pedir confirmação antes de guardar'
         },
         menu: {
             file: 'Ficheiro',
@@ -3477,7 +3559,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Diagrama guardado como SVG',
             failedToSaveDiagram: 'Falha ao guardar diagrama',
             failedToCopyCode: 'Falha ao copiar código',
-            unsupportedFile: 'Tipo de ficheiro não suportado: {{filename}}'
+            unsupportedFile: 'Tipo de ficheiro não suportado: {{filename}}',
+            autoSaveFailed: 'Falha ao guardar automaticamente — as alterações não guardadas continuam em memória',
+            savedNewerEdits: 'Guardado — a manter o modo de edição porque tem edições mais recentes'
         },
         modal: {
             confirmExit: 'Confirmar saída',
@@ -3603,7 +3687,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: 'Albastru',
                 cyan: 'Cyan',
                 green: 'Verde'
-            }
+            },
+            files: 'Fișiere',
+            fileSettings: 'Setări fișiere',
+            autoSave: 'Salvare automată a modificărilor',
+            confirmBeforeSave: 'Solicită confirmare înainte de salvare'
         },
         menu: {
             file: 'Fișier',
@@ -3684,7 +3772,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Diagramă salvată ca SVG',
             failedToSaveDiagram: 'Eșec la salvarea diagramei',
             failedToCopyCode: 'Eșec la copierea codului',
-            unsupportedFile: 'Tip fișier neacceptat: {{filename}}'
+            unsupportedFile: 'Tip fișier neacceptat: {{filename}}',
+            autoSaveFailed: 'Salvarea automată a eșuat — modificările nesalvate sunt încă în memorie',
+            savedNewerEdits: 'Salvat — rămân în modul de editare deoarece există modificări mai noi'
         },
         modal: {
             confirmExit: 'Confirmare ieșire',
@@ -3810,7 +3900,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: 'Kék',
                 cyan: 'Cián',
                 green: 'Zöld'
-            }
+            },
+            files: 'Fájlok',
+            fileSettings: 'Fájlbeállítások',
+            autoSave: 'Módosítások automatikus mentése',
+            confirmBeforeSave: 'Mentés előtt kérjen megerősítést'
         },
         menu: {
             file: 'Fájl',
@@ -3891,7 +3985,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Diagram SVG-ként mentve',
             failedToSaveDiagram: 'Diagram mentése sikertelen',
             failedToCopyCode: 'Kód másolása sikertelen',
-            unsupportedFile: 'Nem támogatott fájltípus: {{filename}}'
+            unsupportedFile: 'Nem támogatott fájltípus: {{filename}}',
+            autoSaveFailed: 'Automatikus mentés sikertelen — a nem mentett módosítások még a memóriában vannak',
+            savedNewerEdits: 'Elmentve — a szerkesztési mód marad, mert újabb módosítások vannak'
         },
         modal: {
             confirmExit: 'Kilépés megerősítése',
@@ -4017,7 +4113,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: 'Modrá',
                 cyan: 'Azurová',
                 green: 'Zelená'
-            }
+            },
+            files: 'Soubory',
+            fileSettings: 'Nastavení souborů',
+            autoSave: 'Automaticky ukládat úpravy',
+            confirmBeforeSave: 'Před uložením se zeptat na potvrzení'
         },
         menu: {
             file: 'Soubor',
@@ -4098,7 +4198,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Diagram uložen jako SVG',
             failedToSaveDiagram: 'Nepodařilo se uložit diagram',
             failedToCopyCode: 'Nepodařilo se zkopírovat kód',
-            unsupportedFile: 'Nepodporovaný typ souboru: {{filename}}'
+            unsupportedFile: 'Nepodporovaný typ souboru: {{filename}}',
+            autoSaveFailed: 'Automatické uložení selhalo — neuložené změny zůstávají v paměti',
+            savedNewerEdits: 'Uloženo — zůstávám v režimu úprav, protože máte novější změny'
         },
         modal: {
             confirmExit: 'Potvrdit ukončení',
@@ -4230,7 +4332,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: 'Modrá',
                 cyan: 'Azúrová',
                 green: 'Zelená'
-            }
+            },
+            files: 'Súbory',
+            fileSettings: 'Nastavenia súborov',
+            autoSave: 'Automaticky ukladať úpravy',
+            confirmBeforeSave: 'Pred uložením sa opýtať na potvrdenie'
         },
         menu: {
             file: 'Súbor',
@@ -4311,7 +4417,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Diagram uložený ako SVG',
             failedToSaveDiagram: 'Nepodarilo sa uložiť diagram',
             failedToCopyCode: 'Nepodarilo sa skopírovať kód',
-            unsupportedFile: 'Nepodporovaný typ súboru: {{filename}}'
+            unsupportedFile: 'Nepodporovaný typ súboru: {{filename}}',
+            autoSaveFailed: 'Automatické ukladanie zlyhalo — neuložené zmeny zostávajú v pamäti',
+            savedNewerEdits: 'Uložené — zostávam v režime úprav, pretože máte novšie zmeny'
         },
         modal: {
             confirmExit: 'Potvrdiť ukončenie',
@@ -4437,7 +4545,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: 'Μπλε',
                 cyan: 'Κυανό',
                 green: 'Πράσινο'
-            }
+            },
+            files: 'Αρχεία',
+            fileSettings: 'Ρυθμίσεις αρχείων',
+            autoSave: 'Αυτόματη αποθήκευση αλλαγών',
+            confirmBeforeSave: 'Ζήτηση επιβεβαίωσης πριν την αποθήκευση'
         },
         menu: {
             file: 'Αρχείο',
@@ -4518,7 +4630,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Το διάγραμμα αποθηκεύτηκε ως SVG',
             failedToSaveDiagram: 'Αποτυχία αποθήκευσης διαγράμματος',
             failedToCopyCode: 'Αποτυχία αντιγραφής κώδικα',
-            unsupportedFile: 'Μη υποστηριζόμενος τύπος αρχείου: {{filename}}'
+            unsupportedFile: 'Μη υποστηριζόμενος τύπος αρχείου: {{filename}}',
+            autoSaveFailed: 'Η αυτόματη αποθήκευση απέτυχε — οι μη αποθηκευμένες αλλαγές παραμένουν στη μνήμη',
+            savedNewerEdits: 'Αποθηκεύτηκε — παραμένω σε λειτουργία επεξεργασίας επειδή υπάρχουν νεότερες αλλαγές'
         },
         modal: {
             confirmExit: 'Επιβεβαίωση εξόδου',
@@ -4644,7 +4758,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: 'Sininen',
                 cyan: 'Syaani',
                 green: 'Vihreä'
-            }
+            },
+            files: 'Tiedostot',
+            fileSettings: 'Tiedostoasetukset',
+            autoSave: 'Tallenna muutokset automaattisesti',
+            confirmBeforeSave: 'Pyydä vahvistus ennen tallennusta'
         },
         menu: {
             file: 'Tiedosto',
@@ -4725,7 +4843,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Kaavio tallennettu SVG-muodossa',
             failedToSaveDiagram: 'Kaavion tallennus epäonnistui',
             failedToCopyCode: 'Koodin kopioiminen epäonnistui',
-            unsupportedFile: 'Ei-tuettu tiedostotyyppi: {{filename}}'
+            unsupportedFile: 'Ei-tuettu tiedostotyyppi: {{filename}}',
+            autoSaveFailed: 'Automaattinen tallennus epäonnistui — tallentamattomat muutokset ovat yhä muistissa',
+            savedNewerEdits: 'Tallennettu — pysytään muokkaustilassa, koska sinulla on uudempia muutoksia'
         },
         modal: {
             confirmExit: 'Vahvista poistuminen',
@@ -4851,7 +4971,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: 'Blå',
                 cyan: 'Cyan',
                 green: 'Grøn'
-            }
+            },
+            files: 'Filer',
+            fileSettings: 'Filindstillinger',
+            autoSave: 'Gem ændringer automatisk',
+            confirmBeforeSave: 'Bed om bekræftelse før der gemmes'
         },
         menu: {
             file: 'Fil',
@@ -4932,7 +5056,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Diagram gemt som SVG',
             failedToSaveDiagram: 'Kunne ikke gemme diagram',
             failedToCopyCode: 'Kunne ikke kopiere kode',
-            unsupportedFile: 'Ikke-understøttet filtype: {{filename}}'
+            unsupportedFile: 'Ikke-understøttet filtype: {{filename}}',
+            autoSaveFailed: 'Automatisk gemning mislykkedes — ikke-gemte ændringer er stadig i hukommelsen',
+            savedNewerEdits: 'Gemt — bliver i redigeringstilstand, fordi du har nyere ændringer'
         },
         modal: {
             confirmExit: 'Bekræft afslutning',
@@ -5058,7 +5184,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: 'Blå',
                 cyan: 'Cyan',
                 green: 'Grønn'
-            }
+            },
+            files: 'Filer',
+            fileSettings: 'Filinnstillinger',
+            autoSave: 'Lagre endringer automatisk',
+            confirmBeforeSave: 'Be om bekreftelse før lagring'
         },
         menu: {
             file: 'Fil',
@@ -5139,7 +5269,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Diagram lagret som SVG',
             failedToSaveDiagram: 'Kunne ikke lagre diagram',
             failedToCopyCode: 'Kunne ikke kopiere kode',
-            unsupportedFile: 'Ikke-støttet filtype: {{filename}}'
+            unsupportedFile: 'Ikke-støttet filtype: {{filename}}',
+            autoSaveFailed: 'Automatisk lagring mislyktes — ulagrede endringer er fortsatt i minnet',
+            savedNewerEdits: 'Lagret — forblir i redigeringsmodus fordi du har nyere endringer'
         },
         modal: {
             confirmExit: 'Bekreft avslutning',
@@ -5265,7 +5397,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: 'Biru',
                 cyan: 'Sian',
                 green: 'Hijau'
-            }
+            },
+            files: 'Berkas',
+            fileSettings: 'Pengaturan berkas',
+            autoSave: 'Simpan otomatis perubahan',
+            confirmBeforeSave: 'Minta konfirmasi sebelum menyimpan'
         },
         menu: {
             file: 'Berkas',
@@ -5346,7 +5482,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Diagram disimpan sebagai SVG',
             failedToSaveDiagram: 'Gagal menyimpan diagram',
             failedToCopyCode: 'Gagal menyalin kode',
-            unsupportedFile: 'Jenis berkas tidak didukung: {{filename}}'
+            unsupportedFile: 'Jenis berkas tidak didukung: {{filename}}',
+            autoSaveFailed: 'Penyimpanan otomatis gagal — perubahan yang belum disimpan masih ada di memori',
+            savedNewerEdits: 'Tersimpan — tetap di mode edit karena ada perubahan yang lebih baru'
         },
         modal: {
             confirmExit: 'Konfirmasi Keluar',
@@ -5472,7 +5610,11 @@ export const translations: Record<LanguageCode, Translation> = {
                 blue: 'Mavi',
                 cyan: 'Camgöbeği',
                 green: 'Yeşil'
-            }
+            },
+            files: 'Dosyalar',
+            fileSettings: 'Dosya ayarları',
+            autoSave: 'Düzenlemeleri otomatik kaydet',
+            confirmBeforeSave: 'Kaydetmeden önce onay iste'
         },
         menu: {
             file: 'Dosya',
@@ -5553,7 +5695,9 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Diyagram SVG olarak kaydedildi',
             failedToSaveDiagram: 'Diyagram kaydedilemedi',
             failedToCopyCode: 'Kod kopyalanamadı',
-            unsupportedFile: 'Desteklenmeyen dosya türü: {{filename}}'
+            unsupportedFile: 'Desteklenmeyen dosya türü: {{filename}}',
+            autoSaveFailed: 'Otomatik kaydetme başarısız — kaydedilmemiş değişiklikler hâlâ bellekte',
+            savedNewerEdits: 'Kaydedildi — daha yeni düzenlemeleriniz olduğu için düzenleme modunda kalınıyor'
         },
         modal: {
             confirmExit: 'Çıkışı Onayla',

--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -68,9 +68,13 @@ export const translations: Record<LanguageCode, Translation> = {
             editor: 'Editor',
             preview: 'Preview',
             appearance: 'Appearance',
+            files: 'Files',
             editorSettings: 'Editor Settings',
             previewSettings: 'Preview Settings',
             appearanceSettings: 'Appearance Settings',
+            fileSettings: 'File Settings',
+            autoSave: 'Auto-save edits',
+            confirmBeforeSave: 'Ask for confirmation before saving',
             resetEditorSettings: 'Reset editor settings',
             resetFontSettings: 'Reset font settings',
             font: 'Font',
@@ -200,7 +204,8 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Diagram saved as SVG',
             failedToSaveDiagram: 'Failed to save diagram',
             failedToCopyCode: 'Failed to copy code',
-            unsupportedFile: 'Unsupported file type: {{filename}}'
+            unsupportedFile: 'Unsupported file type: {{filename}}',
+            autoSaveFailed: 'Auto-save failed — unsaved changes still in memory'
         },
         modal: {
             confirmExit: 'Confirm Exit',
@@ -1263,9 +1268,13 @@ export const translations: Record<LanguageCode, Translation> = {
             editor: 'Редактор',
             preview: 'Предпросмотр',
             appearance: 'Внешний вид',
+            files: 'Файлы',
             editorSettings: 'Настройки редактора',
             previewSettings: 'Настройки предпросмотра',
             appearanceSettings: 'Настройки внешнего вида',
+            fileSettings: 'Настройки файлов',
+            autoSave: 'Автосохранение изменений',
+            confirmBeforeSave: 'Спрашивать подтверждение перед сохранением',
             resetEditorSettings: 'Сбросить настройки редактора',
             resetFontSettings: 'Сбросить настройки шрифта',
             font: 'Шрифт',
@@ -1395,7 +1404,8 @@ export const translations: Record<LanguageCode, Translation> = {
             diagramSavedAsSVG: 'Диаграмма сохранена как SVG',
             failedToSaveDiagram: 'Не удалось сохранить диаграмму',
             failedToCopyCode: 'Не удалось скопировать код',
-            unsupportedFile: 'Неподдерживаемый тип файла: {{filename}}'
+            unsupportedFile: 'Неподдерживаемый тип файла: {{filename}}',
+            autoSaveFailed: 'Автосохранение не удалось — несохранённые правки остались только в памяти'
         },
         modal: {
             confirmExit: 'Подтвердить выход',

--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -205,7 +205,8 @@ export const translations: Record<LanguageCode, Translation> = {
             failedToSaveDiagram: 'Failed to save diagram',
             failedToCopyCode: 'Failed to copy code',
             unsupportedFile: 'Unsupported file type: {{filename}}',
-            autoSaveFailed: 'Auto-save failed — unsaved changes still in memory'
+            autoSaveFailed: 'Auto-save failed — unsaved changes still in memory',
+            savedNewerEdits: 'Saved — staying in edit mode because you have newer edits'
         },
         modal: {
             confirmExit: 'Confirm Exit',
@@ -1405,7 +1406,8 @@ export const translations: Record<LanguageCode, Translation> = {
             failedToSaveDiagram: 'Не удалось сохранить диаграмму',
             failedToCopyCode: 'Не удалось скопировать код',
             unsupportedFile: 'Неподдерживаемый тип файла: {{filename}}',
-            autoSaveFailed: 'Автосохранение не удалось — несохранённые правки остались только в памяти'
+            autoSaveFailed: 'Автосохранение не удалось — несохранённые правки остались только в памяти',
+            savedNewerEdits: 'Сохранено — остаюсь в режиме редактирования, так как есть более новые правки'
         },
         modal: {
             confirmExit: 'Подтвердить выход',


### PR DESCRIPTION
## Summary

Implements [#118](https://github.com/alecdotdev/Markpad/issues/118) — configurable auto-save.

- **Two new settings** in a new `Files` category: `autoSave` (default ON) and `confirmBeforeSave` (default OFF). Persisted to `localStorage`. Translations for all 26 supported languages.
- **Per-tab debounced auto-save** (1500 ms) in `MarkdownViewer.svelte`. Per-tab timers + `contentRef` change tracking — switching tabs or typing in another tab doesn't cancel a pending save on a background tab. Untitled tabs are excluded (they need an explicit Save dialog).
- **Atomic write** in Rust `save_file_content` / `save_file_binary`: sibling temp file → `fsync` → `rename`. Atomic on Unix and modern Windows (Rust 1.35+ uses `MoveFileExW(MOVEFILE_REPLACE_EXISTING)`). Preserves symlink targets (via `canonicalize`) and original mode bits.
- **Self-write suppression** in the file-watcher: per-path TTL stops live-mode reload from clobbering keystrokes that land between `fs::write` and the `notify` event.
- **TOCTOU-safe `saveContent(tabId?)`**: snapshots `rawContent` before `invoke`, recomputes `isDirty` against the snapshot. `toggleEdit` / `toggleSplitView` keep the tab editable when post-save dirty (typed during save), so auto-save and Cmd+S keep working. Re-entering edit mode skips the disk reload when the tab is already dirty.
- **Silent save with modal fallback** in `canCloseTab` / `toggleEdit` / `toggleSplitView` / window-close. Pending timer is cancelled only on save/discard branches — Cancel keeps it armed so background auto-save resumes.
- **Window-close flushes dirty tabs** to disk before serializing tab state to localStorage.
- Renamed existing `autoSave` parameter on `toggleEdit` / `toggleSplitView` to `silentSave` to avoid clash with `settings.autoSave`.
- Replaced unused nested i18n keys in modals with the existing flat ones.

## Test plan

- [ ] Open an existing `.md`, type something, wait ~1.5 s — file mtime updates without Cmd+S.
- [ ] Type, then close the tab — no modal; file saved silently.
- [ ] Settings → Files → toggle "Ask for confirmation before saving" — modal returns; debounced background writes stop.
- [ ] Settings → Files → toggle "Auto-save edits" off — back to manual Cmd+S behavior.
- [ ] Open a file, enable Live mode, type — no jump/clobber from the watcher reload.
- [ ] Edit in split mode — auto-save also fires.
- [ ] Click `[ ]` / `[x]` task checkbox in preview — file updated on disk (existing behavior, kept).
- [ ] Window close (Cmd+Q) with dirty tabs — pending edits flushed to disk before tab state goes to localStorage.
- [ ] Two tabs both dirty — typing in one doesn't reset the other's debounce.
- [ ] Cmd+E from a dirty file — silently saves and switches to view (or stays in edit if you typed during the save).
- [ ] Untitled tab + Cmd+S — Save dialog still appears.
- [ ] Linux/Windows: file mode and symlinks preserved across saves (verify with `chmod 600 file` then save; `ln -s file link` then save through the link).

Closes #118.

---

Reviewed in fork through Codex + Copilot before submission ([review PR](https://github.com/wargoblin/Markpad/pull/2)). Three iterations, 10 issues addressed total.