### PR TITLE
fix(editor): wire editor options and shortcuts to what they claim

### DIFF
--- a/scripts/editorOptionWiring.test.ts
+++ b/scripts/editorOptionWiring.test.ts
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+// Editor.svelte translates the settings store into Monaco options and
+// keybindings. Every regression locked here came from that translation layer
+// being wired to the wrong shape: a string option read as a boolean, a
+// modifier that macOS never delivers, one key bound twice, and a native
+// behaviour dropped by the action that replaced it.
+
+const editor = readFileSync('src/lib/components/Editor.svelte', 'utf8');
+const settingsStore = readFileSync('src/lib/stores/settings.svelte.ts', 'utf8');
+
+function count(source: string, pattern: RegExp): number {
+	return source.match(pattern)?.length ?? 0;
+}
+
+function sliceBlock(source: string, startMarker: string, endMarker: string): string {
+	const start = source.indexOf(startMarker);
+	assert.notEqual(start, -1, `expected to find ${startMarker}`);
+	const end = source.indexOf(endMarker, start + startMarker.length);
+	assert.notEqual(end, -1, `expected to find ${endMarker} after ${startMarker}`);
+	return source.slice(start, end);
+}
+
+test('renderLineHighlight is a Monaco string enum, not a boolean flag', () => {
+	// The store holds 'line' / 'none'. Any non-empty string is truthy, so a
+	// ternary on it can only ever produce "line" and silently defeats both the
+	// line-highlight toggle and Zen mode (which sets it to 'none').
+	assert.match(settingsStore, /renderLineHighlight = \$state\('line'\)/);
+	assert.match(settingsStore, /this\.renderLineHighlight = this\.renderLineHighlight === 'line' \? 'none' : 'line'/);
+	assert.match(settingsStore, /this\.renderLineHighlight = 'none'/, 'zen mode sets the string to none');
+
+	assert.doesNotMatch(
+		editor,
+		/renderLineHighlight:\s*settings\.renderLineHighlight\s*\?/,
+		'renderLineHighlight must never be branched on as a boolean',
+	);
+	assert.doesNotMatch(
+		editor,
+		/renderLineHighlight:\s*settings\.renderLineHighlight\s*(?:===|!==)/,
+		'renderLineHighlight must not be re-derived from a comparison either',
+	);
+	assert.equal(
+		count(editor, /renderLineHighlight: settings\.renderLineHighlight as "line" \| "none"/g),
+		2,
+		'creation and updateOptions both forward the stored string unchanged',
+	);
+});
+
+test('editor options are applied by a single updateOptions effect', () => {
+	// Two competing effects (one nested in onMount, one top level) wrote the
+	// same Monaco options with different values — notably fontSize with and
+	// without the zoom factor — so the winner depended on effect ordering.
+	assert.equal(count(editor, /editor\.updateOptions\(\{/g), 1, 'exactly one updateOptions call site');
+
+	const block = sliceBlock(editor, 'editor.updateOptions({', '});');
+	assert.match(block, /wordWrapColumn: settings\.editorMaxWidth/, 'wordWrapColumn survived the merge');
+	assert.match(block, /fontSize: settings\.editorFontSize \* \(zoomLevel \/ 100\)/, 'zoom-aware font size is the surviving one');
+	for (const option of [
+		'minimap',
+		'wordWrap:',
+		'lineNumbers',
+		'renderLineHighlight',
+		'occurrencesHighlight',
+		'fontFamily',
+		'renderWhitespace',
+	]) {
+		assert.ok(block.includes(option), `merged effect still applies ${option}`);
+	}
+});
+
+test('tab cycling avoids Cmd+Tab, which macOS never delivers to the app', () => {
+	// Reference frame: VS Code binds Ctrl+Tab / Ctrl+Shift+Tab with
+	// KeyMod.WinCtrl on macOS (mac override on
+	// workbench.action.quickOpenPreviousRecentlyUsedEditorInGroup) precisely
+	// because Cmd+Tab belongs to the system application switcher.
+	assert.doesNotMatch(
+		editor,
+		/monaco\.KeyMod\.CtrlCmd \| monaco\.KeyCode\.Tab/,
+		'no unconditional CtrlCmd+Tab binding',
+	);
+	assert.doesNotMatch(
+		editor,
+		/monaco\.KeyMod\.CtrlCmd \| monaco\.KeyMod\.Shift \| monaco\.KeyCode\.Tab/,
+		'no unconditional CtrlCmd+Shift+Tab binding',
+	);
+
+	assert.match(
+		editor,
+		/const tabCycleModifier = isMacPlatform\(\)\s*\?\s*monaco\.KeyMod\.WinCtrl\s*:\s*monaco\.KeyMod\.CtrlCmd/,
+		'modifier is chosen per platform: real Ctrl on macOS, CtrlCmd elsewhere',
+	);
+	assert.match(editor, /keybindings: \[tabCycleModifier \| monaco\.KeyCode\.Tab\]/, 'tab-next uses the platform modifier');
+	assert.match(
+		editor,
+		/tabCycleModifier \| monaco\.KeyMod\.Shift \| monaco\.KeyCode\.Tab/,
+		'tab-prev uses the platform modifier',
+	);
+});
+
+test('platform detection reads settings.osType and never writes it', () => {
+	// The `navigator.platform` fallback is deprecated but load-bearing, and it is
+	// asserted here so nobody "modernises" it away. The value is frozen at
+	// "MacIntel" on every Mac, arm64 included (verified on an Apple M5), so it is
+	// wrong about the CPU and permanently right about the vendor — which is the
+	// only thing asked of it. That is why the helper may stay synchronous and why
+	// the keybindings are registered once, at mount, rather than re-registered
+	// when settings.osType resolves. Full argument: the comment on
+	// isMacPlatform() in Editor.svelte.
+	const helper = sliceBlock(editor, 'function isMacPlatform', '\n\t}');
+	assert.match(helper, /settings\.osType !== 'unknown'/, 'prefers the resolved Tauri os type');
+	assert.match(helper, /settings\.osType === 'macos'/);
+	assert.match(helper, /navigator\.platform/, 'falls back while osType is still resolving');
+
+	assert.doesNotMatch(editor, /settings\.osType\s*=[^=]/, 'Editor.svelte must not write to the settings store');
+});
+
+test('Ctrl+S is registered exactly once, by the command-palette action', () => {
+	assert.equal(count(editor, /monaco\.KeyCode\.KeyS/g), 1, 'a single Ctrl+S binding');
+	assert.match(
+		editor,
+		/id: "file-save",[\s\S]*?keybindings: \[monaco\.KeyMod\.CtrlCmd \| monaco\.KeyCode\.KeyS\]/,
+		'the surviving binding is the addAction, which also lists in the command palette',
+	);
+	assert.doesNotMatch(
+		editor,
+		/addCommand\(monaco\.KeyMod\.CtrlCmd \| monaco\.KeyCode\.KeyS/,
+		'the bare addCommand duplicate is gone',
+	);
+});
+
+test('custom copy keeps Monaco\'s whole-line copy on an empty selection', () => {
+	// Reference frame: Monaco ships `emptySelectionClipboard` (documented as
+	// "Copying without a selection copies the current line") on by default, and
+	// its viewmodel builds that text as getLineContent(line) + EOL. VS Code
+	// (editor.emptySelectionClipboard) and Sublime Text behave the same. Since
+	// custom-copy overrides the native copy action, bailing out on an empty
+	// selection deleted the behaviour outright.
+	const copyAction = sliceBlock(editor, 'id: "custom-copy"', 'editor.addCommand');
+
+	assert.doesNotMatch(
+		copyAction,
+		/if \(!selection \|\| selection\.isEmpty\(\)\) return/,
+		'an empty selection is no longer an early return',
+	);
+	assert.match(
+		copyAction,
+		/selection\.isEmpty\(\)\s*\?\s*model\.getLineContent\(selection\.startLineNumber\) \+ model\.getEOL\(\)\s*:\s*model\.getValueInRange\(selection\)/,
+		'empty selection copies the current line plus its line ending',
+	);
+	assert.equal(
+		count(copyAction, /invoke\("clipboard_write_text"/g),
+		1,
+		'both cases go through the one clipboard_write_text path',
+	);
+});
+
+test('Show Whitespace renders every whitespace run, not just trailing', () => {
+	// The setting is labelled without qualification ("Show Whitespace" /
+	// "显示空白"), so "trailing" left interior spaces unmarked.
+	assert.doesNotMatch(editor, /renderWhitespace: settings\.showWhitespace \? "trailing"/);
+	assert.doesNotMatch(editor, /"trailing"/, 'no trailing-only whitespace rendering remains');
+	assert.equal(
+		count(editor, /renderWhitespace: settings\.showWhitespace \? "all" : "none"/g),
+		2,
+		'creation and updateOptions agree on "all"',
+	);
+});

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -76,6 +76,34 @@
 		uiLanguage = settings.language;
 	});
 
+	// `settings.osType` is resolved asynchronously from the Rust side, so it can
+	// still be 'unknown' while the editor registers its keybindings. Fall back to
+	// the synchronous browser hint in that window.
+	//
+	// The fallback reads a deprecated API on purpose, and the deprecation is
+	// precisely what makes it reliable here: we are asking "is this macOS?", not
+	// "which architecture is this?". `navigator.platform` still reports
+	// "MacIntel" on Apple silicon — measured on an M5 (arm64), where the user
+	// agent likewise still claims "Intel Mac OS X 10_15_7". Both values are
+	// frozen deliberately by WebKit and Chromium: years of sites compare
+	// `navigator.platform === 'MacIntel'` exactly, so changing it during the 2020
+	// ARM transition would have made every Mac look like an unknown platform
+	// overnight, and the capped Catalina version exists to limit fingerprinting.
+	// So the string lies about the CPU while staying permanently correct about
+	// the vendor — the only axis this function queries. The fallback therefore
+	// cannot reach a different macOS verdict than `settings.osType` does, and the
+	// keybindings never need re-registering once `osType` resolves.
+	//
+	// `navigator.userAgentData` is not used instead: only its coarse `platform`
+	// field is synchronous, and architecture and platform version sit behind the
+	// asynchronous high-entropy request. Waiting on that would reintroduce the
+	// very delay `settings.osType` already has, which defeats the point of
+	// having a synchronous fallback at all.
+	function isMacPlatform(): boolean {
+		if (settings.osType !== 'unknown') return settings.osType === 'macos';
+		return /^(Mac|iPhone|iPad|iPod)/i.test(navigator.platform || '');
+	}
+
 	self.MonacoEnvironment = {
 		getWorker: function (_moduleId: any, label: string) {
 			if (label === "json") {
@@ -176,7 +204,7 @@
 				| "off"
 				| "relative"
 				| "interval",
-			renderLineHighlight: settings.renderLineHighlight ? "line" : "none",
+			renderLineHighlight: settings.renderLineHighlight as "line" | "none",
 			occurrencesHighlight: settings.occurrencesHighlight
 				? "singleFile"
 				: "off",
@@ -184,7 +212,7 @@
 			fontFamily: settings.editorFont,
 			wordBasedSuggestions: "off",
 			quickSuggestions: false,
-			renderWhitespace: settings.showWhitespace ? "trailing" : "none",
+			renderWhitespace: settings.showWhitespace ? "all" : "none",
 			padding: { top: 20 },
 			scrollbar: {
 				vertical: "visible",
@@ -315,22 +343,6 @@
 			},
 		});
 
-		$effect(() => {
-			if (editor) {
-				editor.updateOptions({
-					minimap: { enabled: settings.minimap },
-					wordWrap: settings.wordWrap as any,
-					wordWrapColumn: settings.editorMaxWidth,
-					lineNumbers: settings.lineNumbers as any,
-					renderLineHighlight: settings.renderLineHighlight as any,
-					occurrencesHighlight: settings.occurrencesHighlight ? "singleFile" : "off",
-					fontSize: settings.editorFontSize,
-					fontFamily: settings.editorFont,
-					renderWhitespace: settings.showWhitespace ? "trailing" : "none",
-				});
-			}
-		});
-
 		const updateTheme = () => {
 			monaco.editor.setTheme(getTheme());
 		};
@@ -384,10 +396,6 @@
 			const text = editor.getModel()?.getValue() || "";
 			wordCount = (text.match(/\S+/g) || []).filter((w) => /\w/.test(w)).length;
 		}
-
-		editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
-			if (onsave) onsave();
-		});
 
 		const insertTextAtCursor = (text: string) => {
 			const selection = editor.getSelection();
@@ -707,10 +715,17 @@
 			run: () => ontoggleSplit?.(),
 		});
 
+		// macOS reserves Cmd+Tab for the system application switcher, so a
+		// CtrlCmd-based binding never reaches the editor there. VS Code binds the
+		// real Ctrl key (KeyMod.WinCtrl) on macOS for its own Tab cycling.
+		const tabCycleModifier = isMacPlatform()
+			? monaco.KeyMod.WinCtrl
+			: monaco.KeyMod.CtrlCmd;
+
 		editor.addAction({
 			id: "tab-next",
 			label: t('menu.nextTab', uiLanguage),
-			keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Tab],
+			keybindings: [tabCycleModifier | monaco.KeyCode.Tab],
 			run: () => onnextTab?.(),
 		});
 
@@ -718,7 +733,7 @@
 			id: "tab-prev",
 			label: t('menu.previousTab', uiLanguage),
 			keybindings: [
-				monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Tab,
+				tabCycleModifier | monaco.KeyMod.Shift | monaco.KeyCode.Tab,
 			],
 			run: () => onprevTab?.(),
 		});
@@ -847,10 +862,16 @@
 			keybindingContext: "editorTextFocus",
 			run: async (ed) => {
 				const selection = ed.getSelection();
-				if (!selection || selection.isEmpty()) return;
+				if (!selection) return;
 				const model = ed.getModel();
 				if (!model) return;
-				const text = model.getValueInRange(selection);
+				// This action replaces Monaco's native copy, so it has to carry
+				// Monaco's own `emptySelectionClipboard` default (also VS Code's and
+				// Sublime Text's): with nothing selected, copy the whole current
+				// line including its line ending.
+				const text = selection.isEmpty()
+					? model.getLineContent(selection.startLineNumber) + model.getEOL()
+					: model.getValueInRange(selection);
 				if (text) {
 					await invoke("clipboard_write_text", { text }).catch(console.error);
 				}
@@ -1203,6 +1224,7 @@
 					| "off"
 					| "wordWrapColumn"
 					| "bounded",
+				wordWrapColumn: settings.editorMaxWidth,
 				lineNumbers: settings.lineNumbers as
 					| "on"
 					| "off"
@@ -1214,7 +1236,7 @@
 					: "off",
 				fontSize: settings.editorFontSize * (zoomLevel / 100),
 				fontFamily: settings.editorFont,
-				renderWhitespace: settings.showWhitespace ? "trailing" : "none",
+				renderWhitespace: settings.showWhitespace ? "all" : "none",
 			});
 		}
 	});


### PR DESCRIPTION
## Summary

Five settings and shortcuts did not do what their labels said. All five were re-verified as present on `master` before any change, and the new tests were run against the **unmodified** `Editor.svelte` first: 7/7 fail there, 7/7 pass after — so they lock the behaviour rather than describe it.

### Line highlight could not be turned off

The setting stores `'line'` or `'none'`, but the editor was constructed with `settings.renderLineHighlight ? "line" : "none"`. A non-empty string is always truthy, so it always resolved to `"line"` — turning the highlight off, and Zen mode (which writes `'none'`), had no effect at construction time.

Two `$effect`s were also writing the same Monaco options, one nested inside `onMount` and one at the top level. They disagreed about `fontSize`: the nested one wrote the raw setting, the top-level one applied the zoom factor. Which value survived depended on effect ordering, so editor zoom was racing settings changes. The nested effect is removed; the survivor keeps the zoom-aware value and absorbs `wordWrapColumn`, the one option only it had set.

### Tab cycling was a dead key on macOS

`CtrlCmd | Tab` resolves to Cmd+Tab there, which the OS application switcher consumes before the webview ever sees it.

**Reference:** VS Code binds the same command with an explicit macOS override — `mac: { primary: KeyMod.WinCtrl | KeyCode.Tab }` in `editorActions.ts`, the real Ctrl key, uncontested on macOS. This uses the same pattern, choosing from `settings.osType` with a synchronous `navigator.platform` fallback for the window before the Rust round trip resolves. (That fallback is a deprecated API on purpose; the rationale is a comment in the source — the value is frozen at `MacIntel` even on Apple silicon, so it lies about the CPU while staying permanently correct about the vendor, which is the only axis this asks about.)

### Ctrl+S was registered twice

Once via `addCommand`, once via the `file-save` action. The bare command is gone; the action remains, so the entry still appears in the command palette.

### Ctrl+C with an empty selection did nothing

Monaco ships `emptySelectionClipboard`, on by default and documented in its own `.d.ts` as "Copying without a selection copies the current line" — the behaviour in VS Code and Sublime Text too. Overriding the native action with an early return silently deleted it. It now copies the line plus its EOL, mirroring Monaco's own `getLineContent(n) + EOL`.

### "Show Whitespace" only marked trailing whitespace

Every locale string is unqualified ("Show Whitespace", "显示空白", "Leerzeichen anzeigen"), so the label already promises all of it. Changing 20+ translations to say "trailing" would be the larger and worse change. `renderWhitespace` is now `"all"`.

## Validation

- `npm run check` — 0 errors, 0 warnings
- `npm test` — 205/205
- New `scripts/editorOptionWiring.test.ts` (7 tests). Beyond the obvious assertions it cross-checks `settings.svelte.ts` to prove the store really holds `'line'`/`'none'` and that Zen mode writes `'none'`; asserts exactly one `updateOptions` call site remains and that no option was lost in the merge; and asserts `Editor.svelte` never *writes* `settings.osType`.