### PR TITLE
fix: avoid stale fold height after leaving edit mode

### DIFF
--- a/scripts/foldLayout.test.ts
+++ b/scripts/foldLayout.test.ts
@@ -25,3 +25,9 @@ test('preview lifecycle starts and cleans up fold observation', () => {
 	assert.match(viewer, /observeFoldLayout\((?:markdownBody|body)\)/);
 	assert.match(viewer, /stopObservingFoldLayout\?\.\(\)/);
 });
+
+test('fold measurement pauses while the preview pane is hidden by edit mode', () => {
+	const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+
+	assert.match(viewer, /if \(!html \|\| !body \|\| \(isEditing && !isSplit\)\) return;/);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -1016,7 +1016,7 @@ import { t } from './utils/i18n.js';
 	$effect(() => {
 		const html = sanitizedHtml;
 		const body = markdownBody;
-		if (!html || !body) return;
+		if (!html || !body || (isEditing && !isSplit)) return;
 
 		let cancelled = false;
 		tick().then(() => {


### PR DESCRIPTION
Fixes #235. Fold measurement pauses while the preview pane is hidden in edit-only mode, preventing a hidden-pane measurement from persisting an oversized fold height.\n\nValidation:\n- node --test --import tsx scripts/foldLayout.test.ts\n- npm run check