### PR TITLE
fix: pasting a URL over a selected URL replaces it instead of nesting

### DIFF
--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -943,6 +943,17 @@
 				if (hasSelection) {
 					const edits = selections.map((selection) => {
 						const selectedText = model.getValueInRange(selection);
+						// Pasting a URL over a URL replaces it. Wrapping would
+						// nest the old URL as the link text — and inside
+						// existing link syntax like ![](url) it produces
+						// broken nesting: ![]([old](new)).
+						if (urlRegex.test(selectedText.trim())) {
+							return {
+								range: selection,
+								text,
+								forceMoveMarkers: true,
+							};
+						}
 						const linkUrl = text.toLowerCase().startsWith("www.")
 							? `http://${text}`
 							: text;


### PR DESCRIPTION
Paste-as-link wraps the selection unconditionally as `[selected](pasted)`. When the selection is itself a URL — the natural gesture for swapping a link target, including inside image syntax — this produces broken nesting:

1. Have `![](https://old-url)` in the document.
2. Select `https://old-url`, paste `https://new-url`.
3. Result: `![]([https://old-url](https://new-url)` — unbalanced and no longer an image.

**Change:** when the selected text is already a URL (reusing the existing `urlRegex`), plain-replace it with the pasted URL instead of wrapping. Same convention as VS Code's markdown paste. Wrapping behavior for non-URL selections is unchanged.

`npm run check`: 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)