### PR TITLE
Fix export to pdf

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1146,7 +1146,11 @@ body {
 	.title-action-btn,
 	.theme-dropdown-container,
 	.control-btn,
-	.lang-label {
+	.lang-label,
+	.top-fade-mask,
+	.toc-overlay-wrapper,
+	.toc-toggle-floating,
+	.find-bar {
 		display: none !important;
 	}
 
@@ -1155,7 +1159,8 @@ body {
 	#app,
 	.markdown-container,
 	.layout-container,
-	.pane.viewer-pane {
+	.pane.viewer-pane,
+	.viewer-content {
 		background: white !important;
 		overflow: visible !important;
 		height: auto !important;
@@ -1179,10 +1184,12 @@ body {
 		position: static !important;
 	}
 
-	.markdown-body pre {
+	.markdown-body pre,
+	.markdown-body pre code {
 		white-space: pre-wrap !important;
-		word-break: break-word !important;
-		overflow-x: visible !important;
+		overflow-wrap: anywhere !important;
+		word-break: normal !important;
+		overflow: visible !important;
 	}
 
 	.markdown-container {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1192,6 +1192,32 @@ body {
 		overflow: visible !important;
 	}
 
+	.markdown-body p,
+	.markdown-body li {
+		orphans: 3;
+		widows: 3;
+	}
+
+	.markdown-body h1,
+	.markdown-body h2,
+	.markdown-body h3,
+	.markdown-body h4,
+	.markdown-body h5,
+	.markdown-body h6 {
+		break-after: avoid;
+		break-inside: avoid;
+	}
+
+	.markdown-body pre,
+	.markdown-body blockquote,
+	.markdown-body table,
+	.markdown-body figure,
+	.markdown-body img,
+	.markdown-body .mermaid-diagram,
+	.markdown-body .katex-display {
+		break-inside: avoid;
+	}
+
 	.markdown-container {
 		zoom: 1 !important;
 	}


### PR DESCRIPTION
Fixes #158

## Summary
- Hide top-fade mask, TOC overlay/toggle, and find bar during print so
  they no longer appear in the exported PDF or mask leading characters.
- Reset overflow on .viewer-content so wide code blocks aren't clipped.
- Replace invalid `word-break: break-word` with `overflow-wrap: anywhere`.
- Add `orphans/widows` and `break-inside: avoid` rules so paragraphs,
  headings, code blocks, and other block elements don't break across
  pages in ugly ways.

## Test plan
- [x] Export a markdown doc with TOC open → no TOC or find bar in PDF.
- [x] First line of body text starts cleanly with no masked characters.
- [x] Long code lines wrap onto next line instead of being clipped.
- [x] Headings don't end up alone at the bottom of a page.
- [x] Browser print-dialog "Headers and footers" can be unchecked.