### PR TITLE
refactor: debounced preview render goes through renderTabPreviewFromRaw

### DIFF
--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -2257,13 +2257,7 @@ import { t } from './utils/i18n.js';
 
 			clearTimeout(debounceTimer);
 			debounceTimer = setTimeout(() => {
-				renderMarkdownPreview(tab.rawContent, tab.path)
-					.then((processed) => {
-						tabManager.updateTabContent(tab.id, processed);
-						(tab as any)._lastRenderedRawContent = tab.rawContent;
-						tick().then(renderRichContent);
-					})
-					.catch(console.error);
+				renderTabPreviewFromRaw(tab).catch(console.error);
 			}, 16);
 		}
 	});


### PR DESCRIPTION
## What

Replaces the hand-written render/write-back/marker/refresh sequence in the editor debounce path with a call to `renderTabPreviewFromRaw`, which already encapsulates exactly those steps (added in #194). Net: −7/+1 lines, no behavior change.

## Why

The debounce block was a byte-for-byte duplicate of the helper's body. Duplicated recipes drift: when the preview pipeline changes (as it did in #194, when front-matter stripping moved into `renderMarkdownPreview`), every hand-copy is a spot the refactor can miss. Keeping a single shared path means future pipeline changes reach every render site at once.

The other direct `renderMarkdownPreview` call sites (initial load, chunked full-content load, untitled-tab toggle, startup restore) were left as-is — each differs from the helper on purpose (conditional rich-content refresh, loading-state handling, empty path for untitled buffers).

## Verification

- `npm run check`: 0 errors, 0 warnings
- `node --test` over all script tests: 56/56 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)