### PR TITLE
Reuse the created window handle during startup

### DIFF
--- a/scripts/windowStartupHandle.test.ts
+++ b/scripts/windowStartupHandle.test.ts
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const backend = readFileSync('src-tauri/src/lib.rs', 'utf8');
+
+test('startup reuses the window handle returned by the builder', () => {
+	assert.match(backend, /let window = window_builder\.build\(\)\?;/);
+	assert.doesNotMatch(backend, /app\.get_webview_window\(label\)\.unwrap\(\)/);
+});

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1348,7 +1348,7 @@ pub fn run() {
                 window_builder = window_builder.decorations(false);
             }
 
-            let _window = window_builder.build()?;
+            let window = window_builder.build()?;
 
             #[cfg(target_os = "macos")]
             {
@@ -1460,8 +1460,6 @@ pub fn run() {
             let theme_pref =
                 fs::read_to_string(theme_path).unwrap_or_else(|_| "system".to_string());
 
-            let window = app.get_webview_window(label).unwrap();
-
             let bg_color = match theme_pref.as_str() {
                 "dark" => Some(tauri::window::Color(24, 24, 24, 255)),
                 "light" => Some(tauri::window::Color(253, 253, 253, 255)),
@@ -1479,9 +1477,7 @@ pub fn run() {
 
             let _ = window.set_background_color(bg_color);
 
-            let _ = _window.set_shadow(true);
-
-            let window = app.get_webview_window(label).unwrap();
+            let _ = window.set_shadow(true);
 
             let file_path = args.iter().skip(1).find(|arg| !arg.starts_with("-"));
 


### PR DESCRIPTION
Fixes #317

Uses the handle returned by `WebviewWindowBuilder::build()` for initial theme application, file delivery, focusing, installer sizing, and centering. This removes two registry lookup `unwrap`s that could panic if window lifecycle state changes during startup.

Adds a regression test that rejects those startup lookup unwraps.

This is stacked after #316 and its predecessors. Merge the predecessor chain first.

Validated with `npm ci`, `npm audit` (0 vulnerabilities), `npm run check` (0 errors, 0 warnings), `npm test` (137 passing), `npm run build`, and `cargo test` (21 passing).