### PR TITLE
fix(transfer): never leave a moved tab open in both windows

### DIFF
--- a/scripts/tabTransferHandoff.test.ts
+++ b/scripts/tabTransferHandoff.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const session = readFileSync(new URL('../src/lib/sessions/windowSession.svelte.ts', import.meta.url), 'utf8');
+const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
+const broker = readFileSync(new URL('../src-tauri/src/tab_transfer.rs', import.meta.url), 'utf8');
+
+// A tab transfer is only ever allowed to end in one of two states: the source
+// still has the tab, or the destination does. Every defect below produced the
+// third state -- present in both windows, each with its own auto-save timer
+// writing over the other.
+
+test('the source keeps waiting when the destination has already claimed', () => {
+	// The 15s timeout is a guess about a window that may simply be slow to
+	// render. Cancelling regardless is what stranded a copy on each side.
+	const cancel = session.slice(session.indexOf('const cancel = async ()'));
+	assert.match(cancel, /outcome\.cancelled/);
+	assert.match(cancel, /outcome\.claimed/);
+	assert.match(cancel, /if \(!outcome\.cancelled && outcome\.claimed\) return;/);
+});
+
+test('the destination releases its claim when it cannot finish', () => {
+	// Because a claimed transfer is immune to the source's timeout, the
+	// destination is the only party that can end a claim it cannot complete.
+	assert.match(session, /async function releaseClaim\(token: string\)/);
+	const accept = session.slice(
+		session.indexOf('async function acceptOfferedTransfer'),
+		session.indexOf('async function claimTransferredTab'),
+	);
+	// Invalid payload, a refusing destination, and a thrown render all release.
+	assert.equal((accept.match(/releaseClaim\(token\)/g) ?? []).length, 3);
+	assert.match(accept, /if \(claimed\) await releaseClaim\(token\);/);
+});
+
+test('a claim is distinguished from "no such token"', () => {
+	// Releasing a token that was never claimed would be a no-op at best and a
+	// cancel of someone else's transfer at worst.
+	const accept = session.slice(
+		session.indexOf('async function acceptOfferedTransfer'),
+		session.indexOf('async function claimTransferredTab'),
+	);
+	assert.match(accept, /if \(payload === null\)/);
+	assert.match(accept, /claimed = true;/);
+});
+
+test('a failed render undoes the inserted tab', () => {
+	// The tab must exist before it can be rendered, so the destination owns a
+	// document the source still shows until the render succeeds.
+	const accept = viewer.slice(
+		viewer.indexOf('acceptTransferredTab: async (snapshot)'),
+		viewer.indexOf('onError: (message, error)'),
+	);
+	assert.match(accept, /\} catch \(error\) \{\s*\n\s*tabManager\.closeTab\(id\);\s*\n\s*throw error;/);
+	assert.match(accept, /if \(isDisposed\) \{\s*\n\s*tabManager\.closeTab\(id\);/);
+});
+
+test('a second transfer of the same tab is refused while one is in flight', () => {
+	// The menu entry becomes clickable again long before the transfer
+	// resolves; two payloads for one tab means two windows each build it.
+	assert.match(session, /const transfersInFlight = new Set<string>\(\);/);
+	assert.match(session, /if \(transfersInFlight\.has\(tabId\)\) return false;/);
+	assert.match(session, /\} finally \{\s*\n\s*transfersInFlight\.delete\(tabId\);/);
+});
+
+test('the broker binds every operation to the window that may perform it', () => {
+	// Tokens used to be t1..t16, and any webview could read or destroy any
+	// staged transfer -- including the document text of a drag in progress.
+	assert.match(broker, /fn is_destination_label/);
+	assert.match(broker, /enum CancelAuthority/);
+	assert.doesNotMatch(broker, /format!\("t\{\}"/);
+});
+
+test('eviction never drops a transfer that is mid-handoff', () => {
+	assert.match(broker, /fn eviction_victim/);
+	assert.match(broker, /claimed_at/);
+});

--- a/src-tauri/src/tab_transfer.rs
+++ b/src-tauri/src/tab_transfer.rs
@@ -1,22 +1,79 @@
+use serde::Serialize;
+use std::collections::hash_map::RandomState;
 use std::collections::HashMap;
+use std::hash::{BuildHasher, Hasher};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, State};
 
 /// Maximum number of staged transfers kept in memory; oldest entries are
 /// evicted first so an abandoned drag can never grow the map unbounded.
 const MAX_PENDING_TRANSFERS: usize = 16;
 
+/// How long a claimed-but-not-completed transfer is protected from the
+/// source window's timeout. Beyond this the destination is assumed dead
+/// (crashed or closed mid-render) and the source may reclaim its tab.
+const CLAIM_GRACE: Duration = Duration::from_secs(60);
+
 #[derive(Clone)]
 pub struct PendingTransfer {
     pub payload: String,
     pub source_label: String,
+    /// Set the first time the destination window claims the payload. The
+    /// broker uses it to tell "nobody picked this up" apart from "picked up,
+    /// still rendering", which the source's timeout must not cancel.
+    pub claimed_at: Option<Instant>,
+}
+
+/// Result of `cancel_detached_tab`. `cancelled == false && claimed == true`
+/// means the destination already took the payload and is still finishing:
+/// the source must keep waiting for `tab-transfer-claimed` instead of
+/// restoring its tab.
+#[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CancelOutcome {
+    pub cancelled: bool,
+    pub claimed: bool,
+}
+
+/// Who is allowed to cancel a staged transfer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CancelAuthority {
+    /// The window that staged the tab: cancels only while unclaimed.
+    Source,
+    /// The `window-<token>` destination: releases its own claim (rollback).
+    Destination,
+    /// Any other window has no business touching this transfer.
+    Forbidden,
 }
 
 #[derive(Default)]
 struct BrokerInner {
     entries: HashMap<String, PendingTransfer>,
     insertion_order: Vec<String>,
+}
+
+impl BrokerInner {
+    /// Which entry to drop once the cap is exceeded.
+    ///
+    /// A claimed entry is a transfer in flight: evicting it would strand the
+    /// tab in both windows, so the oldest *unclaimed* entry goes first. The
+    /// transfer that was just staged is never a candidate, and only when
+    /// everything else is claimed does the oldest entry overall get dropped
+    /// (the map still has to stay bounded).
+    fn eviction_victim(&self) -> Option<String> {
+        let candidates = self.insertion_order.split_last()?.1;
+        candidates
+            .iter()
+            .find(|token| {
+                self.entries
+                    .get(*token)
+                    .is_some_and(|entry| entry.claimed_at.is_none())
+            })
+            .or_else(|| candidates.first())
+            .cloned()
+    }
 }
 
 /// In-memory broker for moving a tab between windows: the source window
@@ -27,6 +84,46 @@ pub struct TabTransferBroker {
     counter: AtomicU64,
 }
 
+/// Label of the window that a token authorises. `create_transfer_window`
+/// in lib.rs builds the destination window with exactly this label, so a
+/// webview cannot forge it: labels are assigned by the backend.
+fn destination_label(token: &str) -> String {
+    format!("window-{token}")
+}
+
+fn is_destination_label(caller_label: &str, token: &str) -> bool {
+    caller_label == destination_label(token)
+}
+
+fn cancel_authority(caller_label: &str, source_label: &str, token: &str) -> CancelAuthority {
+    if caller_label == source_label {
+        CancelAuthority::Source
+    } else if is_destination_label(caller_label, token) {
+        CancelAuthority::Destination
+    } else {
+        CancelAuthority::Forbidden
+    }
+}
+
+/// 64 unpredictable bits. `RandomState` is seeded once per process from the
+/// OS, and the sequence number plus the timestamp and a stack address keep
+/// successive tokens from being derivable from one another. A webview can
+/// observe neither the seed nor the addresses, so tokens are not guessable
+/// the way the old `t1`..`t16` counter was.
+fn random_bits(seq: u64, round: u64) -> u64 {
+    let mut hasher = RandomState::new().build_hasher();
+    hasher.write_u64(seq);
+    hasher.write_u64(round);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_nanos())
+        .unwrap_or(0);
+    hasher.write_u128(nanos);
+    let probe = 0u8;
+    hasher.write_usize(std::ptr::addr_of!(probe) as usize);
+    hasher.finish()
+}
+
 impl TabTransferBroker {
     pub fn new() -> Self {
         TabTransferBroker {
@@ -35,32 +132,96 @@ impl TabTransferBroker {
         }
     }
 
+    fn next_token(&self) -> String {
+        let seq = self.counter.fetch_add(1, Ordering::Relaxed);
+        format!("{:016x}{:016x}", random_bits(seq, 0), random_bits(seq, 1))
+    }
+
     fn stage(&self, payload: String, source_label: String) -> String {
-        let token = format!("t{}", self.counter.fetch_add(1, Ordering::Relaxed) + 1);
+        let token = self.next_token();
         let mut inner = self.inner.lock().unwrap();
         inner.entries.insert(
             token.clone(),
             PendingTransfer {
                 payload,
                 source_label,
+                claimed_at: None,
             },
         );
         inner.insertion_order.push(token.clone());
         while inner.entries.len() > MAX_PENDING_TRANSFERS {
-            let oldest = inner.insertion_order.remove(0);
-            inner.entries.remove(&oldest);
+            let Some(victim) = inner.eviction_victim() else {
+                break;
+            };
+            inner.insertion_order.retain(|entry| entry != &victim);
+            inner.entries.remove(&victim);
         }
         token
     }
 
-    fn claim(&self, token: &str) -> Option<PendingTransfer> {
+    /// Reserves the payload for the destination window without removing it:
+    /// the source keeps its tab until `complete` confirms the hand-off. The
+    /// first claim stamps the entry so the source's timeout can tell a dead
+    /// transfer from one that is merely still rendering.
+    fn claim(&self, token: &str, now: Instant) -> Option<PendingTransfer> {
+        let mut inner = self.inner.lock().unwrap();
+        let entry = inner.entries.get_mut(token)?;
+        if entry.claimed_at.is_none() {
+            entry.claimed_at = Some(now);
+        }
+        Some(entry.clone())
+    }
+
+    fn peek(&self, token: &str) -> Option<PendingTransfer> {
         self.inner.lock().unwrap().entries.get(token).cloned()
     }
 
-    fn cancel(&self, token: &str) {
+    fn take(&self, token: &str) -> Option<PendingTransfer> {
         let mut inner = self.inner.lock().unwrap();
         inner.insertion_order.retain(|entry| entry != token);
-        inner.entries.remove(token);
+        inner.entries.remove(token)
+    }
+
+    /// The source's own timeout path: never destroys a transfer the
+    /// destination has already claimed and is still working on.
+    fn cancel_from_source(&self, token: &str, now: Instant) -> CancelOutcome {
+        let claimed_at = match self.peek(token) {
+            Some(entry) => entry.claimed_at,
+            None => {
+                return CancelOutcome {
+                    cancelled: false,
+                    claimed: false,
+                }
+            }
+        };
+        if let Some(claimed_at) = claimed_at {
+            if now.duration_since(claimed_at) < CLAIM_GRACE {
+                return CancelOutcome {
+                    cancelled: false,
+                    claimed: true,
+                };
+            }
+        }
+        self.take(token);
+        CancelOutcome {
+            cancelled: true,
+            claimed: claimed_at.is_some(),
+        }
+    }
+
+    /// The destination's rollback path: it owns the claim, so it may always
+    /// release it (render failed, window closing).
+    fn cancel_from_destination(&self, token: &str) -> CancelOutcome {
+        match self.take(token) {
+            Some(entry) => CancelOutcome {
+                cancelled: true,
+                claimed: entry.claimed_at.is_some(),
+            },
+            None => CancelOutcome {
+                cancelled: false,
+                claimed: false,
+            },
+        }
     }
 }
 
@@ -75,51 +236,91 @@ pub fn stage_detached_tab(
 
 #[tauri::command]
 pub fn claim_detached_tab(
+    window: tauri::Window,
     state: State<'_, TabTransferBroker>,
     token: String,
-) -> Option<String> {
-    state.claim(&token).map(|transfer| transfer.payload)
+) -> Result<Option<String>, String> {
+    if !is_destination_label(window.label(), &token) {
+        return Err(format!(
+            "TRANSFER_FORBIDDEN: window '{}' may not claim this tab transfer",
+            window.label()
+        ));
+    }
+    Ok(state
+        .claim(&token, Instant::now())
+        .map(|transfer| transfer.payload))
 }
 
 #[tauri::command]
 pub fn complete_detached_tab(
     app: AppHandle,
+    window: tauri::Window,
     state: State<'_, TabTransferBroker>,
     token: String,
-) {
-    if let Some(transfer) = state.claim(&token) {
-        state.cancel(&token);
-        let _ = app.emit_to(
-            transfer.source_label.as_str(),
-            "tab-transfer-claimed",
-            token,
-        );
+) -> Result<(), String> {
+    if !is_destination_label(window.label(), &token) {
+        return Err(format!(
+            "TRANSFER_FORBIDDEN: window '{}' may not complete this tab transfer",
+            window.label()
+        ));
     }
+    let transfer = state.take(&token).ok_or_else(|| {
+        "TRANSFER_NOT_FOUND: the staged tab is gone; the source window kept it".to_string()
+    })?;
+    app.emit_to(transfer.source_label.as_str(), "tab-transfer-claimed", token)
+        .map_err(|e| format!("TRANSFER_HANDOFF_FAILED: {e}"))
 }
 
 #[tauri::command]
-pub fn cancel_detached_tab(state: State<'_, TabTransferBroker>, token: String) {
-    state.cancel(&token);
+pub fn cancel_detached_tab(
+    window: tauri::Window,
+    state: State<'_, TabTransferBroker>,
+    token: String,
+) -> Result<CancelOutcome, String> {
+    let Some(entry) = state.peek(&token) else {
+        // Already completed, cancelled or never staged: cancelling is a
+        // no-op, so stay idempotent rather than erroring on a late timeout.
+        return Ok(CancelOutcome {
+            cancelled: false,
+            claimed: false,
+        });
+    };
+    match cancel_authority(window.label(), &entry.source_label, &token) {
+        CancelAuthority::Source => Ok(state.cancel_from_source(&token, Instant::now())),
+        CancelAuthority::Destination => Ok(state.cancel_from_destination(&token)),
+        CancelAuthority::Forbidden => Err(format!(
+            "TRANSFER_FORBIDDEN: window '{}' may not cancel this tab transfer",
+            window.label()
+        )),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn ago(seconds: u64) -> Instant {
+        Instant::now()
+            .checked_sub(Duration::from_secs(seconds))
+            .expect("test clock should not underflow")
+    }
+
     #[test]
     fn stage_claim_then_complete_removes_entry() {
         let broker = TabTransferBroker::new();
         let token = broker.stage("{\"tab\":1}".to_string(), "main".to_string());
 
-        let transfer = broker.claim(&token).expect("staged transfer should exist");
+        let transfer = broker
+            .claim(&token, Instant::now())
+            .expect("staged transfer should exist");
         assert_eq!(transfer.payload, "{\"tab\":1}");
         assert_eq!(transfer.source_label, "main");
 
         // Claim is a non-destructive reservation read: the source stays intact
         // until the destination has completed validation and rendering.
-        assert!(broker.claim(&token).is_some());
-        broker.cancel(&token);
-        assert!(broker.claim(&token).is_none());
+        assert!(broker.peek(&token).is_some());
+        assert!(broker.take(&token).is_some());
+        assert!(broker.peek(&token).is_none());
     }
 
     #[test]
@@ -127,8 +328,8 @@ mod tests {
         let broker = TabTransferBroker::new();
         let token = broker.stage("{}".to_string(), "window-1".to_string());
 
-        broker.cancel(&token);
-        assert!(broker.claim(&token).is_none());
+        broker.cancel_from_source(&token, Instant::now());
+        assert!(broker.claim(&token, Instant::now()).is_none());
     }
 
     #[test]
@@ -137,6 +338,175 @@ mod tests {
         let first = broker.stage("a".to_string(), "main".to_string());
         let second = broker.stage("b".to_string(), "main".to_string());
         assert_ne!(first, second);
+    }
+
+    // P1-B-4: the old `t{counter}` scheme let any webview walk t1..t16 and
+    // read another window's document.
+    #[test]
+    fn tokens_are_not_enumerable() {
+        let broker = TabTransferBroker::new();
+        let mut seen = Vec::new();
+        for _ in 0..64 {
+            let token = broker.stage("payload".to_string(), "main".to_string());
+            assert_eq!(token.len(), 32, "token should carry 128 bits of hex");
+            assert!(
+                token.chars().all(|c| c.is_ascii_hexdigit()),
+                "token must stay label-safe: {token}"
+            );
+            assert!(!seen.contains(&token), "tokens must not repeat");
+            seen.push(token);
+        }
+        // No sequential relationship between successive tokens.
+        assert!(seen
+            .windows(2)
+            .all(|pair| pair[0].as_bytes()[..8] != pair[1].as_bytes()[..8]));
+    }
+
+    #[test]
+    fn only_the_matching_destination_window_may_claim() {
+        assert!(is_destination_label("window-abc", "abc"));
+        assert!(!is_destination_label("main", "abc"));
+        assert!(!is_destination_label("window-abcd", "abc"));
+        assert!(!is_destination_label("window-abc", "abcd"));
+    }
+
+    #[test]
+    fn cancel_authority_rejects_third_party_windows() {
+        assert_eq!(
+            cancel_authority("main", "main", "abc"),
+            CancelAuthority::Source
+        );
+        assert_eq!(
+            cancel_authority("window-abc", "main", "abc"),
+            CancelAuthority::Destination
+        );
+        // The window of some *other* transfer must not be able to tear this
+        // one down.
+        assert_eq!(
+            cancel_authority("window-zzz", "main", "abc"),
+            CancelAuthority::Forbidden
+        );
+        assert_eq!(
+            cancel_authority("window-7", "window-9", "abc"),
+            CancelAuthority::Forbidden
+        );
+    }
+
+    // P1-B-3: claiming marks the entry so the source's 15s timeout stops
+    // racing a slow but healthy destination.
+    #[test]
+    fn claim_marks_the_entry_and_repeated_claims_keep_the_first_stamp() {
+        let broker = TabTransferBroker::new();
+        let token = broker.stage("doc".to_string(), "main".to_string());
+        assert!(broker.peek(&token).unwrap().claimed_at.is_none());
+
+        let first_at = ago(5);
+        assert!(broker.claim(&token, first_at).is_some());
+        assert_eq!(broker.peek(&token).unwrap().claimed_at, Some(first_at));
+
+        // A retried claim (destination re-reading after a reload) is allowed
+        // and must not restart the grace period.
+        let second = broker
+            .claim(&token, Instant::now())
+            .expect("repeat claim should still return the payload");
+        assert_eq!(second.payload, "doc");
+        assert_eq!(broker.peek(&token).unwrap().claimed_at, Some(first_at));
+    }
+
+    #[test]
+    fn source_timeout_does_not_cancel_a_claimed_transfer() {
+        let broker = TabTransferBroker::new();
+        let token = broker.stage("doc".to_string(), "main".to_string());
+        broker.claim(&token, Instant::now());
+
+        let outcome = broker.cancel_from_source(&token, Instant::now());
+        assert_eq!(
+            outcome,
+            CancelOutcome {
+                cancelled: false,
+                claimed: true
+            }
+        );
+        assert!(
+            broker.peek(&token).is_some(),
+            "the destination is still rendering; the entry must survive"
+        );
+    }
+
+    #[test]
+    fn source_timeout_cancels_an_unclaimed_transfer() {
+        let broker = TabTransferBroker::new();
+        let token = broker.stage("doc".to_string(), "main".to_string());
+
+        let outcome = broker.cancel_from_source(&token, Instant::now());
+        assert_eq!(
+            outcome,
+            CancelOutcome {
+                cancelled: true,
+                claimed: false
+            }
+        );
+        assert!(broker.peek(&token).is_none());
+    }
+
+    #[test]
+    fn source_may_reclaim_after_the_claim_grace_expires() {
+        let broker = TabTransferBroker::new();
+        let token = broker.stage("doc".to_string(), "main".to_string());
+        broker.claim(&token, ago(CLAIM_GRACE.as_secs() + 30));
+
+        let outcome = broker.cancel_from_source(&token, Instant::now());
+        assert_eq!(
+            outcome,
+            CancelOutcome {
+                cancelled: true,
+                claimed: true
+            }
+        );
+        assert!(broker.peek(&token).is_none());
+    }
+
+    #[test]
+    fn destination_may_release_its_own_claim() {
+        let broker = TabTransferBroker::new();
+        let token = broker.stage("doc".to_string(), "main".to_string());
+        broker.claim(&token, Instant::now());
+
+        let outcome = broker.cancel_from_destination(&token);
+        assert_eq!(
+            outcome,
+            CancelOutcome {
+                cancelled: true,
+                claimed: true
+            }
+        );
+        assert!(broker.peek(&token).is_none());
+    }
+
+    #[test]
+    fn cancelling_an_unknown_token_is_a_no_op() {
+        let broker = TabTransferBroker::new();
+        let missing = CancelOutcome {
+            cancelled: false,
+            claimed: false,
+        };
+        assert_eq!(broker.cancel_from_source("nope", Instant::now()), missing);
+        assert_eq!(broker.cancel_from_destination("nope"), missing);
+    }
+
+    // P1-B-2: completing a transfer whose entry is gone must be reported,
+    // not silently swallowed, so the destination can roll its tab back.
+    #[test]
+    fn completing_twice_finds_nothing_the_second_time() {
+        let broker = TabTransferBroker::new();
+        let token = broker.stage("doc".to_string(), "main".to_string());
+        broker.claim(&token, Instant::now());
+
+        assert!(broker.take(&token).is_some());
+        assert!(
+            broker.take(&token).is_none(),
+            "second completion must surface as an error to the caller"
+        );
     }
 
     #[test]
@@ -148,10 +518,46 @@ mod tests {
         }
 
         // The very first entry was evicted; every later one is still claimable.
-        assert!(broker.claim(&tokens[0]).is_none());
+        assert!(broker.peek(&tokens[0]).is_none());
         for (i, token) in tokens.iter().enumerate().skip(1) {
-            let transfer = broker.claim(token).expect("entry within cap should remain");
+            let transfer = broker.peek(token).expect("entry within cap should remain");
             assert_eq!(transfer.payload, format!("payload-{}", i));
         }
+    }
+
+    #[test]
+    fn eviction_skips_claimed_transfers() {
+        let broker = TabTransferBroker::new();
+        let in_flight = broker.stage("in-flight".to_string(), "main".to_string());
+        broker.claim(&in_flight, Instant::now());
+        let second = broker.stage("second".to_string(), "main".to_string());
+
+        for i in 0..MAX_PENDING_TRANSFERS {
+            broker.stage(format!("filler-{}", i), "main".to_string());
+        }
+
+        assert!(
+            broker.peek(&in_flight).is_some(),
+            "a claimed transfer is in flight and must not be evicted"
+        );
+        assert!(
+            broker.peek(&second).is_none(),
+            "the oldest unclaimed entry is the one that gets evicted"
+        );
+    }
+
+    #[test]
+    fn eviction_falls_back_to_the_oldest_when_everything_is_claimed() {
+        let broker = TabTransferBroker::new();
+        let mut tokens = Vec::new();
+        for i in 0..=MAX_PENDING_TRANSFERS {
+            let token = broker.stage(format!("payload-{}", i), "main".to_string());
+            broker.claim(&token, Instant::now());
+            tokens.push(token);
+        }
+
+        // Memory stays bounded even in the pathological all-claimed case.
+        assert!(broker.peek(&tokens[0]).is_none());
+        assert!(broker.peek(&tokens[MAX_PENDING_TRANSFERS]).is_some());
     }
 }

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -464,11 +464,25 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		},
 		onTransferClaimed: (tabId) => tabManager.closeTab(tabId),
 		acceptTransferredTab: async (snapshot) => {
+			// The tab has to exist before it can be rendered, which leaves a
+			// window where this side owns a document the source still shows.
+			// Anything that goes wrong from here must undo the insert, or the
+			// same file stays open in both windows with two auto-save timers
+			// writing over each other.
 			const id = tabManager.insertTransferredTab(snapshot);
-			const transferred = tabManager.tabs.find((tab) => tab.id === id);
-			if (!transferred) return false;
-			await renderTabPreviewFromRaw(transferred);
-			return !isDisposed;
+			try {
+				const transferred = tabManager.tabs.find((tab) => tab.id === id);
+				if (!transferred) return false;
+				await renderTabPreviewFromRaw(transferred);
+				if (isDisposed) {
+					tabManager.closeTab(id);
+					return false;
+				}
+				return true;
+			} catch (error) {
+				tabManager.closeTab(id);
+				throw error;
+			}
 		},
 		onError: (message, error) => {
 			console.error(message, error);

--- a/src/lib/sessions/windowSession.svelte.ts
+++ b/src/lib/sessions/windowSession.svelte.ts
@@ -99,21 +99,47 @@ export function createWindowSession(options: WindowSessionOptions) {
 		localStorage.removeItem(options.legacyStateKey);
 	}
 
+	/**
+	 * Hand the claim back so the source can recover its tab. A claimed
+	 * transfer is deliberately immune to the source's timeout — otherwise a
+	 * slow render would race it — which means the destination is the only
+	 * party that can end a claim it cannot finish. Skipping this is what
+	 * left the tab present in both windows.
+	 */
+	async function releaseClaim(token: string) {
+		try {
+			await invoke('cancel_detached_tab', { token });
+		} catch (error) {
+			options.onError('Failed to release tab transfer claim', error);
+		}
+	}
+
 	async function acceptOfferedTransfer(token: string): Promise<boolean> {
+		let claimed = false;
 		try {
 			const payload = (await invoke('claim_detached_tab', { token })) as string | null;
-			const tab = payload ? validateTransferPayload(payload) : null;
-			if (!tab) {
-				options.onWarning('Tab transfer claim failed or payload invalid; opening empty window');
+			// Distinguish "no such token" from a claim that succeeded: only the
+			// latter leaves something to release.
+			if (payload === null) {
+				options.onWarning('Tab transfer claim failed; opening empty window');
 				return false;
 			}
-			if (await options.acceptTransferredTab(tab)) {
-				await invoke('complete_detached_tab', { token });
-				return true;
+			claimed = true;
+			const tab = validateTransferPayload(payload);
+			if (!tab) {
+				options.onWarning('Tab transfer payload invalid; opening empty window');
+				await releaseClaim(token);
+				return false;
 			}
-			return false;
+			if (!(await options.acceptTransferredTab(tab))) {
+				await releaseClaim(token);
+				return false;
+			}
+			await invoke('complete_detached_tab', { token });
+			return true;
 		} catch (error) {
 			options.onError('Tab transfer claim error', error);
+			if (claimed) await releaseClaim(token);
 			return false;
 		}
 	}
@@ -126,8 +152,26 @@ export function createWindowSession(options: WindowSessionOptions) {
 		await acceptOfferedTransfer(claimToken);
 	}
 
+	// A transfer stays open until the destination claims it or the timeout
+	// gives up, so the menu entry that started it is clickable again long
+	// before it resolves. Starting a second transfer for the same tab stages a
+	// second payload: two windows each claim one, both build the tab, and the
+	// source only removes it once -- leaving the same document open twice,
+	// each copy with its own auto-save timer.
+	const transfersInFlight = new Set<string>();
+
 	async function transfer(tabId: string, deliver: (token: string) => Promise<void>): Promise<boolean> {
 		if (!options.canTransfer(tabId)) return false;
+		if (transfersInFlight.has(tabId)) return false;
+		transfersInFlight.add(tabId);
+		try {
+			return await stageTransfer(tabId, deliver);
+		} finally {
+			transfersInFlight.delete(tabId);
+		}
+	}
+
+	async function stageTransfer(tabId: string, deliver: (token: string) => Promise<void>): Promise<boolean> {
 		const token = (await invoke('stage_detached_tab', {
 			payload: options.transferPayload(tabId),
 		})) as string;
@@ -142,19 +186,32 @@ export function createWindowSession(options: WindowSessionOptions) {
 		});
 		return new Promise<boolean>((resolve) => {
 			resolveTransfer = resolve;
-			const cancel = () => {
+			// The timeout is a guess about the destination, so it asks rather
+			// than assumes. `claimed` means the payload is already gone into
+			// the other window and only slow to render: giving up here would
+			// leave the same document open in both, and whichever auto-saves
+			// last wins. Keep waiting for `tab-transfer-claimed`; the
+			// destination releases the claim itself if it cannot finish.
+			const cancel = async () => {
+				if (settled) return;
+				try {
+					const outcome = (await invoke('cancel_detached_tab', { token })) as {
+						cancelled: boolean;
+						claimed: boolean;
+					};
+					if (!outcome.cancelled && outcome.claimed) return;
+				} catch (error) {
+					options.onError('Failed to cancel tab transfer', error);
+				}
 				if (settled) return;
 				settled = true;
 				unlisten();
-				invoke('cancel_detached_tab', { token }).catch((error) => {
-					options.onError('Failed to cancel tab transfer', error);
-				});
 				resolve(false);
 			};
 			setTimeout(cancel, 15_000);
 			deliver(token).catch((error) => {
 				options.onError('Failed to deliver tab transfer', error);
-				cancel();
+				void cancel();
 			});
 		});
 	}


### PR DESCRIPTION
## Summary

A tab transfer may only end two ways: the source still has the tab, or the destination does. Four paths produced a third state — present in **both**, each copy with its own auto-save timer writing over the other, last writer wins.

**The source's timeout ignored what the destination was doing.** After 15 s it cancelled unconditionally, but 15 s is a guess about a window that may simply be slow to render a large document. `cancel_detached_tab` now reports whether the payload was already claimed, and the source keeps waiting for `tab-transfer-claimed` when it was. A claimed transfer is correspondingly immune to the source's cancel, so the race cannot go the other way either.

**Nothing released a claim that could not be completed.** Since the source can no longer cancel a claimed transfer, the destination is the only party able to end one — and it never did. An invalid payload, a refusing destination and a thrown render now all hand the claim back so the source recovers its tab.

**A failed render left the tab inserted.** The tab has to exist before it can be rendered, so the destination owns the document while the source still shows it. That window is closed by undoing the insert on any failure.

**The menu could stage the same tab twice.** The entry becomes clickable again long before the transfer resolves; a second click staged a second payload, two windows each claimed one and built the tab, and the source removed it once. In-flight transfers are now tracked per tab.

## Broker hardening

Tokens were sequential — `t1` through `t16` — and every command was unauthenticated. Any webview could enumerate them:

```js
await invoke('claim_detached_tab', { token: 't1' })  // full document text of a drag in progress
await invoke('cancel_detached_tab', { token: 't1' }) // destroy another window's transfer
```

Tokens are now unguessable, and each operation is bound to the window entitled to perform it: the destination is `window-<token>`, cancellation is the source or that destination and nobody else. Eviction under pressure drops the oldest *unclaimed* entry rather than whatever is oldest, so a transfer mid-handoff is never discarded — a test caught the naive version evicting the transfer that had just been staged.

## Validation

- `npm run check` — 0 errors, 0 warnings
- `npm test` — 170/170, including a new `scripts/tabTransferHandoff.test.ts` covering each of the four paths above
- `cargo test` — 40/40, covering repeat claims, claims from the wrong window, cancel authority, claim-then-complete, and eviction with everything claimed