### PR TITLE
fix: open YouTube embeds externally

### DIFF
--- a/docs/superpowers/plans/2026-08-02-youtube-external-fallback.md
+++ b/docs/superpowers/plans/2026-08-02-youtube-external-fallback.md
@@ -1,0 +1,84 @@
+# YouTube External Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace broken in-app YouTube embeds with thumbnail links that open the original video in the system browser.
+
+**Architecture:** The Markdown HTML post-processor already recognizes standalone YouTube links and linked images. It will replace each recognized element with an anchor containing a thumbnail image and accessible label. The existing preview click handler already routes external HTTP(S) anchors to Tauri's opener plugin, so the card shares the normal external-link path.
+
+**Tech Stack:** Svelte 5, TypeScript, DOM APIs, Node's built-in test runner, Tauri opener plugin.
+
+## Global Constraints
+
+- Support Windows, macOS, and Linux without platform-specific frontend code.
+- Do not add a dependency or alter Markdown parsing outside recognized YouTube links.
+- Preserve the source URL as the card anchor's `href`.
+- Do not create an iframe or require a YouTube `frame-src` CSP allowance.
+
+---
+
+### Task 1: Specify and implement the rendered fallback card
+
+**Files:**
+- Modify: `scripts/youtubeExternalFallback.test.ts`
+- Modify: `src/lib/utils/markdown.ts:42-65,518-535`
+- Modify: `src-tauri/tauri.conf.json:15-22`
+
+**Interfaces:**
+- Consumes: `processMarkdownHtml(html, filePath, collapsedHeaders)`.
+- Produces: HTML anchors with class `youtube-link`, original video `href`, and a thumbnail URL derived from the validated ID.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+test('standalone YouTube links become thumbnail anchors to the original URL', () => {
+	const html = processMarkdownHtml(
+		'<p><a href="https://youtu.be/dQw4w9WgXcQ">Watch</a></p>',
+		'',
+		new Set(),
+	);
+
+	assert.match(html, /<a[^>]+class="youtube-link"[^>]+href="https:\/\/youtu\.be\/dQw4w9WgXcQ"/);
+	assert.match(html, /https:\/\/i\.ytimg\.com\/vi\/dQw4w9WgXcQ\/hqdefault\.jpg/);
+	assert.doesNotMatch(html, /<iframe/);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test --import tsx scripts/youtubeExternalFallback.test.ts`
+
+Expected: FAIL because the generated HTML contains an iframe and no `youtube-link` card.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+function replaceWithYoutubeLink(element: Element, videoId: string, href: string) {
+	const link = element.ownerDocument.createElement('a');
+	link.className = 'youtube-link';
+	link.href = href;
+	link.target = '_blank';
+	link.rel = 'noopener noreferrer';
+	link.setAttribute('aria-label', 'Open YouTube video in browser');
+	const image = element.ownerDocument.createElement('img');
+	image.src = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+	image.alt = 'YouTube video thumbnail';
+	link.appendChild(image);
+	element.replaceWith(link);
+}
+```
+
+Call this helper for validated standalone YouTube image and anchor URLs, pass through the source URL, remove the iframe CSS, and remove YouTube from `frame-src`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test --import tsx scripts/youtubeExternalFallback.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-08-02-youtube-external-fallback.md scripts/youtubeExternalFallback.test.ts src/lib/utils/markdown.ts src-tauri/tauri.conf.json
+git commit -m "fix: open YouTube embeds externally"
+```

--- a/scripts/youtubeExternalFallback.test.ts
+++ b/scripts/youtubeExternalFallback.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const markdown = readFileSync('src/lib/utils/markdown.ts', 'utf8');
+const markdownViewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
 const tauriConfig = readFileSync('src-tauri/tauri.conf.json', 'utf8');
 
 test('YouTube links render as browser-opening thumbnail anchors', () => {
@@ -20,4 +21,17 @@ test('YouTube detection includes recognized embed URLs', () => {
 
 test('the app no longer permits YouTube frames', () => {
 	assert.doesNotMatch(tauriConfig, /frame-src/);
+});
+
+test('linked YouTube thumbnails are not intercepted by image zoom', () => {
+	const linkHandlerStart = markdownViewer.indexOf('async function handleLinkClick(e: MouseEvent)');
+	const linkHandler = markdownViewer.slice(linkHandlerStart, markdownViewer.indexOf('\n\tasync function toggleTaskCheckbox', linkHandlerStart));
+	const anchorGuard = linkHandler.indexOf("const a = target.closest('a');");
+	const imageZoom = linkHandler.indexOf("const img = target.closest('img');");
+
+	assert.ok(anchorGuard !== -1 && imageZoom !== -1 && anchorGuard < imageZoom);
+	assert.match(
+		linkHandler,
+		/if \(a\) \{[\s\S]*?if \(relativeMarkdownTarget\) \{[\s\S]*?return;[\s\S]*?\}\n\s*return;\n\s*\}\n\n\s*\/\/ media zoom handling/,
+	);
 });

--- a/scripts/youtubeExternalFallback.test.ts
+++ b/scripts/youtubeExternalFallback.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const markdown = readFileSync('src/lib/utils/markdown.ts', 'utf8');
+const tauriConfig = readFileSync('src-tauri/tauri.conf.json', 'utf8');
+
+test('YouTube links render as browser-opening thumbnail anchors', () => {
+	assert.match(markdown, /function replaceWithYoutubeLink\(element: Element, videoId: string, href: string\)/);
+	assert.match(markdown, /link\.className = ['"]youtube-link['"]/);
+	assert.match(markdown, /link\.href = href/);
+	assert.match(markdown, /https:\/\/i\.ytimg\.com\/vi\/\$\{videoId\}\/hqdefault\.jpg/);
+	assert.match(markdown, /replaceWithYoutubeLink\(a, videoId, href\)/);
+	assert.doesNotMatch(markdown, /createElement\(["']iframe["']\)/);
+});
+
+test('YouTube detection includes recognized embed URLs', () => {
+	assert.match(markdown, /url\.includes\(["']youtube\.com\/embed\/["']\)/);
+});
+
+test('the app no longer permits YouTube frames', () => {
+	assert.doesNotMatch(tauriConfig, /frame-src/);
+});

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,6 @@
         "style-src": "'self' 'unsafe-inline' https://fonts.googleapis.com",
         "img-src": "'self' asset: https: http://asset.localhost blob: data:",
         "connect-src": "'self'",
-        "frame-src": "https://www.youtube.com https://www.youtube-nocookie.com",
         "font-src": "'self' https://fonts.gstatic.com"
       },
       "assetProtocol": {

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -3558,21 +3558,17 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		}
 	}
 
-	:global(.video-container) {
-		position: relative;
-		padding-bottom: 56.25%;
-		height: 0;
-		overflow: hidden;
+	:global(.youtube-link) {
+		display: block;
 		max-width: 100%;
 		margin: 1em 0;
 	}
 
-	:global(.video-container iframe) {
-		position: absolute;
-		top: 0;
-		left: 0;
+	:global(.youtube-link img) {
+		display: block;
 		width: 100%;
-		height: 100%;
+		aspect-ratio: 16 / 9;
+		object-fit: cover;
 		border-radius: 8px;
 	}
 

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -1508,6 +1508,8 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 				await openRelativeMarkdownTarget(relativeMarkdownTarget);
 				return;
 			}
+
+			return;
 		}
 
         // media zoom handling

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -40,7 +40,13 @@ export function resolvePath(basePath: string, relativePath: string): string {
 }
 
 export function isYoutubeLink(url: string): boolean {
-	return url.includes("youtube.com/watch") || url.includes("youtu.be/");
+	return (
+		url.includes("youtube.com/watch") ||
+		url.includes("youtube.com/embed/") ||
+		url.includes("youtube.com/v/") ||
+		url.includes("youtube.com/u/") ||
+		url.includes("youtu.be/")
+	);
 }
 
 export function getYoutubeId(url: string): string | null {
@@ -50,18 +56,18 @@ export function getYoutubeId(url: string): string | null {
 	return match && match[2].length === 11 ? match[2] : null;
 }
 
-function replaceWithYoutubeEmbed(element: Element, videoId: string) {
-	const container = element.ownerDocument.createElement("div");
-	container.className = "video-container";
-	const iframe = element.ownerDocument.createElement("iframe");
-	iframe.src = `https://www.youtube.com/embed/${videoId}`;
-	iframe.title = "YouTube video player";
-	iframe.frameBorder = "0";
-	iframe.allow =
-		"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share";
-	iframe.allowFullscreen = true;
-	container.appendChild(iframe);
-	element.replaceWith(container);
+function replaceWithYoutubeLink(element: Element, videoId: string, href: string) {
+	const link = element.ownerDocument.createElement("a");
+	link.className = "youtube-link";
+	link.href = href;
+	link.setAttribute("aria-label", "Open YouTube video in browser");
+
+	const thumbnail = element.ownerDocument.createElement("img");
+	thumbnail.src = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+	thumbnail.alt = "YouTube video thumbnail";
+	link.appendChild(thumbnail);
+
+	element.replaceWith(link);
 }
 
 export function getLanguage(path: string): string {
@@ -517,7 +523,7 @@ export function processMarkdownHtml(
 
 			if (isYoutubeLink(src)) {
 				const videoId = getYoutubeId(src);
-				if (videoId) replaceWithYoutubeEmbed(img, videoId);
+				if (videoId) replaceWithYoutubeLink(img, videoId, src);
 			}
 		}
 	}
@@ -532,7 +538,7 @@ export function processMarkdownHtml(
 				parent.childNodes.length === 1
 			) {
 				const videoId = getYoutubeId(href);
-				if (videoId) replaceWithYoutubeEmbed(a, videoId);
+				if (videoId) replaceWithYoutubeLink(a, videoId, href);
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- replace in-app YouTube iframes with clickable thumbnail cards
- open the original YouTube URL through Markpad's existing system-browser link handler
- prevent linked thumbnails from opening the preview image-zoom overlay
- remove the no-longer-needed YouTube frame CSP permission

Fixes #230

## Validation

- `npm ci`
- `npm run check`
- `npm test`
- `cargo test`

## Local bundle validation

- macOS Bundle: `com.alecdotdev.markpad.pr230`, version `2.6.14-pr230.local.1`
- Built with `npm run tauri build` in an isolated clone.
- Opened a Markdown document containing a YouTube URL; the thumbnail card rendered, and clicking it opened the original video in the system browser without opening Markpad's image-zoom overlay.