### PR TITLE
Fix loose task list checkbox layout

### DIFF
--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -184,36 +184,155 @@ function processBlockIds(root: Element, doc: Document) {
 	}
 }
 
+const taskTextBoundaryTags = new Set([
+	"ADDRESS",
+	"ARTICLE",
+	"ASIDE",
+	"BLOCKQUOTE",
+	"DD",
+	"DETAILS",
+	"DIALOG",
+	"DIV",
+	"DL",
+	"DT",
+	"FIELDSET",
+	"FIGCAPTION",
+	"FIGURE",
+	"FOOTER",
+	"FORM",
+	"H1",
+	"H2",
+	"H3",
+	"H4",
+	"H5",
+	"H6",
+	"HEADER",
+	"HR",
+	"LI",
+	"MAIN",
+	"NAV",
+	"OL",
+	"P",
+	"PRE",
+	"SECTION",
+	"TABLE",
+	"UL",
+]);
+
+function stripLeadingWhitespace(nodes: Node[]) {
+	for (let index = 0; index < nodes.length; ) {
+		const node = nodes[index];
+		if (node.nodeType !== 3) break;
+
+		const trimmed = node.textContent?.replace(/^\s+/, "") || "";
+		if (trimmed) {
+			node.textContent = trimmed;
+			break;
+		}
+		node.parentNode?.removeChild(node);
+		nodes.splice(index, 1);
+	}
+}
+
+function isWhitespaceText(node: Node) {
+	return node.nodeType === 3 && !node.textContent?.trim();
+}
+
+function startsWithNode(element: Element, target: Node) {
+	const firstContentNode = Array.from(element.childNodes).find(
+		(node) => !isWhitespaceText(node),
+	);
+	return firstContentNode === target;
+}
+
+function isTaskCheckbox(input: Element, li: Element) {
+	const looksRenderedByTaskList =
+		input.hasAttribute("data-task-checkbox") ||
+		li.classList.contains("task-list-item");
+	if (!looksRenderedByTaskList) return false;
+
+	const inputParent = input.parentElement;
+	if (inputParent === li) {
+		return startsWithNode(li, input);
+	}
+
+	return (
+		inputParent?.tagName === "P" &&
+		inputParent.parentElement === li &&
+		startsWithNode(li, inputParent) &&
+		startsWithNode(inputParent, input)
+	);
+}
+
 function processTaskItems(root: Element) {
 	for (const input of Array.from(
 		root.querySelectorAll('li input[type="checkbox"]'),
 	)) {
+		const li = input.closest("li");
+		if (!li) continue;
+		if (!isTaskCheckbox(input, li)) continue;
+
 		input.setAttribute("data-task-checkbox", "");
 		input.removeAttribute("disabled");
 		(input as HTMLInputElement).style.cursor = "pointer";
 
-		const li = input.closest("li");
-		if (!li) continue;
+		const inputParagraph = input.parentElement;
+		if (inputParagraph?.tagName === "P" && inputParagraph.parentElement === li) {
+			li.insertBefore(input, inputParagraph);
+		}
 
 		const nodes = Array.from(li.childNodes);
 		const inputIdx = nodes.indexOf(input);
+		if (inputIdx === -1) continue;
 		const afterInput = nodes.slice(inputIdx + 1);
 
-		const inlineNodes = [];
+		const inlineNodes: Node[] = [];
+		let paragraphNode: Element | null = null;
 		for (const n of afterInput) {
-			if (
-				n.nodeType === 1 &&
-				["P", "DIV", "UL", "OL"].includes((n as Element).tagName)
-			)
+			if (n.nodeType === 3 && !n.textContent?.trim()) {
+				inlineNodes.push(n);
+				continue;
+			}
+
+			if (n.nodeType === 1 && taskTextBoundaryTags.has((n as Element).tagName)) {
+				const onlyLeadingWhitespace = inlineNodes.every(
+					(node) => node.nodeType === 3 && !node.textContent?.trim(),
+				);
+				if ((n as Element).tagName === "P" && onlyLeadingWhitespace) {
+					paragraphNode = n as Element;
+				}
 				break;
+			}
 			inlineNodes.push(n);
 		}
 
-		if (inlineNodes.length > 0) {
+		const hasInlineText = inlineNodes.some(
+			(n) => n.nodeType !== 3 || n.textContent?.trim(),
+		);
+		if (paragraphNode) {
+			stripLeadingWhitespace(inlineNodes);
+			const paragraphChildren = Array.from(paragraphNode.childNodes);
+			const hasParagraphText = paragraphChildren.some(
+				(n) => n.nodeType !== 3 || n.textContent?.trim(),
+			);
+			if (!hasParagraphText) {
+				paragraphNode.remove();
+			} else {
+				stripLeadingWhitespace(paragraphChildren);
+				const wrapper = root.ownerDocument!.createElement("span");
+				wrapper.className = "task-text";
+				for (const n of paragraphChildren) wrapper.appendChild(n);
+				paragraphNode.replaceWith(wrapper);
+			}
+		} else if (hasInlineText) {
+			const insertBeforeNode = afterInput[inlineNodes.length] || null;
+			stripLeadingWhitespace(inlineNodes);
 			const wrapper = root.ownerDocument!.createElement("span");
 			wrapper.className = "task-text";
 			for (const n of inlineNodes) wrapper.appendChild(n);
-			li.insertBefore(wrapper, afterInput[inlineNodes.length] || null);
+			li.insertBefore(wrapper, insertBeforeNode);
+		} else {
+			stripLeadingWhitespace(inlineNodes);
 		}
 
 		if ((input as HTMLInputElement).checked) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1277,26 +1277,42 @@ body {
 
 .markdown-body ul li.task-list-item,
 .markdown-body .task-list-item {
+	--task-checkbox-size: 15px;
 	padding-left: 0;
 	margin-left: -1.5em;
-	display: flex;
+	display: grid;
+	grid-template-columns: var(--task-checkbox-size) minmax(0, 1fr);
+	column-gap: 0.5em;
 	align-items: baseline;
-	gap: 0.5em;
+}
+
+.markdown-body .task-text {
+	display: block;
+	min-width: 0;
+	grid-column: 2;
+}
+
+.markdown-body .task-list-item > :not(input[data-task-checkbox]):not(.task-text) {
+	grid-column: 2;
+}
+
+.markdown-body .task-list-item > input[data-task-checkbox] + :not(.task-text) {
+	grid-row: 2;
 }
 
 .markdown-body input[data-task-checkbox] {
 	-webkit-appearance: none;
 	appearance: none;
-	width: 15px;
-	height: 15px;
-	min-width: 15px;
+	width: var(--task-checkbox-size, 15px);
+	height: var(--task-checkbox-size, 15px);
+	min-width: var(--task-checkbox-size, 15px);
 	border: 1.5px solid var(--color-border-default);
 	border-radius: 3px;
 	background: transparent;
 	cursor: pointer;
 	position: relative;
 	top: 2px;
-	flex-shrink: 0;
+	grid-column: 1;
 	transition: background-color 0.1s ease, border-color 0.1s ease;
 }
 


### PR DESCRIPTION
## Summary
- Fix loose task-list items so the checkbox stays aligned with the label instead of being separated by Comrak paragraph wrappers.
- Normalize task labels into the existing `.task-text` wrapper while keeping nested lists and block content in the task content column.
- Guard task normalization so user-authored inline HTML checkboxes are not treated as markdown task checkboxes.

Fixes #85

## Testing
- `npm run check`
- `cargo check`
- `cargo test`
- Browser smoke: loose/tight task items, nested lists, long labels, leading inline labels, block content, and inline HTML checkbox preservation.

## Review
- Fork PR CI passed on the final SHA.
- Fork Copilot review: no new comments on the final SHA.
- Codex and Claude reviews: no major/blocking issues on the final SHA.