### PR TITLE
fix(export): inline local images on Windows

### DIFF
--- a/scripts/exportHtml.test.ts
+++ b/scripts/exportHtml.test.ts
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 
 import { parseFrontMatter } from '../src/lib/utils/frontMatter.js';
 import {
+	isAssetUrl,
 	normalizeAssetPath,
 	renderStaticFrontMatterPanel,
 	resolveExportImagePath,
@@ -18,6 +19,43 @@ test('normalizeAssetPath decodes Tauri asset URLs for Windows drive paths and UN
 		normalizeAssetPath('asset://localhost/%5C%5Cserver%5Cshare%5Cimage.png'),
 		'\\\\server\\share\\image.png',
 	);
+});
+
+test('normalizeAssetPath accepts the shape convertFileSrc actually emits on Windows', () => {
+	// convertFileSrc returns `http://asset.localhost/...` on Windows and Android,
+	// and `asset://localhost/...` elsewhere. Only the second form was handled, so
+	// no local image was ever inlined into a Windows export.
+	assert.equal(
+		normalizeAssetPath('http://asset.localhost/C%3A%2FUsers%2FDaniel%2Fimg%2Fdiagram.png'),
+		'C:/Users/Daniel/img/diagram.png',
+	);
+	assert.equal(
+		normalizeAssetPath('https://asset.localhost/C%3A%2FDocs%2Fa%20b.png'),
+		'C:/Docs/a b.png',
+	);
+	// Look-alike hosts must stay remote.
+	assert.equal(normalizeAssetPath('http://asset.localhost.evil.test/C:/secret.png'), null);
+	assert.equal(normalizeAssetPath('http://asset.localhostx/C:/secret.png'), null);
+	assert.equal(normalizeAssetPath('https://example.test/a.png'), null);
+});
+
+test('isAssetUrl distinguishes asset URLs from ordinary remote ones', () => {
+	assert.equal(isAssetUrl('asset://localhost/a.png'), true);
+	assert.equal(isAssetUrl('http://asset.localhost/a.png'), true);
+	assert.equal(isAssetUrl('https://asset.localhost/a.png'), true);
+	assert.equal(isAssetUrl('http://asset.localhost.evil.test/a.png'), false);
+	assert.equal(isAssetUrl('https://example.test/a.png'), false);
+});
+
+test('a Windows asset URL is inlined rather than treated as a remote image', () => {
+	// The remote-scheme bail-out used to run first, so the Windows asset URL was
+	// dropped before it could be recognised: not inlined, and not counted as a
+	// missing image either, so the export silently shipped a dead link.
+	assert.equal(
+		resolveExportImagePath('http://asset.localhost/C%3A%2FDocs%2Fimg%2Fa.png', 'C:\\Docs\\note.md'),
+		'C:/Docs/img/a.png',
+	);
+	assert.equal(resolveExportImagePath('http://asset.localhost.evil.test/a.png', 'C:\\Docs\\note.md'), null);
 });
 
 test('resolveExportImagePath preserves remote/data images and resolves local paths cross-platform', () => {

--- a/src/lib/utils/exportHtml.ts
+++ b/src/lib/utils/exportHtml.ts
@@ -52,14 +52,27 @@ function normalizeUrlPathname(pathname: string): string {
 	return path;
 }
 
+// `convertFileSrc` does not produce the same shape everywhere: Windows (and
+// Android) get `http://asset.localhost/<encoded path>`, every other platform
+// gets `asset://localhost/<encoded path>`. The app's own CSP lists both. Missing
+// the `asset.localhost` form meant no local image was ever inlined on Windows.
+const assetHostPattern = /^https?:\/\/asset\.localhost(?:\/|$)/i;
+const assetSchemePattern = /^asset:/i;
+
+export function isAssetUrl(src: string): boolean {
+	return assetSchemePattern.test(src) || assetHostPattern.test(src);
+}
+
 export function normalizeAssetPath(src: string): string | null {
-	if (!src.startsWith('asset:')) return null;
+	if (!isAssetUrl(src)) return null;
 
 	try {
 		const url = new URL(src);
 		return normalizeUrlPathname(url.pathname);
 	} catch {
-		const path = src.replace(/^asset:\/\/localhost\/?/i, '');
+		const path = src
+			.replace(/^asset:\/\/localhost\/?/i, '')
+			.replace(/^https?:\/\/asset\.localhost\/?/i, '');
 		return normalizeUrlPathname('/' + path);
 	}
 }
@@ -67,10 +80,13 @@ export function normalizeAssetPath(src: string): string | null {
 export function resolveExportImagePath(src: string, tabPath: string): string | null {
 	const trimmed = src.trim();
 	if (!trimmed) return null;
-	if (/^(?:https?:|data:|blob:)/i.test(trimmed)) return null;
-
+	// Must run before the remote-scheme bail-out: the Windows asset URL *is* an
+	// `http:` URL, and bailing out early skipped both the inlining and the
+	// `missingImages` counter, so the export silently shipped dead links.
 	const assetPath = normalizeAssetPath(trimmed);
 	if (assetPath) return assetPath;
+
+	if (/^(?:https?:|data:|blob:)/i.test(trimmed)) return null;
 
 	if (/^file:/i.test(trimmed)) {
 		try {


### PR DESCRIPTION
## Summary

`convertFileSrc` does not return the same shape on every platform: Windows (and Android) get `http://asset.localhost/<encoded path>`, everywhere else gets `asset://localhost/<encoded path>`. The app's own CSP lists both forms, but `normalizeAssetPath` only recognised the second.

Worse, the remote-scheme bail-out ran first. Because the Windows asset URL *is* an `http:` URL, it was discarded before it could be recognised — so the image was neither inlined **nor** counted in `missingImages`. A Windows export silently shipped `http://asset.localhost/...` references that are dead the moment the file leaves the app, and the "some images could not be inlined" toast never fired.

This recognises both shapes and checks for them before the remote bail-out. The host match is anchored, so `asset.localhost.evil.test` and `asset.localhostx` stay remote.

## Reviewer note

The existing tests passed only because they used `asset://localhost/C:/…` — a shape `convertFileSrc` never actually produces (it percent-encodes the path). The new cases use the real encoded output for both platforms, plus look-alike hosts as negatives.

## Validation

- `npm run check` — 0 errors, 0 warnings
- `npm test` — 156/156