### PR TITLE
Support Ctrl+F4 to close active tab on Windows

### DIFF
--- a/docs/requirements/157-ctrl-f4-close-tab.md
+++ b/docs/requirements/157-ctrl-f4-close-tab.md
@@ -1,0 +1,21 @@
+# Ctrl+F4 zum Tab schließen
+Datum: 2026-06-13
+Status: done
+
+## Was
+Ctrl+F4 schließt den aktiven Tab — identisches Verhalten wie das bestehende Ctrl+W.
+
+## Warum
+Auf Windows ist Ctrl+F4 der plattformübliche Shortcut zum Schließen eines Dokuments/Tabs (z.B. in IDEs, Office, Browser). Ohne ihn fühlt sich Markpad auf Windows nicht nativ an.
+
+## Akzeptanzkriterien
+- [ ] Ctrl+F4 schließt den aktiven Tab
+- [ ] Unsaved-Changes-Dialog erscheint genauso wie bei Ctrl+W
+- [ ] Kein Unterschied im Verhalten zu Ctrl+W
+
+## Out of scope
+- Neue UI-Elemente oder Einstellungen
+- macOS / Linux (dort ist Ctrl+F4 kein Standard)
+
+## Offene Fragen
+- keine

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -2035,6 +2035,10 @@ import { t } from './utils/i18n.js';
 			e.preventDefault();
 			closeFile();
 		}
+		if (cmdOrCtrl && e.code === 'F4') {
+			e.preventDefault();
+			closeFile();
+		}
 		if (cmdOrCtrl && !e.shiftKey && key === 't') {
 			e.preventDefault();
 			tabManager.addHomeTab();


### PR DESCRIPTION
Closes #157

Added Ctrl+F4 as an alternative shortcut to close the active tab on Windows, matching the platform convention used in IDEs, Office, and other tabbed desktop apps.

Behavior is identical to the existing Ctrl+W — including the unsaved-changes confirmation flow.