### PR TITLE
Add a minimal macOS Settings menu

### DIFF
--- a/docs/superpowers/plans/2026-08-02-issue-281-minimal-macos-menu.md
+++ b/docs/superpowers/plans/2026-08-02-issue-281-minimal-macos-menu.md
@@ -1,0 +1,31 @@
+# Issue 281: Minimal macOS application menu
+
+## Goal
+
+Provide only macOS application-level native actions while retaining Markpad's
+in-window controls as the source of document and window actions.
+
+## Scope
+
+- Keep the application menu's About, Settings, update, Services, hide, and
+  quit actions.
+- Give Settings the `Cmd+,` accelerator.
+- Remove native File, Edit, and Window submenus.
+- Route Settings only to the focused webview and open the modal; it must not
+  toggle an already-open modal or broadcast to other windows.
+
+## Implementation
+
+1. Build a `menu-app-settings` menu item in the existing macOS-only setup and
+   attach only the application submenu to the native menu bar.
+2. Route `menu-app-settings` through the existing focused-window event path.
+3. Listen for that event in `MarkdownViewer` and set `showSettings = true`,
+   matching the titlebar callback.
+4. Remove now-unused native File action listeners and the macOS keyboard guard
+   for their old accelerators.
+
+## Validation
+
+- Add source-contract tests for the native menu shape and focused-window
+  Settings event wiring.
+- Run `npm ci`, `npm run check`, `npm test`, and `cargo test`.

--- a/scripts/issue281MinimalMacosMenu.test.ts
+++ b/scripts/issue281MinimalMacosMenu.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const tauriLib = readFileSync('src-tauri/src/lib.rs', 'utf8');
+const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+
+test('macOS native menu keeps only application-level actions', () => {
+	const menuStart = tauriLib.indexOf('#[cfg(target_os = "macos")]\n            {\n                use tauri::menu');
+	assert.notEqual(menuStart, -1, 'macOS native menu setup must exist');
+
+	const menuEnd = tauriLib.indexOf('\n            let config_dir', menuStart);
+	const menuSetup = tauriLib.slice(menuStart, menuEnd);
+
+	assert.match(menuSetup, /MenuItemBuilder::with_id\("menu-app-settings", "Settings…"\)\s*\.accelerator\("CmdOrCtrl\+,"\)/);
+	assert.match(menuSetup, /MenuItemBuilder::with_id\("check-updates", "Check for Updates…"\)/);
+	assert.match(menuSetup, /PredefinedMenuItem::services\(app, None\)/);
+	assert.match(menuSetup, /PredefinedMenuItem::hide\(app, None\)/);
+	assert.doesNotMatch(menuSetup, /PredefinedMenuItem::(?:hide_others|show_all)/);
+	assert.match(menuSetup, /\.items\(&\[&app_submenu\]\)/);
+	assert.doesNotMatch(menuSetup, /SubmenuBuilder::new\(app, "(?:File|Edit|Window)"\)/);
+});
+
+test('native Settings opens only the focused window settings modal', () => {
+	assert.match(tauriLib, /if id == "menu-app-settings" \{\s*let _ = app\.emit_to\(window\.label\(\), "menu-app-settings", \(\)\);/);
+	assert.match(viewer, /appWindow\.listen\('menu-app-settings', \(\) => \{\s*showSettings = true;\s*\}\)/);
+});

--- a/scripts/reloadOpenToolbar.test.ts
+++ b/scripts/reloadOpenToolbar.test.ts
@@ -7,20 +7,17 @@ const titleBar = readFileSync('src/lib/components/TitleBar.svelte', 'utf8');
 const editor = readFileSync('src/lib/components/Editor.svelte', 'utf8');
 const tauriLib = readFileSync('src-tauri/src/lib.rs', 'utf8');
 
-test('manual reload is wired through menu, titlebar, and F5 with dirty-state protection', () => {
+test('manual reload is wired through titlebar and F5 with dirty-state protection', () => {
 	assert.match(markdownViewer, /async function reloadFromDisk\(\)/);
 	assert.match(markdownViewer, /await canCloseTab\(activeId\)/);
 	assert.match(markdownViewer, /loadMarkdown\(tab\.path,\s*\{[\s\S]*preserveEditState:\s*true/);
 	assert.match(markdownViewer, /code === 'F5'[\s\S]*reloadFromDisk\(\)/);
-	assert.match(markdownViewer, /listen\('menu-file-reload'[\s\S]*reloadFromDisk\(\)/);
 	assert.match(titleBar, /onreloadFromDisk/);
 	assert.match(titleBar, /id === 'reload'/);
-	assert.match(tauriLib, /menu-file-reload/);
-	assert.match(tauriLib, /\.accelerator\("F5"\)/);
+	assert.doesNotMatch(tauriLib, /menu-file-reload/);
 });
 
-test('preview-level open shortcut handles Ctrl/Cmd+O outside Monaco without double-handling macOS native menu', () => {
-	assert.match(markdownViewer, /settings\.osType === 'macos'[\s\S]*key === 'o'[\s\S]*return/);
+test('preview-level open shortcut handles Ctrl/Cmd+O outside Monaco', () => {
 	assert.match(markdownViewer, /cmdOrCtrl[\s\S]*key === 'o'[\s\S]*selectFile\(\)/);
 });
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1358,6 +1358,9 @@ pub fn run() {
 
                 let check_item =
                     MenuItemBuilder::with_id("check-updates", "Check for Updates…").build(app)?;
+                let settings_item = MenuItemBuilder::with_id("menu-app-settings", "Settings…")
+                    .accelerator("CmdOrCtrl+,")
+                    .build(app)?;
 
                 let app_submenu = SubmenuBuilder::new(app, &app_name)
                     .item(&PredefinedMenuItem::about(
@@ -1366,13 +1369,12 @@ pub fn run() {
                         None,
                     )?)
                     .separator()
+                    .item(&settings_item)
                     .item(&check_item)
                     .separator()
                     .item(&PredefinedMenuItem::services(app, None)?)
                     .separator()
                     .item(&PredefinedMenuItem::hide(app, None)?)
-                    .item(&PredefinedMenuItem::hide_others(app, None)?)
-                    .item(&PredefinedMenuItem::show_all(app, None)?)
                     .separator()
                     .item(
                         &MenuItemBuilder::with_id(
@@ -1384,72 +1386,8 @@ pub fn run() {
                     )
                     .build()?;
 
-                let file_submenu = SubmenuBuilder::new(app, "File")
-                    .item(
-                        &MenuItemBuilder::with_id("menu-file-new", "New File")
-                            .accelerator("CmdOrCtrl+T")
-                            .build(app)?,
-                    )
-                    .item(
-                        &MenuItemBuilder::with_id("menu-file-open", "Open File…")
-                            .accelerator("CmdOrCtrl+O")
-                            .build(app)?,
-                    )
-                    .item(
-                        &MenuItemBuilder::with_id("menu-file-reload", "Reload from Disk")
-                            .accelerator("F5")
-                            .build(app)?,
-                    )
-                    .item(
-                        &MenuItemBuilder::with_id("menu-file-close", "Close")
-                            .accelerator("CmdOrCtrl+W")
-                            .build(app)?,
-                    )
-                    .separator()
-                    .item(
-                        &MenuItemBuilder::with_id("menu-file-save", "Save")
-                            .accelerator("CmdOrCtrl+S")
-                            .build(app)?,
-                    )
-                    .item(
-                        &MenuItemBuilder::with_id("menu-file-save-as", "Save As…")
-                            .accelerator("CmdOrCtrl+Shift+S")
-                            .build(app)?,
-                    )
-                    .separator()
-                    .item(
-                        &MenuItemBuilder::with_id("menu-file-export-html", "Export as HTML")
-                            .build(app)?,
-                    )
-                    .item(
-                        &MenuItemBuilder::with_id("menu-file-export-pdf", "Export as PDF")
-                            .build(app)?,
-                    )
-                    .build()?;
-
-                let edit_submenu = SubmenuBuilder::new(app, "Edit")
-                    .item(&PredefinedMenuItem::undo(app, None)?)
-                    .item(&PredefinedMenuItem::redo(app, None)?)
-                    .separator()
-                    .item(&PredefinedMenuItem::cut(app, None)?)
-                    .item(&PredefinedMenuItem::copy(app, None)?)
-                    .item(&PredefinedMenuItem::paste(app, None)?)
-                    .item(&PredefinedMenuItem::select_all(app, None)?)
-                    .separator()
-                    .item(
-                        &MenuItemBuilder::with_id("menu-edit-find", "Find…")
-                            .accelerator("CmdOrCtrl+F")
-                            .build(app)?,
-                    )
-                    .build()?;
-
-                let window_submenu = SubmenuBuilder::new(app, "Window")
-                    .item(&PredefinedMenuItem::minimize(app, None)?)
-                    .item(&PredefinedMenuItem::close_window(app, None)?)
-                    .build()?;
-
                 let menu = MenuBuilder::new(app)
-                    .items(&[&app_submenu, &file_submenu, &edit_submenu, &window_submenu])
+                    .items(&[&app_submenu])
                     .build()?;
 
                 app.set_menu(menu)?;
@@ -1567,12 +1505,11 @@ pub fn run() {
                 .or_else(|| app.get_webview_window("main"));
             let Some(window) = target else { return };
 
-            if id == "check-updates" {
+            if id == "menu-app-settings" {
+                let _ = app.emit_to(window.label(), "menu-app-settings", ());
+            } else if id == "check-updates" {
                 let _ = app.emit_to(window.label(), "menu-check-updates", ());
-            } else if id == "menu-app-quit"
-                || id.starts_with("menu-file-")
-                || id.starts_with("menu-edit-")
-            {
+            } else if id == "menu-app-quit" {
                 let _ = app.emit_to(window.label(), id, ());
             }
         })

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -119,9 +119,8 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	let findBar = $state<{ reapply: () => void; clearHighlights: () => void } | null>(null);
 
 	// Decide where Cmd/Ctrl+F should land based on what's visible and where
-	// focus is. Used by both the JS keydown handler (Win/Linux + macOS in-page
-	// shortcut) and the macOS native menu listener (which fires Cmd+F via the
-	// Edit menu accelerator and bypasses the JS keydown path).
+	// focus is. The in-window shortcut remains the canonical route on every
+	// platform.
 	function triggerFindAction() {
 		const active = document.activeElement as Node | null;
 		const editorHasFocus = !!editorPaneEl && !!active && editorPaneEl.contains(active);
@@ -2268,17 +2267,10 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		const key = e.key.toLowerCase();
 		const code = e.code;
 
-		// On macOS the native menu accelerators (⌘T, ⌘W, ⌘S, ⌘Q) take priority
-		// via NSMenu; the JS keydown handler should not also fire for them, or
-		// we'd double-handle (e.g. open two new tabs on ⌘T). The !e.shiftKey
-		// guards keep ⌘⇧T (undo close tab) routed through this handler as
-		// before — only the bare combos are claimed by the menu.
+		// The macOS application menu owns ⌘Q. Document shortcuts remain in the
+		// in-window controls, so they continue to act on the current webview.
 		if (settings.osType === 'macos' && cmdOrCtrl && !e.shiftKey) {
 			if (key === 'q') return; // → menu-app-quit
-			if (key === 'w') return; // → menu-file-close
-			if (key === 's') return; // → menu-file-save
-			if (key === 't') return; // → menu-file-new
-			if (key === 'o') return; // → menu-file-open
 		}
 
 		const isSplit = tabManager.activeTab?.isSplit;
@@ -2374,7 +2366,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		}
 		if (cmdOrCtrl && key === ',') {
 			e.preventDefault();
-			showSettings = !showSettings;
+			showSettings = true;
 		}
 		// Ctrl/Cmd+F: route to either Monaco's built-in find or the preview
 		// FindBar depending on focus and which panes are visible. We only
@@ -2664,16 +2656,6 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 				}),
 			);
 			unlisteners.push(
-				await appWindow.listen('menu-edit-file', () => {
-					toggleEdit();
-				}),
-			);
-			unlisteners.push(
-				await appWindow.listen('menu-edit-find', () => {
-					triggerFindAction();
-				}),
-			);
-			unlisteners.push(
 				await appWindow.listen('menu-tab-rename', async (event) => {
 					const tabId = event.payload as string;
 					const tab = tabManager.tabs.find((t) => t.id === tabId);
@@ -2763,26 +2745,17 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 				}),
 			);
 			unlisteners.push(
+				await appWindow.listen('menu-app-settings', () => {
+					showSettings = true;
+				}),
+			);
+			unlisteners.push(
 				await appWindow.listen('menu-check-updates', () => {
 					updateStore.openDialog();
 				}),
 			);
-			// Native macOS menubar — Markpad ▸ Quit and File ▸ * — bridged
-			// to the same handlers the in-window burger button uses, so the
-			// menu and the burger stay behaviourally identical. Save mirrors
-			// the keydown guard (`isEditing || isSplit`) so menu ⌘S in pure
-			// view mode is a no-op, matching the keyboard shortcut.
+			// Native macOS application menu only owns application-level actions.
 			unlisteners.push(await appWindow.listen('menu-app-quit',         () => appExit()));
-			unlisteners.push(await appWindow.listen('menu-file-new',         () => handleNewFile()));
-			unlisteners.push(await appWindow.listen('menu-file-open',        () => selectFile()));
-			unlisteners.push(await appWindow.listen('menu-file-reload',      () => reloadFromDisk()));
-			unlisteners.push(await appWindow.listen('menu-file-close',       () => closeFile()));
-			unlisteners.push(await appWindow.listen('menu-file-save',        () => {
-				if (isEditing || tabManager.activeTab?.isSplit) saveContent();
-			}));
-			unlisteners.push(await appWindow.listen('menu-file-save-as',     () => saveContentAs()));
-			unlisteners.push(await appWindow.listen('menu-file-export-html', () => exportAsHtml()));
-			unlisteners.push(await appWindow.listen('menu-file-export-pdf', () => exportAsPdf()));
 			unlisteners.push(
 				await appWindow.onCloseRequested(async (event) => {
 					console.log('onCloseRequested triggered');


### PR DESCRIPTION
## Summary

- reduce the macOS native menu to app-level actions
- add `Settings…` with the standard `Cmd+,` shortcut
- route Settings to the currently focused Markpad window

Fixes #281

## Validation

- `npm ci`
- `npm run check`
- `npm test`
- `cargo test`

## Local bundle validation

- macOS Bundle: `com.alecdotdev.markpad.pr281`, version `2.6.14-pr281.local.1`
- Built with `npm run tauri build` in an isolated clone.
- Verified the native menu contains only About, Settings…, Check for Updates…, Services, Hide, and Quit. `Settings…` opened the existing Settings modal in the focused window.