### PR TITLE
fix(preview): stop a leading --- from swallowing prose, and batch fold measurement

### DIFF
--- a/scripts/foldMeasurementBatching.test.ts
+++ b/scripts/foldMeasurementBatching.test.ts
@@ -1,0 +1,170 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+// `--fold-content-height` is resolved into `height` by styles.css, so writing it
+// invalidates layout and any `scrollHeight` read that follows forces a
+// synchronous reflow. Measuring one wrapper at a time therefore costs one
+// full-document reflow per foldable heading. There is no DOM here to time a
+// real reflow, so these tests drive the real `observeFoldLayout` through a
+// recording stand-in for the DOM and lock the structural property that makes
+// the reflows constant: no style write may sit between two measurements.
+
+type LayoutEvent =
+	| { type: 'clear'; id: string }
+	| { type: 'read'; id: string }
+	| { type: 'write'; id: string; value: string }
+	| { type: 'suppress'; id: string }
+	| { type: 'restore'; id: string }
+	| { type: 'commit' };
+
+const isWrite = (event: LayoutEvent) => event.type !== 'read' && event.type !== 'commit';
+
+function createFoldRoot(specs: { id: string; height: number | null }[]) {
+	const events: LayoutEvent[] = [];
+
+	const wrappers = specs.map(({ id, height }) => {
+		const content =
+			height === null
+				? null
+				: {
+						get scrollHeight() {
+							events.push({ type: 'read', id });
+							return height;
+						},
+					};
+
+		return {
+			style: {
+				set transition(value: string) {
+					events.push({ type: value === 'none' ? 'suppress' : 'restore', id });
+				},
+				setProperty(name: string, value: string) {
+					events.push({ type: 'write', id, value: `${name}:${value}` });
+				},
+				removeProperty(name: string) {
+					events.push({ type: 'clear', id: `${id}:${name}` });
+				},
+			},
+			querySelector: () => content,
+		};
+	});
+
+	const root = {
+		querySelectorAll: () => wrappers,
+		get offsetHeight() {
+			events.push({ type: 'commit' });
+			return 0;
+		},
+	};
+
+	return { root, events };
+}
+
+async function runFoldLayout(specs: { id: string; height: number | null }[]) {
+	// Imported before the stubs go in, so only the synchronous run below sees them.
+	const { observeFoldLayout } = await import('../src/lib/utils/foldLayout.js');
+	const { root, events } = createFoldRoot(specs);
+	const frames: (() => void)[] = [];
+	const globals = globalThis as Record<string, unknown>;
+	const saved = {
+		requestAnimationFrame: globals.requestAnimationFrame,
+		cancelAnimationFrame: globals.cancelAnimationFrame,
+		ResizeObserver: globals.ResizeObserver,
+		window: globals.window,
+	};
+
+	globals.requestAnimationFrame = (callback: () => void) => frames.push(callback);
+	globals.cancelAnimationFrame = () => {};
+	globals.ResizeObserver = class {
+		observe() {}
+		disconnect() {}
+	};
+	globals.window = { addEventListener() {}, removeEventListener() {} };
+
+	try {
+		const stop = observeFoldLayout(root as unknown as HTMLElement);
+		for (const frame of frames.splice(0)) frame();
+		stop();
+		return events;
+	} finally {
+		Object.assign(globals, saved);
+	}
+}
+
+test('fold measurement reads every height before it writes any of them', async () => {
+	const events = await runFoldLayout([
+		{ id: 'outer', height: 300 },
+		{ id: 'inner', height: 120.4 },
+		{ id: 'deepest', height: 40 },
+	]);
+
+	const firstRead = events.findIndex((event) => event.type === 'read');
+	const lastRead = events.map((event) => event.type).lastIndexOf('read');
+	const interleaved = events.slice(firstRead, lastRead + 1).filter(isWrite);
+
+	assert.deepEqual(
+		interleaved,
+		[],
+		'a style write between two measurements forces one synchronous reflow per wrapper',
+	);
+
+	const reads = events.filter((event) => event.type === 'read').map((event) => (event as { id: string }).id);
+	assert.deepEqual(reads.slice().sort(), ['deepest', 'inner', 'outer']);
+
+	const firstHeightWrite = events.findIndex((event) => event.type === 'write');
+	assert.ok(firstHeightWrite > lastRead, 'every height must be published after the last measurement');
+});
+
+test('each wrapper is measured at its natural height, not at its stale published one', async () => {
+	const events = await runFoldLayout([
+		{ id: 'outer', height: 300 },
+		{ id: 'inner', height: 120 },
+	]);
+
+	const firstRead = events.findIndex((event) => event.type === 'read');
+	const cleared = events
+		.slice(0, firstRead)
+		.filter((event) => event.type === 'clear')
+		.map((event) => (event as { id: string }).id);
+
+	assert.deepEqual(cleared, ['outer:--fold-content-height', 'inner:--fold-content-height']);
+});
+
+test('measured heights are published rounded up, then committed by one reflow', async () => {
+	const events = await runFoldLayout([
+		{ id: 'outer', height: 300 },
+		{ id: 'inner', height: 120.4 },
+	]);
+
+	assert.deepEqual(
+		events.filter((event) => event.type === 'write'),
+		[
+			{ type: 'write', id: 'outer', value: '--fold-content-height:300px' },
+			{ type: 'write', id: 'inner', value: '--fold-content-height:121px' },
+		],
+	);
+
+	const commit = events.findIndex((event) => event.type === 'commit');
+	const lastWrite = events.map((event) => event.type).lastIndexOf('write');
+	const firstRestore = events.findIndex((event) => event.type === 'restore');
+
+	assert.equal(events.filter((event) => event.type === 'commit').length, 1);
+	assert.ok(lastWrite < commit, 'the reflow must come after every height write');
+	assert.ok(commit < firstRestore, 'transitions may only come back once the heights are committed');
+});
+
+test('wrappers without rendered content are skipped instead of measured', async () => {
+	const events = await runFoldLayout([
+		{ id: 'empty', height: null },
+		{ id: 'real', height: 80 },
+	]);
+
+	assert.deepEqual(
+		events.filter((event) => (event as { id?: string }).id?.startsWith('empty')),
+		[],
+	);
+	assert.deepEqual(
+		events.filter((event) => event.type === 'write'),
+		[{ type: 'write', id: 'real', value: '--fold-content-height:80px' }],
+	);
+});

--- a/scripts/frontMatterProseBlock.test.ts
+++ b/scripts/frontMatterProseBlock.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { getMarkdownBodyWithoutFrontMatter, parseFrontMatter } from '../src/lib/utils/frontMatter.js';
+
+// A document may open with a thematic break and then use a setext underline for
+// its first heading. That looks exactly like a front matter block, but the text
+// between the rules is prose, not metadata, so it has to survive into the body.
+const proseBetweenRules = `---
+Lead paragraph
+---
+
+Body starts here.
+`;
+
+test('a leading --- block that is not a YAML mapping stays in the rendered body', () => {
+	const parsed = parseFrontMatter(proseBetweenRules);
+
+	assert.equal(parsed.exists, false);
+	assert.equal(parsed.valid, true);
+	assert.equal(parsed.raw, '');
+	assert.deepEqual(parsed.fields, []);
+	assert.deepEqual(parsed.data, {});
+	assert.equal(parsed.body, proseBetweenRules);
+	assert.equal(getMarkdownBodyWithoutFrontMatter(proseBetweenRules), proseBetweenRules);
+});
+
+test('prose that spans several lines between the rules is not swallowed either', () => {
+	const markdown = '---\nline one\nline two\n---\n\nBody\n';
+	const parsed = parseFrontMatter(markdown);
+
+	assert.equal(parsed.exists, false);
+	assert.equal(parsed.body, markdown);
+});
+
+test('a leading --- block holding a bare YAML sequence is not metadata', () => {
+	const markdown = '---\n- one\n- two\n---\n\nBody\n';
+	const parsed = parseFrontMatter(markdown);
+
+	assert.equal(parsed.exists, false);
+	assert.equal(parsed.body, markdown);
+});
+
+test('front matter that is a mapping keeps working, including empty and string-valued ones', () => {
+	const empty = parseFrontMatter('---\n---\n\nBody\n');
+	assert.equal(empty.exists, true);
+	assert.equal(empty.valid, true);
+	assert.deepEqual(empty.fields, []);
+	assert.equal(empty.body, 'Body\n');
+
+	const blank = parseFrontMatter('---\n\n---\n\nBody\n');
+	assert.equal(blank.exists, true);
+	assert.equal(blank.body, 'Body\n');
+
+	const stringValued = parseFrontMatter('---\ntitle: hello\n---\n\nBody\n');
+	assert.equal(stringValued.exists, true);
+	assert.equal(stringValued.valid, true);
+	assert.deepEqual(
+		stringValued.fields.map((field) => [field.key, field.kind, field.displayValue]),
+		[['title', 'string', 'hello']],
+	);
+	assert.equal(stringValued.body, 'Body\n');
+
+	const crlf = parseFrontMatter('---\r\ntitle: hello\r\n---\r\n\r\nBody\r\n');
+	assert.equal(crlf.exists, true);
+	assert.equal(crlf.body, 'Body\r\n');
+});
+
+test('a malformed mapping is still reported as broken front matter rather than body', () => {
+	const parsed = parseFrontMatter('---\ntitle: [broken\n---\n\n# Body\n');
+
+	assert.equal(parsed.exists, true);
+	assert.equal(parsed.valid, false);
+	assert.equal(parsed.body, '# Body\n');
+});

--- a/src/lib/utils/foldLayout.ts
+++ b/src/lib/utils/foldLayout.ts
@@ -2,34 +2,55 @@ const FOLD_WRAPPER_SELECTOR = '.foldable-content-wrapper';
 const FOLD_CONTENT_SELECTOR = ':scope > .content-inner';
 
 function updateFoldHeights(root: HTMLElement) {
-	// Innermost wrappers first so a parent measures its child's freshly
-	// written height rather than a stale one.
-	const wrappers = Array.from(
-		root.querySelectorAll<HTMLElement>(FOLD_WRAPPER_SELECTOR),
-	).reverse();
+	const wrappers = Array.from(root.querySelectorAll<HTMLElement>(FOLD_WRAPPER_SELECTOR));
 
-	// Reflow-driven height writes must land instantly. The `height` transition
-	// exists only to animate fold/unfold; letting it also animate every resize
-	// leaves the expanded wrapper shorter than its content for ~0.25s, so the
-	// following section overlaps the still-visible overflow. Suppress the
-	// transition around the write, force one layout to commit it, then restore
-	// the stylesheet transition for the next fold toggle.
-	const written: HTMLElement[] = [];
+	// Every `--fold-content-height` write invalidates layout, because
+	// `styles.css` resolves that custom property into the wrapper's `height`.
+	// So a `scrollHeight` read taken between two writes forces a synchronous
+	// full-document reflow, and interleaving them costs one reflow per wrapper:
+	// a long document with hundreds of foldable headings then drops frames on
+	// every keystroke, since ResizeObserver reruns this on each render. Reads
+	// and writes are therefore kept in separate passes, which caps the cost at
+	// two reflows no matter how many wrappers there are.
+	//
+	// Reflow-driven height writes must also land instantly. The `height`
+	// transition exists only to animate fold/unfold; letting it also animate
+	// every resize leaves the expanded wrapper shorter than its content for
+	// ~0.25s, so the following section overlaps the still-visible overflow.
+	// The transition stays suppressed across the whole measure/write cycle and
+	// is restored once the final heights are committed.
+	const pending: { wrapper: HTMLElement; content: HTMLElement }[] = [];
 	for (const wrapper of wrappers) {
 		const content = wrapper.querySelector<HTMLElement>(FOLD_CONTENT_SELECTOR);
 		if (!content) continue;
 
+		// Write pass 1: drop the previous height so each wrapper is measured at
+		// its natural size. A nested wrapper still pinned to a stale height
+		// would otherwise distort its parent's measurement — the reason the
+		// interleaved version had to walk innermost-first, which a batched read
+		// pass cannot rely on. Collapsed wrappers keep `height: 0` from the more
+		// specific `.is-collapsed` rule and stay collapsed throughout.
 		wrapper.style.transition = 'none';
-		wrapper.style.setProperty('--fold-content-height', `${Math.ceil(content.scrollHeight)}px`);
-		written.push(wrapper);
+		wrapper.style.removeProperty('--fold-content-height');
+		pending.push({ wrapper, content });
 	}
 
-	if (written.length === 0) return;
+	if (pending.length === 0) return;
+
+	// Read pass: the first `scrollHeight` commits the cleared heights with a
+	// single reflow, and the remaining reads hit that same clean layout. No
+	// paint happens mid-task, so the cleared state is never visible.
+	const heights = pending.map(({ content }) => Math.ceil(content.scrollHeight));
+
+	// Write pass 2: publish the measured heights without reading anything back.
+	pending.forEach(({ wrapper }, index) => {
+		wrapper.style.setProperty('--fold-content-height', `${heights[index]}px`);
+	});
 
 	// Single forced reflow commits every suppressed height write at once.
 	void root.offsetHeight;
 
-	for (const wrapper of written) {
+	for (const { wrapper } of pending) {
 		wrapper.style.transition = '';
 	}
 }

--- a/src/lib/utils/frontMatter.ts
+++ b/src/lib/utils/frontMatter.ts
@@ -89,6 +89,17 @@ function toPlainRecord(value: unknown): Record<string, unknown> {
 	return value as Record<string, unknown>;
 }
 
+// Front matter is metadata, so the block has to parse as a YAML mapping. Jekyll
+// rejects anything else outright (`validate_data!` raises unless the parsed
+// value `is_a?(Hash)`) and Hugo fails to unmarshal it into its map type; when a
+// leading `---` block is not key/value pairs, no static-site generator or
+// editor treats it as metadata. An empty block (`---\n---`) is still legal and
+// empty metadata, so only a parsed scalar or sequence disqualifies it.
+function isFrontMatterMapping(value: unknown): boolean {
+	if (value === null || value === undefined) return true;
+	return typeof value === 'object' && !Array.isArray(value) && !(value instanceof Date);
+}
+
 function toField([key, value]: [string, unknown]): FrontMatterField {
 	const kind = getValueKind(value);
 	return {
@@ -104,17 +115,16 @@ function toField([key, value]: [string, unknown]): FrontMatterField {
 export function parseFrontMatter(content: string): FrontMatterParseResult {
 	const range = findFrontMatterRange(content);
 	const lineEnding = range?.lineEnding ?? detectLineEnding(content);
-	if (!range) {
-		return {
-			exists: false,
-			valid: true,
-			raw: '',
-			body: content,
-			fields: [],
-			data: {},
-			lineEnding,
-		};
-	}
+	const notFrontMatter: FrontMatterParseResult = {
+		exists: false,
+		valid: true,
+		raw: '',
+		body: content,
+		fields: [],
+		data: {},
+		lineEnding,
+	};
+	if (!range) return notFrontMatter;
 
 	const doc = parseDocument(range.raw, { prettyErrors: false });
 	if (doc.errors.length > 0) {
@@ -130,7 +140,15 @@ export function parseFrontMatter(content: string): FrontMatterParseResult {
 		};
 	}
 
-	const data = toPlainRecord(doc.toJSON());
+	// A document whose first line is `---` but whose block is prose, not a
+	// mapping, is ordinary markdown: the opening `---` is a thematic break and
+	// the closing one underlines a setext heading. Stripping it would delete
+	// visible text from the rendered body without showing it as metadata
+	// anywhere, so hand the whole document back as body.
+	const parsed = doc.toJSON();
+	if (!isFrontMatterMapping(parsed)) return notFrontMatter;
+
+	const data = toPlainRecord(parsed);
 	return {
 		exists: true,
 		valid: true,


### PR DESCRIPTION
## A document that opens with a horizontal rule lost its first paragraph

```markdown
---
Lead-in sentence
---

Body starts here
```

The first `---` is a rule and the second is a setext underline making the lead-in an H2. But the parser only checked that the block was *delimited*, not that its contents were a mapping. The lead-in parsed as a bare YAML scalar, was normalised to `{}`, and came back `valid: true, fields: []` — so it rendered as **neither a property nor prose**. It was cut from the body and displayed nowhere.

A block whose YAML is not a mapping is no longer treated as front matter. Verified not to disturb the neighbours: an empty block (`---\n---`) is still valid empty front matter, a mapping whose values happen to be strings still yields fields, and malformed YAML still reports `valid: false` on the existing path. CRLF too.

### Reference frame

- **Jekyll** — `Convertible#read_yaml` calls `validate_data!`, which raises `InvalidYAMLFrontMatterError` `unless self.data.is_a?(Hash)`.
- **Hugo** — front matter deserialises into `map[string]interface{}`; a non-map block fails the build.
- **Obsidian** — properties require `name: value` at the very start; when the YAML is not valid it simply builds no properties and **the text stays visible in the note**.

Counter-evidence, recorded honestly: the strip-oriented JS libraries (`vfile-matter` and friends) do `yaml.parse(...) || {}` and strip regardless — which is exactly what this did. But those are pipeline tools. Among the applications that actually shape what a person expects, none silently deletes the part it could not parse. Markpad is a viewer, not a build step, so failing the document the way Jekyll does is wrong here; Obsidian's tolerant end of that range — render it as prose — is what this implements.

## Fold heights were measured with a write between every read

The loop published `--fold-content-height` on one wrapper and then read `scrollHeight` off the next. `styles.css` consumes that variable as `height`, so each write invalidates layout: a document with N collapsible headings forced **N synchronous reflows**, on every render and every resize. The comment claimed the opposite — *"Single forced reflow commits every suppressed height write at once"* — which described the intent, not the code.

It now clears, then reads every height, then writes them all, with one commit: two reflows regardless of document size.

**One deviation from a plain read-all-then-write-all**, worth flagging: the old `.reverse()` (innermost first) existed so a parent would read a child's freshly published height rather than a stale one. Batching alone would lose that. Adding a clearing pass before the reads makes every wrapper get measured at its **natural** height, which is strictly stronger — so `.reverse()` could be dropped rather than worked around. The clear is a batched write that does not interleave with reads, transitions are already suppressed before it, and nothing paints mid-task, so no intermediate state is visible. Collapsed wrappers stay at zero via the higher-specificity `.is-collapsed` rule.

No CSS changes.

## Validation

- `npm run check` — 0 errors, 0 warnings
- `npm test` — 214/214 (9 new)

**Baseline counter-check:** with both source files stashed, **6 of the 9 new tests fail** on unmodified code. The 3 that pass are guardrails that should be green on both sides (valid mapping / empty block / CRLF still parse; bad YAML still reports `valid: false`; a wrapper without an inner element is skipped).

**What the fold test does and does not cover:** there is no real DOM under `node --test`, so it cannot measure actual reflows. It drives the real `observeFoldLayout` with a recording fake — `scrollHeight` getters log reads, `style` mutations log writes — and asserts the structural property that *no style write occurs between the first and last read*, which is the exact shape of thrashing. It does not prove the browser reflows only twice, and it does not exercise real layout for nested wrappers. No API surface was added for testability.