### PR TITLE
fix: preserve tabs after document read errors

### DIFF
--- a/scripts/documentLoadFailure.test.ts
+++ b/scripts/documentLoadFailure.test.ts
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const session = readFileSync('src/lib/sessions/documentSession.svelte.ts', 'utf8');
+
+test('a transient missing-file read error preserves the open tab', () => {
+	assert.doesNotMatch(session, /tabManager\.closeTab/);
+	assert.match(session, /options\.onError\('Error loading file', error\);/);
+});

--- a/scripts/macosPdfExport.test.ts
+++ b/scripts/macosPdfExport.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+test('all Markpad webviews may invoke Tauri native printing', () => {
+	const capability = JSON.parse(readFileSync('src-tauri/capabilities/default.json', 'utf8')) as {
+		windows: string[];
+		permissions: string[];
+	};
+
+	assert.deepEqual(capability.windows, ['main', 'installer', 'window-*']);
+	assert.ok(
+		capability.permissions.includes('core:webview:allow-print'),
+		'macOS replaces window.print() with Tauri native printing, which requires this permission',
+	);
+});

--- a/scripts/reloadOpenToolbar.test.ts
+++ b/scripts/reloadOpenToolbar.test.ts
@@ -24,10 +24,10 @@ test('preview-level open shortcut handles Ctrl/Cmd+O outside Monaco without doub
 	assert.match(markdownViewer, /cmdOrCtrl[\s\S]*key === 'o'[\s\S]*selectFile\(\)/);
 });
 
-test('editor toolbar delegates to Monaco actions and exposes expected Markdown commands', () => {
+test('editor toolbar forwards Monaco actions and optional payloads', () => {
 	assert.match(markdownViewer, /import EditorToolbar from '\.\/components\/EditorToolbar\.svelte'/);
-	assert.match(markdownViewer, /<EditorToolbar[\s\S]*onaction=\{\(actionId\) => editorPane\?\.runEditorAction\(actionId\)\}/);
-	assert.match(editor, /export function runEditorAction\(actionId: string\)/);
+	assert.match(markdownViewer, /<EditorToolbar[\s\S]*onaction=\{\(actionId, payload\) => editorPane\?\.runEditorAction\(actionId, payload\)\}/);
+	assert.match(editor, /export function runEditorAction\(actionId: string, payload\?: any\)/);
 
 	for (const actionId of [
 		'fmt-bold',

--- a/scripts/windowTitleCapability.test.ts
+++ b/scripts/windowTitleCapability.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+test('all Markpad windows may update their native title', () => {
+	const capability = JSON.parse(readFileSync('src-tauri/capabilities/default.json', 'utf8')) as {
+		permissions: string[];
+	};
+
+	assert.ok(
+		capability.permissions.includes('core:window:allow-set-title'),
+		'window tags and active document names call appWindow.setTitle(), which requires this permission',
+	);
+});

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -15,6 +15,7 @@
     "dialog:default",
     "core:webview:allow-print",
     "core:window:allow-start-dragging",
+    "core:window:allow-set-title",
     "core:window:allow-minimize",
     "core:window:allow-toggle-maximize",
     "core:window:allow-close",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -13,6 +13,7 @@
     "opener:allow-open-url",
     "opener:allow-open-path",
     "dialog:default",
+    "core:webview:allow-print",
     "core:window:allow-start-dragging",
     "core:window:allow-minimize",
     "core:window:allow-toggle-maximize",

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -1172,9 +1172,13 @@
 							<h2>{t('settings.toolbarsSettings', settings.language)}</h2>
 						</div>
 
-						<div class="toolbar-section">
-							<div class="toolbar-section-header">
-								<h3>{t('settings.applicationToolbar', settings.language)}</h3>
+						<details class="toolbar-settings toolbar-settings-accordion">
+							<summary class="toolbar-settings-summary">
+								<span class="toolbar-settings-chevron" aria-hidden="true"></span>
+								<span>{t('settings.applicationToolbar', settings.language)}</span>
+							</summary>
+							<div class="toolbar-settings-body">
+								<div class="toolbar-section-header">
 								<button
 									type="button"
 									class="reset-text-btn"
@@ -1248,12 +1252,17 @@
 										</div>
 									</div>
 								{/each}
+								</div>
 							</div>
-						</div>
+						</details>
 
-						<div class="toolbar-section" style="margin-top: 24px;">
-							<div class="toolbar-section-header">
-								<h3>{t('settings.editorToolbar', settings.language)}</h3>
+						<details class="toolbar-settings toolbar-settings-accordion">
+							<summary class="toolbar-settings-summary">
+								<span class="toolbar-settings-chevron" aria-hidden="true"></span>
+								<span>{t('settings.editorToolbar', settings.language)}</span>
+							</summary>
+							<div class="toolbar-settings-body">
+								<div class="toolbar-section-header">
 								<button
 									type="button"
 									class="reset-text-btn"
@@ -1311,8 +1320,9 @@
 										</div>
 									</div>
 								{/each}
+								</div>
 							</div>
-						</div>
+						</details>
 					</div>
 					{:else if activeCategory === 'files'}
 					<div class="settings-group">
@@ -1712,10 +1722,21 @@
 		display: none;
 	}
 
-	.toolbar-section {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
+	.toolbar-settings-chevron {
+		width: 7px;
+		height: 7px;
+		border-right: 1.5px solid var(--color-fg-muted);
+		border-bottom: 1.5px solid var(--color-fg-muted);
+		transform: rotate(-45deg);
+		transition: transform 0.12s ease;
+	}
+
+	.toolbar-settings[open] .toolbar-settings-chevron {
+		transform: rotate(45deg);
+	}
+
+	.toolbar-settings-body {
+		padding-bottom: 12px;
 	}
 
 	.toolbar-section-header {
@@ -1723,15 +1744,6 @@
 		align-items: center;
 		justify-content: space-between;
 		padding-bottom: 2px;
-	}
-
-	.toolbar-section-header h3 {
-		margin: 0;
-		font-size: 12px;
-		font-weight: 600;
-		color: var(--color-fg-muted);
-		text-transform: uppercase;
-		letter-spacing: 0.5px;
 	}
 
 	.toolbar-settings-list {

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -142,11 +142,10 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 			if (filePath) options.saveRecentFile(filePath);
 		} catch (error) {
 			console.error('Error loading file:', error);
-			const errorText = String(error);
-			if (errorText.includes('The system cannot find the file specified') || errorText.includes('No such file or directory')) {
-				options.deleteRecentFile(filePath);
-				if (tabManager.activeTab?.path === filePath) tabManager.closeTab(tabManager.activeTab.id);
-			} else options.onError('Error loading file', error);
+			// A watcher can observe a transient gap while another process replaces
+			// the file. Keep the already-open buffer and recent-file entry instead
+			// of closing the tab and discarding the user's recovery path.
+			options.onError('Error loading file', error);
 		}
 	}
 


### PR DESCRIPTION
Fixes #292

Keep the tab, its in-memory buffer, and the recent-file entry when a document read fails. A transient missing-file event during an external atomic replacement can no longer close a recoverable document.

Depends on #288. Please merge in this order: #286 → #287 → #288 → this PR.

Validation:
- npm ci
- npm run check
- npm test
- cargo test