### PR TITLE
fix: preserve dirty content when toggling tasks

### DIFF
--- a/scripts/taskToggleMemory.test.ts
+++ b/scripts/taskToggleMemory.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
+
+test('preview task toggles transform the active in-memory buffer before saving', () => {
+	const taskToggle = viewer.match(/async function toggleTaskCheckbox[\s\S]*?\n\t}\n\n\n\n\tfunction saveRecentFile/);
+	assert.ok(taskToggle);
+	assert.doesNotMatch(taskToggle[0], /read_file_content/);
+	assert.match(taskToggle[0], /const raw = tab\.rawContent;/);
+	assert.match(taskToggle[0], /tabManager\.updateTabRawContent\(tab\.id, updated\);/);
+	assert.match(taskToggle[0], /await saveContent\(tab\.id\)/);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -1465,15 +1465,7 @@ import { t } from './utils/i18n.js';
 	async function toggleTaskCheckbox(checkbox: HTMLInputElement) {
 		const tab = tabManager.activeTab;
 		if (!tab || !tab.path) return;
-
-		// always read latest from disk to avoid stale state
-		let raw: string;
-		try {
-			raw = (await invoke('read_file_content', { path: tab.path })) as string;
-		} catch (e) {
-			console.error('failed to read file for task toggle', e);
-			return;
-		}
+		const raw = tab.rawContent;
 
 		// find which task item this is by counting checkboxes in DOM
 		const allBoxes = Array.from(markdownBody?.querySelectorAll('[data-task-checkbox]') || []);
@@ -1496,15 +1488,10 @@ import { t } from './utils/i18n.js';
 
 		if (updated === raw) return;
 
-		// save file
-		try {
-			await invoke('save_file_content', { path: tab.path, content: updated });
-			tab.rawContent = updated;
-			tab.originalContent = updated;
-		} catch (e) {
-			console.error('failed to save task toggle', e);
-			return;
-		}
+		// Update the single in-memory source before saving. saveContent keeps the
+		// tab dirty if its write fails, so a disk error cannot discard this edit.
+		tabManager.updateTabRawContent(tab.id, updated);
+		await saveContent(tab.id);
 
 		// update DOM optimistically
 		checkbox.checked = nowChecked;


### PR DESCRIPTION
Fixes #244.

## Summary

- Transform preview task checkboxes from the active tab rawContent instead of rereading the file from disk.
- Reuse saveContent so watcher suppression and dirty-state handling stay consistent.
- Keep the changed buffer dirty if saving fails.

## Validation

- `node --test --import tsx scripts/taskToggleMemory.test.ts`
- `npm run check`
