### PR TITLE
fix(documents): stop partial buffers and external changes from destroying work

### DIFF
--- a/scripts/externalChangeReload.test.ts
+++ b/scripts/externalChangeReload.test.ts
@@ -1,0 +1,175 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+// Live Mode watches the open file and reloads it when something else writes
+// it — git checkout, a cloud sync, a second Markpad window. The reload path
+// replaces rawContent AND originalContent, so a buffer with unsaved edits is
+// not just overwritten, it stops looking dirty afterwards: the user cannot
+// even tell what they lost. Turning Live Mode ON must likewise never pull
+// disk content over the buffer; it only installs the watcher.
+
+const g = globalThis as any;
+const runeEffect = (fn: () => void) => {
+	void fn;
+};
+runeEffect.root = (fn: () => unknown) => fn();
+g.$state = (value: unknown) => value;
+g.$state.raw = (value: unknown) => value;
+g.$state.snapshot = (value: unknown) => value;
+g.$derived = (value: unknown) => value;
+g.$derived.by = (fn: () => unknown) => fn();
+g.$effect = runeEffect;
+g.window = g.window ?? {};
+let handleInvoke: (cmd: string, args: any) => unknown = (cmd) => {
+	throw new Error(`unexpected invoke: ${cmd}`);
+};
+g.window.__TAURI_INTERNALS__ = {
+	invoke: (cmd: string, args: any) => Promise.resolve(handleInvoke(cmd, args)),
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
+
+const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
+
+function makeSession() {
+	return createDocumentSession({
+		setShowHome: () => {},
+		currentFile: () => tabManager.activeTab?.path ?? '',
+		resetScrollHistory: () => {},
+		renderMarkdown: async () => '',
+		afterLoad: async () => {},
+		saveRecentFile: () => {},
+		deleteRecentFile: () => {},
+		setLoadingTabs: () => {},
+		measureInitialViewport: () => {},
+		isScrolling: () => false,
+		renderRichContent: () => {},
+		onError: () => {},
+		selfWriteGraceMs: 400,
+		cancelPendingAutoSave: () => {},
+		askClose: async () => 'discard' as const,
+		onCloseSaveNewerEdits: () => {},
+		onCloseAutoSaveFailed: () => {},
+	});
+}
+
+function open(path: string, content: string) {
+	tabManager.addTab(path, content);
+	return tabManager.activeTab!;
+}
+
+test('a clean tab that owns the changed file is reloaded', () => {
+	tabManager.closeAll();
+	const session = makeSession();
+	const tab = open('/notes/a.md', 'on disk');
+
+	assert.deepEqual(session.resolveExternalChange('/notes/a.md'), {
+		action: 'reload',
+		tabId: tab.id,
+		path: '/notes/a.md',
+	});
+});
+
+test('a tab with unsaved edits is never reloaded behind the user', () => {
+	tabManager.closeAll();
+	const session = makeSession();
+	const tab = open('/notes/a.md', 'on disk');
+	tabManager.updateTabRawContent(tab.id, 'my unsaved paragraph');
+
+	const outcome = session.resolveExternalChange('/notes/a.md');
+
+	assert.equal(outcome.action, 'conflict');
+	assert.equal((outcome as { tabId: string }).tabId, tab.id);
+	// The buffer and its dirty marker must both survive: overwriting
+	// originalContent is what made the loss invisible after the fact.
+	assert.equal(tab.rawContent, 'my unsaved paragraph');
+	assert.equal(tab.originalContent, 'on disk');
+	assert.equal(tab.isDirty, true);
+});
+
+test('the changed path decides which tab is affected, not whichever tab is active', () => {
+	tabManager.closeAll();
+	const session = makeSession();
+	const a = open('/notes/a.md', 'a on disk');
+	const b = open('/notes/b.md', 'b on disk');
+	tabManager.setActive(b.id);
+	tabManager.updateTabRawContent(b.id, 'b unsaved');
+
+	const outcome = session.resolveExternalChange('/notes/a.md');
+
+	// Reloading here would pull b.md's disk content over b's unsaved buffer
+	// because a.md changed. Whatever the outcome, it must not name tab b.
+	assert.notEqual((outcome as { tabId?: string }).tabId, b.id);
+	assert.equal(b.rawContent, 'b unsaved');
+	assert.notEqual(a.id, b.id);
+});
+
+test('a change to a file no tab holds is ignored', () => {
+	tabManager.closeAll();
+	const session = makeSession();
+	open('/notes/a.md', 'a on disk');
+
+	assert.deepEqual(session.resolveExternalChange('/notes/elsewhere.md'), { action: 'ignore' });
+	assert.deepEqual(session.resolveExternalChange(''), { action: 'ignore' });
+});
+
+test('our own writes still suppress the reload', async () => {
+	// Saving fires the watcher too. Reloading on that event would clobber any
+	// keystroke that landed between the write and the notification.
+	tabManager.closeAll();
+	const session = makeSession();
+	const tab = open('/notes/a.md', 'on disk');
+	tabManager.updateTabRawContent(tab.id, 'my edit');
+	handleInvoke = (cmd) => {
+		if (cmd === 'save_file_content') return null;
+		throw new Error(`unexpected invoke: ${cmd}`);
+	};
+
+	assert.equal(await session.saveContent(tab.id), true);
+
+	assert.deepEqual(session.resolveExternalChange('/notes/a.md'), { action: 'ignore' });
+});
+
+// --- wiring that cannot be executed outside a Svelte runtime ---
+
+test('the watcher listener routes every event through the guarded resolution', () => {
+	const listener = viewer.slice(viewer.indexOf("listen('file-changed'"));
+	const body = listener.slice(0, listener.indexOf('}),'));
+	assert.match(body, /resolveExternalChange/);
+	// The old body called loadMarkdown(currentFile) directly.
+	assert.doesNotMatch(body, /loadMarkdown\(currentFile\)/);
+});
+
+test('a conflict is surfaced with both choices instead of resolving itself', () => {
+	assert.match(viewer, /externalChangeConflicts/);
+	assert.match(viewer, /t\('externalChange\.reload'/);
+	assert.match(viewer, /t\('externalChange\.keepMine'/);
+});
+
+test('the debounced auto-save is held back while a conflict is unanswered', () => {
+	// Otherwise the 1.5s timer fires while the bar is still asking "reload or
+	// keep mine": the user's edits survive, but the external change is gone
+	// from disk before either answer can be given.
+	const effect = viewer.slice(viewer.indexOf('Auto-save effect.'));
+	const body = effect.slice(0, effect.indexOf('for (const id of ['));
+	assert.match(body, /hasPendingConflict: externalChangeConflicts\[tab\.id\] === true/);
+	assert.match(body, /const eligible = [^;]*!s\.hasPendingConflict/);
+});
+
+test('an explicit save answers the conflict and takes the bar down', () => {
+	// Pressing Cmd+S is a decision. Leaving the bar up afterwards would ask a
+	// question the user already answered.
+	const wrapper = viewer.slice(viewer.indexOf('async function saveContent(tabId?: string)'));
+	const body = wrapper.slice(0, wrapper.indexOf('async function saveContentAs'));
+	assert.match(body, /clearExternalChangeConflict/);
+});
+
+test('turning Live Mode on installs the watcher without reloading', () => {
+	// Enabling a watcher is not a request to discard the buffer, and this was
+	// the one loadMarkdown call in the app with no canCloseTab in front of it.
+	const toggle = viewer.slice(viewer.indexOf('function toggleLiveMode'));
+	const body = toggle.slice(0, toggle.indexOf('\n\t}') + 3);
+	assert.doesNotMatch(body, /loadMarkdown/);
+});

--- a/scripts/liveModeWatchedPath.test.ts
+++ b/scripts/liveModeWatchedPath.test.ts
@@ -9,7 +9,14 @@ test('Live Mode routes a watcher notification to its watched path', () => {
 	assert.match(runtime, /emit_to\(event_label\.as_str\(\), "file-changed", watched_path\.clone\(\)\)/);
 	assert.match(viewer, /await appWindow\.listen\('file-changed', \(event\) => \{/);
 	assert.match(viewer, /const changedPath = event\.payload as string;/);
-	assert.match(viewer, /if \(!liveMode \|\| !currentFile \|\| changedPath !== currentFile\) return;/);
+	// The listener no longer compares the payload with the active file itself:
+	// resolveExternalChange looks up the tab that OWNS the changed path (and
+	// refuses to reload it when it has unsaved edits). See
+	// externalChangeReload.test.ts for the routing behaviour.
+	assert.match(viewer, /if \(!liveMode\) return;/);
+	assert.match(viewer, /documentSession\.resolveExternalChange\(changedPath\)/);
+	const session = readFileSync('src/lib/sessions/documentSession.svelte.ts', 'utf8');
+	assert.match(session, /tabManager\.tabs\.find\(\(tab\) => tab\.path === changedPath\)/);
 });
 
 test('Live Mode follows the active file instead of retaining a previous tab watcher', () => {

--- a/scripts/truncatedBufferGuard.test.ts
+++ b/scripts/truncatedBufferGuard.test.ts
@@ -1,0 +1,270 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+// A markdown file larger than 50KB is opened twice: `open_markdown_preview`
+// returns the first 50KB so something renders immediately, and a background
+// `read_file_content` fills in the rest. Between the two, the tab's ONLY
+// buffer is a partial copy of the document. Anything that writes that buffer
+// back — auto-save, Cmd+S, a task checkbox, a tab moved to another window —
+// permanently truncates the user's file.
+//
+// These tests drive the real TabManager and the real document session with a
+// stubbed Tauri bridge, so they lock the behaviour, not the wording.
+
+const g = globalThis as any;
+const runeEffect = (fn: () => void) => {
+	void fn;
+};
+runeEffect.root = (fn: () => unknown) => fn();
+g.$state = (value: unknown) => value;
+g.$state.raw = (value: unknown) => value;
+g.$state.snapshot = (value: unknown) => value;
+g.$derived = (value: unknown) => value;
+g.$derived.by = (fn: () => unknown) => fn();
+g.$effect = runeEffect;
+g.window = g.window ?? {};
+
+const PREVIEW_BYTES = 50000;
+const FULL = `# big\n\n${'x'.repeat(PREVIEW_BYTES)}\n\ntail that must never be lost\n`;
+const PARTIAL = FULL.slice(0, PREVIEW_BYTES);
+
+let invokeCalls: Array<{ cmd: string; args: any }> = [];
+/** Set per test. Return a never-settling promise to freeze the partial state. */
+let handleInvoke: (cmd: string, args: any) => unknown = () => {
+	throw new Error('unexpected invoke');
+};
+
+g.window.__TAURI_INTERNALS__ = {
+	invoke: (cmd: string, args: any) => {
+		invokeCalls.push({ cmd, args });
+		return Promise.resolve(handleInvoke(cmd, args)).then((value) => value);
+	},
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
+
+const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
+
+const errors: string[] = [];
+
+function makeSession() {
+	return createDocumentSession({
+		setShowHome: () => {},
+		currentFile: () => tabManager.activeTab?.path ?? '',
+		resetScrollHistory: () => {},
+		renderMarkdown: async (raw: string) => `<p>${raw.length}</p>`,
+		afterLoad: async () => {},
+		saveRecentFile: () => {},
+		deleteRecentFile: () => {},
+		setLoadingTabs: () => {},
+		measureInitialViewport: () => {},
+		isScrolling: () => false,
+		renderRichContent: () => {},
+		onError: (message) => errors.push(message),
+		selfWriteGraceMs: 400,
+		cancelPendingAutoSave: () => {},
+		askClose: async () => 'discard' as const,
+		onCloseSaveNewerEdits: () => {},
+		onCloseAutoSaveFailed: () => {},
+	});
+}
+
+function reset() {
+	tabManager.closeAll();
+	invokeCalls = [];
+	errors.length = 0;
+}
+
+/** Open a >50KB file and leave the background full read pending forever. */
+async function openPartial(path = '/docs/big.md') {
+	handleInvoke = (cmd) => {
+		if (cmd === 'open_markdown_preview') return ['<p>preview</p>', PARTIAL, false];
+		if (cmd === 'read_file_content') return new Promise(() => {});
+		throw new Error(`unexpected invoke: ${cmd}`);
+	};
+	const session = makeSession();
+	await session.loadMarkdown(path);
+	const tab = tabManager.activeTab!;
+	assert.equal(tab.rawContent, PARTIAL, 'precondition: the buffer is the partial read');
+	return { session, tab };
+}
+
+test('a partially loaded buffer is marked as incomplete', async () => {
+	reset();
+	const { tab } = await openPartial();
+
+	// Without this flag nothing downstream can tell a 50KB document from the
+	// first 50KB of a 5MB one — the buffer looks authoritative and clean.
+	assert.equal(tab.isTruncated, true);
+	assert.equal(tab.isDirty, false);
+});
+
+test('a fully loaded buffer is not marked as incomplete', async () => {
+	reset();
+	handleInvoke = (cmd) => {
+		if (cmd === 'open_markdown_preview') return ['<p>full</p>', FULL, true];
+		throw new Error(`unexpected invoke: ${cmd}`);
+	};
+	const session = makeSession();
+	await session.loadMarkdown('/docs/small.md');
+
+	assert.notEqual(tabManager.activeTab!.isTruncated, true);
+	assert.equal(tabManager.activeTab!.rawContent, FULL);
+});
+
+test('saving refuses to write a partial buffer over the file', async () => {
+	reset();
+	const { session, tab } = await openPartial();
+
+	const saved = await session.saveContent(tab.id);
+
+	assert.equal(saved, false);
+	assert.equal(
+		invokeCalls.some((call) => call.cmd === 'save_file_content'),
+		false,
+		'the partial buffer must never reach save_file_content',
+	);
+	assert.ok(errors.length > 0, 'the refusal is reported, not silent');
+});
+
+test('completing a partial buffer replaces it with the whole file and unblocks saving', async () => {
+	reset();
+	const { session, tab } = await openPartial();
+
+	handleInvoke = (cmd) => {
+		if (cmd === 'read_file_content') return FULL;
+		if (cmd === 'save_file_content') return null;
+		throw new Error(`unexpected invoke: ${cmd}`);
+	};
+
+	assert.equal(await session.ensureFullContent(tab.id), true);
+	assert.equal(tab.rawContent, FULL);
+	assert.notEqual(tab.isTruncated, true);
+
+	assert.equal(await session.saveContent(tab.id), true);
+	const write = invokeCalls.find((call) => call.cmd === 'save_file_content');
+	assert.equal(write?.args.content, FULL);
+});
+
+test('completing a buffer that is already whole does not re-read the file', async () => {
+	reset();
+	handleInvoke = (cmd) => {
+		if (cmd === 'open_markdown_preview') return ['<p>full</p>', FULL, true];
+		throw new Error(`unexpected invoke: ${cmd}`);
+	};
+	const session = makeSession();
+	await session.loadMarkdown('/docs/small.md');
+	const before = invokeCalls.length;
+
+	assert.equal(await session.ensureFullContent(tabManager.activeTabId!), true);
+	assert.equal(invokeCalls.length, before);
+});
+
+test('a partial buffer that already carries edits is never silently discarded', async () => {
+	reset();
+	const { session, tab } = await openPartial();
+	// Should be unreachable now that every editing entry point completes the
+	// buffer first, but if it ever happens the fix must not trade one kind of
+	// data loss for another.
+	tabManager.updateTabRawContent(tab.id, `${PARTIAL}edited`);
+
+	handleInvoke = (cmd) => {
+		if (cmd === 'read_file_content') return FULL;
+		throw new Error(`unexpected invoke: ${cmd}`);
+	};
+
+	assert.equal(await session.ensureFullContent(tab.id), false);
+	assert.equal(tab.rawContent, `${PARTIAL}edited`);
+	assert.equal(await session.saveContent(tab.id), false);
+});
+
+test('a load into an editable pane reads the whole file instead of the preview slice', async () => {
+	// F5 / "reload from disk" preserves edit state. Taking the preview
+	// shortcut there hands the editor a partial buffer, and the next keystroke
+	// arms auto-save on it.
+	reset();
+	handleInvoke = (cmd) => {
+		if (cmd === 'open_markdown_preview') return ['<p>preview</p>', PARTIAL, false];
+		if (cmd === 'read_file_content') return FULL;
+		throw new Error(`unexpected invoke: ${cmd}`);
+	};
+	tabManager.addTab('/docs/big.md', '');
+	const tab = tabManager.activeTab!;
+	tab.isEditing = true;
+	const session = makeSession();
+
+	await session.loadMarkdown('/docs/big.md', { preserveEditState: true, skipTabManagement: true });
+
+	assert.equal(tab.rawContent, FULL);
+	assert.notEqual(tab.isTruncated, true);
+	assert.equal(
+		invokeCalls.some((call) => call.cmd === 'open_markdown_preview'),
+		false,
+	);
+});
+
+test('toggling a task checkbox completes the buffer before writing it', async () => {
+	reset();
+	const doc = `- [ ] first\n\n${'y'.repeat(PREVIEW_BYTES)}\n\n- [ ] last\n`;
+	const partial = doc.slice(0, PREVIEW_BYTES);
+	handleInvoke = (cmd) => {
+		if (cmd === 'open_markdown_preview') return ['<p>preview</p>', partial, false];
+		if (cmd === 'read_file_content') return new Promise(() => {});
+		throw new Error(`unexpected invoke: ${cmd}`);
+	};
+	const session = makeSession();
+	await session.loadMarkdown('/docs/tasks.md');
+	const tab = tabManager.activeTab!;
+	assert.equal(tab.rawContent, partial);
+
+	handleInvoke = (cmd) => {
+		if (cmd === 'read_file_content') return doc;
+		if (cmd === 'save_file_content') return null;
+		throw new Error(`unexpected invoke: ${cmd}`);
+	};
+	await session.toggleTaskCheckbox(1, true);
+
+	const write = invokeCalls.find((call) => call.cmd === 'save_file_content');
+	assert.ok(write, 'the checkbox toggle still saves');
+	assert.equal(write!.args.content, doc.replace('- [ ] first', '- [x] first'));
+	assert.ok(
+		(write!.args.content as string).includes('- [ ] last'),
+		'the part of the file past the preview window survives',
+	);
+});
+
+// --- wiring that cannot be executed outside a Svelte runtime ---
+
+test('entering split view completes a partial buffer instead of trusting it', () => {
+	// The old guard was `!tab.rawContent`, which a partial buffer satisfies:
+	// split view opened on the truncated text, the first keystroke made it
+	// dirty, and auto-save wrote it back 1.5s later.
+	const split = viewer.slice(viewer.indexOf('async function toggleSplitView'));
+	const enter = split.slice(0, split.indexOf('} else {'));
+	assert.match(enter, /ensureFullContent/);
+	// And it has to stop when the buffer could not be completed, rather than
+	// opening an editor over the partial text anyway.
+	assert.match(enter, /if \(!\(await documentSession\.ensureFullContent\(tab\.id\)\)\) \{[\s\S]*?return;/);
+	// The empty-buffer read must go through the store so the tab does not keep
+	// a stale "partial" flag that would then block every save.
+	assert.match(enter, /tabManager\.setTabRawContent\(tab\.id, content\)/);
+});
+
+test('a partial buffer cannot be handed to another window', () => {
+	// The destination rebuilds the tab from the payload alone and has no way
+	// to know the text is incomplete, so its auto-save would truncate the file.
+	const canTransfer = viewer.slice(viewer.indexOf('canTransfer: (tabId)'), viewer.indexOf('transferPayload:'));
+	assert.match(canTransfer, /isTruncated/);
+	const detach = viewer.slice(viewer.indexOf('async function handleDetach'), viewer.indexOf('async function carryActiveTabToNextWindow'));
+	assert.match(detach, /ensureFullContent/);
+});
+
+test('front matter edits in preview mode complete the buffer first', () => {
+	for (const entry of ['async function handleFrontMatterEdit', 'async function handleFrontMatterListChange']) {
+		const handler = viewer.slice(viewer.indexOf(entry));
+		const body = handler.slice(0, handler.indexOf('\n\tfunction ') + 1 || handler.indexOf('\n\tasync function ') + 1);
+		assert.match(body, /ensureFullContent/, `${entry} must not edit a partial buffer`);
+	}
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -458,13 +458,19 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			if (tabManager.activeTabId === tab.id) tick().then(renderRichContent);
 		},
 		dropRestoredTab: (tabId) => tabManager.closeTab(tabId),
+		// A partially loaded buffer must never be handed to another window.
+		// The transfer payload has no field for "incomplete" (see
+		// tabTransfer.ts) and the destination rebuilds the tab from the
+		// payload alone, so the arriving copy would look authoritative and its
+		// auto-save would truncate the file. handleDetach and moveTabToWindow
+		// complete the buffer first; these predicates are the backstop.
 		canTransfer: (tabId) => {
 			const tab = tabManager.tabs.find((item) => item.id === tabId);
-			return !isCloseWalkActive && tab !== undefined && tab.path !== 'HOME';
+			return !isCloseWalkActive && tab !== undefined && tab.path !== 'HOME' && !tab.isTruncated;
 		},
 		canDetach: (tabId) => {
 			const tab = tabManager.tabs.find((item) => item.id === tabId);
-			return !isCloseWalkActive && tab !== undefined && tab.path !== 'HOME' && tabManager.tabs.length >= 2;
+			return !isCloseWalkActive && tab !== undefined && tab.path !== 'HOME' && !tab.isTruncated && tabManager.tabs.length >= 2;
 		},
 		transferPayload: (tabId) => {
 			const tab = tabManager.tabs.find((item) => item.id === tabId);
@@ -816,6 +822,13 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	async function handleFrontMatterEdit(field: FrontMatterField, value: string) {
 		const tab = tabManager.activeTab;
 		if (!tab) return;
+		// Front matter is editable from reading mode, which a large file can
+		// reach while its buffer is still the preview slice. Rewriting that
+		// slice and saving it would drop the rest of the document.
+		if (!(await documentSession.ensureFullContent(tab.id))) {
+			addToast(t('toast.partialDocument', settings.language), 'error');
+			return;
+		}
 
 		try {
 			const nextValue = parseFrontMatterEditableValue(field, value);
@@ -894,6 +907,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	async function handleFrontMatterListChange(field: FrontMatterField, nextItems: string[]) {
 		const tab = tabManager.activeTab;
 		if (!tab) return;
+		// Same partial-buffer guard as handleFrontMatterEdit.
+		if (!(await documentSession.ensureFullContent(tab.id))) {
+			addToast(t('toast.partialDocument', settings.language), 'error');
+			return;
+		}
 
 		try {
 			const nextRaw = updateFrontMatterField(tab.rawContent, field.key, nextItems);
@@ -1717,9 +1735,10 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 				} else {
 					try {
 						const content = (await invoke('read_file_content', { path: tab.path })) as string;
-						tab.rawContent = content;
+						// Goes through the store so a tab that held only the
+						// large-file preview slice stops being flagged partial.
+						tabManager.setTabRawContent(tab.id, content);
 						tab.isEditing = true;
-						tab.isDirty = false;
 					} catch (e) {
 						console.error('Failed to read file for editing', e);
 					}
@@ -1731,11 +1750,57 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	}
 
 	async function saveContent(tabId?: string): Promise<boolean> {
-		return documentSession.saveContent(tabId);
+		const saved = await documentSession.saveContent(tabId);
+		// Every route into here is an explicit decision — Cmd+S, the close
+		// dialog, a mode-toggle dialog — and the background debounce is held
+		// back entirely while a conflict is open (see the auto-save effect).
+		// So a save that lands here IS the answer "keep my version": our text
+		// is now the newest on disk and the bar has nothing left to ask.
+		if (saved) clearExternalChangeConflict(tabId ?? tabManager.activeTabId ?? '');
+		return saved;
 	}
 
 	async function saveContentAs(): Promise<boolean> {
 		return documentSession.saveContentAs();
+	}
+
+	// --- External change conflicts ---
+	// A file changed on disk while the tab holding it had unsaved edits. The
+	// reload is NOT performed: `setTabRawContent` replaces originalContent
+	// too, so an automatic reload would erase the edits and the fact that
+	// there were any. The tab is flagged instead and the user picks.
+	let externalChangeConflicts = $state<Record<string, true>>({});
+	let activeExternalChangeConflict = $derived(
+		tabManager.activeTabId ? externalChangeConflicts[tabManager.activeTabId] === true : false,
+	);
+
+	function noteExternalChangeConflict(tabId: string) {
+		if (externalChangeConflicts[tabId]) return;
+		externalChangeConflicts = { ...externalChangeConflicts, [tabId]: true };
+	}
+
+	function clearExternalChangeConflict(tabId: string) {
+		if (!externalChangeConflicts[tabId]) return;
+		const next = { ...externalChangeConflicts };
+		delete next[tabId];
+		externalChangeConflicts = next;
+	}
+
+	/** "Reload": the user chose the disk version over their own edits. */
+	async function resolveExternalChangeByReloading() {
+		const tab = tabManager.activeTab;
+		if (!tab?.path) return;
+		clearExternalChangeConflict(tab.id);
+		await loadMarkdown(tab.path, {
+			preserveEditState: true,
+			skipTabManagement: true,
+			resetScrollHistory: true,
+		});
+	}
+
+	/** "Keep my version": dismiss. The buffer stays dirty and saveable. */
+	function resolveExternalChangeByKeepingBuffer() {
+		if (tabManager.activeTabId) clearExternalChangeConflict(tabManager.activeTabId);
 	}
 
 	/**
@@ -1780,13 +1845,26 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			isDirty: tab.isDirty,
 			editable: tab.isEditing || tab.isSplit,
 			contentRef: tab.rawContent,
+			// Reactive too: clearing a conflict re-arms the timer on the next
+			// keystroke, so answering the bar resumes normal auto-save.
+			hasPendingConflict: externalChangeConflicts[tab.id] === true,
 		}));
 
 		untrack(() => {
 			const seenIds = new Set<string>();
 			for (const s of snapshot) {
 				seenIds.add(s.id);
-				const eligible = s.isDirty && s.path !== '' && s.editable;
+				// A tab with an unanswered external-change conflict is NOT
+				// eligible: the debounce would fire while the bar is still
+				// asking "reload or keep mine", write the buffer, and destroy
+				// the disk version the question was about — leaving the user to
+				// answer a question whose "reload" branch no longer exists.
+				// Only the silent background timer is held back. Every explicit
+				// save (Cmd+S, the close and mode-toggle dialogs) still goes
+				// through: pressing Save IS the answer "keep mine", and the
+				// `saveContent` wrapper clears the conflict so the bar comes
+				// down instead of re-asking.
+				const eligible = s.isDirty && s.path !== '' && s.editable && !s.hasPendingConflict;
 				const prevRef = lastContentRefByTab.get(s.id);
 				const refChanged = prevRef !== s.contentRef;
 
@@ -2265,14 +2343,26 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		if (!tab) return;
 
 		if (!tab.isSplit) {
-			if (!tab.isEditing && !tab.rawContent && tab.path) {
+			// Split view puts an editor on the buffer, and the first keystroke
+			// arms auto-save. Two buffers must never reach that point: an empty
+			// one (restored tab whose content was never read) and a partial one
+			// (large file whose background read has not landed, or was dropped
+			// because the user entered split during the ~2s window). The old
+			// guard was `!tab.rawContent`, which a partial buffer satisfies —
+			// so split view edited the truncated text and auto-save wrote it
+			// back over the whole file. `toggleEdit` always re-reads, which is
+			// why the same bug never reached the full editor.
+			if (tab.path && !tab.isEditing && !tab.rawContent) {
 				try {
 					const content = (await invoke('read_file_content', { path: tab.path })) as string;
-					tab.rawContent = content;
-					tab.originalContent = content;
+					tabManager.setTabRawContent(tab.id, content);
 				} catch (e) {
 					console.error('Failed to load raw content for split view', e);
 				}
+			}
+			if (!(await documentSession.ensureFullContent(tab.id))) {
+				addToast(t('toast.partialDocument', settings.language), 'error');
+				return;
 			}
 			tabManager.setSplitEnabled(tab.id, true);
 			if (liveMode) toggleLiveMode();
@@ -2531,11 +2621,23 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	// the Rust broker (never disk, never localStorage), and the source tab is
 	// deleted only after the destination confirms the claim, so any failure —
 	// window creation error, timeout — leaves the tab exactly where it was.
+	// A large file may still be holding only its preview slice. The receiving
+	// window cannot tell, so the buffer is completed here, before the payload
+	// is built — otherwise the document arrives short and gets written back
+	// that way.
 	async function handleDetach(tabId: string) {
-		await windowSession.detach(tabId);
+		if (!(await documentSession.ensureFullContent(tabId))) {
+			addToast(t('toast.partialDocument', settings.language), 'error');
+			return false;
+		}
+		return windowSession.detach(tabId);
 	}
 
 	async function moveTabToWindow(tabId: string, targetLabel: string, focusAfter = false) {
+		if (!(await documentSession.ensureFullContent(tabId))) {
+			addToast(t('toast.partialDocument', settings.language), 'error');
+			return false;
+		}
 		const moved = await windowSession.transfer(tabId, (token) => invoke('offer_tab_to_window', { targetLabel, token }));
 		if (moved && focusAfter) await invoke('focus_window', { label: targetLabel });
 		return moved;
@@ -2722,12 +2824,19 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			unlisteners.push(
 				await appWindow.listen('file-changed', (event) => {
 					const changedPath = event.payload as string;
-					if (!liveMode || !currentFile || changedPath !== currentFile) return;
-					// Skip events caused by our own auto-save / save invocations,
-					// otherwise the reload would clobber any keystrokes that landed
-					// between fs::write and this listener firing.
-					if (!documentSession.shouldReloadExternalChange(currentFile)) return;
-					loadMarkdown(currentFile);
+					if (!liveMode) return;
+					// The event names the changed file. Which tab that touches —
+					// and whether it may be reloaded at all — is decided by the
+					// session: it owns the self-write grace window (so our own
+					// auto-save does not bounce back) and it refuses to reload a
+					// tab with unsaved edits.
+					const outcome = documentSession.resolveExternalChange(changedPath);
+					if (outcome.action === 'ignore') return;
+					if (outcome.action === 'conflict') {
+						noteExternalChangeConflict(outcome.tabId);
+						return;
+					}
+					loadMarkdown(outcome.path);
 				}),
 			);
 
@@ -3123,6 +3232,18 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		oncloseTab={closeTabAndWindowIfLast} />
 
 	<Settings show={showSettings} {theme} onSetTheme={(t) => (theme = t)} onclose={() => (showSettings = false)} />
+
+	{#if activeExternalChangeConflict && !showHome}
+		<div class="external-change-bar" role="status">
+			<span class="external-change-text">{t('externalChange.message', settings.language)}</span>
+			<button class="external-change-action" onclick={resolveExternalChangeByReloading}>
+				{t('externalChange.reload', settings.language)}
+			</button>
+			<button class="external-change-action primary" onclick={resolveExternalChangeByKeepingBuffer}>
+				{t('externalChange.keepMine', settings.language)}
+			</button>
+		</div>
+	{/if}
 
 	{#if tabManager.activeTab && (tabManager.activeTab.path !== '' || tabManager.activeTab.title !== 'Recents') && !showHome}
 			<div
@@ -3972,6 +4093,49 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		box-shadow: 0 8px 30px rgba(0, 0, 0, 0.25);
 	}
 
+	/*
+	 * `.layout-container` is absolutely positioned from top: 0, so a bar in
+	 * normal flow would end up underneath it. Pinned just below the 36px
+	 * title bar instead, the way editors surface file-changed-on-disk notices.
+	 */
+	.external-change-bar {
+		position: fixed;
+		top: 36px;
+		left: 0;
+		right: 0;
+		z-index: 40000;
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 8px 14px;
+		background: color-mix(in srgb, var(--color-attention-fg, #9a6700) 14%, var(--color-canvas-overlay));
+		border-bottom: 1px solid var(--color-border-default);
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+		color: var(--color-fg-default);
+		font-family: var(--win-font), sans-serif;
+		font-size: 13px;
+	}
+	.external-change-text {
+		flex: 1;
+		min-width: 0;
+	}
+	.external-change-action {
+		flex: none;
+		padding: 4px 10px;
+		border: 1px solid var(--color-border-default);
+		border-radius: 6px;
+		background: var(--color-canvas-default);
+		color: var(--color-fg-default);
+		font-family: inherit;
+		font-size: 12px;
+		cursor: pointer;
+	}
+	.external-change-action:hover {
+		background: color-mix(in srgb, var(--color-accent-fg) 8%, var(--color-canvas-default));
+	}
+	.external-change-action.primary {
+		border-color: color-mix(in srgb, var(--color-accent-fg) 40%, transparent);
+	}
 	.toast-container {
 		position: fixed;
 		bottom: 24px;

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -12,6 +12,16 @@ export type LoadMarkdownOptions = {
 	resetScrollHistory?: boolean;
 };
 
+/**
+ * What to do about a file the watcher reported as changed on disk.
+ * `conflict` means the owning tab has unsaved edits, so the choice belongs
+ * to the user rather than to a background reload.
+ */
+export type ExternalChangeOutcome =
+	| { action: 'ignore' }
+	| { action: 'reload'; tabId: string; path: string }
+	| { action: 'conflict'; tabId: string; path: string };
+
 type DocumentSessionOptions = {
 	setShowHome: (value: boolean) => void;
 	currentFile: () => string;
@@ -53,6 +63,67 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		return true;
 	}
 
+	/**
+	 * Decide what a `file-changed` event should do. The event names the file
+	 * that changed, so the tab that OWNS that path is the one affected —
+	 * reloading "the active tab" would pull one document's disk content over
+	 * a different document's buffer.
+	 *
+	 * A tab with unsaved edits is never reloaded: `setTabRawContent` replaces
+	 * `originalContent` too, so the overwrite would also erase the evidence
+	 * that anything was lost. The caller offers the user the choice instead.
+	 */
+	function resolveExternalChange(changedPath: string): ExternalChangeOutcome {
+		if (!changedPath) return { action: 'ignore' };
+		if (!shouldReloadExternalChange(changedPath)) return { action: 'ignore' };
+
+		const active = tabManager.activeTab;
+		const owner =
+			active && active.path === changedPath
+				? active
+				: tabManager.tabs.find((tab) => tab.path === changedPath);
+		if (!owner) return { action: 'ignore' };
+
+		if (owner.isDirty) return { action: 'conflict', tabId: owner.id, path: changedPath };
+
+		// `loadMarkdown` always writes into the active tab, so a background
+		// owner cannot be refreshed through it. The watcher only ever follows
+		// the active file, so this is a guard against a stale in-flight event,
+		// not a dropped update.
+		if (owner.id !== tabManager.activeTabId) return { action: 'ignore' };
+
+		return { action: 'reload', tabId: owner.id, path: changedPath };
+	}
+
+	/**
+	 * Replace a partial buffer (the >50KB preview read) with the whole file.
+	 * Must be awaited by every path that can lead to a write — entering the
+	 * editor or split view, editing front matter, toggling a task checkbox,
+	 * moving the tab to another window — because writing the partial buffer
+	 * back permanently truncates the document.
+	 *
+	 * Returns false when the buffer is still partial afterwards. A partial
+	 * buffer that already carries edits is left alone: replacing it would
+	 * trade the file's tail for the user's typing, so the caller has to stop
+	 * instead. Every editing entry point calls this first, which is what makes
+	 * that state unreachable in practice.
+	 */
+	async function ensureFullContent(tabId: string): Promise<boolean> {
+		const tab = tabManager.tabs.find((item) => item.id === tabId);
+		if (!tab) return false;
+		if (!tab.isTruncated) return true;
+		if (!tab.path) return true;
+		if (tab.isDirty) return false;
+		try {
+			const full = (await invoke('read_file_content', { path: tab.path })) as string;
+			tabManager.setTabRawContent(tabId, full);
+			return true;
+		} catch (error) {
+			options.onError('Error loading the rest of the file', error);
+			return false;
+		}
+	}
+
 	function updateLoading(tabId: string, loading: boolean) {
 		if (loading) loadingTabs.add(tabId);
 		else loadingTabs.delete(tabId);
@@ -87,11 +158,28 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 				if (tab && !loadOptions.preserveEditState && !existing) tab.isEditing = settings.startInEditor;
 				const initialIsEditing = tab?.isEditing ?? false;
 				const initialIsSplit = tab?.isSplit ?? false;
-				const [, content, isFull] = (await invoke('open_markdown_preview', { path: filePath, maxBytes: 50000 })) as [string, string, boolean];
+				// `open_markdown_preview` returns only the first 50KB of a large
+				// file, which is fine behind a read-only preview because the
+				// background read below completes it. An editor bound to that
+				// partial buffer is one keystroke away from auto-saving it back
+				// over the whole document, so a pane that can write always gets
+				// the complete file up front — this is the path F5 and "reload
+				// from disk" take while edit or split mode is preserved.
+				let content: string;
+				let isFull: boolean;
+				if (initialIsEditing || initialIsSplit) {
+					content = (await invoke('read_file_content', { path: filePath })) as string;
+					isFull = true;
+				} else {
+					[, content, isFull] = (await invoke('open_markdown_preview', { path: filePath, maxBytes: 50000 })) as [string, string, boolean];
+				}
 				if (pendingNavigateTabId) tabManager.navigate(pendingNavigateTabId, filePath);
 				const processed = await options.renderMarkdown(content, filePath);
 				tabManager.updateTabContent(activeId, processed);
-				tabManager.setTabRawContent(activeId, content);
+				// `isFull === false` means this is only the leading slice of a
+				// large file. Marking the tab keeps anything downstream from
+				// mistaking it for the whole document and writing it back.
+				tabManager.setTabRawContent(activeId, content, !isFull);
 
 				if (!isFull) {
 					const canApplyFullLoad = () => {
@@ -151,6 +239,13 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 	async function saveContent(tabId?: string): Promise<boolean> {
 		const tab = tabId ? tabManager.tabs.find((item) => item.id === tabId) : tabManager.activeTab;
 		if (!tab) return false;
+		// Backstop, not the main defence: every path that lets the user change
+		// a large file completes its buffer first. If one is ever missed, the
+		// write must fail loudly rather than silently truncate the document.
+		if (tab.isTruncated) {
+			options.onError('Refusing to save a partially loaded document', new Error(tab.path));
+			return false;
+		}
 		let targetPath = tab.path;
 		if (!targetPath) {
 			const selected = await save({
@@ -185,6 +280,11 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 	async function saveContentAs(): Promise<boolean> {
 		const tab = tabManager.activeTab;
 		if (!tab) return false;
+		// A partial buffer would produce a silently incomplete copy.
+		if (tab.isTruncated) {
+			options.onError('Refusing to save a partially loaded document', new Error(tab.path));
+			return false;
+		}
 		const selected = await save({
 			filters: [
 				{ name: 'Markdown', extensions: ['md'] },
@@ -213,6 +313,9 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 	async function toggleTaskCheckbox(sourceLine: number, nowChecked: boolean) {
 		const tab = tabManager.activeTab;
 		if (!tab || !tab.path) return false;
+		// Reading mode can reach a large file before its full buffer arrives.
+		// Editing and saving the preview slice would drop everything past it.
+		if (!(await ensureFullContent(tab.id))) return false;
 		const raw = tab.rawContent;
 		const body = getMarkdownBodyWithoutFrontMatter(raw);
 		const updatedBody = body.replace(/^(\s*(?:>\s*)*(?:[-+*]|\d+[.)])\s+)\[( |x|X)\]/gm, (match, prefix, _state, offset) => {
@@ -250,5 +353,5 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		return true;
 	}
 
-	return { loadMarkdown, saveContent, saveContentAs, toggleTaskCheckbox, shouldReloadExternalChange, canCloseTab };
+	return { loadMarkdown, saveContent, saveContentAs, toggleTaskCheckbox, shouldReloadExternalChange, resolveExternalChange, ensureFullContent, canCloseTab };
 }

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -30,6 +30,15 @@ export interface Tab {
 	isSplit: boolean;
 	splitRatio: number;
 	isScrollSynced: boolean;
+	/**
+	 * True while `rawContent` holds only the leading slice of a large file
+	 * (the >50KB preview read) instead of the whole document. Such a buffer
+	 * looks clean and authoritative but writing it back truncates the file,
+	 * so every path that can reach disk must complete it first — see
+	 * `ensureFullContent` in documentSession. Optional because tabs built
+	 * from a cross-window transfer payload always arrive complete.
+	 */
+	isTruncated?: boolean;
 }
 
 class TabManager {
@@ -137,7 +146,8 @@ class TabManager {
 					anchorLine: typeof saved.anchorLine === 'number' ? saved.anchorLine : 0,
 					isSplit: saved.isSplit === true,
 					splitRatio: typeof saved.splitRatio === 'number' ? saved.splitRatio : 0.5,
-					isScrollSynced: saved.isScrollSynced === true
+					isScrollSynced: saved.isScrollSynced === true,
+					isTruncated: false
 				});
 			}
 
@@ -177,7 +187,8 @@ class TabManager {
 			anchorLine: 0,
 			isSplit: false,
 			splitRatio: 0.5,
-			isScrollSynced: false
+			isScrollSynced: false,
+			isTruncated: false
 		});
 
 		this.activeTabId = id;
@@ -207,7 +218,8 @@ class TabManager {
 			anchorLine: 0,
 			isSplit: false,
 			splitRatio: 0.5,
-			isScrollSynced: false
+			isScrollSynced: false,
+			isTruncated: false
 		});
 
 		this.activeTabId = id;
@@ -238,7 +250,8 @@ class TabManager {
 			anchorLine: 0,
 			isSplit: false,
 			splitRatio: 0.5,
-			isScrollSynced: false
+			isScrollSynced: false,
+			isTruncated: false
 		});
 
 		this.activeTabId = id;
@@ -302,12 +315,24 @@ class TabManager {
 		}
 	}
 
-	setTabRawContent(id: string, raw: string) {
+	/**
+	 * Replace a tab's buffer with what was just read from disk: the new text
+	 * becomes both the buffer and the saved baseline, so the tab is clean.
+	 *
+	 * `isTruncated` says whether that read covered the whole file. It defaults
+	 * to false because every caller but the large-file preview read supplies a
+	 * complete document, and a stale `true` is the dangerous direction: it
+	 * would block saving a file that is actually intact. The opposite mistake
+	 * — a partial buffer that claims to be whole — is what truncates files, so
+	 * the preview read must pass it explicitly.
+	 */
+	setTabRawContent(id: string, raw: string, isTruncated = false) {
 		const tab = this.tabs.find((t) => t.id === id);
 		if (tab) {
 			tab.rawContent = raw;
 			tab.originalContent = raw;
 			tab.isDirty = false;
+			tab.isTruncated = isTruncated;
 		}
 	}
 

--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -252,7 +252,13 @@ export const translations: Record<LanguageCode, Translation> = {
             autoSaveFailed: 'Auto-save failed — unsaved changes still in memory',
 			noOtherWindows: 'No other windows to merge',
             savedNewerEdits: 'Saved — staying in edit mode because you have newer edits',
-            openExportedFileFailed: 'Could not open exported file'
+            openExportedFileFailed: 'Could not open exported file',
+            partialDocument: 'Cannot edit yet — this file is not fully loaded'
+        },
+        externalChange: {
+            message: 'This file changed on disk while you had unsaved changes.',
+            reload: 'Reload from disk',
+            keepMine: 'Keep my version'
         },
         modal: {
             confirmExit: 'Confirm Exit',
@@ -589,7 +595,13 @@ export const translations: Record<LanguageCode, Translation> = {
             autoSaveFailed: '自动保存失败 — 未保存的更改仍在内存中',
 			noOtherWindows: '没有其他可合并的窗口',
 			savedNewerEdits: '已保存 — 因为存在更新的编辑,继续保持编辑模式',
-			openExportedFileFailed: '无法打开导出的文件'
+			openExportedFileFailed: '无法打开导出的文件',
+			partialDocument: '暂时无法编辑 — 文件尚未完整加载'
+        },
+        externalChange: {
+            message: '此文件在你有未保存修改时被外部程序改动。',
+            reload: '从磁盘重新加载',
+            keepMine: '保留我的版本'
         },
         modal: {
             confirmExit: '确认退出',


### PR DESCRIPTION
## A truncated preview buffer could be written back over the whole file

Opening a document larger than 50 KB starts with `open_markdown_preview(maxBytes: 50000)`, and `setTabRawContent` made that partial text both the buffer **and** the baseline — `isDirty=false`, nothing marking it incomplete. The background full read is abandoned if the tab changes mode or gets edited meanwhile, and `toggleSplitView` only re-read when `!tab.rawContent`; a partial buffer is not empty, so it did not.

Four routes reached that state, not the one in the original report:

| Route | What the user did |
|---|---|
| Split view | `Ctrl+\` during the ~2 s window, then typed — auto-save wrote the partial buffer |
| Task checkbox | ticked a checkbox **from reading mode** on a large document |
| Front matter | edited a property **from reading mode** |
| `reloadFromDisk` / F5 | handed the *editor itself* a partial buffer |

A tab now records whether its buffer is partial, every editable entry point completes it from disk first, and saving refuses a partial buffer as a backstop.

**Detaching completes it too.** `TransferableTab` has no field for the flag and `validateTransferPayload` rebuilds the tab explicitly, so an unknown field is dropped — the destination window would have inherited a short buffer that looked authoritative, with its own auto-save timer. Fixed on the source side, with `canTransfer`/`canDetach` as a fail-closed backstop.

## An external change overwrote unsaved edits silently

The watcher listener checked live mode and the self-write grace window but never `tab.isDirty` — and `setTabRawContent` rewrites `originalContent` too, so a `git checkout`, a cloud sync, or another window saving the same file took the edits with **no trace that anything had been dirty**. A dirty tab now raises a conflict the user answers (reload / keep mine) instead of being reloaded under them.

**The debounced auto-save is held back while a conflict is unanswered.** Otherwise the timer writes 1.5 s later and drops the external change while the bar is still asking which version to keep. Explicit saves still go through — pressing Save *is* the answer "keep mine", and the save path clears the conflict so the bar comes down rather than re-asking. The debounce is the only thing that ever writes without being asked, so it is the only thing suppressed. That rule covers the close and mode-toggle dialogs too, which reach disk through the same wrapper.

## Live Mode needed no change

`Cmd/Ctrl+L` overwriting the buffer was already fixed by #296 — toggling now installs the watcher without reloading. Verified on this baseline; the existing regression lock is kept and repointed at the new tests.

## Validation

- `npm run check` — 0 errors, 0 warnings
- `npm test` — 226/226

**Baseline counter-check:** the two new files were extracted onto an untouched tree and run there — **19 of 21 assertions fail on `master`**. The two that pass are deliberate: a negative control (*"a fully loaded buffer is not marked as incomplete"*) and the #296 Live Mode lock. The check was re-run after rebasing onto #371 to confirm that PR's Rust read-path changes did not accidentally satisfy any of them; every assertion that was red before is still red.

These are behaviour tests, not source-pattern matching: they install a rune shim, import the real `tabManager` and `createDocumentSession`, and stub the Tauri bridge at `window.__TAURI_INTERNALS__`. Only four assertions that live inside `.svelte` markup are source checks.

## Note

Four i18n keys are added for the conflict bar and the partial-document toast, filled for `en` and `zh-CN`; the other locales fall back to English, which is the existing pattern in this file for recently added strings.