### PR TITLE
i18n: complete missing Korean (ko) translation keys

### DIFF
--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -1151,9 +1151,11 @@ export const translations: Record<LanguageCode, Translation> = {
             editor: '편집기',
             preview: '미리보기',
             appearance: '외관',
+            toolbars: '툴바',
             editorSettings: '편집기 설정',
             previewSettings: '미리보기 설정',
             appearanceSettings: '외관 설정',
+            toolbarsSettings: '툴바 설정',
             resetEditorSettings: '편집기 설정 초기화',
             resetFontSettings: '글꼴 설정 초기화',
             font: '글꼴',
@@ -1194,6 +1196,15 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: '기본 밝게',
             themeDefaultDark: '기본 어둡게',
             themeFollowSystem: '시스템 따르기',
+            toolbar: '툴바',
+            editorToolbar: '편집기 툴바',
+            applicationToolbar: '애플리케이션 툴바',
+            toolbarPlacement: '툴바 위치',
+            toolbarOnBar: '표시줄',
+            toolbarInMenu: '메뉴',
+            resetToolbar: '툴바 초기화',
+            moveUp: '위로 이동',
+            moveDown: '아래로 이동',
             colors: {
                 default: '기본',
                 yellow: '노란색',
@@ -1210,6 +1221,17 @@ export const translations: Record<LanguageCode, Translation> = {
             autoSave: '편집 내용 자동 저장',
             confirmBeforeSave: '저장 전 확인'
         },
+        colors: {
+            default: '기본',
+            yellow: '노란색',
+            orange: '주황색',
+            red: '빨간색',
+            pink: '분홍색',
+            purple: '보라색',
+            blue: '파란색',
+            cyan: '청록색',
+            green: '초록색'
+        },
         menu: {
             file: '파일',
             edit: '편집',
@@ -1219,6 +1241,7 @@ export const translations: Record<LanguageCode, Translation> = {
             openFile: '파일 열기',
             save: '저장',
             saveAs: '다른 이름으로 저장',
+            reloadFromDisk: '디스크에서 다시 로드',
             closeFile: '파일 닫기',
             closeWindow: '창 닫기',
             undo: '실행 취소',
@@ -1237,6 +1260,7 @@ export const translations: Record<LanguageCode, Translation> = {
             resetZoom: '확대/축소 초기화',
             settings: '설정',
             about: '정보',
+            checkForUpdates: '업데이트 확인…',
             github: 'GitHub',
             documentation: '문서',
             home: '홈',
@@ -1245,7 +1269,12 @@ export const translations: Record<LanguageCode, Translation> = {
             exit: '종료',
             zenMode: '禅 모드',
             tabs: '탭 {{action}}',
+            back: '뒤로',
+            forward: '앞으로',
             openLocation: '위치 열기',
+            openFileLocation: '파일 위치 열기',
+            openInNewTab: '새 탭에서 열기',
+            copyFullPath: '전체 경로 복사',
             splitView: '분할 보기',
             syncScroll: '스크롤 동기화',
             fullWidth: '전체 너비',
@@ -1280,7 +1309,18 @@ export const translations: Record<LanguageCode, Translation> = {
             saveDiagramAsSvg: '다이어그램을 SVG로 저장...',
             wordWrapOff: '끄기',
             wordWrapOn: '창',
-            wordWrapColumn: '열'
+            wordWrapColumn: '열',
+            find: '찾기…'
+        },
+        find: {
+            placeholder: '찾기',
+            next: '다음 일치 항목',
+            previous: '이전 일치 항목',
+            close: '닫기',
+            matchCount: '{{current}} / {{total}}',
+            noMatches: '결과 없음',
+            caseSensitive: '대소문자 구분',
+            wholeWord: '단어 단위로 찾기'
         },
         toast: {
             imageSavedSuccessfully: '이미지가 저장되었습니다',
@@ -1291,7 +1331,8 @@ export const translations: Record<LanguageCode, Translation> = {
             failedToCopyCode: '코드 복사 실패',
             unsupportedFile: '지원되지 않는 파일 형식: {{filename}}',
             autoSaveFailed: '자동 저장 실패 — 저장되지 않은 변경 사항은 메모리에 남아 있습니다',
-            savedNewerEdits: '저장됨 — 새로운 편집이 있어 편집 모드를 유지합니다'
+            savedNewerEdits: '저장됨 — 새로운 편집이 있어 편집 모드를 유지합니다',
+            openExportedFileFailed: '내보낸 파일을 열 수 없습니다'
         },
         modal: {
             confirmExit: '종료 확인',
@@ -1300,7 +1341,36 @@ export const translations: Record<LanguageCode, Translation> = {
             youHaveUnsavedChanges: '"{title}"에 저장되지 않은 변경 사항이 있습니다. 닫기 전에 저장하시겠습니까?',
             youHaveUnsavedChangesBeforeReturning: '저장되지 않은 변경 사항이 있습니다. 보기 모드로 돌아가기 전에 저장하시겠습니까?',
             youHaveUnsavedChangesBeforeClosingSplitView: '저장되지 않은 변경 사항이 있습니다. 분할 보기를 닫기 전에 저장하시겠습니까?',
-            youHaveUnsavedFiles: '저장되지 않은 {{count}}개 파일이 있습니다. 변경 사항을 저장하시겠습니까?'
+            youHaveUnsavedFiles: '저장되지 않은 {{count}}개 파일이 있습니다. 변경 사항을 저장하시겠습니까?',
+            openExportedFileTitle: '내보낸 파일을 여시겠습니까?',
+            openExportedHtmlMessage: 'HTML 내보내기가 저장되었습니다. 지금 여시겠습니까?'
+        },
+        update: {
+            checkingHeader: '업데이트 확인 중…',
+            checkingBody: 'Markpad의 최신 버전을 찾는 중…',
+            upToDateHeader: '최신 버전입니다',
+            upToDateBody: '현재 Markpad 최신 버전(v{{version}})을 사용 중입니다.',
+            upToDateBodyNoVersion: '현재 Markpad 최신 버전을 사용 중입니다.',
+            availableHeader: '업데이트 사용 가능',
+            availableBody: 'Markpad v{{latest}}을(를) 사용할 수 있습니다. 현재 버전은 v{{current}}입니다.',
+            releaseNotes: '릴리스 노트',
+            downloadingHeader: '업데이트 다운로드 중…',
+            downloadingBody: 'Markpad v{{version}} 다운로드 중…',
+            downloadingProgress: '{{total}}MB 중 {{downloaded}}MB ({{pct}}%)',
+            downloadingProgressUnknown: '{{downloaded}}MB 다운로드됨',
+            downloadingHint: '업데이트 준비가 완료되면 Markpad가 자동으로 다시 시작됩니다.',
+            errorCheckHeader: '업데이트 확인 실패',
+            errorCheckBody: '업데이트를 확인할 수 없습니다.',
+            errorDownloadHeader: '업데이트 다운로드 실패',
+            errorDownloadBody: '업데이트를 다운로드하거나 설치할 수 없습니다.',
+            errorInstallHeader: '다시 시작 실패',
+            errorInstallBody: '업데이트는 다운로드되었지만 Markpad를 자동으로 다시 시작할 수 없습니다. 설치를 완료하려면 Markpad를 종료했다가 다시 여세요.',
+            notConfiguredHint: '이 빌드에는 아직 업데이트가 구성되지 않았습니다.',
+            cancel: '취소',
+            ok: '확인',
+            downloadInstall: '다운로드 및 설치',
+            close: '닫기',
+            retry: '재시도'
         },
         home: {
             welcomeToMarkpad: 'Markpad에 오신 것을 환영합니다',
@@ -1313,7 +1383,11 @@ export const translations: Record<LanguageCode, Translation> = {
         editor: {
             status: {
                 lineCol: '줄 {{line}}, 열 {{col}}',
+                selected: '{{count}}개 선택됨',
+                selections: '{{count}}개 선택 영역',
                 words: '{{count}}개 단어',
+                crlf: 'CRLF',
+                utf8: 'UTF-8',
                 lines: '{{count}}개 줄'
             }
         },
@@ -1325,23 +1399,73 @@ export const translations: Record<LanguageCode, Translation> = {
         tooltip: {
             menu: '메뉴',
             more: '더 보기',
+            back: '뒤로',
+            forward: '앞으로',
             moreActions: '더 많은 작업',
             settings: '설정',
             resetZoom: '확대/축소 초기화',
             reset: '초기화',
             zenMode: '禅 모드',
+            toggleZenMode: '禅 모드 전환',
             tabs: '탭 {{action}}',
             hide: '숨기기',
             show: '표시',
             openFileLocation: '파일 위치 열기',
+            toggleSplitView: '분할 보기 전환',
             splitView: '분할 보기',
+            toggleScrollSync: '스크롤 동기화 전환',
             scrollSync: '스크롤 동기화',
+            toggleFullWidth: '전체 너비 전환',
             fullWidth: '전체 너비',
+            reloadFromDisk: '디스크에서 다시 로드',
+            toggleAutoReload: '자동 다시 로드 전환',
             autoReload: '자동 다시 로드',
             editFile: '파일 편집',
             changeTheme: '테마 변경',
+            undock: '도킹 해제',
+            dock: '도킹',
+            switchSide: '위치 전환',
+            toggleFold: '접기 전환',
+            undockToc: '목차 도킹 해제',
+            dockToc: '목차 도킹',
+            showTableOfContents: '목차 표시',
+            hideTableOfContents: '목차 숨기기',
+            newTab: '새 탭',
+            close: '닫기',
+            find: '찾기',
             zoomIn: '확대',
             zoomOut: '축소'
+        },
+        toc: {
+            noHeadingsFound: '제목을 찾을 수 없습니다'
+        },
+        dragAndDrop: {
+            embed: '삽입하려면 놓으세요',
+            open: '열려면 놓으세요'
+        },
+        installer: {
+            markdownViewer: '마크다운 뷰어',
+            current: '현재:',
+            target: '대상:',
+            simpleMarkdownViewer: '간단한 마크다운 뷰어',
+            justMe: '나만',
+            allUsers: '모든 사용자',
+            registerMd: '.md 파일의 기본 프로그램으로 등록',
+            createDesktopShortcut: '바탕화면 바로가기 만들기',
+            addToStartMenu: '시작 메뉴에 추가',
+            launchAfterInstallation: '설치 후 실행',
+            installedFor: '설치 대상:',
+            repairFileAssociations: '파일 연결 복구',
+            launchAfterUpdate: '업데이트 후 실행',
+            uninstall: '제거',
+            updateRepair: '업데이트/복구',
+            installForAllUsers: '모든 사용자를 위해 설치',
+            installNow: '지금 설치',
+            requiresAdmin: '관리자 권한이 필요합니다',
+            updating: '업데이트 중',
+            installing: '설치 중',
+            markpad: 'Markpad...',
+            accessDenied: '액세스가 거부되었습니다. 관리자 권한으로 다시 실행해 주세요.'
         },
         uninstaller: {
             uninstallMarkpad: 'Markpad를 제거하시겠습니까?',
@@ -1357,7 +1481,8 @@ export const translations: Record<LanguageCode, Translation> = {
         common: {
             close: '닫기',
             minimize: '최소화',
-            maximize: '최대화'
+            maximize: '최대화',
+            loadingFullDocument: '전체 문서를 불러오는 중...'
         }
     },
     ru: {


### PR DESCRIPTION
## Motivation

This adds Korean (`ko`) translation support — to help Korean-speaking users use this
open-source project more comfortably in their own language.
(한국 사람들의 오픈소스 이용에 도움이 되게 하기 위해서 한글화 작업을 하였습니다.)

## Changes

- `src/lib/utils/i18n.ts`: the existing `ko` translation block only had 175 of the 288 leaf keys present in the `en` block (missing 113 keys), so those strings silently fell back to English for Korean users. This PR fills in the 113 missing keys — covering toolbar settings, the color-tag names, the find bar, the update dialog, the Windows installer/uninstaller strings, several tooltips, and a few misc entries — with Korean translations.
- No existing `ko` values were changed, reordered, or removed. All `{{placeholder}}` tokens (e.g. `{{count}}`, `{{version}}`, `{{current}}`) are preserved exactly as in the English source.
- Note: there are 12 pre-existing `ko` keys (e.g. `settings.colors.*`, `editor.status.lines`, `tooltip.zoomIn`/`zoomOut`) that no longer exist in `en` — this appears to be legacy debt shared by nearly every other language in the file, not something introduced or specific to `ko`, so it was left untouched to keep this PR focused.

## Testing

- Parsed both the `en` and `ko` objects out of `i18n.ts` and diffed their leaf-key sets programmatically: after this change, all 288 `en` keys exist in `ko` (0 missing), and no `{{placeholder}}` tokens were dropped or altered.
- Verified none of the 175 pre-existing `ko` translations (or any other language block) changed by diffing before/after parsed objects.
- Ran `npm run check` (svelte-check) — 0 errors, 0 warnings.