### PR TITLE
fix: delimit parenthesized autolinks

### DIFF
--- a/scripts/reloadOpenToolbar.test.ts
+++ b/scripts/reloadOpenToolbar.test.ts
@@ -24,10 +24,10 @@ test('preview-level open shortcut handles Ctrl/Cmd+O outside Monaco without doub
 	assert.match(markdownViewer, /cmdOrCtrl[\s\S]*key === 'o'[\s\S]*selectFile\(\)/);
 });
 
-test('editor toolbar delegates to Monaco actions and exposes expected Markdown commands', () => {
+test('editor toolbar forwards Monaco actions and optional payloads', () => {
 	assert.match(markdownViewer, /import EditorToolbar from '\.\/components\/EditorToolbar\.svelte'/);
-	assert.match(markdownViewer, /<EditorToolbar[\s\S]*onaction=\{\(actionId\) => editorPane\?\.runEditorAction\(actionId\)\}/);
-	assert.match(editor, /export function runEditorAction\(actionId: string\)/);
+	assert.match(markdownViewer, /<EditorToolbar[\s\S]*onaction=\{\(actionId, payload\) => editorPane\?\.runEditorAction\(actionId, payload\)\}/);
+	assert.match(editor, /export function runEditorAction\(actionId: string, payload\?: any\)/);
 
 	for (const actionId of [
 		'fmt-bold',

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -276,6 +276,22 @@ mod tests {
     }
 
     #[test]
+    fn autolink_inside_parentheses_stops_before_adjacent_text() {
+        let input = "See (https://www.speedtest.net/awards/united_states/)for more information.";
+        let html = convert_markdown(input);
+
+        assert!(
+            html.contains("href=\"https://www.speedtest.net/awards/united_states/\""),
+            "got: {html}"
+        );
+        assert!(html.contains(")for more information."), "got: {html}");
+        assert!(
+            !html.contains("href=\"https://www.speedtest.net/awards/united_states/)for\""),
+            "got: {html}"
+        );
+    }
+
+    #[test]
     fn path_components_reject_traversal_separators_and_absolute_paths() {
         for invalid in ["", ".", "..", "../theme", "folder/theme", "folder\\theme", "/tmp/theme"] {
             assert!(safe_path_component(invalid, "test").is_err(), "{invalid}");
@@ -631,9 +647,81 @@ fn process_wikilinks<'a>(content: &'a str) -> Cow<'a, str> {
     processed
 }
 
+fn process_parenthesized_autolinks(content: &str) -> Cow<'_, str> {
+    let regions = code_region_ranges(content);
+    let mut output = String::new();
+    let mut copied_to = 0;
+    let mut scan_from = 0;
+
+    while let Some(opening_offset) = content[scan_from..].find('(') {
+        let opening = scan_from + opening_offset;
+        let url_start = opening + 1;
+        let url_tail = &content[url_start..];
+        if !(url_tail.starts_with("http://")
+            || url_tail.starts_with("https://")
+            || url_tail.starts_with("ftp://"))
+        {
+            scan_from = url_start;
+            continue;
+        }
+
+        let mut depth = 1usize;
+        let mut closing = None;
+        for (offset, ch) in url_tail.char_indices() {
+            if ch.is_whitespace() {
+                break;
+            }
+            match ch {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        closing = Some(url_start + offset);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let Some(closing) = closing else {
+            scan_from = url_start;
+            continue;
+        };
+        let after_closing = closing + ')'.len_utf8();
+        let adjacent_text = content[after_closing..]
+            .chars()
+            .next()
+            .is_some_and(char::is_alphanumeric);
+        if !adjacent_text || in_code_region(&regions, opening) {
+            scan_from = after_closing;
+            continue;
+        }
+
+        let url = &content[url_start..closing];
+        output.push_str(&content[copied_to..url_start]);
+        output.push('[');
+        output.push_str(url);
+        output.push_str("](");
+        output.push_str(url);
+        output.push_str(")");
+        output.push(')');
+        copied_to = after_closing;
+        scan_from = after_closing;
+    }
+
+    if output.is_empty() {
+        Cow::Borrowed(content)
+    } else {
+        output.push_str(&content[copied_to..]);
+        Cow::Owned(output)
+    }
+}
+
 #[tauri::command]
 fn convert_markdown(content: &str) -> String {
-    let processed_embeds = process_internal_embeds(content);
+    let processed_autolinks = process_parenthesized_autolinks(content);
+    let processed_embeds = process_internal_embeds(&processed_autolinks);
     let processed_links = process_wikilinks(&processed_embeds);
 
     let mut options = ComrakOptions {

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -1172,9 +1172,13 @@
 							<h2>{t('settings.toolbarsSettings', settings.language)}</h2>
 						</div>
 
-						<div class="toolbar-section">
-							<div class="toolbar-section-header">
-								<h3>{t('settings.applicationToolbar', settings.language)}</h3>
+						<details class="toolbar-settings toolbar-settings-accordion">
+							<summary class="toolbar-settings-summary">
+								<span class="toolbar-settings-chevron" aria-hidden="true"></span>
+								<span>{t('settings.applicationToolbar', settings.language)}</span>
+							</summary>
+							<div class="toolbar-settings-body">
+								<div class="toolbar-section-header">
 								<button
 									type="button"
 									class="reset-text-btn"
@@ -1248,12 +1252,17 @@
 										</div>
 									</div>
 								{/each}
+								</div>
 							</div>
-						</div>
+						</details>
 
-						<div class="toolbar-section" style="margin-top: 24px;">
-							<div class="toolbar-section-header">
-								<h3>{t('settings.editorToolbar', settings.language)}</h3>
+						<details class="toolbar-settings toolbar-settings-accordion">
+							<summary class="toolbar-settings-summary">
+								<span class="toolbar-settings-chevron" aria-hidden="true"></span>
+								<span>{t('settings.editorToolbar', settings.language)}</span>
+							</summary>
+							<div class="toolbar-settings-body">
+								<div class="toolbar-section-header">
 								<button
 									type="button"
 									class="reset-text-btn"
@@ -1311,8 +1320,9 @@
 										</div>
 									</div>
 								{/each}
+								</div>
 							</div>
-						</div>
+						</details>
 					</div>
 					{:else if activeCategory === 'files'}
 					<div class="settings-group">
@@ -1712,10 +1722,21 @@
 		display: none;
 	}
 
-	.toolbar-section {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
+	.toolbar-settings-chevron {
+		width: 7px;
+		height: 7px;
+		border-right: 1.5px solid var(--color-fg-muted);
+		border-bottom: 1.5px solid var(--color-fg-muted);
+		transform: rotate(-45deg);
+		transition: transform 0.12s ease;
+	}
+
+	.toolbar-settings[open] .toolbar-settings-chevron {
+		transform: rotate(45deg);
+	}
+
+	.toolbar-settings-body {
+		padding-bottom: 12px;
 	}
 
 	.toolbar-section-header {
@@ -1723,15 +1744,6 @@
 		align-items: center;
 		justify-content: space-between;
 		padding-bottom: 2px;
-	}
-
-	.toolbar-section-header h3 {
-		margin: 0;
-		font-size: 12px;
-		font-weight: 600;
-		color: var(--color-fg-muted);
-		text-transform: uppercase;
-		letter-spacing: 0.5px;
 	}
 
 	.toolbar-settings-list {


### PR DESCRIPTION
Fixes #290

Parenthesized bare URLs followed immediately by text are rendered as explicit Markdown links, so the closing parenthesis and following text stay outside the URL.

Includes a Rust regression test for the reported Speedtest URL.

Depends on #286 because upstream master currently has the toolbar-test regression fixed there; merge #286 first.