### PR TITLE
Keep Settings modal drag accessible

### DIFF
--- a/scripts/toolbarCustomizationWiring.test.ts
+++ b/scripts/toolbarCustomizationWiring.test.ts
@@ -63,9 +63,13 @@ test('settings modal uses a dedicated resize handle instead of native CSS resize
 	assert.match(settingsComponent, /\.settings-modal[\s\S]*max-height:/);
 });
 
-test('settings modal can be dragged by the header and resized from every edge', () => {
+test('settings modal starts dragging only from the non-interactive header surface', () => {
 	assert.match(settingsComponent, /handleSettingsModalDragPointerDown/);
-	assert.match(settingsComponent, /class="settings-header"[\s\S]*onpointerdown=\{handleSettingsModalDragPointerDown\}/);
+	assert.match(settingsComponent, /class="settings-modal"[\s\S]*onpointerdown=\{handleSettingsModalDragPointerDown\}/);
+	assert.match(settingsComponent, /closest\('\.settings-header'\)/);
+	assert.doesNotMatch(settingsComponent, /class="settings-header"[^>]*onpointerdown=/);
+	assert.match(settingsComponent, /isSettingsHeaderInteractiveTarget\(e\.target\)/);
+
 	assert.match(settingsComponent, /settingsResizeHandles/);
 	for (const handleClass of ['resize-n', 'resize-ne', 'resize-e', 'resize-se', 'resize-s', 'resize-sw', 'resize-w', 'resize-nw']) {
 		assert.match(settingsComponent, new RegExp(`className: '${handleClass}'`));

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -313,7 +313,8 @@
 	}
 
 	function handleSettingsModalDragPointerDown(e: PointerEvent) {
-		if (e.button !== 0 || isSettingsHeaderInteractiveTarget(e.target)) return;
+		const header = e.target instanceof HTMLElement ? e.target.closest('.settings-header') : null;
+		if (e.button !== 0 || !header || !settingsModal?.contains(header) || isSettingsHeaderInteractiveTarget(e.target)) return;
 		const frame = getCurrentSettingsModalFrame();
 		if (!frame) return;
 
@@ -575,8 +576,9 @@
 			aria-modal="true"
 			aria-labelledby="settings-title"
 			tabindex="-1"
+			onpointerdown={handleSettingsModalDragPointerDown}
 			onkeydown={handleModalKeydown}>
-			<div class="settings-header" onpointerdown={handleSettingsModalDragPointerDown}>
+			<div class="settings-header">
 				<h1 id="settings-title">{t('settings.title', settings.language)}</h1>
 				<button class="close-btn" onclick={onclose} aria-label={t('common.close', settings.language)}>
 					<svg


### PR DESCRIPTION
Fixes #311

Moves the pointer listener from the non-interactive header to the existing dialog element, while starting a drag only when the event originated from the header’s non-interactive surface. The close button remains excluded. This preserves mouse dragging without giving a header that contains a button an invalid interactive role.

Adds a regression test for the event ownership and scope.

This is stacked after #310; merge the predecessor chain first.

Validated with `npm run check` (0 errors, 0 warnings), `npm test` (136 passing), `npm run build`, and `cargo test` (21 passing).