### PR TITLE
fix(editor): preserve copied image path for undo

### DIFF
--- a/scripts/managedImageUndo.test.ts
+++ b/scripts/managedImageUndo.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { managedImageFromCopy } from '../src/lib/utils/managedImages.js';
+
+test('undo metadata retains the collision-resolved image filename and paste-time directory', () => {
+	const image = managedImageFromCopy({
+		embed: '![alt](img/logo_1710000000.png)',
+		parentDir: 'C:/notes',
+		imageDirectory: 'img',
+		relativePath: 'img/logo_1710000000.png',
+	});
+
+	assert.deepEqual(image, {
+		embed: '![alt](img/logo_1710000000.png)',
+		parentDir: 'C:/notes',
+		imageDirectory: 'img',
+		filename: 'logo_1710000000.png',
+	});
+});

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -3,6 +3,7 @@
 	import { tabManager } from "../stores/tabs.svelte.js";
 	import { settings } from "../stores/settings.svelte.js";
 	import { t } from '../utils/i18n.js';
+	import { managedImageFromCopy, type ManagedImage } from '../utils/managedImages.js';
 
 	import * as monaco from "monaco-editor";
 	import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
@@ -61,11 +62,7 @@
 	let vimStatusNode = $state<HTMLDivElement>();
 	let editor: monaco.editor.IStandaloneCodeEditor;
 	let isApplyingExternalScroll = false;
-	const managedImages: {
-		embed: string;
-		filename: string;
-		parentDir: string;
-	}[] = $state([]);
+	const managedImages: ManagedImage[] = $state([]);
 
 	let cursorPosition = $state<monaco.Position | null>(null);
 	let selectionCount = $state(0);
@@ -764,11 +761,10 @@
 				const last = managedImages[managedImages.length - 1];
 				if (!currentContent.includes(last.embed)) {
 					managedImages.pop();
-						const imgDirName = settings.imageDirectory || "img";
-						const imgPath = `${last.parentDir}/${imgDirName}/${last.filename}`;
+						const imgPath = `${last.parentDir}/${last.imageDirectory}/${last.filename}`;
 						invoke("delete_file", { path: imgPath })
 							.then(() => {
-								invoke("cleanup_empty_img_dir", { parentDir: last.parentDir, imageDirectory: imgDirName });
+								invoke("cleanup_empty_img_dir", { parentDir: last.parentDir, imageDirectory: last.imageDirectory });
 							})
 							.catch(console.error);
 				}
@@ -905,7 +901,7 @@
 								},
 							]);
 
-							managedImages.push({ embed, filename, parentDir });
+							managedImages.push(managedImageFromCopy({ embed, parentDir, imageDirectory: imgDirName, relativePath: relPath }));
 							return;
 						}
 					}
@@ -1295,8 +1291,7 @@
 				],
 			);
 
-			const actualFilename = path.split(/[/\\]/).pop() || "image";
-			managedImages.push({ embed, filename: actualFilename, parentDir });
+			managedImages.push(managedImageFromCopy({ embed, parentDir, imageDirectory: imgDirName, relativePath: relPath }));
 		} catch (err) {
 			console.error("Failed to copy dropped file:", err);
 		}

--- a/src/lib/utils/managedImages.ts
+++ b/src/lib/utils/managedImages.ts
@@ -1,0 +1,23 @@
+export type ManagedImage = {
+	embed: string;
+	parentDir: string;
+	imageDirectory: string;
+	filename: string;
+};
+
+export function managedImageFromCopy({
+	embed,
+	parentDir,
+	imageDirectory,
+	relativePath,
+}: {
+	embed: string;
+	parentDir: string;
+	imageDirectory: string;
+	relativePath: string;
+}): ManagedImage {
+	const filename = relativePath.split('/').pop();
+	if (!filename) throw new Error('Copied image path has no filename');
+
+	return { embed, parentDir, imageDirectory, filename };
+}


### PR DESCRIPTION
## Summary

Undoing a dropped or pasted image now removes the exact copied file, even when a filename collision changed its name. It also keeps the image-directory setting that applied when the image was inserted, so changing the setting later cannot redirect Undo to a different folder.

## Validation

- `npm test`
- `npm run check` (0 errors; one existing Settings modal a11y warning)
