### PR TITLE
refactor: deterministic fold wrapper ids

### DIFF
--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -682,6 +682,10 @@ export function processMarkdownHtml(
 	processInlineMath(doc.body);
 
 	const headings = Array.from(doc.querySelectorAll("h1, h2, h3, h4, h5, h6"));
+	// The heading↔wrapper pairing only needs to be unique within this
+	// render's output (the previous DOM is replaced wholesale), so a
+	// counter keeps the HTML deterministic for identical input.
+	let nextFoldId = 0;
 	for (const h of headings) {
 		const chevron = doc.createElement("span");
 		chevron.className = "header-fold-icon";
@@ -709,7 +713,7 @@ export function processMarkdownHtml(
 		}
 		if (h.parentNode) h.parentNode.insertBefore(wrapper, h.nextSibling);
 
-		const mappingId = "wrap-" + Math.random().toString(36).substr(2, 9);
+		const mappingId = "wrap-" + nextFoldId++;
 		h.setAttribute("data-fold-target", mappingId);
 		wrapper.id = mappingId;
 


### PR DESCRIPTION
## What

Replaces `"wrap-" + Math.random().toString(36).substr(2, 9)` with a per-render counter for the fold wrapper ids in `processMarkdownHtml`. Net: same behavior, deterministic output.

## Why

The `data-fold-target` ↔ `wrapper.id` pairing only needs to be unique within a single render's output — the article's previous DOM is replaced wholesale on re-render, so cross-render uniqueness buys nothing. With random ids, identical markdown input produces different HTML every render, which defeats snapshot testing and makes diffs noisy. (Also retires a `substr` deprecation.)

The mermaid element id a few lines down also uses `Math.random`, but is deliberately left alone: mermaid keeps global state across renders, so its uniqueness requirement is wider than one render.

## Verification

- Full script test suite green; `npm run check` 0 errors / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)