### PR TITLE
Make the floating TOC toggle visible in preview mode

### DIFF
--- a/scripts/issue261EditorPdf.test.ts
+++ b/scripts/issue261EditorPdf.test.ts
@@ -32,3 +32,17 @@ test('print layout lets the viewer pane escape the interactive split flex ratio'
 		/@media print\s*\{[\s\S]*?\.pane\.viewer-pane\s*\{[\s\S]*?flex:\s*none\s*!important;/,
 	);
 });
+
+test('floating toc toggle keeps a visible translucent surface outside edit mode', () => {
+	const selector = viewer.slice(
+		viewer.indexOf('\t.toc-toggle-floating {'),
+		viewer.indexOf('\n\t.toc-toggle-floating.expanded {'),
+	);
+
+	assert.match(selector, /background-color:\s*color-mix\(in srgb, var\(--color-canvas-default\) 82%, transparent\);/);
+	assert.match(selector, /border:\s*1px solid var\(--color-border-default\);/);
+	assert.match(selector, /box-shadow:\s*0 2px 8px rgba\(0, 0, 0, 0\.12\);/);
+	assert.match(selector, /backdrop-filter:\s*blur\(8px\);/);
+	assert.match(viewer, /\.toc-toggle-floating:focus-visible\s*\{[\s\S]*?outline:\s*2px solid var\(--color-accent-fg\);/);
+	assert.doesNotMatch(viewer, /\.toc-toggle-floating\.in-edit-mode:not\(\.expanded\)/);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -3999,15 +3999,20 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		background-color: transparent;
-		border: none;
+		background-color: color-mix(in srgb, var(--color-canvas-default) 82%, transparent);
+		border: 1px solid var(--color-border-default);
 		border-radius: 4px;
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+		backdrop-filter: blur(8px);
+		-webkit-backdrop-filter: blur(8px);
 		color: var(--color-fg-muted);
 		cursor: pointer;
 		z-index: 1001;
 		transition: 
 			left 0.3s cubic-bezier(0.4, 0, 0.2, 1),
 			background-color 0.2s ease,
+			border-color 0.2s ease,
+			box-shadow 0.2s ease,
 			color 0.2s ease,
 			opacity 0.2s ease,
 			transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -4030,6 +4035,14 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 
 	.layout-container:hover .toc-toggle-floating,
 	.toc-toggle-floating:hover {
+		background-color: color-mix(in srgb, var(--color-canvas-default) 90%, transparent);
+		color: var(--color-fg-default);
+		opacity: 1;
+	}
+
+	.toc-toggle-floating:focus-visible {
+		outline: 2px solid var(--color-accent-fg);
+		outline-offset: 2px;
 		opacity: 1;
 	}
 
@@ -4094,15 +4107,6 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 
 	.layout-container.editing .toc-overlay-wrapper.on-right {
 		border-left-color: var(--color-border-default);
-	}
-
-	.toc-toggle-floating.in-edit-mode:not(.expanded) {
-		background-color: var(--color-canvas-default);
-		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-		border: 1px solid var(--color-border-default);
-		opacity: 0.9;
-		backdrop-filter: blur(8px);
-		-webkit-backdrop-filter: blur(8px);
 	}
 
 	.toc-resize-handle {


### PR DESCRIPTION
## Summary

- give the floating table-of-contents toggle a subtle translucent rounded surface in preview-only and edit modes
- keep its 28px geometry, side placement, animation, icon direction, tooltip, accessible label, and behavior unchanged
- add a regression test that prevents the control from returning to an edit-only card or a transparent bare icon

## Why

In preview-only mode the collapsed TOC control was only a bare chevron. It blended into the document canvas and was easy to confuse with nearby toolbar affordances. The new base surface is intentionally quieter than hover/active states while remaining visible through its translucent canvas, border, and shadow.

## Validation

- `npm run check` (0 errors, 0 warnings)
- `npm test` (151 passed)
- `cargo test` (27 passed)
- isolated macOS release bundle: verified the collapsed control in preview-only and edit modes, then opened/closed the TOC without changing the installed app

Fixes #330.

## Chain

Depends on #329. Please merge after #329; this is a focused visual follow-up and remains draft until its parent lands.