### PR TITLE
ci: gate releases on complete platform artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,9 +250,9 @@ jobs:
   generate-update-feed:
     needs: [create-release, build]
     runs-on: ubuntu-latest
-    # Run even when one matrix leg failed (the existing sig_count > 0 sanity
-    # check inside still gates publication on at least one platform succeeding).
-    if: ${{ always() && needs.create-release.result == 'success' }}
+    # The updater feed must describe a complete release. Do not publish an
+    # update if any platform build failed or was cancelled.
+    if: ${{ always() && needs.create-release.result == 'success' && needs.build.result == 'success' }}
     steps:
       - name: Generate latest.json
         env:
@@ -266,18 +266,17 @@ jobs:
           # publish an empty latest.json that would overwrite a previously-good one.
           gh release download "v$VERSION" --repo "$REPO" --pattern "*.sig" --dir ./sigs
 
-          sig_count=$(find ./sigs -maxdepth 1 -name "*.sig" -type f | wc -l)
-          if [ "$sig_count" -eq 0 ]; then
-            echo "ERROR: no .sig files in release v${VERSION} — every matrix build either failed or didn't produce updater artifacts. Aborting before overwriting latest.json with an empty feed." >&2
-            exit 1
-          fi
-
           # Default Tauri v2 updater mode: macOS .app.tar.gz, Windows NSIS *-setup.exe, Linux *.AppImage
           # (NOT v1Compatible mode — which would use .nsis.zip / .AppImage.tar.gz wrappers)
           MAC_SIG=$(ls ./sigs/*.app.tar.gz.sig 2>/dev/null | head -1 || true)
           WIN_X64_SIG=$(ls ./sigs/*x64*-setup.exe.sig 2>/dev/null | head -1 || true)
           WIN_ARM_SIG=$(ls ./sigs/*arm64*-setup.exe.sig 2>/dev/null | head -1 || true)
           LINUX_SIG=$(ls ./sigs/*.AppImage.sig 2>/dev/null | head -1 || true)
+
+          if [ -z "$MAC_SIG" ] || [ -z "$WIN_X64_SIG" ] || [ -z "$WIN_ARM_SIG" ] || [ -z "$LINUX_SIG" ]; then
+            echo "ERROR: release v${VERSION} is missing one or more required updater signatures. Aborting before publishing latest.json." >&2
+            exit 1
+          fi
 
           platform_entry() {
             local sig_file="$1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,9 @@ jobs:
       - name: check frontend
         run: npm run check
 
+      - name: run frontend behavior tests
+        run: npm test
+
       - name: run cargo test
         run: |
           cd src-tauri

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,6 +1,9 @@
 name: Test Build (No Release)
 
 on:
+  # Keep release packaging changes from reaching a draft release without a
+  # platform build check.
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -30,6 +33,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
+          cache: npm
 
       - name: install rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -43,12 +47,12 @@ jobs:
             sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf rpm
 
       - name: install frontend dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build app
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"
-        run: npm run tauri build -- ${{ matrix.args }}
+        run: npm run tauri build -- --no-sign ${{ matrix.args }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"dev:installer": "tauri dev -- -- --install",
 		"build": "vite build",
 		"preview": "vite preview",
+		"test": "node --test --import tsx 'scripts/*.test.ts'",
 		"test:frontmatter": "node --test --import tsx scripts/frontMatter.test.ts scripts/frontMatterDisclosure.test.ts",
 		"test:workflows": "node --test --import tsx scripts/exportHtml.test.ts scripts/exportOpenPrompt.test.ts scripts/reloadOpenToolbar.test.ts scripts/editorToolbar.test.ts scripts/titlebarToolbar.test.ts scripts/toolbarCustomizationWiring.test.ts",
 		"test:settings-scroll": "node --test --import tsx scripts/previewScrollSync.test.ts scripts/toolbarCustomizationWiring.test.ts",


### PR DESCRIPTION
Fixes #240.

## Summary

- Add one npm test entry point that runs every scripts/*.test.ts file.
- Run that behavior suite in the pull-request workflow.
- Run the no-release multi-platform package build workflow for pull requests.
- Publish latest.json only after the complete build matrix succeeds and macOS, Windows x64, Windows ARM64, and Linux updater signatures all exist.

## Validation

- `npm test` (83 passing)
- `npm run check`
- YAML parsed with Ruby Psych for all workflow files
