### PR TITLE
fix: ignore stale large-file loads

### DIFF
--- a/scripts/largeFileLoadRevision.test.ts
+++ b/scripts/largeFileLoadRevision.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
+
+test('large-file completion requires the current clean load revision and unchanged view mode', () => {
+	assert.match(viewer, /const loadRevisionByTab = new Map<string, number>\(\);/);
+	assert.match(viewer, /const fullLoadRevision = \(loadRevisionByTab\.get\(activeId\) \?\? 0\) \+ 1;/);
+	assert.match(viewer, /loadRevisionByTab\.set\(activeId, fullLoadRevision\);/);
+	assert.match(
+		viewer,
+		/loadRevisionByTab\.get\(activeId\) === fullLoadRevision[\s\S]*!targetTab\.isDirty[\s\S]*targetTab\.isEditing === initialIsEditing[\s\S]*targetTab\.isSplit === initialIsSplit/,
+	);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -210,6 +210,7 @@ import { t } from './utils/i18n.js';
 	let canGoForwardInFileHistory = $derived(tabManager.activeTabId ? tabManager.canGoForward(tabManager.activeTabId) : false);
 
 	let loadingTabs = $state<string[]>([]);
+	const loadRevisionByTab = new Map<string, number>();
 	let isAtBottom = $state(false);
 
 	let showHome = $state(false);
@@ -785,6 +786,8 @@ import { t } from './utils/i18n.js';
 			}
 			const activeId = tabManager.activeTabId;
 			if (!activeId) return;
+			const fullLoadRevision = (loadRevisionByTab.get(activeId) ?? 0) + 1;
+			loadRevisionByTab.set(activeId, fullLoadRevision);
 
 			const isMarkdown = hasMarkdownLinkExtension(filePath);
 			const tab = tabManager.tabs.find((t) => t.id === activeId);
@@ -794,6 +797,8 @@ import { t } from './utils/i18n.js';
 				if (tab && !options.preserveEditState && !existing) {
 					tab.isEditing = settings.startInEditor;
 				}
+				const initialIsEditing = tab?.isEditing ?? false;
+				const initialIsSplit = tab?.isSplit ?? false;
 				const [, content, isFull] = await invoke('open_markdown_preview', { path: filePath, maxBytes: 50000 }) as [string, string, boolean];
 				if (pendingNavigateTabId) {
 					tabManager.navigate(pendingNavigateTabId, filePath);
@@ -803,6 +808,16 @@ import { t } from './utils/i18n.js';
 				tabManager.setTabRawContent(activeId, content);
 
 				if (!isFull) {
+					const canApplyFullLoad = () => {
+						const targetTab = tabManager.tabs.find((t) => t.id === activeId);
+						return (
+							targetTab?.path === filePath &&
+							loadRevisionByTab.get(activeId) === fullLoadRevision &&
+							!targetTab.isDirty &&
+							targetTab.isEditing === initialIsEditing &&
+							targetTab.isSplit === initialIsSplit
+						);
+					};
 					loadingTabs = [...loadingTabs, activeId];
 					tick().then(() => {
 						if (markdownBody) isAtBottom = markdownBody.scrollHeight <= markdownBody.clientHeight + 100;
@@ -814,9 +829,13 @@ import { t } from './utils/i18n.js';
 									setTimeout(applyFull, 100);
 									return;
 								}
-								if (tabManager.tabs.find((t) => t.id === activeId)?.path === filePath) {
+								if (canApplyFullLoad()) {
 									renderMarkdownPreview(fullContent, filePath)
 										.then((fullProcessed) => {
+											if (!canApplyFullLoad()) {
+												loadingTabs = loadingTabs.filter((id) => id !== activeId);
+												return;
+											}
 											tabManager.updateTabContent(activeId, fullProcessed);
 											tabManager.setTabRawContent(activeId, fullContent);
 											loadingTabs = loadingTabs.filter((id) => id !== activeId);


### PR DESCRIPTION
Fixes #246.

## Summary

- Give each tab load a revision and ignore older background completions.
- Apply complete large-file content only while the request is current, the tab is clean, and edit/split mode has not changed.
- Recheck those conditions after async rendering before writing state.

## Validation

- `node --test --import tsx scripts/largeFileLoadRevision.test.ts`
- `npm run check`
