### PR TITLE
Add Ctrl/Cmd+F find-in-text for the markdown preview pane

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "markpad",
-	"version": "2.6.6",
+	"version": "2.6.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "markpad",
-			"version": "2.6.6",
+			"version": "2.6.8",
 			"license": "MIT",
 			"dependencies": {
 				"@tauri-apps/api": "^2",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1028,6 +1028,12 @@ pub fn run() {
                     .item(&PredefinedMenuItem::copy(app, None)?)
                     .item(&PredefinedMenuItem::paste(app, None)?)
                     .item(&PredefinedMenuItem::select_all(app, None)?)
+                    .separator()
+                    .item(
+                        &MenuItemBuilder::with_id("menu-edit-find", "Find…")
+                            .accelerator("CmdOrCtrl+F")
+                            .build(app)?,
+                    )
                     .build()?;
 
                 let window_submenu = SubmenuBuilder::new(app, "Window")
@@ -1139,7 +1145,10 @@ pub fn run() {
 
             if id == "check-updates" {
                 let _ = window.emit("menu-check-updates", ());
-            } else if id == "menu-app-quit" || id.starts_with("menu-file-") {
+            } else if id == "menu-app-quit"
+                || id.starts_with("menu-file-")
+                || id.starts_with("menu-edit-")
+            {
                 let _ = window.emit(id, ());
             }
         })

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -18,6 +18,7 @@
 	import ContextMenu, { type ContextMenuItem } from './components/ContextMenu.svelte';
 	import Toc from './components/Toc.svelte';
 	import Toast from './components/Toast.svelte';
+	import FindBar from './components/FindBar.svelte';
 	import { exportAsHtml as _exportHtml, exportAsPdf } from './utils/export';
 	import ZoomOverlay from './components/ZoomOverlay.svelte';
 import { processMarkdownHtml } from './utils/markdown';
@@ -78,6 +79,9 @@ import { t } from './utils/i18n.js';
 		revealHeader: (text: string) => void;
 	} | null>(null);
 	let liveMode = $state(false);
+
+	let findOpen = $state(false);
+	let findBar = $state<{ reapply: () => void; clearHighlights: () => void } | null>(null);
 
 	let isDragging = $state(false);
 	let dragTarget = $state<'editor' | 'preview' | null>(null);
@@ -331,6 +335,7 @@ import { t } from './utils/i18n.js';
 	$effect(() => {
 		const _ = tabManager.activeTabId;
 		showHome = false;
+		findOpen = false;
 	});
 
 	function processHighlights(root: Element) {
@@ -691,6 +696,16 @@ import { t } from './utils/i18n.js';
 
 	$effect(() => {
 		if (sanitizedHtml && markdownBody && !isEditing && hljs && renderMathInElement && mermaid) renderRichContent();
+	});
+
+	// Re-apply find highlights after the preview HTML is replaced. The
+	// `bind:innerHTML={sanitizedHtml}` on the article wipes the DOM on every
+	// edit/render pass; without this, highlights vanish until the user
+	// re-types in the find bar.
+	$effect(() => {
+		const _ = sanitizedHtml;
+		if (!findOpen || !findBar) return;
+		tick().then(() => findBar?.reapply());
 	});
 
 	$effect(() => {
@@ -2069,6 +2084,17 @@ import { t } from './utils/i18n.js';
 			e.preventDefault();
 			showSettings = !showSettings;
 		}
+		// Ctrl/Cmd+F: open the preview find bar, but only when the editor
+		// (Monaco) doesn't have focus — Monaco ships its own native find
+		// widget and we don't want to fight it in Edit/Split mode.
+		if (cmdOrCtrl && !e.shiftKey && !e.altKey && key === 'f') {
+			const active = document.activeElement as Node | null;
+			const editorHasFocus = !!editorPaneEl && !!active && editorPaneEl.contains(active);
+			if (!editorHasFocus && markdownBody) {
+				e.preventDefault();
+				findOpen = true;
+			}
+		}
 	}
 
 	function pushScrollHistory() {
@@ -2281,6 +2307,11 @@ import { t } from './utils/i18n.js';
 			unlisteners.push(
 				await listen('menu-edit-file', () => {
 					toggleEdit();
+				}),
+			);
+			unlisteners.push(
+				await listen('menu-edit-find', () => {
+					if (markdownBody) findOpen = true;
 				}),
 			);
 			unlisteners.push(
@@ -2577,6 +2608,7 @@ import { t } from './utils/i18n.js';
 		{theme}
 		onSetTheme={(t) => (theme = t)}
 		onopenSettings={() => (showSettings = true)}
+		onfind={() => { if (markdownBody) findOpen = true; }}
 		oncloseTab={closeTabAndWindowIfLast} />
 	<div class="loading-screen">
 		<svg class="spinner" viewBox="0 0 50 50">
@@ -2620,6 +2652,7 @@ import { t } from './utils/i18n.js';
 		{theme}
 		onSetTheme={(t) => (theme = t)}
 		onopenSettings={() => (showSettings = true)}
+		onfind={() => { if (markdownBody) findOpen = true; }}
 		oncloseTab={closeTabAndWindowIfLast} />
 
 	<Settings show={showSettings} {theme} onSetTheme={(t) => (theme = t)} onclose={() => (showSettings = false)} />
@@ -2675,7 +2708,13 @@ import { t } from './utils/i18n.js';
 						class="pane viewer-pane" 
 						class:active={!isEditing || isSplit} 
 						style="flex: {isSplit ? 1 - tabManager.activeTab.splitRatio : (!isEditing) ? 1 : 0}">
-						
+
+						<FindBar
+							bind:this={findBar}
+							bind:open={findOpen}
+							{markdownBody}
+							language={settings.language} />
+
 						<div class="viewer-content">
 							<article
 								bind:this={markdownBody}

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -77,11 +77,27 @@ import { t } from './utils/i18n.js';
 		undo: () => void;
 		redo: () => void;
 		revealHeader: (text: string) => void;
+		triggerFind: () => void;
 	} | null>(null);
 	let liveMode = $state(false);
 
 	let findOpen = $state(false);
 	let findBar = $state<{ reapply: () => void; clearHighlights: () => void } | null>(null);
+
+	// Decide where Cmd/Ctrl+F should land based on what's visible and where
+	// focus is. Used by both the JS keydown handler (Win/Linux + macOS in-page
+	// shortcut) and the macOS native menu listener (which fires Cmd+F via the
+	// Edit menu accelerator and bypasses the JS keydown path).
+	function triggerFindAction() {
+		const active = document.activeElement as Node | null;
+		const editorHasFocus = !!editorPaneEl && !!active && editorPaneEl.contains(active);
+		const previewVisible = !isEditing || !!tabManager.activeTab?.isSplit;
+		if (editorHasFocus || !previewVisible) {
+			editorPane?.triggerFind?.();
+		} else if (markdownBody) {
+			findOpen = true;
+		}
+	}
 
 	let isDragging = $state(false);
 	let dragTarget = $state<'editor' | 'preview' | null>(null);
@@ -2084,15 +2100,16 @@ import { t } from './utils/i18n.js';
 			e.preventDefault();
 			showSettings = !showSettings;
 		}
-		// Ctrl/Cmd+F: open the preview find bar, but only when the editor
-		// (Monaco) doesn't have focus — Monaco ships its own native find
-		// widget and we don't want to fight it in Edit/Split mode.
+		// Ctrl/Cmd+F: route to either Monaco's built-in find or the preview
+		// FindBar depending on focus and which panes are visible. We only
+		// preventDefault when we actually take the action ourselves —
+		// otherwise we let Monaco's own keybinding fire.
 		if (cmdOrCtrl && !e.shiftKey && !e.altKey && key === 'f') {
 			const active = document.activeElement as Node | null;
 			const editorHasFocus = !!editorPaneEl && !!active && editorPaneEl.contains(active);
-			if (!editorHasFocus && markdownBody) {
+			if (!editorHasFocus) {
 				e.preventDefault();
-				findOpen = true;
+				triggerFindAction();
 			}
 		}
 	}
@@ -2311,7 +2328,7 @@ import { t } from './utils/i18n.js';
 			);
 			unlisteners.push(
 				await listen('menu-edit-find', () => {
-					if (markdownBody) findOpen = true;
+					triggerFindAction();
 				}),
 			);
 			unlisteners.push(
@@ -2608,7 +2625,7 @@ import { t } from './utils/i18n.js';
 		{theme}
 		onSetTheme={(t) => (theme = t)}
 		onopenSettings={() => (showSettings = true)}
-		onfind={() => { if (markdownBody) findOpen = true; }}
+		onfind={triggerFindAction}
 		oncloseTab={closeTabAndWindowIfLast} />
 	<div class="loading-screen">
 		<svg class="spinner" viewBox="0 0 50 50">
@@ -2652,7 +2669,7 @@ import { t } from './utils/i18n.js';
 		{theme}
 		onSetTheme={(t) => (theme = t)}
 		onopenSettings={() => (showSettings = true)}
-		onfind={() => { if (markdownBody) findOpen = true; }}
+		onfind={triggerFindAction}
 		oncloseTab={closeTabAndWindowIfLast} />
 
 	<Settings show={showSettings} {theme} onSetTheme={(t) => (theme = t)} onclose={() => (showSettings = false)} />

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -1120,6 +1120,12 @@
 		editor?.trigger("keyboard", "redo", null);
 	}
 
+	export const triggerFind = () => {
+		if (!editor) return;
+		editor.focus();
+		editor.getAction("actions.find")?.run();
+	}
+
 	export const getValue = () => editor?.getValue() || "";
 	export const setValue = (val: string) => editor?.setValue(val);
 	export const focus = () => editor?.focus();

--- a/src/lib/components/FindBar.svelte
+++ b/src/lib/components/FindBar.svelte
@@ -1,0 +1,501 @@
+<script lang="ts">
+	import { fly } from 'svelte/transition';
+	import { tick } from 'svelte';
+	import { t } from '../utils/i18n.js';
+	import type { LanguageCode } from '../utils/i18n.js';
+
+	let {
+		open = $bindable(false),
+		markdownBody,
+		language = 'en' as LanguageCode,
+	} = $props<{
+		open: boolean;
+		markdownBody: HTMLElement | null;
+		language?: LanguageCode;
+	}>();
+
+	const FIND_MARK_CLASS = 'markpad-find-match';
+	const FIND_MARK_ACTIVE_CLASS = 'active';
+	const MAX_MATCHES = 5000;
+	const DEBOUNCE_MS = 80;
+
+	let inputEl = $state<HTMLInputElement>();
+	let query = $state('');
+	let caseSensitive = $state(false);
+	let wholeWord = $state(false);
+	let matchCount = $state(0);
+	let activeIndex = $state(-1);
+	let truncated = $state(false);
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function isHostElement(el: Element | null): boolean {
+		if (!el) return false;
+		const tag = el.tagName;
+		return (
+			tag === 'CODE' ||
+			tag === 'PRE' ||
+			tag === 'SCRIPT' ||
+			tag === 'STYLE' ||
+			tag === 'NOSCRIPT' ||
+			el.classList.contains(FIND_MARK_CLASS)
+		);
+	}
+
+	function isInsideHost(node: Node, root: Element): boolean {
+		let curr: Node | null = node.parentNode;
+		while (curr && curr !== root) {
+			if (curr.nodeType === Node.ELEMENT_NODE && isHostElement(curr as Element)) return true;
+			curr = curr.parentNode;
+		}
+		return false;
+	}
+
+	export function clearHighlights() {
+		const root = markdownBody as HTMLElement | null;
+		if (!root) return;
+		const marks = Array.from(
+			root.querySelectorAll(`mark.${FIND_MARK_CLASS}`),
+		) as HTMLElement[];
+		for (const mark of marks) {
+			const parent = mark.parentNode;
+			if (!parent) continue;
+			while (mark.firstChild) parent.insertBefore(mark.firstChild, mark);
+			parent.removeChild(mark);
+			parent.normalize();
+		}
+	}
+
+	function escapeForDisplay(s: string): string {
+		return s;
+	}
+
+	function findInTextNode(text: string, needle: string): number[] {
+		// returns array of start indices for non-overlapping matches
+		const indices: number[] = [];
+		if (!needle) return indices;
+		const haystack = caseSensitive ? text : text.toLowerCase();
+		const search = caseSensitive ? needle : needle.toLowerCase();
+		let from = 0;
+		while (from <= haystack.length - search.length) {
+			const i = haystack.indexOf(search, from);
+			if (i === -1) break;
+			if (wholeWord) {
+				const before = i === 0 ? '' : haystack.charAt(i - 1);
+				const after = haystack.charAt(i + search.length);
+				const isBoundary = (c: string) => c === '' || !/[\p{L}\p{N}_]/u.test(c);
+				if (!isBoundary(before) || !isBoundary(after)) {
+					from = i + 1;
+					continue;
+				}
+			}
+			indices.push(i);
+			from = i + search.length;
+		}
+		return indices;
+	}
+
+	function applyHighlights() {
+		if (!markdownBody) {
+			matchCount = 0;
+			activeIndex = -1;
+			truncated = false;
+			return;
+		}
+		clearHighlights();
+		if (!query) {
+			matchCount = 0;
+			activeIndex = -1;
+			truncated = false;
+			return;
+		}
+
+		const root = markdownBody;
+		const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+			acceptNode(node: Node) {
+				const text = (node as Text).nodeValue;
+				if (!text) return NodeFilter.FILTER_REJECT;
+				if (isInsideHost(node, root)) return NodeFilter.FILTER_REJECT;
+				return NodeFilter.FILTER_ACCEPT;
+			},
+		});
+
+		const targets: Text[] = [];
+		let node: Node | null;
+		while ((node = walker.nextNode())) targets.push(node as Text);
+
+		let total = 0;
+		let hitCap = false;
+		const created: HTMLElement[] = [];
+
+		outer: for (const textNode of targets) {
+			const text = textNode.nodeValue || '';
+			const indices = findInTextNode(text, query);
+			if (indices.length === 0) continue;
+
+			const parent = textNode.parentNode;
+			if (!parent) continue;
+			const doc = textNode.ownerDocument || document;
+			const frag = doc.createDocumentFragment();
+			let cursor = 0;
+			for (const i of indices) {
+				if (total >= MAX_MATCHES) {
+					hitCap = true;
+					break outer;
+				}
+				if (i > cursor) frag.appendChild(doc.createTextNode(text.slice(cursor, i)));
+				const mark = doc.createElement('mark');
+				mark.className = FIND_MARK_CLASS;
+				mark.textContent = text.slice(i, i + query.length);
+				frag.appendChild(mark);
+				created.push(mark);
+				cursor = i + query.length;
+				total++;
+			}
+			if (cursor < text.length) frag.appendChild(doc.createTextNode(text.slice(cursor)));
+			parent.replaceChild(frag, textNode);
+		}
+
+		matchCount = total;
+		truncated = hitCap;
+		if (total === 0) {
+			activeIndex = -1;
+		} else {
+			activeIndex = 0;
+			setActive(0);
+		}
+	}
+
+	function getMarks(): HTMLElement[] {
+		const root = markdownBody as HTMLElement | null;
+		if (!root) return [];
+		return Array.from(
+			root.querySelectorAll(`mark.${FIND_MARK_CLASS}`),
+		) as HTMLElement[];
+	}
+
+	function setActive(index: number, scroll: boolean = true) {
+		const marks = getMarks();
+		if (marks.length === 0) {
+			activeIndex = -1;
+			return;
+		}
+		const safe = ((index % marks.length) + marks.length) % marks.length;
+		marks.forEach((m, i) => m.classList.toggle(FIND_MARK_ACTIVE_CLASS, i === safe));
+		activeIndex = safe;
+		if (scroll) {
+			marks[safe].scrollIntoView({ block: 'center', behavior: 'smooth' });
+		}
+	}
+
+	export function next() {
+		if (matchCount === 0) return;
+		setActive(activeIndex + 1);
+	}
+
+	export function prev() {
+		if (matchCount === 0) return;
+		setActive(activeIndex - 1);
+	}
+
+	function scheduleApply() {
+		if (debounceTimer) clearTimeout(debounceTimer);
+		debounceTimer = setTimeout(() => {
+			debounceTimer = null;
+			applyHighlights();
+		}, DEBOUNCE_MS);
+	}
+
+	export function reapply() {
+		// Public hook for parent: call after the preview HTML is replaced
+		// so existing matches survive across re-renders.
+		applyHighlights();
+	}
+
+	function close() {
+		clearHighlights();
+		query = '';
+		matchCount = 0;
+		activeIndex = -1;
+		truncated = false;
+		open = false;
+	}
+
+	$effect(() => {
+		// Re-run search when query/options change.
+		// Touch reactive dependencies explicitly so $effect tracks them.
+		query;
+		caseSensitive;
+		wholeWord;
+		if (!open) return;
+		scheduleApply();
+	});
+
+	$effect(() => {
+		if (!open) {
+			clearHighlights();
+			return;
+		}
+		// On open, focus and select the input so typing replaces.
+		tick().then(() => {
+			inputEl?.focus();
+			inputEl?.select();
+		});
+	});
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			e.stopPropagation();
+			close();
+			return;
+		}
+		if (e.key === 'Enter') {
+			e.preventDefault();
+			e.stopPropagation();
+			if (e.shiftKey) prev();
+			else next();
+			return;
+		}
+		if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'g') {
+			e.preventDefault();
+			e.stopPropagation();
+			if (e.shiftKey) prev();
+			else next();
+		}
+	}
+
+	function countLabel(): string {
+		if (!query) return '';
+		if (matchCount === 0) return t('find.noMatches', language);
+		const total = truncated ? `${MAX_MATCHES}+` : String(matchCount);
+		return t('find.matchCount', language)
+			.replace('{{current}}', String(activeIndex + 1))
+			.replace('{{total}}', total);
+	}
+</script>
+
+{#if open}
+	<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+	<div
+		class="find-bar"
+		role="search"
+		transition:fly={{ y: -8, duration: 120 }}
+		onkeydown={handleKeydown}>
+		<div class="find-input-wrap">
+			<svg class="find-icon" width="14" height="14" viewBox="0 0 24 24" fill="none"
+				stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+				aria-hidden="true">
+				<circle cx="11" cy="11" r="7"></circle>
+				<line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+			</svg>
+			<input
+				bind:this={inputEl}
+				bind:value={query}
+				type="text"
+				class="find-input"
+				placeholder={t('find.placeholder', language)}
+				aria-label={t('find.placeholder', language)}
+				spellcheck="false"
+				autocomplete="off" />
+			<span class="find-count" class:no-matches={!!query && matchCount === 0}>
+				{countLabel()}
+			</span>
+		</div>
+
+		<button
+			type="button"
+			class="find-toggle"
+			class:active={caseSensitive}
+			title={t('find.caseSensitive', language)}
+			aria-label={t('find.caseSensitive', language)}
+			aria-pressed={caseSensitive}
+			onclick={() => (caseSensitive = !caseSensitive)}>
+			Aa
+		</button>
+		<button
+			type="button"
+			class="find-toggle"
+			class:active={wholeWord}
+			title={t('find.wholeWord', language)}
+			aria-label={t('find.wholeWord', language)}
+			aria-pressed={wholeWord}
+			onclick={() => (wholeWord = !wholeWord)}>
+			ab|
+		</button>
+
+		<div class="find-divider"></div>
+
+		<button
+			type="button"
+			class="find-btn"
+			title={t('find.previous', language)}
+			aria-label={t('find.previous', language)}
+			disabled={matchCount === 0}
+			onclick={prev}>
+			<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+				stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+				<polyline points="18 15 12 9 6 15"></polyline>
+			</svg>
+		</button>
+		<button
+			type="button"
+			class="find-btn"
+			title={t('find.next', language)}
+			aria-label={t('find.next', language)}
+			disabled={matchCount === 0}
+			onclick={next}>
+			<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+				stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+				<polyline points="6 9 12 15 18 9"></polyline>
+			</svg>
+		</button>
+		<button
+			type="button"
+			class="find-btn"
+			title={t('find.close', language)}
+			aria-label={t('find.close', language)}
+			onclick={close}>
+			<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+				stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+				<line x1="18" y1="6" x2="6" y2="18"></line>
+				<line x1="6" y1="6" x2="18" y2="18"></line>
+			</svg>
+		</button>
+	</div>
+{/if}
+
+<style>
+	.find-bar {
+		position: absolute;
+		top: 8px;
+		right: 16px;
+		z-index: 50;
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		padding: 4px 6px;
+		background: var(--bg-tertiary, var(--color-canvas-subtle));
+		border: 1px solid var(--color-border-muted);
+		border-radius: 6px;
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+		font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+		font-size: 12px;
+		color: var(--text-primary, var(--color-fg-default));
+		user-select: none;
+	}
+
+	.find-input-wrap {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		padding: 2px 6px;
+		background: var(--color-canvas-default);
+		border: 1px solid var(--color-border-muted);
+		border-radius: 4px;
+		min-width: 220px;
+	}
+
+	.find-input-wrap:focus-within {
+		border-color: var(--color-accent-fg);
+	}
+
+	.find-icon {
+		flex-shrink: 0;
+		opacity: 0.6;
+	}
+
+	.find-input {
+		flex: 1;
+		min-width: 0;
+		border: none;
+		outline: none;
+		background: transparent;
+		color: inherit;
+		font: inherit;
+		padding: 4px 0;
+	}
+
+	.find-count {
+		flex-shrink: 0;
+		font-size: 11px;
+		opacity: 0.7;
+		white-space: nowrap;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.find-count.no-matches {
+		color: #d73a49;
+		opacity: 1;
+	}
+
+	.find-toggle {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 24px;
+		height: 24px;
+		padding: 0 4px;
+		border: 1px solid transparent;
+		border-radius: 4px;
+		background: transparent;
+		color: inherit;
+		font: inherit;
+		font-size: 11px;
+		cursor: pointer;
+		font-family: inherit;
+	}
+
+	.find-toggle:hover {
+		background: var(--color-neutral-muted, rgba(128, 128, 128, 0.15));
+	}
+
+	.find-toggle.active {
+		background: var(--color-accent-subtle, rgba(67, 138, 243, 0.25));
+		border-color: var(--color-accent-fg);
+		color: var(--color-accent-fg);
+	}
+
+	.find-divider {
+		width: 1px;
+		height: 18px;
+		background: var(--color-border-muted);
+		margin: 0 2px;
+	}
+
+	.find-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 24px;
+		height: 24px;
+		padding: 0;
+		border: none;
+		border-radius: 4px;
+		background: transparent;
+		color: inherit;
+		cursor: pointer;
+	}
+
+	.find-btn:hover:not(:disabled) {
+		background: var(--color-neutral-muted, rgba(128, 128, 128, 0.15));
+	}
+
+	.find-btn:disabled {
+		opacity: 0.4;
+		cursor: default;
+	}
+
+	:global(.markdown-body mark.markpad-find-match) {
+		background-color: var(--highlight-color, rgba(255, 208, 0, 0.4));
+		color: inherit;
+		padding: 0;
+		border-radius: 2px;
+		box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.05);
+	}
+
+	:global(.markdown-body mark.markpad-find-match.active) {
+		background-color: #ff8c00;
+		color: #000;
+		box-shadow: 0 0 0 1px #ff8c00, 0 0 0 3px rgba(255, 140, 0, 0.25);
+	}
+</style>

--- a/src/lib/components/FindBar.svelte
+++ b/src/lib/components/FindBar.svelte
@@ -65,10 +65,6 @@
 		}
 	}
 
-	function escapeForDisplay(s: string): string {
-		return s;
-	}
-
 	function findInTextNode(text: string, needle: string): number[] {
 		// returns array of start indices for non-overlapping matches
 		const indices: number[] = [];
@@ -119,40 +115,46 @@
 			},
 		});
 
-		const targets: Text[] = [];
-		let node: Node | null;
-		while ((node = walker.nextNode())) targets.push(node as Text);
-
 		let total = 0;
 		let hitCap = false;
-		const created: HTMLElement[] = [];
 
-		outer: for (const textNode of targets) {
+		// Walk and process in a single pass. We advance the walker BEFORE
+		// mutating each text node so its internal currentNode never points
+		// at a detached node — replaceChild on the previous text node would
+		// otherwise leave the walker in an undefined state.
+		let textNode = walker.nextNode() as Text | null;
+		while (textNode) {
+			const next = walker.nextNode() as Text | null;
+
 			const text = textNode.nodeValue || '';
 			const indices = findInTextNode(text, query);
-			if (indices.length === 0) continue;
-
-			const parent = textNode.parentNode;
-			if (!parent) continue;
-			const doc = textNode.ownerDocument || document;
-			const frag = doc.createDocumentFragment();
-			let cursor = 0;
-			for (const i of indices) {
-				if (total >= MAX_MATCHES) {
-					hitCap = true;
-					break outer;
+			if (indices.length > 0) {
+				const parent = textNode.parentNode;
+				if (parent) {
+					const doc = textNode.ownerDocument || document;
+					const frag = doc.createDocumentFragment();
+					let cursor = 0;
+					let breakOut = false;
+					for (const i of indices) {
+						if (total >= MAX_MATCHES) {
+							hitCap = true;
+							breakOut = true;
+							break;
+						}
+						if (i > cursor) frag.appendChild(doc.createTextNode(text.slice(cursor, i)));
+						const mark = doc.createElement('mark');
+						mark.className = FIND_MARK_CLASS;
+						mark.textContent = text.slice(i, i + query.length);
+						frag.appendChild(mark);
+						cursor = i + query.length;
+						total++;
+					}
+					if (cursor < text.length) frag.appendChild(doc.createTextNode(text.slice(cursor)));
+					parent.replaceChild(frag, textNode);
+					if (breakOut) break;
 				}
-				if (i > cursor) frag.appendChild(doc.createTextNode(text.slice(cursor, i)));
-				const mark = doc.createElement('mark');
-				mark.className = FIND_MARK_CLASS;
-				mark.textContent = text.slice(i, i + query.length);
-				frag.appendChild(mark);
-				created.push(mark);
-				cursor = i + query.length;
-				total++;
 			}
-			if (cursor < text.length) frag.appendChild(doc.createTextNode(text.slice(cursor)));
-			parent.replaceChild(frag, textNode);
+			textNode = next;
 		}
 
 		matchCount = total;
@@ -197,10 +199,21 @@
 		setActive(activeIndex - 1);
 	}
 
+	function cancelPendingApply() {
+		if (debounceTimer) {
+			clearTimeout(debounceTimer);
+			debounceTimer = null;
+		}
+	}
+
 	function scheduleApply() {
-		if (debounceTimer) clearTimeout(debounceTimer);
+		cancelPendingApply();
 		debounceTimer = setTimeout(() => {
 			debounceTimer = null;
+			// Guard against a stale timer firing after the bar has closed
+			// (e.g. parent flips `open` to false on tab switch without
+			// going through close()).
+			if (!open) return;
 			applyHighlights();
 		}, DEBOUNCE_MS);
 	}
@@ -212,6 +225,7 @@
 	}
 
 	function close() {
+		cancelPendingApply();
 		clearHighlights();
 		query = '';
 		matchCount = 0;
@@ -232,6 +246,10 @@
 
 	$effect(() => {
 		if (!open) {
+			// External close (e.g. parent flipping `open` on tab switch).
+			// Drop any pending debounced re-search so it can't fire after
+			// we've already cleared the DOM.
+			cancelPendingApply();
 			clearHighlights();
 			return;
 		}

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -51,6 +51,7 @@
 		theme = 'system',
 		onSetTheme,
 		onopenSettings,
+		onfind,
 	} = $props<{
 		isFocused: boolean;
 		isScrolled: boolean;
@@ -88,6 +89,7 @@
 		theme?: string;
 		onSetTheme?: (theme: string) => void;
 		onopenSettings?: () => void;
+		onfind?: () => void;
 	}>();
 
 	const appWindow = getCurrentWindow();
@@ -205,6 +207,12 @@
 			}
 			if (isMarkdown && !tabManager.activeTab?.isSplit) {
 				list.push('edit');
+			}
+			// Find in preview: only meaningful when a preview is actually
+			// visible (view mode or split). In pure edit mode Monaco's own
+			// Ctrl+F handles search, so we hide the entry there.
+			if (isMarkdown && (!isEditing || tabManager.activeTab?.isSplit)) {
+				list.push('find');
 			}
 			list.push('zen');
 			list.push('tabs');
@@ -547,6 +555,26 @@
 						</svg>
 						<span class="action-label">{t('menu.tabs', currentLanguage).replace('{{action}}', settings.showTabs ? t('menu.hide', currentLanguage) : t('menu.show', currentLanguage) )}</span>
 						<span class="menu-shortcut">{modifier}+Shift+B</span>
+					</button>
+				{:else if id === 'find'}
+					<button
+						class="title-action-btn"
+						onclick={() => {
+							hideTooltip();
+							kebabMenuOpen = false;
+							onfind?.();
+						}}
+						aria-label={t('menu.find', currentLanguage)}
+											onmouseenter={(e) => showTooltip(e, t('menu.find', currentLanguage), 'F')}
+						onmousedown={(e) => e.preventDefault()}
+						onmouseleave={hideTooltip}
+						transition:fly={{ x: 10, duration: 200 }}>
+						<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+							<circle cx="11" cy="11" r="7"></circle>
+							<line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+						</svg>
+						<span class="action-label">{t('menu.find', currentLanguage)}</span>
+						<span class="menu-shortcut">{modifier}+F</span>
 					</button>
 				{:else if id === 'open_loc'}
 					<button

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -564,8 +564,8 @@
 							kebabMenuOpen = false;
 							onfind?.();
 						}}
-						aria-label={t('menu.find', currentLanguage)}
-											onmouseenter={(e) => showTooltip(e, t('menu.find', currentLanguage), 'F')}
+						aria-label={t('tooltip.find', currentLanguage)}
+											onmouseenter={(e) => showTooltip(e, t('tooltip.find', currentLanguage), 'F')}
 						onmousedown={(e) => e.preventDefault()}
 						onmouseleave={hideTooltip}
 						transition:fly={{ x: 10, duration: 200 }}>

--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -196,7 +196,18 @@ export const translations: Record<LanguageCode, Translation> = {
             saveDiagramAsSvg: 'Save Diagram As SVG...',
             wordWrapOff: 'Off',
             wordWrapOn: 'Window',
-            wordWrapColumn: 'Column'
+            wordWrapColumn: 'Column',
+            find: 'Find…'
+        },
+        find: {
+            placeholder: 'Find',
+            next: 'Next match',
+            previous: 'Previous match',
+            close: 'Close',
+            matchCount: '{{current}} of {{total}}',
+            noMatches: 'No results',
+            caseSensitive: 'Match case',
+            wholeWord: 'Match whole word'
         },
         toast: {
             imageSavedSuccessfully: 'Image saved successfully',

--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -306,7 +306,8 @@ export const translations: Record<LanguageCode, Translation> = {
             showTableOfContents: 'Show Table of Contents',
             hideTableOfContents: 'Hide Table of Contents',
             newTab: 'New Tab',
-            close: 'Close'
+            close: 'Close',
+            find: 'Find'
         },
         toc: {
             noHeadingsFound: 'No headings found'


### PR DESCRIPTION
## Summary

Adds a find-in-text widget for the rendered markdown preview pane, accessible via `Ctrl/Cmd+F`. Closes the gap where the editor (Monaco) already had built-in find but the preview / Live mode / preview side of Split view had nothing — Tauri's WebView suppresses the browser-native `Ctrl+F`, so users had no way to search rendered content.

## What's new

- **`FindBar.svelte`** — overlay pinned to the top-right of the preview pane.
  - Debounced search input
  - Match-case (`Aa`) and whole-word (`ab|`) toggles
  - Prev / Next / Close buttons + a `3 of 17` / `No results` counter
  - Keyboard: `Enter` next, `Shift+Enter` previous, `Cmd/Ctrl+G` next, `Esc` close
  - Active match scrolls into view; non-active matches use the existing `--highlight-color` CSS var so they pick up the user's theme
- Highlighting via `<mark class="markpad-find-match">` wrapping inside a `TreeWalker` pass that skips `CODE` / `PRE` / `SCRIPT` / `STYLE`. Re-applies automatically when `sanitizedHtml` changes (so highlights survive edits in Split / Live mode).
- Match cap of 5,000 with a `5000+` indicator to keep huge documents responsive.

## Wiring

- `MarkdownViewer.svelte` — `Ctrl/Cmd+F` handler that defers to Monaco when the editor has focus, otherwise opens the bar. Closes on tab switch. Listens for the new `menu-edit-find` event.
- `TitleBar.svelte` — new "Find…" entry in the kebab dropdown (visible whenever a preview is rendered: view mode or split, hidden in pure edit mode where Monaco's own find applies).
- `src-tauri/src/lib.rs` — adds `Find…` (`CmdOrCtrl+F`) to the macOS native Edit menu and forwards `menu-edit-*` events to the focused webview. No-op on Windows/Linux (keeps the existing `#[cfg(target_os = "macos")]` block).
- `i18n.ts` — adds `menu.find` and a `find.*` namespace under English. Other languages fall back via the existing `t()` resolver.

## Out of scope

- Find/replace (preview is read-only).
- Re-implementing editor find — Monaco's native widget is left untouched.

## Testing

- `npm run check`: 0 errors, only pre-existing warnings.
- `npm run build`: clean.
- Manually verified via `npm run dev` (browser SvelteKit dev server):
  - View mode: `Ctrl+F` opens the bar; typing highlights matches; Enter / Shift+Enter cycle; Esc closes.
  - Split mode: focus in editor → Monaco's find; focus in preview → custom bar.
  - Edit-only mode: kebab "Find…" entry hidden as expected.
  - Tab switch closes the bar and clears highlights.
  - Edge cases: matches inside code blocks are skipped; query containing regex meta characters works (literal match); highlights survive a re-render after editing in split view.