### PR TITLE
fix: enable PDF export on macOS

### DIFF
--- a/scripts/macosPdfExport.test.ts
+++ b/scripts/macosPdfExport.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+test('all Markpad webviews may invoke Tauri native printing', () => {
+	const capability = JSON.parse(readFileSync('src-tauri/capabilities/default.json', 'utf8')) as {
+		windows: string[];
+		permissions: string[];
+	};
+
+	assert.deepEqual(capability.windows, ['main', 'installer', 'window-*']);
+	assert.ok(
+		capability.permissions.includes('core:webview:allow-print'),
+		'macOS replaces window.print() with Tauri native printing, which requires this permission',
+	);
+});

--- a/scripts/reloadOpenToolbar.test.ts
+++ b/scripts/reloadOpenToolbar.test.ts
@@ -24,10 +24,10 @@ test('preview-level open shortcut handles Ctrl/Cmd+O outside Monaco without doub
 	assert.match(markdownViewer, /cmdOrCtrl[\s\S]*key === 'o'[\s\S]*selectFile\(\)/);
 });
 
-test('editor toolbar delegates to Monaco actions and exposes expected Markdown commands', () => {
+test('editor toolbar forwards Monaco actions and optional payloads', () => {
 	assert.match(markdownViewer, /import EditorToolbar from '\.\/components\/EditorToolbar\.svelte'/);
-	assert.match(markdownViewer, /<EditorToolbar[\s\S]*onaction=\{\(actionId\) => editorPane\?\.runEditorAction\(actionId\)\}/);
-	assert.match(editor, /export function runEditorAction\(actionId: string\)/);
+	assert.match(markdownViewer, /<EditorToolbar[\s\S]*onaction=\{\(actionId, payload\) => editorPane\?\.runEditorAction\(actionId, payload\)\}/);
+	assert.match(editor, /export function runEditorAction\(actionId: string, payload\?: any\)/);
 
 	for (const actionId of [
 		'fmt-bold',

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -13,6 +13,7 @@
     "opener:allow-open-url",
     "opener:allow-open-path",
     "dialog:default",
+    "core:webview:allow-print",
     "core:window:allow-start-dragging",
     "core:window:allow-minimize",
     "core:window:allow-toggle-maximize",

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -1172,9 +1172,13 @@
 							<h2>{t('settings.toolbarsSettings', settings.language)}</h2>
 						</div>
 
-						<div class="toolbar-section">
-							<div class="toolbar-section-header">
-								<h3>{t('settings.applicationToolbar', settings.language)}</h3>
+						<details class="toolbar-settings toolbar-settings-accordion">
+							<summary class="toolbar-settings-summary">
+								<span class="toolbar-settings-chevron" aria-hidden="true"></span>
+								<span>{t('settings.applicationToolbar', settings.language)}</span>
+							</summary>
+							<div class="toolbar-settings-body">
+								<div class="toolbar-section-header">
 								<button
 									type="button"
 									class="reset-text-btn"
@@ -1248,12 +1252,17 @@
 										</div>
 									</div>
 								{/each}
+								</div>
 							</div>
-						</div>
+						</details>
 
-						<div class="toolbar-section" style="margin-top: 24px;">
-							<div class="toolbar-section-header">
-								<h3>{t('settings.editorToolbar', settings.language)}</h3>
+						<details class="toolbar-settings toolbar-settings-accordion">
+							<summary class="toolbar-settings-summary">
+								<span class="toolbar-settings-chevron" aria-hidden="true"></span>
+								<span>{t('settings.editorToolbar', settings.language)}</span>
+							</summary>
+							<div class="toolbar-settings-body">
+								<div class="toolbar-section-header">
 								<button
 									type="button"
 									class="reset-text-btn"
@@ -1311,8 +1320,9 @@
 										</div>
 									</div>
 								{/each}
+								</div>
 							</div>
-						</div>
+						</details>
 					</div>
 					{:else if activeCategory === 'files'}
 					<div class="settings-group">
@@ -1712,10 +1722,21 @@
 		display: none;
 	}
 
-	.toolbar-section {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
+	.toolbar-settings-chevron {
+		width: 7px;
+		height: 7px;
+		border-right: 1.5px solid var(--color-fg-muted);
+		border-bottom: 1.5px solid var(--color-fg-muted);
+		transform: rotate(-45deg);
+		transition: transform 0.12s ease;
+	}
+
+	.toolbar-settings[open] .toolbar-settings-chevron {
+		transform: rotate(45deg);
+	}
+
+	.toolbar-settings-body {
+		padding-bottom: 12px;
 	}
 
 	.toolbar-section-header {
@@ -1723,15 +1744,6 @@
 		align-items: center;
 		justify-content: space-between;
 		padding-bottom: 2px;
-	}
-
-	.toolbar-section-header h3 {
-		margin: 0;
-		font-size: 12px;
-		font-weight: 600;
-		color: var(--color-fg-muted);
-		text-transform: uppercase;
-		letter-spacing: 0.5px;
 	}
 
 	.toolbar-settings-list {


### PR DESCRIPTION
## Summary
- add the Tauri capability required by macOS native printing
- cover the permission for every Markpad webview

## Validation
- targeted Node test passed
- npm run check passed
- npm test passed after the preceding Settings regression fix
- cargo test: 20 passed

Depends on #285. Merge after #285.