### PR TITLE
feat: reveal truncated tab titles with a hover marquee

### DIFF
--- a/src/lib/components/Tab.svelte
+++ b/src/lib/components/Tab.svelte
@@ -112,7 +112,10 @@
 		display: flex;
 		align-items: center;
 		height: 28px;
-		min-width: 100px;
+		/* Tabs compress before overflowing: 72px still fits the ellipsized
+		   label and the close affordance, and buys roughly a third more
+		   tabs on screen before the strip starts scrolling. */
+		min-width: 72px;
 		max-width: 200px;
 		padding: 0;
 		margin: 0;

--- a/src/lib/components/Tab.svelte
+++ b/src/lib/components/Tab.svelte
@@ -27,6 +27,22 @@
 		items: [],
 	});
 
+	// A truncated title scrolls into view while the pointer rests on the
+	// tab (marquee), instead of compressing tabs below readability. The
+	// overflow is measured on hover because tab widths are flex-driven.
+	let labelEl = $state<HTMLSpanElement>();
+	let marqueeOffset = $state(0);
+
+	function startTitleMarquee() {
+		if (!labelEl) return;
+		const overflow = labelEl.scrollWidth - labelEl.clientWidth;
+		if (overflow > 0) marqueeOffset = overflow;
+	}
+
+	function stopTitleMarquee() {
+		marqueeOffset = 0;
+	}
+
 	function handleClose(e: MouseEvent) {
 		e.stopPropagation();
 		onclose(e);
@@ -82,13 +98,25 @@
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="tab {isActive ? 'active' : ''}" class:last={isLast} role="group" title={tab.path || 'Recents'} oncontextmenu={handleContextMenu}>
+<div
+	class="tab {isActive ? 'active' : ''}"
+	class:last={isLast}
+	role="group"
+	title={tab.path || 'Recents'}
+	oncontextmenu={handleContextMenu}
+	onmouseenter={startTitleMarquee}
+	onmouseleave={stopTitleMarquee}>
 	<button class="tab-content-btn" onclick={onclick} onmousedown={(e) => {
 		if (e.button === 0) e.preventDefault();
 		handleMiddleClick(e);
 	}}>
-		<span class="tab-label">
-			{tab.title}
+		<span class="tab-label" class:marquee={marqueeOffset > 0} bind:this={labelEl}>
+			<span
+				class="tab-label-text"
+				style:transform={marqueeOffset > 0 ? `translateX(-${marqueeOffset}px)` : ''}
+				style:transition-duration={marqueeOffset > 0 ? `${Math.max(300, marqueeOffset * 20)}ms` : '150ms'}>
+				{tab.title}
+			</span>
 		</span>
 	</button>
 	<div class="tab-actions">
@@ -112,10 +140,7 @@
 		display: flex;
 		align-items: center;
 		height: 28px;
-		/* Tabs compress before overflowing: 72px still fits the ellipsized
-		   label and the close affordance, and buys roughly a third more
-		   tabs on screen before the strip starts scrolling. */
-		min-width: 72px;
+		min-width: 100px;
 		max-width: 200px;
 		padding: 0;
 		margin: 0;
@@ -168,6 +193,21 @@
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
+	}
+
+	/* While the marquee runs, the ellipsis gives way to the sliding text. */
+	.tab-label.marquee {
+		text-overflow: clip;
+	}
+
+	.tab-label-text {
+		display: inline;
+	}
+
+	.tab-label.marquee .tab-label-text {
+		display: inline-block;
+		transition-property: transform;
+		transition-timing-function: linear;
 	}
 
 	.tab-actions {

--- a/src/lib/components/TabList.svelte
+++ b/src/lib/components/TabList.svelte
@@ -186,9 +186,13 @@
 			tabindex="-1"
 			oncontextmenu={handleContainerContextMenu}
 			onwheel={(e) => {
-				if (e.deltaY !== 0) {
+				// Trackpads report horizontal two-finger swipes as deltaX;
+				// only translating deltaY left sideways swipes dead. Use
+				// whichever axis dominates the gesture.
+				const delta = Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY;
+				if (delta !== 0) {
 					e.preventDefault();
-					e.currentTarget.scrollLeft += e.deltaY;
+					e.currentTarget.scrollLeft += delta;
 				}
 			}}>
 			{#each tabManager.tabs as tab, i (tab.id)}

--- a/src/lib/components/TabList.svelte
+++ b/src/lib/components/TabList.svelte
@@ -186,13 +186,9 @@
 			tabindex="-1"
 			oncontextmenu={handleContainerContextMenu}
 			onwheel={(e) => {
-				// Trackpads report horizontal two-finger swipes as deltaX;
-				// only translating deltaY left sideways swipes dead. Use
-				// whichever axis dominates the gesture.
-				const delta = Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY;
-				if (delta !== 0) {
+				if (e.deltaY !== 0) {
 					e.preventDefault();
-					e.currentTarget.scrollLeft += delta;
+					e.currentTarget.scrollLeft += e.deltaY;
 				}
 			}}>
 			{#each tabManager.tabs as tab, i (tab.id)}


### PR DESCRIPTION
When a tab title does not fit, resting the pointer on the tab slides the hidden part into view — duration proportional to the hidden width — and it snaps back on leave. The ellipsis yields to the sliding text only while the marquee runs. Tab widths are unchanged (compressing them just makes every title unreadable), and no behavior changes for titles that fit.

(An earlier revision of this PR also touched the wheel handler under the mistaken belief that horizontal trackpad swipes were broken — the strip is `overflow-x: auto`, so they were always handled natively. That change is reverted; the handler still only maps vertical wheels to horizontal scroll, as upstream intended.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)