### PR TITLE
Add "Check for Updates…" menu item and update dialog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,3 +164,14 @@ All file operations go through Rust commands - never use Node.js fs APIs.
 - The app runs as SPA (ssr: false in +layout.ts)
 - Uses Monaco Editor for text editing
 - Supports Windows, macOS, and Linux
+
+## Versioning
+
+When bumping the app version, update both files in the same commit:
+
+- `package.json` `version`
+- `src-tauri/Cargo.toml` `version`
+
+Tauri runtime reads `app.package_info().version` from `Cargo.toml`, while the
+Tauri config and the frontend rely on `package.json`. Keeping them in sync is
+mandatory for `tauri-plugin-updater` to compare versions correctly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
 	"name": "markpad",
-	"version": "2.6.1",
+	"version": "2.6.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "markpad",
-			"version": "2.6.1",
+			"version": "2.6.6",
 			"license": "MIT",
 			"dependencies": {
 				"@tauri-apps/api": "^2",
 				"@tauri-apps/plugin-clipboard-manager": "^2.3.2",
 				"@tauri-apps/plugin-dialog": "^2.5.0",
 				"@tauri-apps/plugin-opener": "^2",
+				"@tauri-apps/plugin-process": "^2.3.1",
+				"@tauri-apps/plugin-updater": "^2.10.1",
 				"@types/dompurify": "^3.0.5",
 				"dompurify": "^3.3.1",
 				"highlight.js": "^11.11.1",
@@ -1338,6 +1340,24 @@
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
 				"@tauri-apps/api": "^2.8.0"
+			}
+		},
+		"node_modules/@tauri-apps/plugin-process": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+			"integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+			"license": "MIT OR Apache-2.0",
+			"dependencies": {
+				"@tauri-apps/api": "^2.8.0"
+			}
+		},
+		"node_modules/@tauri-apps/plugin-updater": {
+			"version": "2.10.1",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
+			"integrity": "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==",
+			"license": "MIT OR Apache-2.0",
+			"dependencies": {
+				"@tauri-apps/api": "^2.10.1"
 			}
 		},
 		"node_modules/@types/cookie": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
 		"@tauri-apps/plugin-clipboard-manager": "^2.3.2",
 		"@tauri-apps/plugin-dialog": "^2.5.0",
 		"@tauri-apps/plugin-opener": "^2",
+		"@tauri-apps/plugin-process": "^2.3.1",
+		"@tauri-apps/plugin-updater": "^2.10.1",
 		"@types/dompurify": "^3.0.5",
 		"dompurify": "^3.3.1",
 		"highlight.js": "^11.11.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Markpad"
-version = "2.3.1"
+version = "2.6.6"
 dependencies = [
  "arboard",
  "base64 0.22.1",
@@ -27,10 +27,12 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-prevent-default",
+ "tauri-plugin-process",
  "tauri-plugin-single-instance",
+ "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "winreg 0.52.0",
- "zip",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -2682,6 +2684,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3042,6 +3050,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3209,6 +3229,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3901,15 +3935,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3988,10 +4027,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -4002,6 +4054,33 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4678,6 +4757,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4892,6 +4982,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
 name = "tauri-plugin-single-instance"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4904,6 +5004,39 @@ dependencies = [
  "tracing",
  "windows-sys 0.60.2",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.2",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -5801,6 +5934,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6578,6 +6720,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "xdg"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6783,6 +6935,18 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "zopfli",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.13.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Markpad"
-version = "2.3.1"
+version = "2.6.6"
 description = "Simple Markdown viewer and text editor"
 authors = ["you"]
 edition = "2021"
@@ -31,6 +31,8 @@ serde = { version = "1", features = ["derive"] }
 comrak = "0.18"
 serde_json = "1"
 tauri-plugin-prevent-default = "2.0.0-rc.1"
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 notify = "6"
 regex = "1"
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -20,6 +20,8 @@
     "core:window:allow-unmaximize",
     "core:window:allow-show",
     "core:window:allow-hide",
-    "core:window:allow-destroy"
+    "core:window:allow-destroy",
+    "updater:default",
+    "process:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
+use tauri::menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder};
 use tauri::{AppHandle, Emitter, Manager, State};
 
 /// Write `bytes` to `target` durably and atomically: write to a sibling temp
@@ -888,6 +889,8 @@ pub fn run() {
                 .set_focus();
         }))
         .plugin(tauri_plugin_prevent_default::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .plugin(
             tauri_plugin_window_state::Builder::default()
                 .with_state_flags(
@@ -945,6 +948,53 @@ pub fn run() {
             }
 
             let _window = window_builder.build()?;
+
+            #[cfg(target_os = "macos")]
+            {
+                let app_name = app.package_info().name.clone();
+
+                let check_item =
+                    MenuItemBuilder::with_id("check-updates", "Check for Updates…").build(app)?;
+
+                let app_submenu = SubmenuBuilder::new(app, &app_name)
+                    .item(&PredefinedMenuItem::about(
+                        app,
+                        Some(&format!("About {}", app_name)),
+                        None,
+                    )?)
+                    .separator()
+                    .item(&check_item)
+                    .separator()
+                    .item(&PredefinedMenuItem::services(app, None)?)
+                    .separator()
+                    .item(&PredefinedMenuItem::hide(app, None)?)
+                    .item(&PredefinedMenuItem::hide_others(app, None)?)
+                    .item(&PredefinedMenuItem::show_all(app, None)?)
+                    .separator()
+                    .item(&PredefinedMenuItem::quit(app, None)?)
+                    .build()?;
+
+                let edit_submenu = SubmenuBuilder::new(app, "Edit")
+                    .item(&PredefinedMenuItem::undo(app, None)?)
+                    .item(&PredefinedMenuItem::redo(app, None)?)
+                    .separator()
+                    .item(&PredefinedMenuItem::cut(app, None)?)
+                    .item(&PredefinedMenuItem::copy(app, None)?)
+                    .item(&PredefinedMenuItem::paste(app, None)?)
+                    .item(&PredefinedMenuItem::select_all(app, None)?)
+                    .build()?;
+
+                let window_submenu = SubmenuBuilder::new(app, "Window")
+                    .item(&PredefinedMenuItem::minimize(app, None)?)
+                    .item(&PredefinedMenuItem::close_window(app, None)?)
+                    .build()?;
+
+                let menu = MenuBuilder::new(app)
+                    .items(&[&app_submenu, &edit_submenu, &window_submenu])
+                    .build()?;
+
+                app.set_menu(menu)?;
+            }
 
             let config_dir = app.path().app_config_dir()?;
             let theme_path = config_dir.join("theme.txt");
@@ -1026,6 +1076,11 @@ pub fn run() {
             cleanup_empty_img_dir,
             list_directory_contents
         ])
+        .on_menu_event(|app, event| {
+            if event.id().as_ref() == "check-updates" {
+                let _ = app.emit("menu-check-updates", ());
+            }
+        })
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(|_app_handle, _event| {

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -13,6 +13,8 @@
 	import TitleBar from './components/TitleBar.svelte';
 	import Editor from './components/Editor.svelte';
 	import Modal from './components/Modal.svelte';
+	import UpdateDialog from './components/UpdateDialog.svelte';
+	import { updateStore } from './stores/update.svelte.js';
 	import ContextMenu, { type ContextMenuItem } from './components/ContextMenu.svelte';
 	import Toc from './components/Toc.svelte';
 	import Toast from './components/Toast.svelte';
@@ -2244,6 +2246,11 @@ import { t } from './utils/i18n.js';
 				}),
 			);
 			unlisteners.push(
+				await listen('menu-check-updates', () => {
+					updateStore.openDialog();
+				}),
+			);
+			unlisteners.push(
 				await appWindow.onCloseRequested(async (event) => {
 					console.log('onCloseRequested triggered');
 					if (isForceExiting) return;
@@ -2693,6 +2700,8 @@ import { t } from './utils/i18n.js';
 		onconfirm={handleModalConfirm}
 		onsave={handleModalSave}
 		oncancel={handleModalCancel} />
+
+	<UpdateDialog />
 
 	<div class="toast-container">
 		{#each toasts as toast (toast.id)}

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -2,6 +2,7 @@
 	import { invoke } from '@tauri-apps/api/core';
 	import { getVersion } from '@tauri-apps/api/app';
 	import { settings, DEFAULT_FONTS, type OSType } from '../stores/settings.svelte.js';
+	import { updateStore } from '../stores/update.svelte.js';
 	import { fade, scale, fly } from 'svelte/transition';
 	import { t, getSupportedLanguages } from '../utils/i18n.js';
 	import type { LanguageCode } from '../utils/i18n.js';
@@ -250,6 +251,25 @@
 					</button>
 
 					<div class="nav-footer">
+						<button
+							class="check-updates-btn"
+							onclick={() => updateStore.openDialog()}
+							aria-label="Check for updates">
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								width="16"
+								height="16"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+								stroke-linecap="round"
+								stroke-linejoin="round">
+								<polyline points="23 4 23 10 17 10"></polyline>
+								<path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path>
+							</svg>
+							<span>Check for updates…</span>
+						</button>
 						<button
 							class="github-btn"
 							onclick={() =>
@@ -822,7 +842,8 @@
 		flex-direction: column;
 	}
 
-	.github-btn {
+	.github-btn,
+	.check-updates-btn {
 		display: flex;
 		align-items: center;
 		padding: 8px 12px;
@@ -836,10 +857,22 @@
 		text-align: left;
 		transition: all 0.1s;
 		gap: 8px;
+		font-family: inherit;
 	}
 
-	.github-btn:hover {
+	.github-btn:hover,
+	.check-updates-btn:hover {
 		opacity: 1;
+	}
+
+	.check-updates-btn svg {
+		width: 16px;
+		height: 16px;
+		flex-shrink: 0;
+	}
+
+	.check-updates-btn span {
+		margin-top: 1px;
 	}
 
 	.github-btn .github-icon {

--- a/src/lib/components/UpdateDialog.svelte
+++ b/src/lib/components/UpdateDialog.svelte
@@ -1,0 +1,316 @@
+<script lang="ts">
+	import { fade, scale } from 'svelte/transition';
+	import { updateStore } from '../stores/update.svelte.js';
+
+	$effect(() => {
+		if (updateStore.show && updateStore.phase === 'idle') {
+			updateStore.runCheck();
+		}
+	});
+
+	function close() {
+		updateStore.close();
+	}
+
+	function retry() {
+		updateStore.runCheck();
+	}
+
+	function startDownload() {
+		updateStore.startDownload();
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (updateStore.phase === 'downloading') return;
+		if (e.key === 'Escape') close();
+		if (e.key === 'Enter') {
+			if (updateStore.phase === 'available') startDownload();
+			else if (updateStore.phase === 'up-to-date' || updateStore.phase === 'error') close();
+		}
+	}
+
+	function handleBackdrop() {
+		if (updateStore.phase !== 'downloading') close();
+	}
+
+	function fmtMB(bytes: number) {
+		return (bytes / (1024 * 1024)).toFixed(1);
+	}
+
+	let progressPct = $derived(
+		updateStore.total > 0 ? Math.min(100, (updateStore.downloaded / updateStore.total) * 100) : 0,
+	);
+</script>
+
+{#if updateStore.show}
+	<div
+		class="update-backdrop"
+		transition:fade={{ duration: 150 }}
+		onclick={handleBackdrop}
+		role="presentation">
+		<div
+			class="update-content"
+			transition:scale={{ duration: 200, start: 0.95 }}
+			onclick={(e) => e.stopPropagation()}
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="update-title"
+			tabindex="-1"
+			onkeydown={handleKeydown}>
+			<div class="update-header">
+				<h3 id="update-title">
+					{#if updateStore.phase === 'checking'}
+						Checking for updates…
+					{:else if updateStore.phase === 'up-to-date'}
+						You're up to date
+					{:else if updateStore.phase === 'available'}
+						Update available
+					{:else if updateStore.phase === 'downloading'}
+						Downloading update…
+					{:else if updateStore.phase === 'error'}
+						Update check failed
+					{:else}
+						Markpad
+					{/if}
+				</h3>
+			</div>
+
+			<div class="update-body">
+				{#if updateStore.phase === 'checking'}
+					<div class="centered-row">
+						<span class="spinner" aria-hidden="true"></span>
+						<p>Looking for the latest version of Markpad…</p>
+					</div>
+				{:else if updateStore.phase === 'up-to-date'}
+					<p>
+						You're using the latest version of Markpad
+						{#if updateStore.current}(v{updateStore.current}){/if}.
+					</p>
+				{:else if updateStore.phase === 'available'}
+					<p class="lead">
+						Markpad <strong>v{updateStore.latest}</strong> is available.
+						You're on v{updateStore.current}.
+					</p>
+					{#if updateStore.notes}
+						<details class="notes">
+							<summary>Release notes</summary>
+							<pre>{updateStore.notes}</pre>
+						</details>
+					{/if}
+				{:else if updateStore.phase === 'downloading'}
+					<p class="lead">Downloading Markpad v{updateStore.latest}…</p>
+					<progress max={updateStore.total || undefined} value={updateStore.downloaded}></progress>
+					<p class="progress-text">
+						{#if updateStore.total > 0}
+							{fmtMB(updateStore.downloaded)} MB of {fmtMB(updateStore.total)} MB ({progressPct.toFixed(0)}%)
+						{:else}
+							{fmtMB(updateStore.downloaded)} MB downloaded
+						{/if}
+					</p>
+					<p class="hint">Markpad will restart automatically when the update is ready.</p>
+				{:else if updateStore.phase === 'error'}
+					<p>Could not check for updates.</p>
+					<pre class="error-detail">{updateStore.errorMsg}</pre>
+				{/if}
+			</div>
+
+			<div class="update-footer">
+				{#if updateStore.phase === 'checking' || updateStore.phase === 'downloading'}
+					<button
+						class="btn secondary"
+						onclick={close}
+						disabled={updateStore.phase === 'downloading'}>
+						Cancel
+					</button>
+				{:else if updateStore.phase === 'up-to-date'}
+					<button class="btn primary" onclick={close}>OK</button>
+				{:else if updateStore.phase === 'available'}
+					<button class="btn secondary" onclick={close}>Cancel</button>
+					<button class="btn primary" onclick={startDownload}>Download &amp; Install</button>
+				{:else if updateStore.phase === 'error'}
+					<button class="btn secondary" onclick={close}>Close</button>
+					<button class="btn primary" onclick={retry}>Retry</button>
+				{/if}
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.update-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.4);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 30000;
+	}
+
+	.update-content {
+		background: var(--color-canvas-default);
+		border: 1px solid var(--color-border-default);
+		border-radius: 6px;
+		width: 460px;
+		max-width: 92vw;
+		box-shadow: 0 20px 50px rgba(0, 0, 0, 0.3);
+		overflow: hidden;
+		font-family: var(--win-font);
+	}
+
+	.update-header {
+		padding: 20px 24px 12px 24px;
+	}
+
+	.update-header h3 {
+		margin: 0;
+		font-size: 16px;
+		font-weight: 600;
+		color: var(--color-fg-default);
+	}
+
+	.update-body {
+		padding: 0 24px 20px 24px;
+		font-size: 14px;
+		line-height: 1.5;
+		color: var(--color-fg-muted);
+	}
+
+	.update-body p {
+		margin: 0 0 8px 0;
+	}
+
+	.update-body p.lead {
+		color: var(--color-fg-default);
+	}
+
+	.update-body p.hint {
+		font-size: 12px;
+		color: var(--color-fg-muted);
+		margin-top: 8px;
+	}
+
+	.update-body p.progress-text {
+		font-size: 12px;
+		color: var(--color-fg-muted);
+		font-variant-numeric: tabular-nums;
+	}
+
+	progress {
+		width: 100%;
+		height: 8px;
+		margin: 12px 0 4px 0;
+		appearance: none;
+	}
+	progress::-webkit-progress-bar {
+		background: var(--color-neutral-muted);
+		border-radius: 4px;
+	}
+	progress::-webkit-progress-value {
+		background: var(--color-accent-fg);
+		border-radius: 4px;
+		transition: width 0.1s linear;
+	}
+
+	.notes {
+		margin-top: 12px;
+		font-size: 13px;
+	}
+	.notes summary {
+		cursor: pointer;
+		color: var(--color-fg-default);
+	}
+	.notes pre {
+		margin: 8px 0 0 0;
+		padding: 12px;
+		background: var(--color-canvas-subtle);
+		border: 1px solid var(--color-border-muted);
+		border-radius: 6px;
+		max-height: 180px;
+		overflow: auto;
+		white-space: pre-wrap;
+		word-break: break-word;
+		font-family: var(--win-font);
+		font-size: 13px;
+		color: var(--color-fg-muted);
+	}
+
+	.error-detail {
+		margin: 8px 0 0 0;
+		padding: 8px 10px;
+		background: var(--color-canvas-subtle);
+		border: 1px solid var(--color-border-muted);
+		border-radius: 4px;
+		font-size: 12px;
+		font-family: var(--win-font);
+		white-space: pre-wrap;
+		word-break: break-word;
+		color: var(--color-fg-muted);
+	}
+
+	.centered-row {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+	}
+
+	.spinner {
+		width: 16px;
+		height: 16px;
+		border: 2px solid var(--color-neutral-muted);
+		border-top-color: var(--color-accent-fg);
+		border-radius: 50%;
+		animation: spin 0.8s linear infinite;
+		display: inline-block;
+		flex-shrink: 0;
+	}
+
+	@keyframes spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	.update-footer {
+		padding: 16px 24px;
+		background: var(--color-canvas-subtle);
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		gap: 8px;
+		border-top: 1px solid var(--color-border-muted);
+	}
+
+	.btn {
+		padding: 6px 16px;
+		border-radius: 6px;
+		font-size: 14px;
+		font-weight: 500;
+		cursor: pointer;
+		transition: all 0.1s;
+		border: 1px solid transparent;
+		font-family: inherit;
+	}
+
+	.btn.secondary {
+		background: transparent;
+		color: var(--color-fg-default);
+		border-color: var(--color-border-default);
+	}
+	.btn.secondary:hover:not(:disabled) {
+		background: var(--color-neutral-muted);
+	}
+
+	.btn.primary {
+		background: var(--color-accent-fg);
+		color: var(--color-btn-fg);
+	}
+	.btn.primary:hover:not(:disabled) {
+		filter: brightness(1.1);
+	}
+
+	.btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+</style>

--- a/src/lib/stores/update.svelte.ts
+++ b/src/lib/stores/update.svelte.ts
@@ -1,0 +1,82 @@
+import { check, type Update } from '@tauri-apps/plugin-updater';
+import { relaunch } from '@tauri-apps/plugin-process';
+import { getVersion } from '@tauri-apps/api/app';
+
+export type UpdatePhase =
+	| 'idle'
+	| 'checking'
+	| 'up-to-date'
+	| 'available'
+	| 'downloading'
+	| 'error';
+
+class UpdateStore {
+	phase = $state<UpdatePhase>('idle');
+	show = $state(false);
+	current = $state('');
+	latest = $state('');
+	downloaded = $state(0);
+	total = $state(0);
+	errorMsg = $state('');
+	notes = $state('');
+	#pending: Update | null = null;
+
+	async openDialog() {
+		this.show = true;
+		await this.runCheck();
+	}
+
+	close() {
+		this.show = false;
+		this.phase = 'idle';
+		this.errorMsg = '';
+		this.notes = '';
+		this.downloaded = 0;
+		this.total = 0;
+		this.#pending = null;
+	}
+
+	async runCheck() {
+		this.phase = 'checking';
+		this.errorMsg = '';
+		this.downloaded = 0;
+		this.total = 0;
+		try {
+			this.current = await getVersion();
+			const u = await check();
+			if (u) {
+				this.#pending = u;
+				this.latest = u.version;
+				this.notes = u.body ?? '';
+				this.phase = 'available';
+			} else {
+				this.phase = 'up-to-date';
+			}
+		} catch (e) {
+			this.errorMsg = e instanceof Error ? e.message : String(e);
+			this.phase = 'error';
+		}
+	}
+
+	async startDownload() {
+		if (!this.#pending) return;
+		this.phase = 'downloading';
+		this.downloaded = 0;
+		this.total = 0;
+		try {
+			await this.#pending.downloadAndInstall((event) => {
+				if (event.event === 'Started') {
+					this.total = event.data.contentLength ?? 0;
+				} else if (event.event === 'Progress') {
+					this.downloaded += event.data.chunkLength;
+				}
+			});
+			await relaunch();
+		} catch (e) {
+			this.errorMsg = e instanceof Error ? e.message : String(e);
+			this.phase = 'error';
+		}
+	}
+}
+
+export const updateStore = new UpdateStore();


### PR DESCRIPTION
## Summary

- Adds a custom macOS app menu so **Markpad → Check for Updates…** sits right after *About Markpad* with separators, while preserving the standard *Services / Hide / Quit / Edit / Window* items.
- New `UpdateDialog.svelte` + `update.svelte.ts` store drive a phase machine (`checking → up-to-date | available → downloading → error`) backed by `tauri-plugin-updater` + `tauri-plugin-process`.
- A "Check for updates…" button in **Settings → nav-footer** is the cross-platform fallback for Windows / Linux (Tauri does not show a system menu there) and a polish entry on macOS.
- Bumps `src-tauri/Cargo.toml` from `2.3.1` → `2.6.6` so it matches `package.json` (Tauri reads the runtime version from `Cargo.toml`); adds a short rule to `AGENTS.md` asking future version bumps to update both files together.

## Why this PR doesn't enable auto-update yet

The `plugins.updater` config section (endpoints + minisign `pubkey`) and the matching CI changes (`createUpdaterArtifacts`, `.app.tar.gz` upload, `latest.json` generation, `TAURI_SIGNING_*` secrets) are intentionally **out of scope here** — those require coordinating with you on signing-key custody and CI changes. With just this PR merged, clicking *Check for Updates…* opens the dialog and lands cleanly in the **error** phase with the plugin's own message. The UI / wiring can be reviewed and merged independently of the signing rollout.

A follow-up PR will add the config + CI bits once we agree on how to manage the keypair.

## Test plan

- [ ] `npm run check` (svelte-check) passes — currently `0 errors, 14 warnings` (warnings are pre-existing, not in new files).
- [ ] `cd src-tauri && cargo check` passes.
- [ ] `cd src-tauri && cargo test` passes.
- [ ] On macOS: `npm run tauri dev` shows **Markpad → About Markpad → ─── → Check for Updates… → ─── → Services → Hide / Hide Others / Show All → ─── → Quit Markpad**.
- [ ] `Cmd+Q`, `Cmd+H`, `Cmd+W`, `Cmd+M` still work; `Cmd+C/V/X/Z/A` work in the editor (Edit submenu uses predefined items).
- [ ] Clicking *Check for Updates…* opens the dialog → goes to `checking` → ends in `error` (expected — endpoint is not configured yet); *Retry* and *Close* work.
- [ ] On Windows / Linux: **Settings** has a "Check for updates…" button next to the GitHub link with the same behaviour.
- [ ] `Esc` and backdrop-click close the dialog except during `downloading` (also covered, but unreachable until the follow-up PR lands).

Reviewed locally with `npm run check` + `cargo check` + `cargo test`.