### PR TITLE
Move split view shortcut off Ctrl+H

### DIFF
--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -1921,9 +1921,9 @@ import { t } from './utils/i18n.js';
 				getCurrentWindow().close();
 			});
 		}
-		if (cmdOrCtrl && key === 'h') {
+		if (cmdOrCtrl && !e.shiftKey && !e.altKey && (code === 'Backslash' || code === 'IntlBackslash')) {
 			e.preventDefault();
-			if (tabManager.activeTabId) toggleSplitView(tabManager.activeTabId);
+			if (tabManager.activeTabId) toggleSplitView(tabManager.activeTabId, true);
 		}
 		if (cmdOrCtrl && key === 'e') {
 			e.preventDefault();

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -546,7 +546,10 @@
 		editor.addAction({
 			id: "view-toggle-split",
 			label: t('menu.toggleSplitView', uiLanguage),
-			keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyH],
+			keybindings: [
+				monaco.KeyMod.CtrlCmd | monaco.KeyCode.Backslash,
+				monaco.KeyMod.CtrlCmd | monaco.KeyCode.IntlBackslash,
+			],
 			run: () => ontoggleSplit?.(),
 		});
 

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -571,7 +571,7 @@
 						class="title-action-btn {tabManager.activeTab?.isSplit ? 'active' : ''}"
 						onclick={() => ontoggleSplit?.()}
 						aria-label={t('tooltip.toggleSplitView', currentLanguage)}
-											onmouseenter={(e) => showTooltip(e, t('tooltip.splitView', currentLanguage), 'H')}
+											onmouseenter={(e) => showTooltip(e, t('tooltip.splitView', currentLanguage), '\\')}
 						onmousedown={(e) => e.preventDefault()}
 						onmouseleave={hideTooltip}
 						transition:fly={{ x: 10, duration: 200 }}>
@@ -586,7 +586,7 @@
 								transform="rotate(0 13 2)"></rect
 							></svg>
 						<span class="action-label">{t('menu.splitView', currentLanguage)}</span>
-						<span class="menu-shortcut">{modifier}+H</span>
+						<span class="menu-shortcut">{modifier}+{'\\'}</span>
 					</button>
 				{:else if id === 'sync'}
 					<button


### PR DESCRIPTION
Fixes #123.

## Summary
- Move Toggle Split View from `Ctrl/Cmd+H` to `Ctrl/Cmd+\` so Monaco Replace can keep the standard `Ctrl+H` shortcut.
- Bind both `Backslash` and `IntlBackslash` for international keyboard layouts.
- Guard the app-level shortcut against Shift and Alt/AltGr so `Ctrl+Alt` combinations are not intercepted.
- Use the existing `silentSave` hotkey path when the shortcut closes split view.
- Update the split-view toolbar tooltip/menu shortcut label.

## Test plan
- `npm run check` (0 errors, existing warnings only)
- `cargo check` (passes, existing `APP_NAME` warning only)
- `cargo test` (passes, 0 tests)
- Internal review PR: https://github.com/wargoblin/Markpad/pull/7