### PR TITLE
fix: toggle full width

### DIFF
--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -2927,13 +2927,13 @@ import { t } from './utils/i18n.js';
 	.markdown-body {
 		box-sizing: border-box;
 		min-width: 200px;
-		margin: 0;
+		margin: 0 auto;
 		padding: 50px clamp(24px, 5vw, 50px);
 		height: 100%;
 		overflow-y: auto;
 		overflow-x: hidden;
 		transform: translate3d(0, 0, 0);
-		max-width: 100%;
+		max-width: 880px;
 		text-align: left;
 		overflow-wrap: anywhere;
 	}
@@ -2989,8 +2989,8 @@ import { t } from './utils/i18n.js';
 	}
 
 	.markdown-body.full-width {
-		padding: 50px clamp(24px, 5vw, 50px);
 		max-width: 100%;
+		margin: 0;
 	}
 
 


### PR DESCRIPTION
In commit a5fda8e ("Fix markdown preview wrapping and open-with registration"), the default .markdown-body rule was rewritten to fix horizontal-overflow issues (wide tables, long code lines, unbounded 50% - 390px side padding on ultrawides). Tables were switched to width: 100%, code to pre-wrap, and the default container picked up max-width: 100% plus a flat clamp(24px, 5vw, 50px) padding.

The collateral damage: .markdown-body.full-width was updated to the same padding: 50px clamp(24px, 5vw, 50px) and already had max-width: 100%. The two rules became byte-for-byte equivalent, so toggling the .full-width class produced zero visual change - the toolbar button flipped its active state, but the article was already rendering full-width in both states.

### **The fix**

Re-introduce a real difference between the two rules without bringing back the unbounded-padding behavior David eliminated:

Default .markdown-body: max-width: 880px + margin: 0 auto → centered ~780px reading column (matches v2.6.4's visible width).
.markdown-body.full-width: max-width: 100% + margin: 0 → fills the pane.
Wrapping rules from a5fda8e are untouched and still apply within whichever container width is active.

Closes also #141 