### PR TITLE
Audit complete dependency lockfile in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,8 @@ jobs:
       - name: install frontend dependencies
         run: npm ci
 
-      - name: audit production dependencies
-        run: npm audit --omit=dev
+      - name: audit complete dependency lockfile
+        run: npm audit
 
       - name: check frontend
         run: npm run check

--- a/scripts/workflowSecurityAudit.test.ts
+++ b/scripts/workflowSecurityAudit.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 
 const workflow = readFileSync('.github/workflows/test.yml', 'utf8');
 
-test('pull-request checks reject vulnerable production dependencies', () => {
-	assert.match(workflow, /name: audit production dependencies[\s\S]*run: npm audit --omit=dev/);
+test('pull-request checks reject vulnerabilities anywhere in the resolved lockfile', () => {
+	assert.match(workflow, /name: audit complete dependency lockfile[\s\S]*run: npm audit(?:\s|$)/);
+	assert.doesNotMatch(workflow, /npm audit --omit=dev/);
 });


### PR DESCRIPTION
Fixes #313

Changes the pull-request security gate from a production-only audit to `npm audit` of the complete resolved lockfile. Build dependencies parse project input during development and release builds, so excluding them hid the SvelteKit/Svelte/Vite findings addressed in #310.

Updates the workflow regression test to require the complete audit and reject a production-only command.

This is stacked after #312 (and therefore #310). Merge the predecessor chain first.

Validated with `npm ci`, `npm audit` (0 vulnerabilities), `npm run check` (0 errors, 0 warnings), `npm test` (136 passing), `npm run build`, and `cargo test` (21 passing).