### PR TITLE
fix: remove duplicate test:frontmatter script key

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
 		"build": "vite build",
 		"preview": "vite preview",
 		"test:frontmatter": "node --test --import tsx scripts/frontMatter.test.ts scripts/frontMatterDisclosure.test.ts",
-		"test:frontmatter": "node --test --import tsx scripts/frontMatter.test.ts",
 		"test:workflows": "node --test --import tsx scripts/exportHtml.test.ts scripts/exportOpenPrompt.test.ts scripts/reloadOpenToolbar.test.ts scripts/editorToolbar.test.ts scripts/titlebarToolbar.test.ts scripts/toolbarCustomizationWiring.test.ts",
 		"test:settings-scroll": "node --test --import tsx scripts/previewScrollSync.test.ts scripts/toolbarCustomizationWiring.test.ts",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",


### PR DESCRIPTION
## Summary

`package.json` declares the `test:frontmatter` script twice:

```json
"test:frontmatter": "node --test --import tsx scripts/frontMatter.test.ts scripts/frontMatterDisclosure.test.ts",
"test:frontmatter": "node --test --import tsx scripts/frontMatter.test.ts",
```

When JSON is parsed, the last duplicate key wins, so the second entry silently shadows the first — `scripts/frontMatterDisclosure.test.ts` is never executed by `npm run test:frontmatter`. This PR removes the second (narrower) entry and keeps the one that runs both test files.

## Verification

Ran `npm run test:frontmatter` locally after the change: 11 tests pass, 0 fail — including the 3 disclosure-panel tests from `frontMatterDisclosure.test.ts` that were previously skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)