### PR TITLE
Fix paste into Monaco find widget

### DIFF
--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -688,6 +688,7 @@
 			id: "custom-copy",
 			label: t('menu.copy', uiLanguage),
 			keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyC],
+			keybindingContext: "editorTextFocus",
 			run: async (ed) => {
 				const selection = ed.getSelection();
 				if (!selection || selection.isEmpty()) return;
@@ -833,7 +834,7 @@
 			} catch (err) {
 				console.error("Paste failed:", err);
 			}
-		});
+		}, "editorTextFocus");
 
 		return () => {
 			window.open = originalOpen;


### PR DESCRIPTION
Fixes #115.\n\n## Summary\n- Scope Markpad's custom Monaco copy shortcut to editor text focus.\n- Scope the custom paste command to editor text focus so Monaco's find widget keeps native clipboard handling.\n\n## Test plan\n- npm run check\n- cargo check\n- cargo test\n- Internal review PR CI passed: https://github.com/wargoblin/Markpad/actions/runs/25441558927\n- Isolated Monaco smoke test: with find widget focused, custom paste/copy handlers do not run; with editor text focused, they still run.