### PR TITLE
Require window-state plugin with size fix

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,7 +26,7 @@ tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-single-instance = "2"
-tauri-plugin-window-state = "2"
+tauri-plugin-window-state = ">=2.2.2, <3"
 serde = { version = "1", features = ["derive"] }
 comrak = "0.18"
 serde_json = "1"
@@ -58,5 +58,3 @@ codegen-units = 1 # Compile crates one after another so the compiler can optimiz
 lto = true # Enables link to optimizations
 opt-level = "s" # Optimize for binary size
 strip = true # Remove debug symbols
-
-


### PR DESCRIPTION
## Summary
- Require `tauri-plugin-window-state` versions that include the upstream fix for the Windows window-size drift regression.
- Keep the existing lockfile resolution on `2.4.1` while making the lower bound explicit as `>=2.2.2, <3`.

Fixes #98

## Test plan
- [x] `cargo metadata --locked --format-version 1 --no-deps --manifest-path src-tauri/Cargo.toml` shows `tauri-plugin-window-state` requirement `>=2.2.2, <3`
- [x] `npm run check`
- [x] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test`

Reviewed with Codex and Copilot in wargoblin/Markpad#6 before submission.