### PR TITLE
Update vulnerable Svelte build toolchain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,15 +27,15 @@
 				"yaml": "^2.9.0"
 			},
 			"devDependencies": {
-				"@sveltejs/adapter-static": "^3.0.6",
-				"@sveltejs/kit": "^2.9.0",
-				"@sveltejs/vite-plugin-svelte": "^5.0.0",
+				"@sveltejs/adapter-static": "^3.0.10",
+				"@sveltejs/kit": "^2.70.2",
+				"@sveltejs/vite-plugin-svelte": "^5.1.1",
 				"@tauri-apps/cli": "^2",
-				"svelte": "^5.0.0",
-				"svelte-check": "^4.0.0",
+				"svelte": "^5.56.8",
+				"svelte-check": "^4.7.4",
 				"tsx": "^4.22.4",
 				"typescript": "~5.6.2",
-				"vite": "^6.0.3"
+				"vite": "^6.4.3"
 			}
 		},
 		"node_modules/@antfu/install-pkg": {
@@ -589,9 +589,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.55.1.tgz",
-			"integrity": "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
+			"integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
 			"cpu": [
 				"arm"
 			],
@@ -603,9 +603,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.55.1.tgz",
-			"integrity": "sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
+			"integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
 			"cpu": [
 				"arm64"
 			],
@@ -617,9 +617,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.55.1.tgz",
-			"integrity": "sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
+			"integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -631,9 +631,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.55.1.tgz",
-			"integrity": "sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
+			"integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
 			"cpu": [
 				"x64"
 			],
@@ -645,9 +645,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.55.1.tgz",
-			"integrity": "sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
+			"integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -659,9 +659,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.55.1.tgz",
-			"integrity": "sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
+			"integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
 			"cpu": [
 				"x64"
 			],
@@ -673,13 +673,16 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.55.1.tgz",
-			"integrity": "sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
+			"integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -687,13 +690,16 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.55.1.tgz",
-			"integrity": "sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
+			"integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -701,13 +707,16 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.55.1.tgz",
-			"integrity": "sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
+			"integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -715,13 +724,16 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.55.1.tgz",
-			"integrity": "sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
+			"integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -729,13 +741,16 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-loong64-gnu": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.55.1.tgz",
-			"integrity": "sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
+			"integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
 			"cpu": [
 				"loong64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -743,13 +758,16 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-loong64-musl": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.55.1.tgz",
-			"integrity": "sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
+			"integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
 			"cpu": [
 				"loong64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -757,13 +775,16 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.55.1.tgz",
-			"integrity": "sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
+			"integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -771,13 +792,16 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-musl": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.55.1.tgz",
-			"integrity": "sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
+			"integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
 			"cpu": [
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -785,13 +809,16 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.55.1.tgz",
-			"integrity": "sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
+			"integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
 			"cpu": [
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -799,13 +826,16 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.55.1.tgz",
-			"integrity": "sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
+			"integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
 			"cpu": [
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -813,13 +843,16 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.55.1.tgz",
-			"integrity": "sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
+			"integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
 			"cpu": [
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -827,13 +860,16 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.1.tgz",
-			"integrity": "sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+			"integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -841,13 +877,16 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.1.tgz",
-			"integrity": "sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
+			"integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -855,9 +894,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-openbsd-x64": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.55.1.tgz",
-			"integrity": "sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
+			"integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
 			"cpu": [
 				"x64"
 			],
@@ -869,9 +908,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-openharmony-arm64": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.55.1.tgz",
-			"integrity": "sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
+			"integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
 			"cpu": [
 				"arm64"
 			],
@@ -883,9 +922,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.55.1.tgz",
-			"integrity": "sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
+			"integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
 			"cpu": [
 				"arm64"
 			],
@@ -897,9 +936,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.55.1.tgz",
-			"integrity": "sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
+			"integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -911,9 +950,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-gnu": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.55.1.tgz",
-			"integrity": "sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
+			"integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
 			"cpu": [
 				"x64"
 			],
@@ -925,9 +964,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.55.1.tgz",
-			"integrity": "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
+			"integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
 			"cpu": [
 				"x64"
 			],
@@ -946,9 +985,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@sveltejs/acorn-typescript": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.8.tgz",
-			"integrity": "sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==",
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.11.tgz",
+			"integrity": "sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -966,24 +1005,23 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.49.4",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.49.4.tgz",
-			"integrity": "sha512-JFtOqDoU0DI/+QSG8qnq5bKcehVb3tCHhOG4amsSYth5/KgO4EkJvi42xSAiyKmXAAULW1/Zdb6lkgGEgSxdZg==",
+			"version": "2.70.2",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.70.2.tgz",
+			"integrity": "sha512-RzRoRpuR2KXqc5yMO0akQHDZeT4AslOlznGITURsqHaVbtyYP4Wn3eE3gxj9JcDyNYO0crkxhdwFHc+2vkVm6w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
-				"@sveltejs/acorn-typescript": "^1.0.5",
+				"@sveltejs/acorn-typescript": "^1.0.9",
 				"@types/cookie": "^0.6.0",
-				"acorn": "^8.14.1",
+				"acorn": "^8.16.0",
 				"cookie": "^0.6.0",
-				"devalue": "^5.3.2",
+				"devalue": "^5.8.1",
 				"esm-env": "^1.2.2",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.5",
 				"mrmime": "^2.0.0",
-				"sade": "^1.8.1",
-				"set-cookie-parser": "^2.6.0",
+				"set-cookie-parser": "^3.0.0",
 				"sirv": "^3.0.0"
 			},
 			"bin": {
@@ -994,10 +1032,10 @@
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.0.0",
-				"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0",
+				"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0",
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
-				"typescript": "^5.3.3",
-				"vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0"
+				"typescript": "^5.3.3 || ^6.0.0",
+				"vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@opentelemetry/api": {
@@ -1006,6 +1044,16 @@
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@sveltejs/load-config": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.1.tgz",
+			"integrity": "sha512-5m3B2cbqQ4TbwW6Xkh66Ntw6dD7gNc77cCxABTTesWcq9jxIzMgTk97pZx5vEtvQx8iokgi7GIphqZe+PGwcZA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18.0.0"
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
@@ -1556,9 +1604,9 @@
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1585,9 +1633,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+			"integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -1597,9 +1645,9 @@
 			}
 		},
 		"node_modules/aria-query": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
-			"integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+			"integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -1658,9 +1706,9 @@
 			"license": "MIT"
 		},
 		"node_modules/cookie": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2228,9 +2276,9 @@
 			}
 		},
 		"node_modules/devalue": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.1.tgz",
-			"integrity": "sha512-jDwizj+IlEZBunHcOuuFVBnIMPAEHvTsJj0BcIp94xYguLRVBcXO853px/MyIJvbVzWdsGvrRweIUWJw8hBP7A==",
+			"version": "5.9.0",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
+			"integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2304,13 +2352,21 @@
 			"license": "MIT"
 		},
 		"node_modules/esrap": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.1.tgz",
-			"integrity": "sha512-GiYWG34AN/4CUyaWAgunGt0Rxvr1PTMlGC0vvEov/uOQYWne2bpN03Um+k8jT+q3op33mKouP2zeJ6OlM+qeUg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.3.0.tgz",
+			"integrity": "sha512-GQ/7RN8uOtEfNpzZzBMTzW9JBcX42oaSVtPzdF+6cEL8pqIL094iUpr9jzYGn4O4P/1S60dJ6izyT8F4LYARng==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/types": "^8.2.0"
+			},
+			"peerDependenciesMeta": {
+				"@typescript-eslint/types": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/fdir": {
@@ -2568,9 +2624,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -2624,9 +2680,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2664,9 +2720,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"version": "8.5.25",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+			"integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
 			"dev": true,
 			"funding": [
 				{
@@ -2684,7 +2740,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -2713,13 +2769,13 @@
 			"license": "Unlicense"
 		},
 		"node_modules/rollup": {
-			"version": "4.55.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
-			"integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
+			"version": "4.62.3",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
+			"integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/estree": "1.0.8"
+				"@types/estree": "1.0.9"
 			},
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -2729,31 +2785,31 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.55.1",
-				"@rollup/rollup-android-arm64": "4.55.1",
-				"@rollup/rollup-darwin-arm64": "4.55.1",
-				"@rollup/rollup-darwin-x64": "4.55.1",
-				"@rollup/rollup-freebsd-arm64": "4.55.1",
-				"@rollup/rollup-freebsd-x64": "4.55.1",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.55.1",
-				"@rollup/rollup-linux-arm-musleabihf": "4.55.1",
-				"@rollup/rollup-linux-arm64-gnu": "4.55.1",
-				"@rollup/rollup-linux-arm64-musl": "4.55.1",
-				"@rollup/rollup-linux-loong64-gnu": "4.55.1",
-				"@rollup/rollup-linux-loong64-musl": "4.55.1",
-				"@rollup/rollup-linux-ppc64-gnu": "4.55.1",
-				"@rollup/rollup-linux-ppc64-musl": "4.55.1",
-				"@rollup/rollup-linux-riscv64-gnu": "4.55.1",
-				"@rollup/rollup-linux-riscv64-musl": "4.55.1",
-				"@rollup/rollup-linux-s390x-gnu": "4.55.1",
-				"@rollup/rollup-linux-x64-gnu": "4.55.1",
-				"@rollup/rollup-linux-x64-musl": "4.55.1",
-				"@rollup/rollup-openbsd-x64": "4.55.1",
-				"@rollup/rollup-openharmony-arm64": "4.55.1",
-				"@rollup/rollup-win32-arm64-msvc": "4.55.1",
-				"@rollup/rollup-win32-ia32-msvc": "4.55.1",
-				"@rollup/rollup-win32-x64-gnu": "4.55.1",
-				"@rollup/rollup-win32-x64-msvc": "4.55.1",
+				"@rollup/rollup-android-arm-eabi": "4.62.3",
+				"@rollup/rollup-android-arm64": "4.62.3",
+				"@rollup/rollup-darwin-arm64": "4.62.3",
+				"@rollup/rollup-darwin-x64": "4.62.3",
+				"@rollup/rollup-freebsd-arm64": "4.62.3",
+				"@rollup/rollup-freebsd-x64": "4.62.3",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
+				"@rollup/rollup-linux-arm-musleabihf": "4.62.3",
+				"@rollup/rollup-linux-arm64-gnu": "4.62.3",
+				"@rollup/rollup-linux-arm64-musl": "4.62.3",
+				"@rollup/rollup-linux-loong64-gnu": "4.62.3",
+				"@rollup/rollup-linux-loong64-musl": "4.62.3",
+				"@rollup/rollup-linux-ppc64-gnu": "4.62.3",
+				"@rollup/rollup-linux-ppc64-musl": "4.62.3",
+				"@rollup/rollup-linux-riscv64-gnu": "4.62.3",
+				"@rollup/rollup-linux-riscv64-musl": "4.62.3",
+				"@rollup/rollup-linux-s390x-gnu": "4.62.3",
+				"@rollup/rollup-linux-x64-gnu": "4.62.3",
+				"@rollup/rollup-linux-x64-musl": "4.62.3",
+				"@rollup/rollup-openbsd-x64": "4.62.3",
+				"@rollup/rollup-openharmony-arm64": "4.62.3",
+				"@rollup/rollup-win32-arm64-msvc": "4.62.3",
+				"@rollup/rollup-win32-ia32-msvc": "4.62.3",
+				"@rollup/rollup-win32-x64-gnu": "4.62.3",
+				"@rollup/rollup-win32-x64-msvc": "4.62.3",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -2795,9 +2851,9 @@
 			"license": "MIT"
 		},
 		"node_modules/set-cookie-parser": {
-			"version": "2.7.2",
-			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-			"integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
+			"integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2833,23 +2889,24 @@
 			"license": "MIT"
 		},
 		"node_modules/svelte": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.46.3.tgz",
-			"integrity": "sha512-Y5juST3x+/ySty5tYJCVWa6Corkxpt25bUZQHqOceg9xfMUtDsFx6rCsG6cYf1cA6vzDi66HIvaki0byZZX95A==",
+			"version": "5.56.8",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.8.tgz",
+			"integrity": "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
-				"@sveltejs/acorn-typescript": "^1.0.5",
+				"@sveltejs/acorn-typescript": "^1.0.10",
 				"@types/estree": "^1.0.5",
+				"@types/trusted-types": "^2.0.7",
 				"acorn": "^8.12.1",
-				"aria-query": "^5.3.1",
+				"aria-query": "5.3.1",
 				"axobject-query": "^4.1.0",
 				"clsx": "^2.1.1",
-				"devalue": "^5.5.0",
+				"devalue": "^5.8.1",
 				"esm-env": "^1.2.1",
-				"esrap": "^2.2.1",
+				"esrap": "^2.2.12",
 				"is-reference": "^3.0.3",
 				"locate-character": "^3.0.0",
 				"magic-string": "^0.30.11",
@@ -2860,13 +2917,14 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.3.5.tgz",
-			"integrity": "sha512-e4VWZETyXaKGhpkxOXP+B/d0Fp/zKViZoJmneZWe/05Y2aqSKj3YN2nLfYPJBQ87WEiY4BQCQ9hWGu9mPT1a1Q==",
+			"version": "4.7.4",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.4.tgz",
+			"integrity": "sha512-IW9ot9YqAoyv8FvyN+eb4ZTe8zgcKZrJLNYU6dzSKkGwEBsSPc4K7lmQ8bKn8W2YMXM6WDfZSSVOaGtekyUfOQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
+				"@sveltejs/load-config": "^0.2.1",
 				"chokidar": "^4.0.1",
 				"fdir": "^6.2.0",
 				"picocolors": "^1.0.0",
@@ -2880,7 +2938,7 @@
 			},
 			"peerDependencies": {
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
-				"typescript": ">=5.0.0"
+				"typescript": "^5.0.0 || ^6.0.0"
 			}
 		},
 		"node_modules/tinyexec": {
@@ -3465,9 +3523,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-			"integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+			"version": "6.4.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+			"integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,17 +36,18 @@
 		"yaml": "^2.9.0"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-static": "^3.0.6",
-		"@sveltejs/kit": "^2.9.0",
-		"@sveltejs/vite-plugin-svelte": "^5.0.0",
+		"@sveltejs/adapter-static": "^3.0.10",
+		"@sveltejs/kit": "^2.70.2",
+		"@sveltejs/vite-plugin-svelte": "^5.1.1",
 		"@tauri-apps/cli": "^2",
-		"svelte": "^5.0.0",
-		"svelte-check": "^4.0.0",
+		"svelte": "^5.56.8",
+		"svelte-check": "^4.7.4",
 		"tsx": "^4.22.4",
 		"typescript": "~5.6.2",
-		"vite": "^6.0.3"
+		"vite": "^6.4.3"
 	},
 	"overrides": {
+		"cookie": "0.7.2",
 		"dompurify": "3.4.12"
 	}
 }


### PR DESCRIPTION
Fixes #309

Updates SvelteKit, Svelte, Vite, and the matching adapter/plugin/check packages within their existing major release lines. The lockfile refresh also updates affected transitive packages.

Pins `cookie` to 0.7.2 because the latest SvelteKit 2 dependency range still resolves its vulnerable 0.6.0 release.

The complete resolved lockfile is clean under `npm audit`.

This is the next stacked change after #308; merge the already-listed predecessor PRs first, then this PR.

Validated with `npm ci`, `npm run check` (0 errors; one Settings drag-header accessibility warning detected by the newer checker is being handled separately), `npm test` (136 passing), `npm run build`, `npm audit` (0 vulnerabilities), and `cargo test` (21 passing).