### PR TITLE
feat: rebuild tab movement across windows

### DIFF
--- a/scripts/tabTransfer.test.ts
+++ b/scripts/tabTransfer.test.ts
@@ -225,5 +225,5 @@ test('source removal waits for destination completion', () => {
 	assert.match(broker, /pub fn complete_detached_tab/);
 	const claim = broker.slice(broker.indexOf('pub fn claim_detached_tab'), broker.indexOf('pub fn complete_detached_tab'));
 	assert.doesNotMatch(claim, /tab-transfer-claimed/);
-	assert.match(session, /invoke\('complete_detached_tab', \{ token: claimToken \}\)/);
+	assert.match(session, /invoke\('complete_detached_tab', \{ token \}\)/);
 });

--- a/scripts/windowOrganization.test.ts
+++ b/scripts/windowOrganization.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const runtime = readFileSync('src-tauri/src/window_runtime.rs', 'utf8');
+const session = readFileSync('src/lib/sessions/windowSession.svelte.ts', 'utf8');
+const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+const tab = readFileSync('src/lib/components/Tab.svelte', 'utf8');
+const titleBar = readFileSync('src/lib/components/TitleBar.svelte', 'utf8');
+
+test('the runtime registers live viewer windows in stable creation order', () => {
+	assert.match(runtime, /window_registry/);
+	assert.match(runtime, /window_counter/);
+	assert.match(runtime, /pub fn set_window_meta/);
+	assert.match(runtime, /pub fn list_viewer_windows/);
+	assert.match(runtime, /list\.sort_by_key\(\|entry\| entry\.meta\.number\)/);
+	assert.match(runtime, /window_registry[\s\S]*?remove\(window\.label\(\)\)/);
+});
+
+test('moving to an existing window uses the acknowledged transfer protocol', () => {
+	assert.match(session, /async function transfer\(/);
+	assert.match(session, /invoke\('complete_detached_tab', \{ token \}\)/);
+	assert.match(session, /onTransferClaimed\(tabId\)/);
+	assert.match(session, /async function acceptOfferedTransfer/);
+	assert.match(viewer, /invoke\('offer_tab_to_window', \{ targetLabel, token \}\)/);
+});
+
+test('window organization exposes move, merge, and carry actions', () => {
+	assert.match(tab, /list_viewer_windows/);
+	assert.match(tab, /menu-tab-move/);
+	assert.match(viewer, /async function mergeAllWindowsHere/);
+	assert.match(viewer, /async function carryActiveTabToNextWindow/);
+	assert.match(viewer, /cmdOrCtrl && e\.shiftKey && key === 'm'/);
+	assert.match(titleBar, /onmergeAllWindows/);
+});

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -330,6 +330,31 @@ fn clear_window_state(app: AppHandle) -> Result<(), String> {
     window_runtime::clear_window_state(app)
 }
 
+#[tauri::command]
+fn set_window_meta(
+    window: tauri::Window,
+    state: State<'_, AppState>,
+    active_tab_title: String,
+    tab_count: usize,
+) {
+    window_runtime::set_window_meta(window, state, active_tab_title, tab_count)
+}
+
+#[tauri::command]
+fn list_viewer_windows(state: State<'_, AppState>) -> Vec<window_runtime::WindowListEntry> {
+    window_runtime::list_viewer_windows(state)
+}
+
+#[tauri::command]
+fn offer_tab_to_window(app: AppHandle, target_label: String, token: String) -> Result<(), String> {
+    window_runtime::offer_tab_to_window(app, target_label, token)
+}
+
+#[tauri::command]
+fn focus_window(app: AppHandle, label: String) -> Result<(), String> {
+    window_runtime::focus_window(app, label)
+}
+
 /// Byte ranges of code regions — fenced code blocks and inline code spans —
 /// paired with CommonMark's rules. The regex alternation previously used for
 /// protection (```` ```.*?```|`.*?` ````) cannot express them: a fence closes
@@ -1487,6 +1512,10 @@ pub fn run() {
             tab_transfer::complete_detached_tab,
             tab_transfer::cancel_detached_tab,
             create_transfer_window,
+            set_window_meta,
+            list_viewer_windows,
+            offer_tab_to_window,
+            focus_window,
             save_window_state,
             load_window_state,
             clear_window_state

--- a/src-tauri/src/window_runtime.rs
+++ b/src-tauri/src/window_runtime.rs
@@ -2,7 +2,10 @@ use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
-use std::sync::Mutex;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Mutex,
+};
 use tauri::{AppHandle, Emitter, Manager, State};
 
 pub struct WatcherState {
@@ -20,6 +23,8 @@ impl WatcherState {
 pub struct AppState {
     pub(crate) startup_file: Mutex<Option<String>>,
     pub(crate) last_focused_viewer: Mutex<Option<String>>,
+    window_registry: Mutex<HashMap<String, WindowMeta>>,
+    window_counter: AtomicU64,
 }
 
 impl AppState {
@@ -27,8 +32,77 @@ impl AppState {
         Self {
             startup_file: Mutex::new(None),
             last_focused_viewer: Mutex::new(None),
+            window_registry: Mutex::new(HashMap::new()),
+            window_counter: AtomicU64::new(0),
         }
     }
+}
+
+#[derive(Clone, serde::Serialize)]
+struct WindowMeta {
+    number: u64,
+    active_tab_title: String,
+    tab_count: usize,
+}
+
+#[derive(Clone, serde::Serialize)]
+pub struct WindowListEntry {
+    label: String,
+    #[serde(flatten)]
+    meta: WindowMeta,
+}
+
+pub fn set_window_meta(
+    window: tauri::Window,
+    state: State<'_, AppState>,
+    active_tab_title: String,
+    tab_count: usize,
+) {
+    let label = window.label().to_string();
+    if label != "main" && !label.starts_with("window-") {
+        return;
+    }
+    let mut registry = state.window_registry.lock().unwrap();
+    let entry = registry.entry(label).or_insert_with(|| WindowMeta {
+        number: state.window_counter.fetch_add(1, Ordering::SeqCst) + 1,
+        active_tab_title: String::new(),
+        tab_count: 0,
+    });
+    entry.active_tab_title = active_tab_title;
+    entry.tab_count = tab_count;
+}
+
+pub fn list_viewer_windows(state: State<'_, AppState>) -> Vec<WindowListEntry> {
+    let registry = state.window_registry.lock().unwrap();
+    let mut list: Vec<WindowListEntry> = registry
+        .iter()
+        .map(|(label, meta)| WindowListEntry {
+            label: label.clone(),
+            meta: meta.clone(),
+        })
+        .collect();
+    list.sort_by_key(|entry| entry.meta.number);
+    list
+}
+
+pub fn offer_tab_to_window(
+    app: AppHandle,
+    target_label: String,
+    token: String,
+) -> Result<(), String> {
+    if app.get_webview_window(&target_label).is_none() {
+        return Err(format!("no such window: {target_label}"));
+    }
+    app.emit_to(target_label.as_str(), "tab-transfer-offer", token)
+        .map_err(|error| error.to_string())
+}
+
+pub fn focus_window(app: AppHandle, label: String) -> Result<(), String> {
+    let window = app
+        .get_webview_window(&label)
+        .ok_or_else(|| format!("no such window: {label}"))?;
+    bring_to_front(&window);
+    Ok(())
 }
 
 pub async fn show_window(window: tauri::Window) {
@@ -200,6 +274,12 @@ pub fn handle_window_event(window: &tauri::Window, event: &tauri::WindowEvent) {
         tauri::WindowEvent::Destroyed => {
             let state = window.state::<WatcherState>();
             state.watchers.lock().unwrap().remove(window.label());
+            let app_state = window.state::<AppState>();
+            app_state
+                .window_registry
+                .lock()
+                .unwrap()
+                .remove(window.label());
         }
         _ => {}
     }

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import { invoke, convertFileSrc } from '@tauri-apps/api/core';
+	import { emitTo } from '@tauri-apps/api/event';
 	import { getCurrentWindow } from '@tauri-apps/api/window';
 	import { onMount, tick, untrack } from 'svelte';
-	import { fly } from 'svelte/transition';
+	import { fade, fly } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
 	import { openPath, openUrl } from '@tauri-apps/plugin-opener';
 	import { open, save, ask } from '@tauri-apps/plugin-dialog';
@@ -405,6 +406,8 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	// red button is not blocked by the dialog overlay, so this keeps a second
 	// close request from starting a competing walk.
 	let isCloseWalkActive = false;
+	let identifyFlash = $state('');
+	let identifyFlashTimer: ReturnType<typeof setTimeout> | undefined;
 
 	// v2 window-state snapshots live under their own key, and the legacy key
 	// is removed on every write: an older Markpad build restoring a v2
@@ -443,6 +446,10 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			if (tabManager.activeTabId === tab.id) tick().then(renderRichContent);
 		},
 		dropRestoredTab: (tabId) => tabManager.closeTab(tabId),
+		canTransfer: (tabId) => {
+			const tab = tabManager.tabs.find((item) => item.id === tabId);
+			return !isCloseWalkActive && tab !== undefined && tab.path !== 'HOME';
+		},
 		canDetach: (tabId) => {
 			const tab = tabManager.tabs.find((item) => item.id === tabId);
 			return !isCloseWalkActive && tab !== undefined && tab.path !== 'HOME' && tabManager.tabs.length >= 2;
@@ -465,6 +472,13 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			addToast(`${message}: ${String(error)}`, 'error');
 		},
 		onWarning: (message, error) => console.warn(message, error),
+	});
+
+	$effect(() => {
+		invoke('set_window_meta', {
+			activeTabTitle: tabManager.activeTab?.title ?? '',
+			tabCount: tabManager.tabs.length,
+		}).catch(() => {});
 	});
 
 	const documentSession = createDocumentSession({
@@ -2233,6 +2247,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			reloadFromDisk();
 			return;
 		}
+		if (cmdOrCtrl && e.shiftKey && key === 'm') {
+			e.preventDefault();
+			carryActiveTabToNextWindow();
+			return;
+		}
 		if (cmdOrCtrl && key === 'w') {
 			e.preventDefault();
 			closeFile();
@@ -2394,6 +2413,47 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	// window creation error, timeout — leaves the tab exactly where it was.
 	async function handleDetach(tabId: string) {
 		await windowSession.detach(tabId);
+	}
+
+	async function moveTabToWindow(tabId: string, targetLabel: string, focusAfter = false) {
+		const moved = await windowSession.transfer(tabId, (token) => invoke('offer_tab_to_window', { targetLabel, token }));
+		if (moved && focusAfter) await invoke('focus_window', { label: targetLabel });
+		return moved;
+	}
+
+	async function carryActiveTabToNextWindow() {
+		const activeId = tabManager.activeTabId;
+		if (!activeId) return;
+		const windows = (await invoke('list_viewer_windows')) as Array<{ label: string; number: number }>;
+		const ordered = windows.slice().sort((a, b) => a.number - b.number);
+		const selfIndex = ordered.findIndex((window) => window.label === appWindow.label);
+		if (selfIndex === -1 || ordered.length === 1) {
+			await handleDetach(activeId);
+			return;
+		}
+		await moveTabToWindow(activeId, ordered[(selfIndex + 1) % ordered.length].label, true);
+	}
+
+	async function mergeAllWindowsHere() {
+		const windows = (await invoke('list_viewer_windows')) as Array<{ label: string }>;
+		const others = windows.filter((window) => window.label !== appWindow.label);
+		if (others.length === 0) {
+			addToast(t('toast.noOtherWindows', settings.language), 'info');
+			return;
+		}
+		await Promise.all(others.map((window) => emitTo(window.label, 'merge-into', appWindow.label)));
+	}
+
+	async function mergeSelfInto(targetLabel: string) {
+		if (isCloseWalkActive) return;
+		for (const tab of [...tabManager.tabs]) {
+			if (tab.path === 'HOME') {
+				tabManager.closeTab(tab.id);
+				continue;
+			}
+			await moveTabToWindow(tab.id, targetLabel);
+		}
+		if (tabManager.tabs.length === 0) await appWindow.destroy();
 	}
 
 	function startDrag(e: MouseEvent, tabId: string | null) {
@@ -2620,6 +2680,30 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 				}),
 			);
 			unlisteners.push(
+				await appWindow.listen('menu-tab-move', (event) => {
+					const { tabId, targetLabel } = event.payload as { tabId: string; targetLabel: string };
+					moveTabToWindow(tabId, targetLabel).catch((error) => console.error('Failed to move tab', error));
+				}),
+			);
+			unlisteners.push(
+				await appWindow.listen<string>('tab-transfer-offer', (event) => {
+					if (isCloseWalkActive) return;
+					windowSession.acceptOfferedTransfer(event.payload);
+				}),
+			);
+			unlisteners.push(
+				await appWindow.listen<string>('merge-into', (event) => {
+					mergeSelfInto(event.payload).catch((error) => console.error('Failed to merge window', error));
+				}),
+			);
+			unlisteners.push(
+				await appWindow.listen<string>('window-identify', (event) => {
+					identifyFlash = event.payload;
+					clearTimeout(identifyFlashTimer);
+					identifyFlashTimer = setTimeout(() => (identifyFlash = ''), 700);
+				}),
+			);
+			unlisteners.push(
 				await appWindow.listen('menu-tab-close-others', async (event) => {
 					const tabId = event.payload as string;
 					const tabsToClose = tabManager.tabs.filter((t) => t.id !== tabId).map((t) => t.id);
@@ -2834,6 +2918,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 
 		return () => {
 			isDisposed = true;
+			clearTimeout(identifyFlashTimer);
 			unlisteners.forEach((u) => u());
 		};
 	});
@@ -2859,6 +2944,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		onselectFile={selectFile}
 		onnewFile={handleNewFile}
 		onopenFile={selectFile}
+		onmergeAllWindows={mergeAllWindowsHere}
 		onsaveFile={saveContent}
 		onsaveFileAs={saveContentAs}
 		onreloadFromDisk={reloadFromDisk}
@@ -2902,6 +2988,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		onselectFile={selectFile}
 		onnewFile={handleNewFile}
 		onopenFile={selectFile}
+		onmergeAllWindows={mergeAllWindowsHere}
 		onsaveFile={saveContent}
 		onsaveFileAs={saveContentAs}
 		onreloadFromDisk={reloadFromDisk}
@@ -3263,6 +3350,12 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		oncancel={handlePromptCancel} />
 
 	<UpdateDialog />
+
+	{#if identifyFlash}
+		<div class="identify-flash" transition:fade={{ duration: 150 }}>
+			<span>{identifyFlash}</span>
+		</div>
+	{/if}
 
 	<div class="toast-container">
 		{#each toasts as toast (toast.id)}
@@ -3743,6 +3836,28 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	@keyframes fadeIn {
 		from { opacity: 0; }
 		to { opacity: 1; }
+	}
+
+	.identify-flash {
+		position: fixed;
+		inset: 0;
+		z-index: 40000;
+		pointer-events: none;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		box-shadow: inset 0 0 0 3px var(--color-accent-fg);
+		border-radius: 8px;
+	}
+
+	.identify-flash span {
+		padding: 10px 22px;
+		border-radius: 10px;
+		background: var(--color-accent-fg);
+		color: #fff;
+		font-size: 20px;
+		font-weight: 600;
+		box-shadow: 0 8px 30px rgba(0, 0, 0, 0.25);
 	}
 
 	.toast-container {

--- a/src/lib/components/ContextMenu.svelte
+++ b/src/lib/components/ContextMenu.svelte
@@ -4,6 +4,7 @@
 		shortcut?: string;
 		disabled?: boolean;
 		onClick?: () => void;
+		onHover?: () => void;
 		separator?: boolean;
 	};
 
@@ -60,6 +61,9 @@
 					<button
 						class="menu-item"
 						disabled={item.disabled}
+						onmouseenter={() => {
+							if (!item.disabled) item.onHover?.();
+						}}
 						onclick={() => {
 							if (!item.disabled && item.onClick) {
 								item.onClick();

--- a/src/lib/components/Tab.svelte
+++ b/src/lib/components/Tab.svelte
@@ -67,7 +67,19 @@
 		invoke('open_file_folder', { path: tab.path }).catch(console.error);
 	}
 
-	function handleContextMenu(e: MouseEvent) {
+	type ViewerWindowEntry = {
+		label: string;
+		number: number;
+		active_tab_title: string;
+		tab_count: number;
+	};
+
+	function windowDisplay(window: ViewerWindowEntry, lang: typeof settings.language): string {
+		const identity = `${t('menu.window', lang)} ${window.number}`;
+		return window.active_tab_title ? `${identity} · ${window.active_tab_title}` : identity;
+	}
+
+	async function handleContextMenu(e: MouseEvent) {
 		e.preventDefault();
 		e.stopPropagation();
 
@@ -77,6 +89,21 @@
 			disabled: action.disabled,
 			onClick: action.id === 'copy-path' ? copyTabPath : openTabFileLocation,
 		}));
+		const selfLabel = getCurrentWindow().label;
+		let moveToWindowItems: ContextMenuItem[] = [];
+		try {
+			const windows = (await invoke('list_viewer_windows')) as ViewerWindowEntry[];
+			moveToWindowItems = windows
+				.filter((window) => window.label !== selfLabel)
+				.map((window) => ({
+					label: `${t('menu.moveToWindow', currentLang)} ${windowDisplay(window, currentLang)}`,
+					disabled: tab.path === 'HOME',
+					onHover: () => emitTo(window.label, 'window-identify', windowDisplay(window, currentLang)),
+					onClick: () => emitTo(selfLabel, 'menu-tab-move', { tabId: tab.id, targetLabel: window.label }),
+				}));
+		} catch (error) {
+			console.error('Failed to list viewer windows', error);
+		}
 
 		tabContextMenu = {
 			show: true,
@@ -102,6 +129,7 @@
 					disabled: tab.path === 'HOME' || tabManager.tabs.length < 2,
 					onClick: () => emitTo(getCurrentWindow().label, 'menu-tab-detach', tab.id),
 				},
+				...moveToWindowItems,
 				{ separator: true },
 				{ label: t('menu.closeFile', currentLang), shortcut: 'Ctrl+W', onClick: () => emitTo(getCurrentWindow().label, 'menu-tab-close', tab.id) },
 				{ label: t('menu.closeOtherTabs', currentLang), onClick: () => emitTo(getCurrentWindow().label, 'menu-tab-close-others', tab.id) },

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -29,6 +29,7 @@
 		onselectFile,
 		onnewFile,
 		onopenFile,
+		onmergeAllWindows,
 		onsaveFile,
 		onsaveFileAs,
 		onreloadFromDisk,
@@ -70,6 +71,7 @@
 		onselectFile?: () => void;
 		onnewFile?: () => void;
 		onopenFile?: () => void;
+		onmergeAllWindows?: () => void;
 		onsaveFile?: () => void;
 		onsaveFileAs?: () => void;
 		onreloadFromDisk?: () => void;
@@ -376,7 +378,7 @@
 				{t('menu.newFile', currentLanguage)}
 				<span class="menu-shortcut">{modifier}+T</span>
 			</button>
-					<button
+			<button
 				class="home-menu-item"
 				onclick={() => {
 					homeMenuOpen = false;
@@ -391,6 +393,14 @@
 					></svg>
 				{t('menu.openFile', currentLanguage)}
 				<span class="menu-shortcut">{modifier}+O</span>
+			</button>
+			<button
+				class="home-menu-item"
+				onclick={() => {
+					homeMenuOpen = false;
+					onmergeAllWindows?.();
+				}}>
+				{t('menu.mergeAllWindows', currentLanguage)}
 			</button>
 					{#if currentFile !== '' || (tabManager.activeTab && tabManager.activeTab.isEditing)}
 						<button

--- a/src/lib/sessions/windowSession.svelte.ts
+++ b/src/lib/sessions/windowSession.svelte.ts
@@ -19,6 +19,7 @@ type WindowSessionOptions = {
 	restoredTabs: () => RestoredTab[];
 	applyRestoredContent: (tabId: string, raw: string) => Promise<void>;
 	dropRestoredTab: (tabId: string) => void;
+	canTransfer: (tabId: string) => boolean;
 	canDetach: (tabId: string) => boolean;
 	transferPayload: (tabId: string) => string;
 	onTransferClaimed: (tabId: string) => void;
@@ -98,54 +99,70 @@ export function createWindowSession(options: WindowSessionOptions) {
 		localStorage.removeItem(options.legacyStateKey);
 	}
 
+	async function acceptOfferedTransfer(token: string): Promise<boolean> {
+		try {
+			const payload = (await invoke('claim_detached_tab', { token })) as string | null;
+			const tab = payload ? validateTransferPayload(payload) : null;
+			if (!tab) {
+				options.onWarning('Tab transfer claim failed or payload invalid; opening empty window');
+				return false;
+			}
+			if (await options.acceptTransferredTab(tab)) {
+				await invoke('complete_detached_tab', { token });
+				return true;
+			}
+			return false;
+		} catch (error) {
+			options.onError('Tab transfer claim error', error);
+			return false;
+		}
+	}
+
 	async function claimTransferredTab() {
 		const claimToken = appWindow.label.startsWith('window-')
 			? appWindow.label.slice('window-'.length)
 			: null;
 		if (!claimToken) return;
-		try {
-			const payload = (await invoke('claim_detached_tab', { token: claimToken })) as string | null;
-			const tab = payload ? validateTransferPayload(payload) : null;
-			if (!tab) {
-				options.onWarning('Tab transfer claim failed or payload invalid; opening empty window');
-				return;
-			}
-			if (await options.acceptTransferredTab(tab)) {
-				await invoke('complete_detached_tab', { token: claimToken });
-			}
-		} catch (error) {
-			options.onError('Tab transfer claim error', error);
-		}
+		await acceptOfferedTransfer(claimToken);
 	}
 
-	async function detach(tabId: string) {
-		if (!options.canDetach(tabId)) return;
+	async function transfer(tabId: string, deliver: (token: string) => Promise<void>): Promise<boolean> {
+		if (!options.canTransfer(tabId)) return false;
 		const token = (await invoke('stage_detached_tab', {
 			payload: options.transferPayload(tabId),
 		})) as string;
 		let settled = false;
+		let resolveTransfer: (moved: boolean) => void;
 		const unlisten = await appWindow.listen<string>('tab-transfer-claimed', (event) => {
 			if (settled || event.payload !== token) return;
 			settled = true;
 			unlisten();
 			options.onTransferClaimed(tabId);
+			resolveTransfer(true);
 		});
-		const cancel = () => {
-			if (settled) return;
-			settled = true;
-			unlisten();
-			invoke('cancel_detached_tab', { token }).catch((error) => {
-				options.onError('Failed to cancel tab transfer', error);
+		return new Promise<boolean>((resolve) => {
+			resolveTransfer = resolve;
+			const cancel = () => {
+				if (settled) return;
+				settled = true;
+				unlisten();
+				invoke('cancel_detached_tab', { token }).catch((error) => {
+					options.onError('Failed to cancel tab transfer', error);
+				});
+				resolve(false);
+			};
+			setTimeout(cancel, 15_000);
+			deliver(token).catch((error) => {
+				options.onError('Failed to deliver tab transfer', error);
+				cancel();
 			});
-		};
-		setTimeout(cancel, 15_000);
-		try {
-			await invoke('create_transfer_window', { token });
-		} catch (error) {
-			options.onError('Failed to open new window', error);
-			cancel();
-		}
+		});
 	}
 
-	return { discardPersistedState, persistState, restore, claimTransferredTab, detach };
+	async function detach(tabId: string) {
+		if (!options.canDetach(tabId)) return false;
+		return transfer(tabId, (token) => invoke('create_transfer_window', { token }));
+	}
+
+	return { discardPersistedState, persistState, restore, claimTransferredTab, acceptOfferedTransfer, detach, transfer };
 }

--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -152,6 +152,9 @@ export const translations: Record<LanguageCode, Translation> = {
             closeFile: 'Close File',
             closeWindow: 'Close Window',
             moveToNewWindow: 'Move to New Window',
+			moveToWindow: 'Move to',
+			window: 'Window',
+			mergeAllWindows: 'Merge All Windows Here',
             undo: 'Undo',
             redo: 'Redo',
             cut: 'Cut',
@@ -239,6 +242,7 @@ export const translations: Record<LanguageCode, Translation> = {
             failedToCopyCode: 'Failed to copy code',
             unsupportedFile: 'Unsupported file type: {{filename}}',
             autoSaveFailed: 'Auto-save failed — unsaved changes still in memory',
+			noOtherWindows: 'No other windows to merge',
             savedNewerEdits: 'Saved — staying in edit mode because you have newer edits',
             openExportedFileFailed: 'Could not open exported file'
         },


### PR DESCRIPTION
## Summary

Tabs can again move directly between live windows without saving or losing unsaved content. The destination acknowledges a brokered transfer before the source removes its tab; a dead or busy destination leaves the source unchanged.

The tab context menu identifies each destination window, the window menu can merge other windows here, and Cmd/Ctrl+Shift+M carries the active tab through windows in creation order (or detaches it when no destination exists).

Rebuilds the functional scope of #225 without its stale merge history. Depends on #278; merge after it.

## Validation

- `npm run check`
- `npm test` (122 passed)
- `cargo test` (20 passed)
