### PR TITLE
fix(preview): migrate full-width preference

### DIFF
--- a/scripts/previewWidth.test.ts
+++ b/scripts/previewWidth.test.ts
@@ -6,6 +6,7 @@ import {
 	adjustPreviewMaxWidth,
 	DEFAULT_PREVIEW_MAX_WIDTH,
 	getPreviewContentWidth,
+	getStoredPreviewFullWidth,
 	MAX_PREVIEW_MAX_WIDTH,
 	MIN_PREVIEW_MAX_WIDTH,
 	normalizePreviewMaxWidth,
@@ -41,6 +42,13 @@ test('preview width shortcut adjustments retain the configured bounds', () => {
 	assert.equal(adjustPreviewMaxWidth(MAX_PREVIEW_MAX_WIDTH, 40), MAX_PREVIEW_MAX_WIDTH);
 });
 
+test('the dedicated full-width preference takes priority over its legacy key', () => {
+	assert.equal(getStoredPreviewFullWidth('true', 'false'), true);
+	assert.equal(getStoredPreviewFullWidth('false', 'true'), false);
+	assert.equal(getStoredPreviewFullWidth(null, 'true'), true);
+	assert.equal(getStoredPreviewFullWidth(null, null), false);
+});
+
 test('settings load, persist, and reset the preview width through one normalizer', () => {
 	assert.match(settingsSource, /previewMaxWidth = \$state\(DEFAULT_PREVIEW_MAX_WIDTH\)/);
 	assert.match(settingsSource, /localStorage\.getItem\('preview\.maxWidth'\)/);
@@ -71,4 +79,11 @@ test('preview width keyboard shortcuts avoid editable controls and app modals', 
 	assert.match(viewerSource, /cmdOrCtrl && e\.altKey && !e\.shiftKey && \(code === 'BracketLeft' \|\| code === 'BracketRight'\)/);
 	assert.match(viewerSource, /isFullWidth = false/);
 	assert.match(viewerSource, /settings\.previewMaxWidth = adjustPreviewMaxWidth\(settings\.previewMaxWidth, code === 'BracketLeft' \? -40 : 40\)/);
+});
+
+test('preview full-width state migrates from the legacy localStorage key', () => {
+	assert.match(viewerSource, /localStorage\.getItem\('preview\.fullWidth'\)/);
+	assert.match(viewerSource, /localStorage\.getItem\('isFullWidth'\)/);
+	assert.match(viewerSource, /localStorage\.setItem\('preview\.fullWidth', String\(isFullWidth\)\)/);
+	assert.match(viewerSource, /localStorage\.removeItem\('isFullWidth'\)/);
 });

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -51,7 +51,7 @@ import {
 	import HomePage from './components/HomePage.svelte';
 import { tabManager } from './stores/tabs.svelte.js';
 import { snapshotTab } from './utils/tabTransfer.js';
-import { adjustPreviewMaxWidth, getPreviewContentWidth } from './utils/previewWidth.js';
+import { adjustPreviewMaxWidth, getPreviewContentWidth, getStoredPreviewFullWidth } from './utils/previewWidth.js';
 import { settings } from './stores/settings.svelte.js';
 import { t } from './utils/i18n.js';
 import { createWindowSession } from './sessions/windowSession.svelte.js';
@@ -217,7 +217,10 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	let isAtBottom = $state(false);
 
 	let showHome = $state(false);
-	let isFullWidth = $state(localStorage.getItem('isFullWidth') === 'true');
+	let isFullWidth = $state(getStoredPreviewFullWidth(
+		localStorage.getItem('preview.fullWidth'),
+		localStorage.getItem('isFullWidth'),
+	));
 	let viewerWidth = $state(0);
 	const TOC_MIN_WIDTH = 180;
 	const TOC_MAX_WIDTH = 420;
@@ -229,7 +232,8 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	);
 
 	$effect(() => {
-		localStorage.setItem('isFullWidth', String(isFullWidth));
+		localStorage.setItem('preview.fullWidth', String(isFullWidth));
+		localStorage.removeItem('isFullWidth');
 	});
 
 	import { parseAndApplyVscodeTheme, clearVscodeTheme } from './utils/theme';

--- a/src/lib/utils/previewWidth.ts
+++ b/src/lib/utils/previewWidth.ts
@@ -16,3 +16,7 @@ export function getPreviewContentWidth(value: unknown, isFullWidth: boolean): nu
 export function adjustPreviewMaxWidth(value: unknown, delta: number): number {
 	return normalizePreviewMaxWidth(normalizePreviewMaxWidth(value) + delta);
 }
+
+export function getStoredPreviewFullWidth(value: string | null, legacyValue: string | null): boolean {
+	return (value ?? legacyValue) === 'true';
+}


### PR DESCRIPTION
## Summary

- Moves Full width persistence from the generic `isFullWidth` key to `preview.fullWidth`.
- Preserves existing users’ setting when the new key is absent; a valid new-key value wins when both exist.
- Removes the legacy key after the current state is persisted.

## Validation

- `npm run check`
- `npm test` (149 passing)
- `npm run build`
- `cargo test` (25 passing)

## Stack

Closes #263. This PR follows #320 → #321 → #322 → #323 → #324.

## Post-deploy monitoring

- Verify current Full width users retain their selection across the first upgraded launch.
- Verify a changed Full width selection persists to the dedicated key.
