### PR TITLE
fix(editor): allow saving from reading mode

### DIFF
--- a/scripts/saveFromReadingMode.test.ts
+++ b/scripts/saveFromReadingMode.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
+
+function keydownSaveBranch(): string {
+	const start = viewer.indexOf("if (cmdOrCtrl && key === 's') {");
+	assert.notEqual(start, -1, 'the Ctrl/Cmd+S keydown branch should exist');
+	const end = viewer.indexOf("if (cmdOrCtrl && e.shiftKey && key === 't')", start);
+	assert.notEqual(end, -1, 'expected a following branch to bound the slice');
+	return viewer.slice(start, end);
+}
+
+// Reported in #168 by @dayeggpi: with a document that was never saved,
+// Ctrl+S in reading mode did nothing at all. `toggleEdit` only runs its
+// save/confirm flow for tabs that already have a path, so an untitled buffer
+// switches to reading mode still dirty — and then the one shortcut that could
+// rescue it was suppressed.
+test('Ctrl+S is not gated on the editor being visible', () => {
+	const branch = keydownSaveBranch();
+	assert.doesNotMatch(branch, /if \(isEditing \|\| isSplit\)/);
+	assert.match(branch, /saveContent\(\)/);
+});
+
+test('an untitled buffer can be saved from reading mode', () => {
+	const branch = keydownSaveBranch();
+	// `path === ''` is the untitled case; documentSession.saveContent opens
+	// the Save dialog for it, so no extra plumbing is needed here.
+	assert.match(branch, /saveTarget\.path === ''/);
+});
+
+test('a saved, unmodified document does not write on Ctrl+S', () => {
+	// Writing unconditionally would touch mtime and wake the file watcher,
+	// which in live mode reloads the tab -- a keystroke that reads as a no-op
+	// to the user should not move the document underneath them.
+	const branch = keydownSaveBranch();
+	assert.match(branch, /saveTarget\.isDirty \|\| saveTarget\.path === ''/);
+});
+
+test('the browser save dialog is always suppressed', () => {
+	// preventDefault has to run for every mode, including the no-op case,
+	// or reading mode would surface the webview's own Save Page dialog.
+	const branch = keydownSaveBranch();
+	const beforeGuard = branch.slice(0, branch.indexOf('const saveTarget'));
+	assert.match(beforeGuard, /e\.preventDefault\(\);/);
+});
+
+test('the HOME tab is not savable', () => {
+	// HOME carries the sentinel path 'HOME' and is never dirty, so the guard
+	// excludes it without naming it. This pins that reasoning: if the guard
+	// ever becomes unconditional, HOME would start opening a Save dialog.
+	const branch = keydownSaveBranch();
+	assert.doesNotMatch(branch, /^\s*saveContent\(\);\s*$/m);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -2347,10 +2347,17 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			if (!isSplit) toggleEdit(true);
 		}
 		if (cmdOrCtrl && key === 's') {
-			if (isEditing || isSplit) {
-				e.preventDefault();
-				saveContent();
-			}
+			// Reading mode used to swallow the shortcut entirely. An untitled
+			// buffer reaches it with content still unsaved — `toggleEdit`
+			// only runs its save flow for tabs that already have a path — so
+			// the only way to keep that text was to switch back to the
+			// editor first. Saving is never mode-specific; the guard now
+			// asks whether there is anything to write, not which pane is
+			// visible. A saved, unmodified document stays a no-op so the
+			// shortcut cannot churn its mtime and wake the file watcher.
+			e.preventDefault();
+			const saveTarget = tabManager.activeTab;
+			if (saveTarget && (saveTarget.isDirty || saveTarget.path === '')) saveContent();
 		}
 
 		if (cmdOrCtrl && e.shiftKey && key === 't') {


### PR DESCRIPTION
## Summary

With a document that was never saved, `Ctrl/Cmd+S` in reading mode did nothing at all.

`toggleEdit` only runs its save-or-confirm flow for tabs that already have a path (`if (tab.isDirty && tab.path !== '')`), so an untitled buffer switches to reading mode with its content still unsaved. The keydown handler then suppressed the shortcut behind `if (isEditing || isSplit)` — the one action that could rescue that text was the one action the mode refused. Nothing on screen suggests the shortcut is unavailable; it just silently does nothing, and the only recovery is knowing to switch back to the editor first.

Saving is not mode-specific. The guard now asks whether there is anything to write rather than which pane happens to be visible:

- an untitled buffer saves from any mode — `documentSession.saveContent` already opens the Save dialog for a pathless tab, so reading mode needs no extra plumbing;
- a saved, unmodified document stays a no-op, so the shortcut cannot churn its mtime and wake the file watcher (which, in live mode, would reload the tab underneath the user);
- the HOME tab is excluded by the same condition without being special-cased — it carries a sentinel path and is never dirty.

`preventDefault` now runs unconditionally, including for the no-op case. Previously reading mode let the shortcut fall through to the webview's own Save Page dialog.

## Credit

Reported by @dayeggpi in #168. That PR also proposed two other changes, both since overtaken by other work: the "autosave + confirm before save prompts every 1.5 s" loop is fixed on `master` (auto-save is now disabled outright while `confirmBeforeSave` is on), and the menu Save entry it edited no longer exists — the macOS File submenu was removed in a later refactor. This lifts the one finding that is still live.

## Validation

- `npm run check` — 0 errors, 0 warnings
- `npm test` — 168/168, including a new `scripts/saveFromReadingMode.test.ts` covering the untitled case, the clean-document no-op, unconditional `preventDefault`, and HOME staying unsavable