### PR TITLE
fix(editor): scope image undo to the tab that owns the image

### DIFF
--- a/scripts/managedImageUndo.test.ts
+++ b/scripts/managedImageUndo.test.ts
@@ -1,19 +1,136 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
-import { managedImageFromCopy } from '../src/lib/utils/managedImages.js';
+import {
+	contentReferencesImage,
+	embedTarget,
+	forgetClosedTabs,
+	imagePathOf,
+	managedImageFromCopy,
+	resolveManagedImageRedo,
+	resolveManagedImageUndo,
+	type ManagedImage,
+} from '../src/lib/utils/managedImages.js';
 
-test('undo metadata retains the collision-resolved image filename and paste-time directory', () => {
-	const image = managedImageFromCopy({
-		embed: '![alt](img/logo_1710000000.png)',
+const editor = readFileSync(new URL('../src/lib/components/Editor.svelte', import.meta.url), 'utf8');
+
+function image(tabId: string, relativePath: string, alt = 'alt'): ManagedImage {
+	return managedImageFromCopy({
+		tabId,
+		embed: `![${alt}](${relativePath})`,
 		parentDir: 'C:/notes',
 		imageDirectory: 'img',
-		relativePath: 'img/logo_1710000000.png',
+		relativePath,
 	});
+}
 
-	assert.deepEqual(image, {
-		embed: '![alt](img/logo_1710000000.png)',
-		parentDir: 'C:/notes',
-		imageDirectory: 'img',
-		filename: 'logo_1710000000.png',
-	});
+test('undo metadata retains the collision-resolved filename and paste-time directory', () => {
+	assert.deepEqual(
+		managedImageFromCopy({
+			tabId: 'tab-1',
+			embed: '![alt](img/logo_1710000000.png)',
+			parentDir: 'C:/notes',
+			imageDirectory: 'img',
+			relativePath: 'img/logo_1710000000.png',
+		}),
+		{
+			tabId: 'tab-1',
+			embed: '![alt](img/logo_1710000000.png)',
+			parentDir: 'C:/notes',
+			imageDirectory: 'img',
+			filename: 'logo_1710000000.png',
+		},
+	);
+});
+
+test("an undo never reaches another tab's image", () => {
+	// The editor keeps one component instance across tab switches. Undoing in
+	// tab B used to inspect the newest entry from any tab, find its embed
+	// missing from B's buffer -- a different document -- and delete a file
+	// tab A was still displaying.
+	const images = [image('tab-a', 'img/a.png'), image('tab-b', 'img/b.png')];
+	const undoInB = resolveManagedImageUndo(images, 'tab-b', 'text with no embeds');
+	assert.equal(undoInB.removed?.filename, 'b.png');
+	assert.deepEqual(
+		undoInB.remaining.map((i) => i.filename),
+		['a.png'],
+	);
+
+	// Tab A's image survives an undo in B even when B's buffer mentions nothing.
+	const onlyA = resolveManagedImageUndo([image('tab-a', 'img/a.png')], 'tab-b', '');
+	assert.equal(onlyA.removed, null);
+	assert.equal(onlyA.remaining.length, 1);
+});
+
+test('editing the caption does not read as removing the image', () => {
+	// `![alt](img/a.png)` -> `![logo](img/a.png)`. Matching the whole embed
+	// string deleted a file the document still pointed at.
+	const stored = image('tab-a', 'img/a.png', 'alt');
+	assert.equal(embedTarget(stored.embed), 'img/a.png');
+	assert.equal(contentReferencesImage('before ![logo](img/a.png) after', stored), true);
+	assert.equal(resolveManagedImageUndo([stored], 'tab-a', '![logo](img/a.png)').removed, null);
+});
+
+test('an image whose target is gone is still collected', () => {
+	const stored = image('tab-a', 'img/a.png');
+	assert.equal(contentReferencesImage('nothing here', stored), false);
+	assert.equal(
+		resolveManagedImageUndo([stored], 'tab-a', 'nothing here').removed?.filename,
+		'a.png',
+	);
+});
+
+test('a similarly named file is not mistaken for the managed one', () => {
+	const stored = image('tab-a', 'img/a.png');
+	assert.equal(contentReferencesImage('![x](img/other-a.png)', stored), false);
+});
+
+test('an unparseable embed falls back to the literal string', () => {
+	// Deleting a referenced file is the worse failure, so an embed we cannot
+	// read is treated as present whenever its exact text appears.
+	const odd: ManagedImage = { ...image('tab-a', 'img/a.png'), embed: 'not an embed' };
+	assert.equal(embedTarget(odd.embed), null);
+	assert.equal(contentReferencesImage('prose not an embed prose', odd), true);
+	assert.equal(contentReferencesImage('prose', odd), false);
+});
+
+test('a redo takes the entry back so the file is not deleted twice', () => {
+	const stored = image('tab-a', 'img/a.png');
+	const afterUndo = resolveManagedImageUndo([stored], 'tab-a', '');
+	assert.equal(afterUndo.removed?.filename, 'a.png');
+
+	const undone = [afterUndo.removed!];
+	const afterRedo = resolveManagedImageRedo(undone, 'tab-a', '![alt](img/a.png)');
+	assert.equal(afterRedo.restored?.filename, 'a.png');
+	assert.deepEqual(afterRedo.remaining, []);
+
+	// And a redo in a different tab leaves it alone.
+	assert.equal(resolveManagedImageRedo(undone, 'tab-b', '![alt](img/a.png)').restored, null);
+});
+
+test('a redo whose embed is absent restores nothing', () => {
+	const undone = [image('tab-a', 'img/a.png')];
+	assert.equal(resolveManagedImageRedo(undone, 'tab-a', 'unrelated').restored, null);
+});
+
+test('closing a tab drops its bookkeeping', () => {
+	const images = [image('tab-a', 'img/a.png'), image('tab-b', 'img/b.png')];
+	assert.deepEqual(
+		forgetClosedTabs(images, new Set(['tab-b'])).map((i) => i.filename),
+		['b.png'],
+	);
+});
+
+test('the delete target is built from the values captured at insert time', () => {
+	assert.equal(imagePathOf(image('tab-a', 'img/a.png')), 'C:/notes/img/a.png');
+});
+
+test('the editor routes undo and redo through the scoped helpers', () => {
+	assert.match(editor, /resolveManagedImageUndo\(\s*\n\s*managedImages,\s*\n\s*activeTabId,/);
+	assert.match(editor, /if \(e\.isRedoing && undoneImages\.length > 0\)/);
+	// The owning tab is captured before the first await, not read back
+	// afterwards -- the copy and the edit are several round trips apart.
+	assert.match(editor, /const pasteTabId = tabManager\.activeTabId;/);
+	assert.match(editor, /const dropTabId = tabManager\.activeTabId;/);
+	assert.doesNotMatch(editor, /currentContent\.includes\(last\.embed\)/);
 });

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -3,7 +3,14 @@
 	import { tabManager } from "../stores/tabs.svelte.js";
 	import { settings } from "../stores/settings.svelte.js";
 	import { t } from '../utils/i18n.js';
-	import { managedImageFromCopy, type ManagedImage } from '../utils/managedImages.js';
+	import {
+		forgetClosedTabs,
+		imagePathOf,
+		managedImageFromCopy,
+		resolveManagedImageRedo,
+		resolveManagedImageUndo,
+		type ManagedImage,
+	} from '../utils/managedImages.js';
 
 	import * as monaco from "monaco-editor";
 	import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
@@ -62,7 +69,11 @@
 	let vimStatusNode = $state<HTMLDivElement>();
 	let editor: monaco.editor.IStandaloneCodeEditor;
 	let isApplyingExternalScroll = false;
-	const managedImages: ManagedImage[] = $state([]);
+	let managedImages: ManagedImage[] = $state([]);
+	// Entries an undo has already deleted. A redo puts the embed back, so the
+	// entry has to leave this list or the next undo would try to delete the
+	// same file again.
+	let undoneImages: ManagedImage[] = $state([]);
 
 	let cursorPosition = $state<monaco.Position | null>(null);
 	let selectionCount = $state(0);
@@ -756,18 +767,38 @@
 		container.addEventListener("wheel", wheelListener, { capture: true });
 
 		const contentChangeListener = editor.onDidChangeModelContent((e) => {
+			const activeTabId = tabManager.activeTabId;
+			if (!activeTabId) return;
+
 			if (e.isUndoing && managedImages.length > 0) {
-				const currentContent = editor.getValue();
-				const last = managedImages[managedImages.length - 1];
-				if (!currentContent.includes(last.embed)) {
-					managedImages.pop();
-						const imgPath = `${last.parentDir}/${last.imageDirectory}/${last.filename}`;
-						invoke("delete_file", { path: imgPath })
-							.then(() => {
-								invoke("cleanup_empty_img_dir", { parentDir: last.parentDir, imageDirectory: last.imageDirectory });
-							})
-							.catch(console.error);
-				}
+				const { removed, remaining } = resolveManagedImageUndo(
+					managedImages,
+					activeTabId,
+					editor.getValue(),
+				);
+				if (!removed) return;
+				managedImages = remaining;
+				undoneImages = [...undoneImages, removed];
+				invoke("delete_file", { path: imagePathOf(removed) })
+					.then(() =>
+						invoke("cleanup_empty_img_dir", {
+							parentDir: removed.parentDir,
+							imageDirectory: removed.imageDirectory,
+						}),
+					)
+					.catch(console.error);
+				return;
+			}
+
+			if (e.isRedoing && undoneImages.length > 0) {
+				const { restored, remaining } = resolveManagedImageRedo(
+					undoneImages,
+					activeTabId,
+					editor.getValue(),
+				);
+				if (!restored) return;
+				undoneImages = remaining;
+				managedImages = [...managedImages, restored];
 			}
 		});
 
@@ -861,7 +892,12 @@
 			try {
 				// check for image in clipboard via Rust
 				const base64Image = await invoke("clipboard_read_image", { macosImageScaling: settings.macosImageScaling }).catch(() => null) as string | null;
-				if (base64Image && tabManager.activeTab?.path) {
+				// Captured before the first await: the copy and the edit are
+				// several round trips apart, and the tab that owns the embed
+				// is the one active when it was inserted, not whichever is
+				// active when the promise settles.
+				const pasteTabId = tabManager.activeTabId;
+				if (base64Image && pasteTabId && tabManager.activeTab?.path) {
 					const ext = "png"; // output of Rust command is always PNG
 					const filename = `paste_${Date.now()}.${ext}`;
 
@@ -901,7 +937,10 @@
 								},
 							]);
 
-							managedImages.push(managedImageFromCopy({ embed, parentDir, imageDirectory: imgDirName, relativePath: relPath }));
+							managedImages = [
+								...managedImages,
+								managedImageFromCopy({ tabId: pasteTabId, embed, parentDir, imageDirectory: imgDirName, relativePath: relPath }),
+							];
 							return;
 						}
 					}
@@ -1163,6 +1202,17 @@
 		}
 	});
 
+	// Closing a tab ends any claim its images had on being deleted by undo.
+	// Without this the lists grow for the lifetime of the window and keep
+	// entries whose tab -- and whose undo stack -- is long gone.
+	$effect(() => {
+		const openTabIds = new Set(tabManager.tabs.map((tab) => tab.id));
+		const prunedManaged = forgetClosedTabs(managedImages, openTabIds);
+		if (prunedManaged.length !== managedImages.length) managedImages = prunedManaged;
+		const prunedUndone = forgetClosedTabs(undoneImages, openTabIds);
+		if (prunedUndone.length !== undoneImages.length) undoneImages = prunedUndone;
+	});
+
 	$effect(() => {
 		const activeTabId = tabManager.activeTabId;
 		const content = value;
@@ -1262,6 +1312,8 @@
 		const match = tabPath.match(/^(.*)[/\\][^/\\]+$/);
 		if (!match) return;
 		const parentDir = match[1];
+		const dropTabId = tabManager.activeTabId;
+		if (!dropTabId) return;
 
 		try {
 			const imgDirName = settings.imageDirectory || "img";
@@ -1298,7 +1350,10 @@
 				],
 			);
 
-			managedImages.push(managedImageFromCopy({ embed, parentDir, imageDirectory: imgDirName, relativePath: relPath }));
+			managedImages = [
+				...managedImages,
+				managedImageFromCopy({ tabId: dropTabId, embed, parentDir, imageDirectory: imgDirName, relativePath: relPath }),
+			];
 		} catch (err) {
 			console.error("Failed to copy dropped file:", err);
 		}

--- a/src/lib/utils/managedImages.ts
+++ b/src/lib/utils/managedImages.ts
@@ -1,4 +1,15 @@
+/**
+ * A pasted or dropped image is copied into the document's image directory
+ * before the embed is written, so undoing the insert has to remove the file
+ * too or the directory fills with orphans.
+ *
+ * That deletion is the only place the editor destroys something outside the
+ * buffer, which makes "is this image still wanted?" a question worth
+ * answering precisely rather than approximately.
+ */
 export type ManagedImage = {
+	/** The tab whose buffer the embed was written into. */
+	tabId: string;
 	embed: string;
 	parentDir: string;
 	imageDirectory: string;
@@ -6,11 +17,13 @@ export type ManagedImage = {
 };
 
 export function managedImageFromCopy({
+	tabId,
 	embed,
 	parentDir,
 	imageDirectory,
 	relativePath,
 }: {
+	tabId: string;
 	embed: string;
 	parentDir: string;
 	imageDirectory: string;
@@ -19,5 +32,80 @@ export function managedImageFromCopy({
 	const filename = relativePath.split('/').pop();
 	if (!filename) throw new Error('Copied image path has no filename');
 
-	return { embed, parentDir, imageDirectory, filename };
+	return { tabId, embed, parentDir, imageDirectory, filename };
+}
+
+export function imagePathOf(image: ManagedImage): string {
+	return `${image.parentDir}/${image.imageDirectory}/${image.filename}`;
+}
+
+/**
+ * The link target of an embed: `![alt](img/a.png)` -> `img/a.png`.
+ *
+ * Matching the whole embed string treats an edited caption as a removed
+ * image. Renaming `![alt]` to `![logo]` and then pressing undo once deleted a
+ * file the document was still pointing at, leaving a broken image the user
+ * never touched. The target is what actually binds the buffer to the file.
+ */
+export function embedTarget(embed: string): string | null {
+	const match = /!\[[^\]]*\]\(([^)]*)\)/.exec(embed);
+	return match ? match[1] : null;
+}
+
+export function contentReferencesImage(content: string, image: ManagedImage): boolean {
+	const target = embedTarget(image.embed);
+	// An embed we cannot parse falls back to the literal string: keeping a
+	// file that is no longer referenced beats deleting one that still is.
+	if (target === null) return content.includes(image.embed);
+	return content.includes(`](${target})`);
+}
+
+/**
+ * Decide what an undo in `tabId` should delete.
+ *
+ * Only the tab that owns an image can orphan it. The editor keeps one
+ * component instance across tab switches, so without this scope an undo in
+ * any tab inspected the newest entry from *any* tab, found its embed absent
+ * from the buffer it happened to be looking at -- of course it was, a
+ * different document -- and deleted a file another tab was still using.
+ */
+export function resolveManagedImageUndo(
+	images: ManagedImage[],
+	tabId: string,
+	content: string,
+): { removed: ManagedImage | null; remaining: ManagedImage[] } {
+	for (let index = images.length - 1; index >= 0; index -= 1) {
+		const candidate = images[index];
+		if (candidate.tabId !== tabId) continue;
+		if (contentReferencesImage(content, candidate)) break;
+		return { removed: candidate, remaining: images.filter((_, i) => i !== index) };
+	}
+	return { removed: null, remaining: images };
+}
+
+/**
+ * A redo puts the embed back, so the entry returns to the managed list and
+ * cannot be deleted a second time.
+ *
+ * The file itself is already gone -- deletion on undo is immediate and this
+ * does not resurrect it. Restoring the bookkeeping is still worth doing: it
+ * stops a later undo from targeting an entry that no longer exists on disk.
+ */
+export function resolveManagedImageRedo(
+	undone: ManagedImage[],
+	tabId: string,
+	content: string,
+): { restored: ManagedImage | null; remaining: ManagedImage[] } {
+	for (let index = undone.length - 1; index >= 0; index -= 1) {
+		const candidate = undone[index];
+		if (candidate.tabId !== tabId) continue;
+		if (!contentReferencesImage(content, candidate)) continue;
+		return { restored: candidate, remaining: undone.filter((_, i) => i !== index) };
+	}
+	return { restored: null, remaining: undone };
+}
+
+/** Drop bookkeeping for tabs that are gone, so the list cannot grow forever. */
+export function forgetClosedTabs(images: ManagedImage[], openTabIds: Set<string>): ManagedImage[] {
+	return images.filter((image) => openTabIds.has(image.tabId));
 }


### PR DESCRIPTION
## Summary

Undoing an image insert deletes the copied file — the only place the editor destroys something outside the buffer. Two ways of deciding *which* file were wrong, and both deleted one the user still had on screen.

### An undo in one tab could delete another tab's image

The editor keeps a single component instance across tab switches, so the managed list mixes every tab's images while the undo handler only ever looked at the newest entry.

```
tab A   drop image        managedImages = [ img/pic.png ]
           │
           │  switch to tab B  (component is not rebuilt)
           ▼
tab B   type, then Ctrl+Z
           handler reads the newest entry — tab A's
           B's buffer does not contain "![alt](img/pic.png)"
              of course not, it is a different document
           → deletes C:/notes/img/pic.png
             which tab A is still displaying
```

Entries now carry the tab that inserted them, and an undo only considers its own.

### Editing the caption read as removing the image

The check was `content.includes(embed)` against the whole embed string, so renaming `![alt](img/a.png)` to `![logo](img/a.png)` made the image look gone. The next undo — of anything — deleted a file the document was still pointing at, leaving a broken image the user never touched. The link target is what binds the buffer to the file, so that is what is matched now.

An embed that cannot be parsed falls back to the literal string: keeping a file that is no longer referenced is the cheaper mistake.

### Redo

Handled rather than ignored — the entry returns to the managed list, so a later undo cannot try to delete the same file twice.

**Known limitation, deliberately not fixed here:** the file itself stays deleted. Undo removes it immediately, and Ctrl+Z followed by Ctrl+Shift+Z therefore restores the embed text pointing at a file that is gone. Fixing that properly means deferring the deletion — for example reaping orphans when the tab closes — which is a behaviour change worth its own review rather than a rider on a data-loss fix.

## Also in this path

- The owning tab is captured **before** the first `await`. The copy and the edit are several round trips apart, so reading the active tab afterwards would misattribute an image if the user switched tabs while the copy was in flight.
- Closing a tab drops its bookkeeping, which otherwise grew for the lifetime of the window.

Follows #357, which fixed the directory and filename the deletion targets.

## Validation

- `npm run check` — 0 errors, 0 warnings
- `npm test` — 173/173. The decision logic is pure and directly executed by the tests: cross-tab isolation both ways, caption edits, look-alike filenames (`img/other-a.png` must not match `img/a.png`), the unparseable-embed fallback, redo re-adoption and cross-tab redo isolation, and closed-tab pruning.