### PR TITLE
Focus the existing window when opening Markdown files

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -121,7 +121,15 @@ mod setup;
 
 #[tauri::command]
 async fn show_window(window: tauri::Window) {
-    window.show().unwrap();
+    let _ = window.show();
+    let _ = window.unminimize();
+    let _ = window.set_focus();
+}
+
+fn bring_webview_window_to_front(window: &tauri::WebviewWindow) {
+    let _ = window.show();
+    let _ = window.unminimize();
+    let _ = window.set_focus();
 }
 
 fn process_internal_embeds(content: &str) -> Cow<'_, str> {
@@ -632,6 +640,9 @@ fn clipboard_read_text() -> Result<String, String> {
 
 #[tauri::command]
 fn clipboard_read_image(macos_image_scaling: bool) -> Result<String, String> {
+    #[cfg(not(target_os = "macos"))]
+    let _ = macos_image_scaling;
+
     let mut clipboard = arboard::Clipboard::new().map_err(|e| e.to_string())?;
     let image = clipboard.get_image().map_err(|e| e.to_string())?;
 
@@ -860,6 +871,9 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_single_instance::init(|app, args, cwd| {
             println!("Single Instance Args: {:?}", args);
+            let Some(window) = app.get_webview_window("main") else {
+                return;
+            };
 
             let path_str = args
                 .iter()
@@ -877,15 +891,9 @@ pub fn run() {
                     cwd_path.join(path).display().to_string()
                 };
 
-                let _ = app
-                    .get_webview_window("main")
-                    .expect("no main window")
-                    .emit("file-path", resolved_path);
+                let _ = window.emit("file-path", resolved_path);
             }
-            let _ = app
-                .get_webview_window("main")
-                .expect("no main window")
-                .set_focus();
+            bring_webview_window_to_front(&window);
         }))
         .plugin(tauri_plugin_prevent_default::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
@@ -1080,6 +1088,7 @@ pub fn run() {
 
             if let Some(path) = file_path {
                 let _ = window.emit("file-path", path.as_str());
+                bring_webview_window_to_front(&window);
             }
 
             // If installer, force size (this will be saved to installer-state, not main-state)
@@ -1166,7 +1175,7 @@ pub fn run() {
 
                         if let Some(window) = _app_handle.get_webview_window("main") {
                             let _ = window.emit("file-path", path_str);
-                            let _ = window.set_focus();
+                            bring_webview_window_to_front(&window);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Route file-open requests from secondary app launches through the already running main window.
- Show, unminimize, and focus the window after receiving a Markdown file path so the opened document is visible immediately.
- Keep the Windows target check warning-free by marking the macOS-only clipboard scaling parameter as intentionally unused on other platforms.

## Issue
fixes #191

## Testing
- `cargo xwin check --target x86_64-pc-windows-msvc`
- `git diff --check`

## Notes
- This PR is intentionally limited to the Tauri window/file-open path. It does not include local release artifacts or process journal files.