### PR TITLE
Add macOS native File submenu with HIG-conformant Quit

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Markpad"
-version = "2.6.6"
+version = "2.6.8"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -972,7 +972,52 @@ pub fn run() {
                     .item(&PredefinedMenuItem::hide_others(app, None)?)
                     .item(&PredefinedMenuItem::show_all(app, None)?)
                     .separator()
-                    .item(&PredefinedMenuItem::quit(app, None)?)
+                    .item(
+                        &MenuItemBuilder::with_id(
+                            "menu-app-quit",
+                            format!("Quit {}", app_name),
+                        )
+                        .accelerator("CmdOrCtrl+Q")
+                        .build(app)?,
+                    )
+                    .build()?;
+
+                let file_submenu = SubmenuBuilder::new(app, "File")
+                    .item(
+                        &MenuItemBuilder::with_id("menu-file-new", "New File")
+                            .accelerator("CmdOrCtrl+T")
+                            .build(app)?,
+                    )
+                    .item(
+                        &MenuItemBuilder::with_id("menu-file-open", "Open File…")
+                            .accelerator("CmdOrCtrl+O")
+                            .build(app)?,
+                    )
+                    .item(
+                        &MenuItemBuilder::with_id("menu-file-close", "Close")
+                            .accelerator("CmdOrCtrl+W")
+                            .build(app)?,
+                    )
+                    .separator()
+                    .item(
+                        &MenuItemBuilder::with_id("menu-file-save", "Save")
+                            .accelerator("CmdOrCtrl+S")
+                            .build(app)?,
+                    )
+                    .item(
+                        &MenuItemBuilder::with_id("menu-file-save-as", "Save As…")
+                            .accelerator("CmdOrCtrl+Shift+S")
+                            .build(app)?,
+                    )
+                    .separator()
+                    .item(
+                        &MenuItemBuilder::with_id("menu-file-export-html", "Export as HTML")
+                            .build(app)?,
+                    )
+                    .item(
+                        &MenuItemBuilder::with_id("menu-file-export-pdf", "Export as PDF")
+                            .build(app)?,
+                    )
                     .build()?;
 
                 let edit_submenu = SubmenuBuilder::new(app, "Edit")
@@ -991,7 +1036,7 @@ pub fn run() {
                     .build()?;
 
                 let menu = MenuBuilder::new(app)
-                    .items(&[&app_submenu, &edit_submenu, &window_submenu])
+                    .items(&[&app_submenu, &file_submenu, &edit_submenu, &window_submenu])
                     .build()?;
 
                 app.set_menu(menu)?;
@@ -1078,8 +1123,24 @@ pub fn run() {
             list_directory_contents
         ])
         .on_menu_event(|app, event| {
-            if event.id().as_ref() == "check-updates" {
-                let _ = app.emit("menu-check-updates", ());
+            let id = event.id().as_ref();
+            // Emit to the focused webview window rather than `app.emit(...)`,
+            // which would broadcast to every webview. Markpad is currently
+            // single-window, but additional webviews (e.g. detached tabs)
+            // would otherwise receive duplicate New/Close/Save invocations.
+            // Falls back to "main" if no window is focused (e.g. menu fired
+            // while the app is in the background).
+            let target = app
+                .webview_windows()
+                .into_values()
+                .find(|w| w.is_focused().unwrap_or(false))
+                .or_else(|| app.get_webview_window("main"));
+            let Some(window) = target else { return };
+
+            if id == "check-updates" {
+                let _ = window.emit("menu-check-updates", ());
+            } else if id == "menu-app-quit" || id.starts_with("menu-file-") {
+                let _ = window.emit(id, ());
             }
         })
         .build(tauri::generate_context!())

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -2013,6 +2013,18 @@ import { t } from './utils/i18n.js';
 		const key = e.key.toLowerCase();
 		const code = e.code;
 
+		// On macOS the native menu accelerators (⌘T, ⌘W, ⌘S, ⌘Q) take priority
+		// via NSMenu; the JS keydown handler should not also fire for them, or
+		// we'd double-handle (e.g. open two new tabs on ⌘T). The !e.shiftKey
+		// guards keep ⌘⇧T (undo close tab) routed through this handler as
+		// before — only the bare combos are claimed by the menu.
+		if (settings.osType === 'macos' && cmdOrCtrl && !e.shiftKey) {
+			if (key === 'q') return; // → menu-app-quit
+			if (key === 'w') return; // → menu-file-close
+			if (key === 's') return; // → menu-file-save
+			if (key === 't') return; // → menu-file-new
+		}
+
 		const isSplit = tabManager.activeTab?.isSplit;
 
 		if (cmdOrCtrl && key === 'w') {
@@ -2360,6 +2372,21 @@ import { t } from './utils/i18n.js';
 					updateStore.openDialog();
 				}),
 			);
+			// Native macOS menubar — Markpad ▸ Quit and File ▸ * — bridged
+			// to the same handlers the in-window burger button uses, so the
+			// menu and the burger stay behaviourally identical. Save mirrors
+			// the keydown guard (`isEditing || isSplit`) so menu ⌘S in pure
+			// view mode is a no-op, matching the keyboard shortcut.
+			unlisteners.push(await listen('menu-app-quit',         () => appExit()));
+			unlisteners.push(await listen('menu-file-new',         () => handleNewFile()));
+			unlisteners.push(await listen('menu-file-open',        () => selectFile()));
+			unlisteners.push(await listen('menu-file-close',       () => closeFile()));
+			unlisteners.push(await listen('menu-file-save',        () => {
+				if (isEditing || tabManager.activeTab?.isSplit) saveContent();
+			}));
+			unlisteners.push(await listen('menu-file-save-as',     () => saveContentAs()));
+			unlisteners.push(await listen('menu-file-export-html', () => exportAsHtml()));
+			unlisteners.push(await listen('menu-file-export-pdf', () => exportAsPdf()));
 			unlisteners.push(
 				await appWindow.onCloseRequested(async (event) => {
 					console.log('onCloseRequested triggered');


### PR DESCRIPTION
## Summary

Adds a **File** submenu to the native macOS menubar so the bar entry users see at the top of their screen exposes the same file actions as the in-window burger button (≡), tailored to Apple Human Interface Guidelines:

- **File**: New File (⌘T), Open File… (⌘O), Close (⌘W), Save (⌘S), Save As… (⌘⇧S), Export as HTML, Export as PDF.
- **Markpad ▸ Quit Markpad** (⌘Q) — replaces the previous `PredefinedMenuItem::quit` (no accelerator) with a custom item that routes through the existing `appExit()` flow, preserving the unsaved-changes prompt and the `appWindow.onCloseRequested` hook that a system-quit otherwise bypasses. Side effect: ⌘Q on macOS now actually shows the unsaved-changes prompt — previously the keydown handler called `getCurrentWindow().close()` directly and skipped `appExit`.

Per macOS HIG, the File submenu only handles document CRUD; Quit lives in the application submenu. That's why **Home** stays in the in-window burger only (it's a navigation toggle, not a file action) and **Exit** is not duplicated under File. Two new entries — **Close ⌘W** and the existing burger items mapped to ⌘ accelerators — are wired up because they're macOS expectations and were already supported by code paths the burger uses (`closeFile`, `saveContent`, etc.).

Wiring follows the same emit/listen pattern PR #130 introduced for "Check for Updates…" — Rust's `.on_menu_event` pushes the menu id as an event and `MarkdownViewer.svelte` listens, calling the same handlers the burger already uses. Four bare keydown branches (⌘T, ⌘W, ⌘S, ⌘Q) are skipped on macOS to avoid double-handling once NSMenu's accelerator path takes priority; ⌘⇧T (undo close tab) and ⌘⇧S keep their existing routes via the `!e.shiftKey` guards.

Windows and Linux are unchanged — the menu block stays inside the existing `#[cfg(target_os = "macos")]` from PR #130 so frameless windows on those platforms keep the burger as the only entry point and don't get a clashing in-window menu bar.

## Test plan

- [x] `npm run check` — 0 errors
- [x] `cargo check` (`src-tauri/`) — clean
- [x] `cargo test` (`src-tauri/`) — passes
- [x] Visual: macOS menubar shows `Apple ▸ Markpad ▸ File ▸ Edit ▸ Window`. File expands with the items above in the right order, with the right accelerators displayed on the right.
- [x] Each File item triggers the same handler as the burger button (`handleNewFile`, `selectFile`, `closeFile`, `saveContent`, `saveContentAs`, `exportAsHtml`, `exportAsPdf`).
- [x] **Quit Markpad** with unsaved changes shows the existing askCustom modal (`modal.confirmExit`) instead of silently closing.
- [x] ⌘T, ⌘O, ⌘W, ⌘S, ⌘⇧S, ⌘Q each fire exactly once (no double-handling) and behave identically to clicking the menu item.
- [x] ⌘⇧T (undo close tab) and ⌘\\ (split view, post PR #135) continue to work via keydown.
- [x] In view mode, menu ⌘S is a no-op (mirrors the keydown guard `if (isEditing || isSplit)`), preventing accidental Save-As dialogs on untitled tabs.
- [x] Edit submenu (Cut/Copy/Paste/Undo/Redo/Select All) and Window submenu (Minimize/Close) — unchanged, work as before.
- [x] Burger ≡ button — all items still work, including Home and Exit (now also reachable via Markpad ▸ Quit).
- [ ] Windows / Linux build via CI — frameless window unchanged, no in-window menu bar surfaces (the cfg-gate keeps the menu macOS-only).

## Notes for reviewers

- A pre-existing path-via-export issue surfaced in fork review (`exportAsHtml` passes unsanitized `htmlContent`) is **not** in this PR's scope — `exportAsHtml()` itself is unchanged here; my menu listener routes to the same function the burger has been using. A focused security PR can address that path consistently for both entry points.
- Internal review (Codex + Copilot + Claude) round 1 surfaced two valid in-scope nits, both applied here: (1) deduplicated `osType` state by reusing `settings.osType` from `stores/settings.svelte.ts`; (2) added `if (isEditing || isSplit)` guard to the `menu-file-save` listener so it mirrors the keydown handler. Round 2 had no new in-scope findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)