### PR TITLE
fix(tabs): stop the tab context menu from leaking and deadlocking

### DIFF
--- a/scripts/tabContextMenuIsolation.test.ts
+++ b/scripts/tabContextMenuIsolation.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const contextMenu = readFileSync(new URL('../src/lib/components/ContextMenu.svelte', import.meta.url), 'utf8');
+const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
+const tab = readFileSync(new URL('../src/lib/components/Tab.svelte', import.meta.url), 'utf8');
+const lib = readFileSync(new URL('../src-tauri/src/lib.rs', import.meta.url), 'utf8');
+
+// Issue #356, first failure: right-clicking a second time while a tab menu is
+// open produced a *different* menu. The open menu's overlay covers the whole
+// viewport, so the second right-click lands on the overlay — which dismissed
+// the tab menu but let the event keep bubbling to the document-level handler,
+// which then opened the document context menu (Copy / Select All / Edit).
+test('the context-menu overlay does not leak right-clicks to the document handler', () => {
+	assert.match(
+		contextMenu,
+		/class="context-menu-overlay"[^>]*oncontextmenu=\{\(e\) => \{ e\.preventDefault\(\); e\.stopPropagation\(\); onhide\(\); \}\}/,
+	);
+});
+
+test('the document context menu is still reachable when no menu overlay is open', () => {
+	// Guard against "fixing" the leak by disabling the document menu outright.
+	assert.match(viewer, /oncontextmenu=\{handleContextMenu\}/);
+	assert.match(viewer, /function handleContextMenu\(e: MouseEvent\) \{/);
+});
+
+test('a tab right-click never reaches the tab-strip container menu', () => {
+	// Tab.svelte stops propagation itself; that is the other half of keeping
+	// exactly one menu per right-click.
+	assert.match(
+		tab,
+		/async function handleContextMenu\(e: MouseEvent\) \{\n\t\te\.preventDefault\(\);\n\t\te\.stopPropagation\(\);/,
+	);
+});
+
+// Issue #356, second failure: "Move to New Window" did nothing on Windows and
+// then froze the whole app (no menus, dead close button, force-kill required).
+// `WebviewWindowBuilder::build()` deadlocks when called from a synchronous
+// Tauri command on Windows/WebView2 — the main thread is blocked inside the
+// command while WebView2 waits for that same thread to pump messages.
+// See tauri-apps/tauri#12521.
+test('create_transfer_window is async so window creation cannot deadlock the main thread', () => {
+	assert.match(lib, /#\[tauri::command\]\nasync fn create_transfer_window\(/);
+	assert.doesNotMatch(lib, /#\[tauri::command\]\nfn create_transfer_window\(/);
+});

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -526,10 +526,16 @@ fn pick_delivery_window(app: &AppHandle) -> Option<tauri::WebviewWindow> {
 /// embeds the transfer token ("window-<token>"), so the new frontend can
 /// derive which pending transfer to claim from its own label — no URL
 /// query involved (the asset protocol 404s on "index.html?x=y" paths).
-/// Deliberately NOT async: sync commands run on the main thread, which
-/// window creation requires on macOS.
+/// Deliberately async. `WebviewWindowBuilder::build()` deadlocks on Windows
+/// when it runs inside a synchronous command: WebView2 needs the main thread
+/// to pump messages while the webview is created, but a sync command IS the
+/// main thread, blocked waiting for build() to return. The whole app then
+/// freezes — no new window, no menus, an unresponsive close button
+/// (tauri-apps/tauri#12521). An async command runs off the event loop, and
+/// Tauri dispatches the actual window creation to the main thread itself, so
+/// macOS's main-thread requirement is still satisfied.
 #[tauri::command]
-fn create_transfer_window(app: AppHandle, token: String) -> Result<(), String> {
+async fn create_transfer_window(app: AppHandle, token: String) -> Result<(), String> {
     window_runtime::create_transfer_window(app, token)
 }
 

--- a/src/lib/components/ContextMenu.svelte
+++ b/src/lib/components/ContextMenu.svelte
@@ -44,7 +44,7 @@
 {#if show}
 	<!-- svelte-ignore a11y_click_events_have_key_events -->
 	<!-- svelte-ignore a11y_no_static_element_interactions -->
-	<div class="context-menu-overlay" onclick={onhide} oncontextmenu={(e) => { e.preventDefault(); onhide(); }}>
+	<div class="context-menu-overlay" onclick={onhide} oncontextmenu={(e) => { e.preventDefault(); e.stopPropagation(); onhide(); }}>
 		<div
 			class="context-menu show-dropdown"
 			bind:this={menuEl}


### PR DESCRIPTION
## Summary

Two independent defects behind #356, both reproduced by reading the code paths rather than the tab-menu routing that the symptoms suggest.

**Two different menus on repeated right-click.** An open context menu renders a `position: fixed` overlay across the whole viewport. A second right-click therefore lands on that overlay, not on the tab. The overlay dismissed the tab menu but only called `preventDefault()` — the event kept bubbling to the document-level `oncontextmenu`, which opened the document menu (Copy / Select All / Edit). That is the second screenshot in the issue. The overlay now stops propagation, so a right-click on a tab always yields the tab menu.

**"Move to New Window" froze the app on Windows.** `create_transfer_window` was a synchronous command calling `WebviewWindowBuilder::build()`. On Windows this deadlocks: WebView2 needs the main thread to pump messages while the webview is created, and a synchronous command *is* the main thread, blocked waiting for `build()` to return (tauri-apps/tauri#12521). The main thread never recovers, which is why no window appears, menus stop responding, the close button does nothing, and the process has to be killed. macOS and Linux are unaffected. Making the command `async` moves it off the event loop; Tauri still dispatches the window creation itself to the main thread, so macOS's main-thread requirement is preserved.

The doc comment on that command claimed the opposite ("Deliberately NOT async: sync commands run on the main thread, which window creation requires on macOS") and has been corrected.

Fixes #356

## Validation

- `npm run check` — 0 errors, 0 warnings
- `npm test` — 157/157
- `cargo check` — clean
- New `scripts/tabContextMenuIsolation.test.ts` pins both fixes, including a guard that the document context menu stays reachable when no overlay is open.

The Windows deadlock cannot be exercised from CI or from macOS; the fix follows the resolution documented in the upstream Tauri issue and needs a confirmation pass on Windows 11.