### PR TITLE
fix(print): keep PDF exports readable in all themes

### DIFF
--- a/scripts/issue261EditorPdf.test.ts
+++ b/scripts/issue261EditorPdf.test.ts
@@ -79,3 +79,18 @@ test('print layout paints a theme-independent page and keeps Markdown alerts int
 	assert.match(printStyles, /\.markdown-body tr\s*\{[\s\S]*?break-inside:\s*avoid;/);
 	assert.doesNotMatch(viewerPrintStyles, /\.markdown-body\s*\{[\s\S]*?padding:\s*0\s*!important;/);
 });
+
+test('print layout keeps wide metadata tables readable', () => {
+	const printStyles = styles.slice(styles.indexOf('@media print {'));
+
+	// Diagram colours are no longer patched from CSS — the export re-renders
+	// them with Mermaid's light theme instead (see utils/mermaidPrint.ts).
+	// Recolouring by class name silently half-applied: sequence-diagram
+	// actors have no `.node` ancestor, so their fill rule missed while the
+	// label rule landed, leaving dark text on a near-black box.
+	assert.doesNotMatch(printStyles, /\.mermaid-diagram svg[^{]*\{[^}]*fill:/);
+	assert.match(printStyles, /\.markdown-body table\s*\{[\s\S]*?table-layout:\s*auto\s*!important;/);
+	assert.match(printStyles, /\.markdown-body table th,[\s\S]*?overflow-wrap:\s*break-word\s*!important;/);
+	assert.match(printStyles, /\.markdown-body \.frontmatter-summary\s*\{[\s\S]*?box-sizing:\s*border-box\s*!important;/);
+	assert.match(printStyles, /\.markdown-body \.frontmatter-title\s*\{[\s\S]*?min-width:\s*0\s*!important;/);
+});

--- a/scripts/issue261EditorPdf.test.ts
+++ b/scripts/issue261EditorPdf.test.ts
@@ -59,3 +59,23 @@ test('print layout gives document content paper-specific rhythm and boundaries',
 	assert.match(printStyles, /\.markdown-body img\s*\{[\s\S]*?max-width:\s*100%\s*!important;/);
 	assert.match(printStyles, /\.markdown-body table\s*\{[\s\S]*?margin:\s*1em 0;/);
 });
+
+test('print layout paints a theme-independent page and keeps Markdown alerts intact', () => {
+	const printStyles = styles.slice(styles.indexOf('@media print {'));
+	const viewerPrintStyles = viewer.slice(viewer.indexOf('\t@media print {'));
+
+	assert.match(printStyles, /@page\s*\{[\s\S]*?margin:\s*0;/);
+	assert.match(printStyles, /\.markdown-body\s*\{[\s\S]*?box-sizing:\s*border-box\s*!important;/);
+	assert.match(printStyles, /\.markdown-body\s*\{[\s\S]*?padding:\s*0\.75in\s*!important;/);
+	assert.match(printStyles, /\.markdown-body\s*\{[\s\S]*?box-decoration-break:\s*clone\s*!important;/);
+	assert.match(printStyles, /\.markdown-body\s*\{[\s\S]*?-webkit-box-decoration-break:\s*clone\s*!important;/);
+	assert.match(printStyles, /\.markdown-body\s*\{[\s\S]*?print-color-adjust:\s*exact\s*!important;/);
+	assert.match(
+		printStyles,
+		/\.markdown-body \.markdown-alert\s*\{[\s\S]*?page-break-inside:\s*avoid\s*!important;[\s\S]*?break-inside:\s*avoid\s*!important;/,
+	);
+	assert.match(printStyles, /\.markdown-body \.markdown-alert\s*\{[\s\S]*?box-decoration-break:\s*clone\s*!important;/);
+	assert.match(printStyles, /\.markdown-body details\.markdown-alert\s*\{[\s\S]*?break-inside:\s*avoid\s*!important;/);
+	assert.match(printStyles, /\.markdown-body tr\s*\{[\s\S]*?break-inside:\s*avoid;/);
+	assert.doesNotMatch(viewerPrintStyles, /\.markdown-body\s*\{[\s\S]*?padding:\s*0\s*!important;/);
+});

--- a/scripts/mermaidPrintTheme.test.ts
+++ b/scripts/mermaidPrintTheme.test.ts
@@ -1,0 +1,158 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import {
+	MERMAID_PRINT_THEME,
+	findRestorableDiagrams,
+	readDiagramSource,
+	rememberDiagramSource,
+	renderDiagramsForPrint,
+	resolveMermaidTheme,
+} from '../src/lib/utils/mermaidPrint.js';
+
+const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
+
+/**
+ * Minimal stand-ins for the DOM pieces the helper touches. Enough to drive
+ * the real implementation without a browser, which is how the rest of
+ * scripts/ tests DOM-adjacent logic.
+ */
+class FakeElement {
+	attributes = new Map<string, string>();
+	innerHTML = '';
+	constructor(public className = '') {}
+	setAttribute(name: string, value: string) {
+		this.attributes.set(name, value);
+	}
+	getAttribute(name: string) {
+		return this.attributes.has(name) ? this.attributes.get(name)! : null;
+	}
+}
+
+class FakeRoot {
+	constructor(private elements: FakeElement[]) {}
+	querySelectorAll(selector: string) {
+		assert.match(selector, /\.mermaid-diagram\[data-mermaid-source\]/);
+		return this.elements.filter(
+			(element) => element.className.includes('mermaid-diagram') && element.getAttribute('data-mermaid-source') !== null,
+		);
+	}
+}
+
+function makeMermaid(behaviour: (source: string) => string) {
+	const themes: string[] = [];
+	return {
+		themes,
+		initialize(config: { startOnLoad: boolean; theme: string }) {
+			themes.push(config.theme);
+		},
+		async render(_id: string, source: string) {
+			return { svg: behaviour(source) };
+		},
+	};
+}
+
+function diagram(source: string | null, html: string) {
+	const element = new FakeElement('mermaid-diagram');
+	if (source !== null) rememberDiagramSource(element, source);
+	element.innerHTML = html;
+	return element;
+}
+
+test('the diagram theme follows the app appearance', () => {
+	assert.equal(resolveMermaidTheme({ theme: 'dark', systemPrefersDark: false }), 'dark');
+	assert.equal(resolveMermaidTheme({ theme: 'light', systemPrefersDark: true }), 'neutral');
+	assert.equal(resolveMermaidTheme({ theme: 'system', systemPrefersDark: true }), 'dark');
+	assert.equal(resolveMermaidTheme({ theme: 'system', systemPrefersDark: false }), 'neutral');
+	// A VS Code theme reports its polarity through the dataset instead.
+	assert.equal(
+		resolveMermaidTheme({ theme: 'vscode:whatever', datasetThemeType: 'dark', systemPrefersDark: false }),
+		'dark',
+	);
+});
+
+test('the source is kept on the container so the diagram can be rebuilt', () => {
+	const element = diagram('flowchart TD\n A --> B', '<svg>screen</svg>');
+	assert.equal(readDiagramSource(element), 'flowchart TD\n A --> B');
+	assert.equal(findRestorableDiagrams(new FakeRoot([element]) as unknown as ParentNode).length, 1);
+	// A diagram rendered before this change carries no source and is skipped
+	// rather than blanked.
+	assert.equal(findRestorableDiagrams(new FakeRoot([diagram(null, '<svg/>')]) as unknown as ParentNode).length, 0);
+});
+
+test('exporting re-renders with the print theme and then restores the screen rendering', async () => {
+	const first = diagram('sequenceDiagram\n A->>B: hi', '<svg>dark-1</svg>');
+	const second = diagram('flowchart TD\n A --> B', '<svg>dark-2</svg>');
+	const mermaid = makeMermaid((source) => `<svg>light:${source.split('\n')[0]}</svg>`);
+
+	const restore = await renderDiagramsForPrint({
+		root: new FakeRoot([first, second]) as unknown as ParentNode,
+		mermaid,
+		sanitizeSvg: (svg) => svg,
+		screenTheme: 'dark',
+		idFactory: (index) => `id-${index}`,
+	});
+
+	assert.equal(first.innerHTML, '<svg>light:sequenceDiagram</svg>');
+	assert.equal(second.innerHTML, '<svg>light:flowchart TD</svg>');
+	assert.deepEqual(mermaid.themes, [MERMAID_PRINT_THEME]);
+
+	restore();
+	assert.equal(first.innerHTML, '<svg>dark-1</svg>');
+	assert.equal(second.innerHTML, '<svg>dark-2</svg>');
+	assert.deepEqual(mermaid.themes, [MERMAID_PRINT_THEME, 'dark']);
+
+	// Restoring twice must not re-run initialize or clobber a later render.
+	first.innerHTML = '<svg>re-rendered later</svg>';
+	restore();
+	assert.equal(first.innerHTML, '<svg>re-rendered later</svg>');
+	assert.deepEqual(mermaid.themes, [MERMAID_PRINT_THEME, 'dark']);
+});
+
+test('a diagram that fails to re-render keeps its screen rendering', async () => {
+	const element = diagram('broken', '<svg>dark</svg>');
+	const errors: unknown[] = [];
+	const mermaid = {
+		themes: [] as string[],
+		initialize(config: { startOnLoad: boolean; theme: string }) {
+			this.themes.push(config.theme);
+		},
+		async render(): Promise<{ svg: string }> {
+			throw new Error('bad diagram');
+		},
+	};
+
+	const restore = await renderDiagramsForPrint({
+		root: new FakeRoot([element]) as unknown as ParentNode,
+		mermaid,
+		sanitizeSvg: (svg) => svg,
+		screenTheme: 'dark',
+		onError: (error) => errors.push(error),
+	});
+
+	assert.equal(element.innerHTML, '<svg>dark</svg>');
+	assert.equal(errors.length, 1);
+	restore();
+	assert.equal(element.innerHTML, '<svg>dark</svg>');
+});
+
+test('the helper is inert when there is nothing to re-render', async () => {
+	const restore = await renderDiagramsForPrint({
+		root: null,
+		mermaid: null,
+		sanitizeSvg: (svg) => svg,
+		screenTheme: 'dark',
+	});
+	restore();
+	assert.equal(typeof restore, 'function');
+});
+
+test('the PDF export wraps the print render and always restores', () => {
+	assert.match(viewer, /const restoreDiagrams = await renderDiagramsForPrint\(\{/);
+	assert.match(viewer, /\} finally \{\n\t\t\trestoreDiagrams\(\);\n\t\t\}/);
+	// The screen render must record the source, or there is nothing to rebuild.
+	assert.match(viewer, /rememberDiagramSource\(container, mermaidCode\);/);
+	// One theme decision, shared by the screen render and the restore.
+	assert.match(viewer, /mermaid\.initialize\(\{ startOnLoad: false, theme: currentMermaidTheme\(\) \}\)/);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -24,6 +24,11 @@
 	import { askToOpenExportedFile } from './utils/openExportedFile.js';
 	import ZoomOverlay from './components/ZoomOverlay.svelte';
 import { processMarkdownHtml } from './utils/markdown';
+import {
+	rememberDiagramSource,
+	renderDiagramsForPrint,
+	resolveMermaidTheme,
+} from './utils/mermaidPrint.js';
 import { observeFoldLayout } from './utils/foldLayout.js';
 import {
 	addFrontMatterListItems,
@@ -947,17 +952,29 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		return documentSession.loadMarkdown(filePath, options);
 	}
 
+	function currentMermaidTheme() {
+		return resolveMermaidTheme({
+			theme,
+			datasetThemeType: document.documentElement.dataset.themeType,
+			systemPrefersDark: window.matchMedia('(prefers-color-scheme: dark)').matches,
+		});
+	}
+
+	// Mermaid puts text inside foreignObject, so the diagram sanitizer is more
+	// permissive than the document one; keep the two in one place.
+	function sanitizeDiagramSvg(svg: string) {
+		return DOMPurify.sanitize(svg, {
+			ADD_TAGS: ['foreignObject'],
+			ADD_ATTR: ['dominant-baseline', 'text-anchor'],
+		});
+	}
+
 	async function renderRichContent() {
 		if (!markdownBody) return;
 
 		if (!hljs || !renderMathInElement || !mermaid) return;
 
-		// Initialize Mermaid with theme based on system preference or override
-		const isSystemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-		const datasetThemeType = document.documentElement.dataset.themeType;
-		const isDark = datasetThemeType === 'dark' || (theme === 'dark') || (theme === 'system' && isSystemDark);
-		const effectiveTheme = isDark ? 'dark' : 'neutral';
-		mermaid.initialize({ startOnLoad: false, theme: effectiveTheme });
+		mermaid.initialize({ startOnLoad: false, theme: currentMermaidTheme() });
 
 		// Process code blocks
 		const codeBlocks = Array.from(markdownBody.querySelectorAll('pre code'));
@@ -977,11 +994,10 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 					// Create container and replace the <pre> block
 					const container = document.createElement('div');
 					container.className = 'mermaid-diagram';
-					// Allow foreignObject for Mermaid text rendering
-					container.innerHTML = DOMPurify.sanitize(svg, {
-						ADD_TAGS: ['foreignObject'],
-						ADD_ATTR: ['dominant-baseline', 'text-anchor'],
-					});
+					// Kept so the export can rebuild the diagram with a light
+					// theme instead of recolouring Mermaid's output.
+					rememberDiagramSource(container, mermaidCode);
+					container.innerHTML = sanitizeDiagramSvg(svg);
 					preEl.replaceWith(container);
 				} catch (error) {
 					console.error('Failed to render Mermaid diagram:', error);
@@ -1844,6 +1860,16 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 
 	async function exportAsPdf() {
 		const tab = tabManager.activeTab;
+		// Mermaid bakes the screen theme into the SVG it emits, so a dark
+		// preview exports unreadable diagrams. Rebuild them light for the
+		// duration of the export rather than trying to recolour the output.
+		const restoreDiagrams = await renderDiagramsForPrint({
+			root: markdownBody,
+			mermaid,
+			sanitizeSvg: sanitizeDiagramSvg,
+			screenTheme: currentMermaidTheme(),
+			onError: (error) => console.error('Failed to re-render diagram for export', error),
+		});
 		try {
 			await _exportPdf({
 				tabPath: tab?.path || '',
@@ -1852,6 +1878,8 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		} catch (error) {
 			console.error('Failed to export PDF', error);
 			addToast('Failed to export PDF', 'error');
+		} finally {
+			restoreDiagrams();
 		}
 	}
 

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -3512,14 +3512,6 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		}
 	}
 
-	@media print {
-		.markdown-body {
-			height: auto !important;
-			overflow: visible !important;
-			padding: 0 !important;
-		}
-	}
-
 	.markdown-container :global(.markdown-body pre),
 	.markdown-container :global(.markdown-body pre code),
 	.markdown-container :global(.markdown-body pre tt),

--- a/src/lib/utils/mermaidPrint.ts
+++ b/src/lib/utils/mermaidPrint.ts
@@ -1,0 +1,114 @@
+/**
+ * Paper needs light diagrams, but Mermaid bakes the theme into the SVG it
+ * emits: fills, strokes and label colours are attributes on the generated
+ * elements, not variables a stylesheet can retarget.
+ *
+ * Overriding them from the print stylesheet means enumerating Mermaid's
+ * internal class names, and those differ per diagram type and drift between
+ * releases — flowchart nodes sit under `g.node`, sequence actors are a bare
+ * `rect.actor`, flowchart labels moved into `foreignObject` in v11 while
+ * sequence labels are still `<text>`. Miss one and the result is worse than
+ * no override at all: the label rule lands, the fill rule does not, and dark
+ * text ends up painted on a dark box.
+ *
+ * So instead of recolouring the output we re-render it. Before an export the
+ * diagrams are rebuilt with Mermaid's light theme from the source we kept on
+ * the container, and the on-screen rendering is restored afterwards. That is
+ * correct for every diagram type, including ones added by future Mermaid
+ * versions, and needs no print CSS at all.
+ */
+
+const SOURCE_ATTR = 'data-mermaid-source';
+
+export const MERMAID_PRINT_THEME = 'neutral';
+
+export interface MermaidRenderer {
+	initialize(config: { startOnLoad: boolean; theme: string }): void;
+	render(id: string, source: string): Promise<{ svg: string }>;
+}
+
+/**
+ * Mermaid's own theme choice for the current appearance. Shared by the
+ * on-screen render and the print restore so the two cannot drift.
+ */
+export function resolveMermaidTheme(input: {
+	theme: string;
+	datasetThemeType?: string;
+	systemPrefersDark: boolean;
+}): string {
+	const isDark =
+		input.datasetThemeType === 'dark' ||
+		input.theme === 'dark' ||
+		(input.theme === 'system' && input.systemPrefersDark);
+	return isDark ? 'dark' : 'neutral';
+}
+
+/** Keeps the source next to the rendered diagram so it can be rebuilt later. */
+export function rememberDiagramSource(container: Element, source: string) {
+	container.setAttribute(SOURCE_ATTR, source);
+}
+
+export function readDiagramSource(container: Element): string | null {
+	return container.getAttribute(SOURCE_ATTR);
+}
+
+export function findRestorableDiagrams(root: ParentNode): Element[] {
+	return Array.from(root.querySelectorAll(`.mermaid-diagram[${SOURCE_ATTR}]`));
+}
+
+export interface PrintDiagramContext {
+	root: ParentNode | null | undefined;
+	mermaid: MermaidRenderer | null | undefined;
+	/** Same sanitizer the on-screen render uses. */
+	sanitizeSvg: (svg: string) => string;
+	/** Mermaid theme to return to once the export is done. */
+	screenTheme: string;
+	printTheme?: string;
+	/** Injected so the id is deterministic under test. */
+	idFactory?: (index: number) => string;
+	onError?: (error: unknown) => void;
+}
+
+/**
+ * Re-renders every diagram under `root` with the print theme and returns a
+ * function that puts the on-screen rendering back. The restore is idempotent
+ * and safe to call from a `finally` even when nothing was re-rendered.
+ */
+export async function renderDiagramsForPrint(context: PrintDiagramContext): Promise<() => void> {
+	const { root, mermaid } = context;
+	if (!root || !mermaid) return () => {};
+
+	const diagrams = findRestorableDiagrams(root);
+	if (diagrams.length === 0) return () => {};
+
+	// Snapshot before touching anything: a diagram whose re-render throws is
+	// left exactly as it was, and the restore still covers it.
+	const snapshots = diagrams.map((element) => ({ element, html: element.innerHTML }));
+
+	const idFactory = context.idFactory ?? ((index: number) => `mermaid-print-${index}-${Math.floor(Math.random() * 10000)}`);
+
+	mermaid.initialize({ startOnLoad: false, theme: context.printTheme ?? MERMAID_PRINT_THEME });
+
+	for (const [index, element] of diagrams.entries()) {
+		const source = readDiagramSource(element);
+		if (!source) continue;
+		try {
+			const { svg } = await mermaid.render(idFactory(index), source);
+			element.innerHTML = context.sanitizeSvg(svg);
+		} catch (error) {
+			// A diagram that fails to re-render keeps its screen rendering:
+			// a dark diagram on paper still beats a blank space.
+			context.onError?.(error);
+		}
+	}
+
+	let restored = false;
+	return () => {
+		if (restored) return;
+		restored = true;
+		mermaid.initialize({ startOnLoad: false, theme: context.screenTheme });
+		for (const snapshot of snapshots) {
+			snapshot.element.innerHTML = snapshot.html;
+		}
+	};
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1382,7 +1382,7 @@ body {
 /* print styles for pdf export */
 @media print {
 	@page {
-		margin: 0.75in;
+		margin: 0;
 		size: auto;
 	}
 
@@ -1445,14 +1445,19 @@ body {
 	}
 
 	.markdown-body {
-		padding: 0 !important;
+		padding: 0.75in !important;
 		margin: 0 !important;
+		box-sizing: border-box !important;
+		box-decoration-break: clone !important;
+		-webkit-box-decoration-break: clone !important;
 		overflow: visible !important;
 		height: auto !important;
 		min-height: auto !important;
 		max-width: 100% !important;
 		color: #000 !important;
 		background: white !important;
+		print-color-adjust: exact !important;
+		-webkit-print-color-adjust: exact !important;
 		position: static !important;
 	}
 
@@ -1493,12 +1498,30 @@ body {
 
 	.markdown-body pre,
 	.markdown-body blockquote,
+	.markdown-body .markdown-alert,
 	.markdown-body table,
 	.markdown-body figure,
 	.markdown-body img,
 	.markdown-body .mermaid-diagram,
 	.markdown-body .katex-display {
 		break-inside: avoid;
+	}
+
+	.markdown-body .markdown-alert {
+		page-break-inside: avoid !important;
+		break-inside: avoid !important;
+		box-decoration-break: clone !important;
+		-webkit-box-decoration-break: clone !important;
+	}
+
+	.markdown-body details.markdown-alert {
+		page-break-inside: avoid !important;
+		break-inside: avoid !important;
+	}
+
+	.markdown-body tr {
+		break-inside: avoid;
+		page-break-inside: avoid;
 	}
 
 	/* Keep screen chrome out of the export while giving the document its own

--- a/src/styles.css
+++ b/src/styles.css
@@ -1469,15 +1469,20 @@ body {
 		overflow: visible !important;
 	}
 
-	/* Paper has no horizontal scrollbar, so restore the fixed table-layout for
-	   export: wide tables wrap to fit the page width instead of being clipped
-	   by the on-screen `display: block; overflow-x: auto` scroll container. */
+	/* Paper has no horizontal scrollbar. Let the browser distribute columns from
+	   their content so wide tables wrap at words instead of one glyph at a time. */
 	.markdown-body table {
 		display: table !important;
-		table-layout: fixed !important;
+		table-layout: auto !important;
 		width: 100% !important;
 		max-width: 100% !important;
 		overflow: visible !important;
+	}
+
+	.markdown-body table th,
+	.markdown-body table td {
+		overflow-wrap: break-word !important;
+		word-break: normal !important;
 	}
 
 	.markdown-body p,
@@ -1522,6 +1527,29 @@ body {
 	.markdown-body tr {
 		break-inside: avoid;
 		page-break-inside: avoid;
+	}
+
+	/* Diagrams are re-rendered with Mermaid's light theme before an
+	   export (see utils/mermaidPrint.ts), so the printed SVG already
+	   carries paper colours and needs no overrides here. Recolouring
+	   Mermaid's output from CSS meant enumerating its internal class
+	   names, which differ per diagram type and change between
+	   releases. */
+
+	.markdown-body .frontmatter-panel,
+	.markdown-body .frontmatter-summary {
+		box-sizing: border-box !important;
+		max-width: 100% !important;
+	}
+
+	.markdown-body .frontmatter-title {
+		min-width: 0 !important;
+		overflow: hidden !important;
+		text-overflow: ellipsis !important;
+	}
+
+	.markdown-body .frontmatter-count {
+		flex-shrink: 0 !important;
 	}
 
 	/* Keep screen chrome out of the export while giving the document its own


### PR DESCRIPTION
## Summary

PDF exports now use a paper layout of their own instead of inheriting the active screen theme, and diagrams are rebuilt for paper rather than recoloured.

**Paper layout.** The page gets its margin from the document body so a dark theme no longer leaves the sheet edges unpainted. Wide tables distribute columns from their content and wrap at word boundaries, alerts and table rows stay inside page boundaries, and the properties panel no longer overflows.

**Diagrams.** Mermaid bakes the active theme into the SVG it emits — fills, strokes and label colours are attributes on the generated elements, not variables a stylesheet can retarget. My first attempt overrode them from the print stylesheet, which means enumerating Mermaid's internal class names; those differ per diagram type and drift between releases. Flowchart nodes sit under `g.node`, sequence actors are a bare `rect.actor`, and flowchart labels moved into `foreignObject` in v11 while sequence labels are still `<text>`.

Missing one is worse than no override at all: the label rule lands, the fill rule does not, and dark text ends up painted on a near-black box. Measured against Mermaid 11.12 rendered with the dark theme, the enumerated rules left sequence diagrams at a contrast ratio of **1.18** — effectively invisible — while flowcharts reached 4.94.

So this now rebuilds the diagrams instead. The screen render keeps the diagram source on its container, and an export re-renders every diagram with Mermaid's light theme before printing, restoring the on-screen rendering afterwards. The same measurement gives **4.75** for sequence diagrams and leaves flowcharts unchanged. It stays correct for diagram types this version has never seen, and the 36 lines of recolouring CSS are gone. Diagram pagination rules stay.

Fixes #232

## Validation

- `npm run check` — 0 errors, 0 warnings
- `npm test` — 161/161, including a new `scripts/mermaidPrintTheme.test.ts` covering the theme decision, source round-trip, re-render, idempotent restore, and the failure path where a diagram that cannot be rebuilt keeps its screen rendering
- Contrast figures above were measured in Chromium against Mermaid 11.12.2 for flowchart, sequence and gantt diagrams, before and after the change
- Page geometry checked across a 111-page export: top margin 54–60pt against a 0.75in target, no page below 40pt