### PR TITLE
fix: restore collapsed toolbar settings

### DIFF
--- a/scripts/reloadOpenToolbar.test.ts
+++ b/scripts/reloadOpenToolbar.test.ts
@@ -24,10 +24,10 @@ test('preview-level open shortcut handles Ctrl/Cmd+O outside Monaco without doub
 	assert.match(markdownViewer, /cmdOrCtrl[\s\S]*key === 'o'[\s\S]*selectFile\(\)/);
 });
 
-test('editor toolbar delegates to Monaco actions and exposes expected Markdown commands', () => {
+test('editor toolbar forwards Monaco actions and optional payloads', () => {
 	assert.match(markdownViewer, /import EditorToolbar from '\.\/components\/EditorToolbar\.svelte'/);
-	assert.match(markdownViewer, /<EditorToolbar[\s\S]*onaction=\{\(actionId\) => editorPane\?\.runEditorAction\(actionId\)\}/);
-	assert.match(editor, /export function runEditorAction\(actionId: string\)/);
+	assert.match(markdownViewer, /<EditorToolbar[\s\S]*onaction=\{\(actionId, payload\) => editorPane\?\.runEditorAction\(actionId, payload\)\}/);
+	assert.match(editor, /export function runEditorAction\(actionId: string, payload\?: any\)/);
 
 	for (const actionId of [
 		'fmt-bold',

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -1172,9 +1172,13 @@
 							<h2>{t('settings.toolbarsSettings', settings.language)}</h2>
 						</div>
 
-						<div class="toolbar-section">
-							<div class="toolbar-section-header">
-								<h3>{t('settings.applicationToolbar', settings.language)}</h3>
+						<details class="toolbar-settings toolbar-settings-accordion">
+							<summary class="toolbar-settings-summary">
+								<span class="toolbar-settings-chevron" aria-hidden="true"></span>
+								<span>{t('settings.applicationToolbar', settings.language)}</span>
+							</summary>
+							<div class="toolbar-settings-body">
+								<div class="toolbar-section-header">
 								<button
 									type="button"
 									class="reset-text-btn"
@@ -1248,12 +1252,17 @@
 										</div>
 									</div>
 								{/each}
+								</div>
 							</div>
-						</div>
+						</details>
 
-						<div class="toolbar-section" style="margin-top: 24px;">
-							<div class="toolbar-section-header">
-								<h3>{t('settings.editorToolbar', settings.language)}</h3>
+						<details class="toolbar-settings toolbar-settings-accordion">
+							<summary class="toolbar-settings-summary">
+								<span class="toolbar-settings-chevron" aria-hidden="true"></span>
+								<span>{t('settings.editorToolbar', settings.language)}</span>
+							</summary>
+							<div class="toolbar-settings-body">
+								<div class="toolbar-section-header">
 								<button
 									type="button"
 									class="reset-text-btn"
@@ -1311,8 +1320,9 @@
 										</div>
 									</div>
 								{/each}
+								</div>
 							</div>
-						</div>
+						</details>
 					</div>
 					{:else if activeCategory === 'files'}
 					<div class="settings-group">
@@ -1712,10 +1722,21 @@
 		display: none;
 	}
 
-	.toolbar-section {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
+	.toolbar-settings-chevron {
+		width: 7px;
+		height: 7px;
+		border-right: 1.5px solid var(--color-fg-muted);
+		border-bottom: 1.5px solid var(--color-fg-muted);
+		transform: rotate(-45deg);
+		transition: transform 0.12s ease;
+	}
+
+	.toolbar-settings[open] .toolbar-settings-chevron {
+		transform: rotate(45deg);
+	}
+
+	.toolbar-settings-body {
+		padding-bottom: 12px;
 	}
 
 	.toolbar-section-header {
@@ -1723,15 +1744,6 @@
 		align-items: center;
 		justify-content: space-between;
 		padding-bottom: 2px;
-	}
-
-	.toolbar-section-header h3 {
-		margin: 0;
-		font-size: 12px;
-		font-weight: 600;
-		color: var(--color-fg-muted);
-		text-transform: uppercase;
-		letter-spacing: 0.5px;
 	}
 
 	.toolbar-settings-list {


### PR DESCRIPTION
## Summary
- restore collapsed Application Toolbar and Editor Toolbar sections in Settings
- keep the newer icon controls and toolbar payload forwarding
- refresh the toolbar assertion for the optional action payload

## Validation
- npm run check: passed with no warnings
- npm test: 127 passed
- cargo test: 20 passed

First PR in the ordered chain.