### PR TITLE
Fix duplicate-heading ToC jumps in the editor

### DIFF
--- a/scripts/tocEditorJump.test.ts
+++ b/scripts/tocEditorJump.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+const editor = readFileSync('src/lib/components/Editor.svelte', 'utf8');
+const toc = readFileSync('src/lib/components/Toc.svelte', 'utf8');
+
+test('ToC editor jumps use the clicked heading source line, not duplicate heading text', () => {
+	assert.match(toc, /onjump\?: \(id: string, text: string, sourceLine: number \| null\) => void;/);
+	assert.match(toc, /const sourceLine = Number\(el\.dataset\.sourcepos\?\.match\(\/\^\(\\d\+\):\/\)\?\.\[1\]\);/);
+	assert.match(viewer, /onjump=\{\(id: string, text: string, sourceLine: number \| null\) => \{[\s\S]*?editorPane\.revealHeader\(sourceLine, text\);/);
+	assert.match(editor, /export function revealHeader\(sourceLine: number \| null, text: string\)/);
+	assert.match(editor, /const lineNumber = sourceLine \?\? 0;[\s\S]*?revealLineInCenterIfOutsideViewport\(lineNumber,/);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -110,7 +110,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		runEditorAction: (actionId: string, payload?: any) => void;
 		undo: () => void;
 		redo: () => void;
-		revealHeader: (text: string) => void;
+		revealHeader: (sourceLine: number | null, text: string) => void;
 		triggerFind: () => void;
 	} | null>(null);
 	let liveMode = $state(false);
@@ -3319,9 +3319,9 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 										{collapsedHeaders} 
 										ontoggleFold={toggleFold} 
 										oncopyref={(text: string) => { const tab = tabManager.activeTab; const fn = tab?.path ? tab.path.split(/[/\\]/).pop()?.replace(/\.[^.]+$/, '') || '' : ''; invoke('clipboard_write_text', { text: fn ? `[[${fn}#${text}]]` : `#${text}` }); }}
-										onjump={(id: string, text: string) => {
+										onjump={(id: string, text: string, sourceLine: number | null) => {
 											if (isEditing && editorPane) {
-												editorPane.revealHeader(text);
+												editorPane.revealHeader(sourceLine, text);
 											}
 										}}
 										oncontext={(e, item) => {

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -1338,10 +1338,22 @@
 		dragCaretDecoration = editor.deltaDecorations(dragCaretDecoration, []);
 	}
 
-	export function revealHeader(text: string) {
+	export function revealHeader(sourceLine: number | null, text: string) {
 		if (!editor) return;
 		const model = editor.getModel();
 		if (!model) return;
+		const lineNumber = sourceLine ?? 0;
+		if (Number.isInteger(lineNumber) && lineNumber > 0) {
+			editor.revealLineInCenterIfOutsideViewport(lineNumber, monaco.editor.ScrollType.Smooth);
+			editor.setSelection({
+				startLineNumber: lineNumber,
+				startColumn: 1,
+				endLineNumber: lineNumber,
+				endColumn: model.getLineMaxColumn(lineNumber),
+			});
+			editor.focus();
+			return;
+		}
 
 		const escapedText = text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 		const regex = new RegExp(`^#+\\s+.*${escapedText}.*$`, "m");

--- a/src/lib/components/Toc.svelte
+++ b/src/lib/components/Toc.svelte
@@ -10,7 +10,7 @@
 		ontoggleFold?: (id: string) => void;
 		oncopyref?: (text: string) => void;
 		oncontext?: (e: MouseEvent, item: TocItem) => void;
-		onjump?: (id: string, text: string) => void;
+		onjump?: (id: string, text: string, sourceLine: number | null) => void;
 		onshowTooltip?: (e: MouseEvent, text: string, shortcut?: string, align?: 'top' | 'right' | 'left' | 'below') => void;
 		onhideTooltip?: () => void;
 	}>();
@@ -188,7 +188,8 @@
 			scrollTocIntoView();
 			
 			const item = items.find(i => i.id === id);
-			if (item) onjump?.(id, item.text);
+			const sourceLine = Number(el.dataset.sourcepos?.match(/^(\d+):/)?.[1]);
+			if (item) onjump?.(id, item.text, Number.isInteger(sourceLine) ? sourceLine : null);
 
 			// highlight element persistently until scroll
 			if (activeTargetEl) activeTargetEl.classList.remove('toc-target-active');


### PR DESCRIPTION
Fixes #202.

The preview already jumps by the deduplicated heading id. The editor path still searched by heading text from line 1, so selecting a duplicate title always focused the first heading.

This change passes the clicked preview heading’s `data-sourcepos` start line through the ToC callback and reveals that exact Monaco line. Text matching remains only as a fallback when a source position is unavailable.

Validation:
- `npm ci`
- `npm run check`
- `npm test` (153 passing)
- `cargo test --manifest-path src-tauri/Cargo.toml` (27 passing)
- isolated macOS release bundle: two identical headings; selecting the second ToC entry in edit mode selected line 5, the second heading.

Depends on #333. Merge after the existing linear chain.