### PR TITLE
fix: restore horizontal scroll for wide tables in preview

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -430,11 +430,17 @@ body {
 .markdown-body table {
 	border-spacing: 0;
 	border-collapse: collapse;
-	display: table;
-	table-layout: fixed;
-	width: 100%;
+	/* Behave like GitHub: keep natural column widths and let a genuinely wide
+	   table scroll horizontally within the content column instead of being
+	   clipped by the article's `overflow-x: hidden`. `display: block` turns the
+	   table itself into the scroll container; cells still wrap (see the
+	   white-space/overflow-wrap rules below), so tables whose content fits keep
+	   wrapping and never show a scrollbar. */
+	display: block;
+	width: max-content;
 	max-width: 100%;
-	overflow: visible;
+	overflow-x: auto;
+	overflow-y: hidden;
 	margin-top: 0;
 	margin-bottom: 16px;
 }
@@ -1189,6 +1195,17 @@ body {
 		white-space: pre-wrap !important;
 		overflow-wrap: anywhere !important;
 		word-break: normal !important;
+		overflow: visible !important;
+	}
+
+	/* Paper has no horizontal scrollbar, so restore the fixed table-layout for
+	   export: wide tables wrap to fit the page width instead of being clipped
+	   by the on-screen `display: block; overflow-x: auto` scroll container. */
+	.markdown-body table {
+		display: table !important;
+		table-layout: fixed !important;
+		width: 100% !important;
+		max-width: 100% !important;
 		overflow: visible !important;
 	}
 


### PR DESCRIPTION
### Problem

Wide tables in the markdown preview run off the right edge and the extra columns are unreachable — there is **no horizontal scrollbar**, and window zoom doesn't help (it scales everything proportionally, so the overflow ratio stays the same). Most visible in a narrow window, in split view, and with CSV tables. Reported on Windows.

### Root cause

The preview article (`.markdown-body`) is `overflow-x: hidden` by design. Since a5fda8e the table uses:

```css
.markdown-body table { display: table; table-layout: fixed; width: 100%; }
```

`table-layout: fixed; width: 100%` forces every column to share the pane width. When it can't compress any further — the combined cell `padding: 6px 13px` (26px/cell) across many columns exceeds the available width, or a cell can't wrap (e.g. `.csv-data` cells are `white-space: nowrap`) — the table overflows and is silently **clipped** by `overflow-x: hidden` instead of scrolling.

### Fix

Make the table a horizontal scroll container, the way GitHub's markdown CSS does:

```css
.markdown-body table {
    display: block;
    width: max-content;
    max-width: 100%;
    overflow-x: auto;
    overflow-y: hidden;
}
```

The existing per-cell wrap rules (`white-space: normal; overflow-wrap: anywhere`) are kept, so tables whose content fits still wrap and never show a scrollbar — only genuinely wide tables scroll. A matching `@media print` override restores `table-layout: fixed` for PDF/HTML export, so exported tables wrap to fit the page (paper can't scroll).

### Notes / trade-off

- Tables that fit now shrink to their content width instead of always stretching to 100% of the pane — this matches GitHub and most markdown renderers.
- Diff is 21 lines in `src/styles.css`, no markup or JS changes, so `data-sourcepos` on tables (scroll-sync) is untouched.

### Testing

- `npm run build` — passes.
- `npm run test:workflows` — 25/25 pass (includes the HTML-export tests).
- Verified the layout in a Chromium/WebView2-equivalent harness: with the current CSS a wide table is clipped with no scroll; with the fix it scrolls and keeps natural column widths, while text-wrapping tables stay scrollbar-free. PDF (`window.print()` → `@media print`) still wraps.
