### PR TITLE
test: pin raw render_markdown invocations to the pipeline allowlist

### DIFF
--- a/scripts/renderPipelineConvention.test.ts
+++ b/scripts/renderPipelineConvention.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+// Every preview render must go through renderMarkdownPreview, which strips
+// YAML front matter before invoking the Rust renderer. Calling the raw
+// `invoke('render_markdown')` command anywhere else silently bypasses that
+// step — the compiler cannot catch it because the command name is a string.
+// This test pins the exact set of files allowed to touch the raw command.
+//
+// If you add a new render call site, use renderMarkdownPreview (or
+// renderTabPreviewFromRaw for the full render-and-apply sequence) instead
+// of widening the allowlist.
+
+const RAW_COMMAND = "invoke('render_markdown'";
+
+const ALLOWED: Record<string, number> = {
+	// The pipeline helper itself — the one legitimate caller.
+	'src/lib/MarkdownViewer.svelte': 1,
+	// Export strips front matter on its own before rendering.
+	'src/lib/utils/export.ts': 1,
+};
+
+function walk(dir: string): string[] {
+	const out: string[] = [];
+	for (const name of readdirSync(dir)) {
+		const path = join(dir, name);
+		if (statSync(path).isDirectory()) out.push(...walk(path));
+		else if (/\.(ts|svelte|js)$/.test(name)) out.push(path);
+	}
+	return out;
+}
+
+test('raw render_markdown invocations appear only at allowlisted sites', () => {
+	const found: Record<string, number> = {};
+	for (const path of walk('src')) {
+		const count = readFileSync(path, 'utf8').split(RAW_COMMAND).length - 1;
+		if (count > 0) found[path.replace(/\\/g, '/')] = count;
+	}
+	assert.deepEqual(
+		found,
+		ALLOWED,
+		'unexpected raw render_markdown call site — render through renderMarkdownPreview instead',
+	);
+});
+
+test('the viewer occurrence lives inside renderMarkdownPreview', () => {
+	const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+	assert.match(
+		viewer,
+		/async function renderMarkdownPreview[\s\S]{0,400}?invoke\('render_markdown'/,
+		'renderMarkdownPreview must be the function wrapping the raw command',
+	);
+});


### PR DESCRIPTION
## What

Adds a source-convention test (same style as the existing script tests) asserting that the raw `invoke('render_markdown')` command appears **only** inside `renderMarkdownPreview` and in `utils/export.ts` (which strips front matter itself).

## Why

`renderMarkdownPreview` exists so every preview render strips YAML front matter before hitting the Rust renderer (#194). But the raw command is a string RPC — the type checker can't flag a call site that bypasses the wrapper, and a bypass renders the front matter into the body (hr + setext heading). This is not hypothetical: two such bypasses have already slipped through merges silently in downstream branches. This test turns the convention into a red test instead of a code-review memory item.

If a future change legitimately needs the raw command, the allowlist in the test is the conscious place to widen it.

## Verification

- New test passes on master (2/2); full script suite still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)