### PR TITLE
ci: verify behaviour on every platform and halve the macOS queue

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -6,18 +6,30 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Every push to a pull request queued another full matrix while the previous
+# one was still waiting for a runner, and both then competed for the same
+# scarce macOS capacity. Only the newest revision of a branch is worth
+# building.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-test:
     strategy:
       fail-fast: false
       matrix:
         include:
+          # One macOS entry, targeting the universal binary the release
+          # actually ships. Two separate arch entries cost two runners from a
+          # pool an order of magnitude smaller than the Linux and Windows
+          # ones -- macOS jobs here finish in 6-8 minutes but were waiting
+          # 20-30 for a slot -- while covering strictly less: universal
+          # compiles both architectures, so an Intel-only break still fails
+          # the check, and it fails on the same artifact the release produces.
           - platform: 'macos-latest'
-            args: '--target aarch64-apple-darwin'
-            os-name: 'macos-aarch64'
-          - platform: 'macos-latest'
-            args: '--target x86_64-apple-darwin'
-            os-name: 'macos-x64'
+            args: '--target universal-apple-darwin'
+            os-name: 'macos-universal'
           - platform: 'ubuntu-22.04'
             args: ''
             os-name: 'linux'
@@ -48,6 +60,18 @@ jobs:
 
       - name: install frontend dependencies
         run: npm ci
+
+      # test.yml runs the suites on Linux only, so a Windows- or macOS-only
+      # regression in the cfg-gated code paths reaches a release build
+      # unchallenged. Running them here makes the platform matrix prove
+      # behaviour, not just that the tree compiles.
+      - name: run frontend behavior tests
+        shell: bash
+        run: npm test
+
+      - name: run cargo test
+        working-directory: src-tauri
+        run: cargo test
 
       - name: Build app
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ test.md
 test_image.png
 src-tauri/output.txt
 
+# Build output and local working directories
+dist/
+.cache/
+.worktrees/


### PR DESCRIPTION
## Summary

`test.yml` runs `npm run check`, `npm test` and `cargo test` on a single `ubuntu-22.04` runner. `test_build.yml` has a platform matrix but only builds.

The matrix therefore proves the tree *compiles* everywhere and nothing more. A Windows- or macOS-only behavioural regression in the `cfg`-gated paths — which is exactly where this project's platform-parity bugs keep landing — reaches a release build unchallenged.

This runs the suites inside the matrix, and pays for the added time twice over.

## Why the matrix shrinks

The matrix built macOS twice, once per architecture. Measured across the currently open pull requests:

| job | runs in | waits for a runner |
|---|---|---|
| `linux` | 9m10s | starts immediately |
| `windows` | 10m19s | starts immediately |
| `macos-aarch64` | 6m06s | **19–30 min** |
| `macos-x64` | 8m10s | **19–30 min, several still queued** |

macOS jobs are the *fastest* here and the slowest to start: capacity, not duration, is the constraint, and every pull request was taking two of those slots.

One entry targeting `universal-apple-darwin` takes one slot and covers strictly more. It compiles both architectures, so an Intel-only break still fails the check — and it fails on the same artifact the release produces, rather than on a pair of single-arch binaries nothing ships.

## Why the concurrency group

Each push to a pull request queued another full matrix while the previous one was still waiting for a runner, and both then competed for the same macOS capacity. Several open pull requests are currently showing duplicated `test`, `linux` and `windows` checks from exactly this. Superseded runs are now cancelled.

## Notes

- `npm test` is pinned to `shell: bash` — its script globs `scripts/*.test.ts`, and the Windows runner's default `pwsh` neither expands the glob nor strips the quotes.
- `cargo test` uses `working-directory` rather than `cd … && …`, so it does not depend on the shell's operator support.
- The Rust toolchain step already installs both Apple targets for `macos-latest`, and the artifact upload already globs `src-tauri/target/*/release/bundle/…`, so both keep working unchanged.
- Also ignores `dist/`, `.cache/` and `.worktrees/`, none of which have tracked files today.

## Validation

- Workflow parses; step order confirmed as install → `npm test` → `cargo test` → build across all three matrix entries.
- Both suites were run on a Windows runner ahead of this PR, on a branch carrying the tab-menu and PDF fixes: `npm test` and `cargo test` both pass there. That was their first execution on Windows and it found no platform-specific failures — the coverage this PR establishes starts from a green baseline.