### PR TITLE
fix(find): reveal collapsed matches, and keep them out of the PDF

### DIFF
--- a/scripts/findCollapsedMatches.test.ts
+++ b/scripts/findCollapsedMatches.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const findBar = readFileSync('src/lib/components/FindBar.svelte', 'utf8');
+
+function slice(source: string, start: string, end: string): string {
+	const from = source.indexOf(start);
+	assert.notEqual(from, -1, `expected to find ${start}`);
+	const to = source.indexOf(end, from + start.length);
+	assert.notEqual(to, -1, `expected to find ${end} after ${start}`);
+	return source.slice(from, to);
+}
+
+test('find keeps counting matches inside collapsed folds', () => {
+	// Reference systems all keep hidden-but-present text findable and reveal
+	// it on a hit: VS Code unfolds the region it jumps into, and Chrome makes
+	// `hidden=until-found` / closed `<details>` content matchable precisely
+	// because it can reveal it. Dropping the matches from the count would be
+	// the `display: none` rule, which is not what a collapsed fold is.
+	const acceptNode = slice(findBar, 'function isHostElement(', 'function isInsideHost(');
+
+	assert.doesNotMatch(acceptNode, /is-collapsed/);
+	assert.doesNotMatch(acceptNode, /foldable-content-wrapper/);
+	assert.doesNotMatch(acceptNode, /markdown-alert-content/);
+});
+
+test('find knows both kinds of collapsed fold container', () => {
+	assert.match(findBar, /\.foldable-content-wrapper\.is-collapsed/);
+	assert.match(findBar, /\.markdown-alert-content\.is-collapsed/);
+});
+
+test('activating a match reveals the folds hiding it before scrolling to it', () => {
+	const setActive = slice(findBar, 'function setActive(', 'export function next()');
+
+	const reveal = setActive.indexOf('revealFoldsAround(');
+	const scroll = setActive.indexOf('scrollIntoView(');
+
+	assert.ok(reveal !== -1, 'setActive must reveal the collapsed folds around the match');
+	assert.ok(scroll !== -1, 'setActive must still scroll the match into view');
+	assert.ok(reveal < scroll, 'the fold has to open before the scroll target is measured');
+});
+
+test('revealing a fold goes through the viewer toggle instead of stripping the class', () => {
+	// `collapsedHeaders` in MarkdownViewer.svelte is the source of truth for
+	// fold state: it re-applies `is-collapsed` on every re-render and feeds
+	// the ToC. Clearing the class here would create a second source of truth
+	// that the next render silently reverts.
+	const reveal = slice(findBar, 'function foldToggleFor(', 'export function clearHighlights()');
+
+	assert.match(reveal, /\.header-fold-icon/);
+	assert.match(reveal, /\.callout-toggle/);
+	assert.match(reveal, /data-fold-target/);
+	assert.match(reveal, /dispatchEvent\(\s*new MouseEvent\('click', \{ bubbles: true \}\)/);
+	assert.doesNotMatch(findBar, /classList\.remove\(\s*['"]is-collapsed/);
+	assert.doesNotMatch(findBar, /classList\.toggle\(\s*['"]is-collapsed/);
+});
+
+test('nested folds are opened outermost first', () => {
+	const reveal = slice(findBar, 'function revealFoldsAround(', 'export function clearHighlights()');
+
+	assert.match(reveal, /while \(curr && curr !== root\)/);
+	assert.match(reveal, /collapsed\.reverse\(\)/);
+});
+
+test('the scroll is re-aimed once the fold height transition has settled', () => {
+	// styles.css animates `.foldable-content-wrapper` height for 0.25s, so the
+	// first scrollIntoView aims at a target that is still moving.
+	const setActive = slice(findBar, 'function setActive(', 'export function next()');
+
+	assert.match(setActive, /setTimeout\(/);
+	assert.match(setActive, /FOLD_TRANSITION_MS/);
+	assert.match(setActive, /isConnected/);
+	assert.match(findBar, /const FOLD_TRANSITION_MS = (\d+);/);
+
+	const ms = Number(findBar.match(/const FOLD_TRANSITION_MS = (\d+);/)?.[1]);
+	assert.ok(ms >= 250, 'must outlast the 0.25s fold transition in styles.css');
+});

--- a/scripts/printFindHighlight.test.ts
+++ b/scripts/printFindHighlight.test.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const styles = readFileSync('src/styles.css', 'utf8');
+const findBar = readFileSync('src/lib/components/FindBar.svelte', 'utf8');
+
+/** The `@media print` block only — not everything that follows it in the file. */
+function extractPrintBlock(source: string): string {
+	const start = source.indexOf('@media print {');
+	assert.notEqual(start, -1, 'src/styles.css must keep an @media print block');
+	let depth = 0;
+	for (let i = source.indexOf('{', start); i < source.length; i += 1) {
+		if (source[i] === '{') depth += 1;
+		else if (source[i] === '}') {
+			depth -= 1;
+			if (depth === 0) return source.slice(start, i + 1);
+		}
+	}
+	throw new Error('unterminated @media print block');
+}
+
+const printBlock = extractPrintBlock(styles);
+
+// A declaration lookup that cannot be satisfied by a vendor-prefixed or
+// longhand-extended neighbour: `box-shadow` must not match
+// `-webkit-box-shadow`, `background` must not match `background-color`.
+const declaration = (name: string) => new RegExp(`(?<![\\w-])${name}:\\s*([^;]+);`);
+
+function printRuleBody(selector: string): string {
+	const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	const match = printBlock.match(new RegExp(`${escaped}[^{}]*\\{([^}]*)\\}`));
+	assert.ok(match, `expected a print rule for ${selector}`);
+	return match[1];
+}
+
+test('the find bar itself stays out of the export', () => {
+	assert.match(printBlock, /\.find-bar[\s\S]{0,40}\{[\s\S]*?display:\s*none\s*!important;/);
+});
+
+test('find highlights are neutralised on paper, not deleted from it', () => {
+	// The mark wraps document text. Hiding it would drop the matched words
+	// from the PDF, so only its decoration may go.
+	const body = printRuleBody('.markdown-body mark.markpad-find-match');
+
+	assert.equal(body.match(declaration('background-color'))?.[1].trim(), 'transparent !important');
+	assert.equal(body.match(declaration('box-shadow'))?.[1].trim(), 'none !important');
+	assert.doesNotMatch(body, /(?<![\w-])display:\s*none/);
+	assert.doesNotMatch(body, /(?<![\w-])visibility:\s*hidden/);
+	assert.doesNotMatch(body, /(?<![\w-])content:/);
+	assert.doesNotMatch(body, /(?<![\w-])font-size:\s*0/);
+});
+
+test('the active find highlight is neutralised too', () => {
+	// `.active` carries its own background, colour and ring, and outranks the
+	// base selector, so the print rule has to name it explicitly.
+	assert.match(findBar, /mark\.markpad-find-match\.active/);
+	assert.match(
+		printBlock,
+		/mark\.markpad-find-match\.active[^{}]*\{[^}]*(?<![\w-])background-color:\s*transparent\s*!important;/,
+	);
+	assert.match(
+		printBlock,
+		/mark\.markpad-find-match\.active[^{}]*\{[^}]*(?<![\w-])box-shadow:\s*none\s*!important;/,
+	);
+});
+
+test('the neutralising rule outranks the component styles it overrides', () => {
+	// FindBar.svelte styles the mark from a `:global()` rule of equal
+	// specificity, and stylesheet order between a component style and
+	// styles.css is not guaranteed, so `!important` is what decides.
+	const body = printRuleBody('.markdown-body mark.markpad-find-match');
+	const findBarRule = findBar.slice(findBar.indexOf(':global(.markdown-body mark.markpad-find-match)'));
+
+	assert.doesNotMatch(findBarRule.slice(0, findBarRule.indexOf('</style>')), /!important/);
+	for (const property of ['background-color', 'box-shadow']) {
+		assert.match(body, new RegExp(`(?<![\\w-])${property}:[^;]*!important;`));
+	}
+});
+
+test('find highlights are not added to the print display:none list', () => {
+	const hiddenRule = printBlock.match(/([^{}]*)\{[^}]*display:\s*none\s*!important;[^}]*\}/);
+	assert.ok(hiddenRule, 'expected the print display:none group');
+	assert.doesNotMatch(hiddenRule[1], /markpad-find-match/);
+});
+
+test('document ==highlight== marks still print', () => {
+	// Only the find marks lose their background. The authored `==highlight==`
+	// is content, so the print block must not blanket-reset every <mark>.
+	assert.doesNotMatch(printRuleBody('.markdown-body mark.markpad-find-match'), /--highlight-color/);
+	assert.doesNotMatch(printBlock, /\.markdown-body mark\s*\{/);
+	assert.doesNotMatch(printBlock, /\.markdown-body mark,/);
+});

--- a/scripts/printOversizedMedia.test.ts
+++ b/scripts/printOversizedMedia.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const styles = readFileSync('src/styles.css', 'utf8');
+
+/** The `@media print` block only — not everything that follows it in the file. */
+function extractPrintBlock(source: string): string {
+	const start = source.indexOf('@media print {');
+	assert.notEqual(start, -1, 'src/styles.css must keep an @media print block');
+	let depth = 0;
+	for (let i = source.indexOf('{', start); i < source.length; i += 1) {
+		if (source[i] === '{') depth += 1;
+		else if (source[i] === '}') {
+			depth -= 1;
+			if (depth === 0) return source.slice(start, i + 1);
+		}
+	}
+	throw new Error('unterminated @media print block');
+}
+
+const printBlock = extractPrintBlock(styles);
+
+// Paper geometry the cap has to satisfy. `@page { margin: 0 }` makes the page
+// box the whole sheet, and `.markdown-body` supplies 0.75in of padding top and
+// bottom, so the printable column is the sheet height minus 1.5in.
+const LETTER_PRINTABLE_IN = 11 - 1.5;
+const A4_PRINTABLE_IN = 11.69 - 1.5;
+
+/** Print rules whose body sets `property` (never a vendor-prefixed variant). */
+function printRulesSetting(property: string): { selector: string; body: string }[] {
+	const declaration = new RegExp(`(?<![\\w-])${property}:\\s*([^;]+);`);
+	const rules: { selector: string; body: string }[] = [];
+	const pattern = /([^{}]+)\{([^{}]*)\}/g;
+	let match: RegExpExecArray | null;
+	while ((match = pattern.exec(printBlock)) !== null) {
+		if (declaration.test(match[2])) rules.push({ selector: match[1].trim(), body: match[2] });
+	}
+	return rules;
+}
+
+function capInInches(body: string): number {
+	const raw = body.match(/(?<![\w-])max-height:\s*([\d.]+)in/);
+	assert.ok(raw, `the cap must be an absolute length in inches, not: ${body.trim()}`);
+	return Number(raw[1]);
+}
+
+test('the print block caps media height at a size both papers can hold', () => {
+	// A replaced element cannot be fragmented, so `break-inside: avoid` on its
+	// own turns anything taller than the printable column into a cropped
+	// image rather than a page break.
+	const capped = printRulesSetting('max-height');
+	assert.ok(capped.length > 0, 'nothing in the print block caps media height');
+
+	for (const rule of capped) {
+		const inches = capInInches(rule.body);
+		assert.ok(inches <= LETTER_PRINTABLE_IN, `${inches}in overflows Letter (${LETTER_PRINTABLE_IN}in)`);
+		assert.ok(inches <= A4_PRINTABLE_IN, `${inches}in overflows A4 (${A4_PRINTABLE_IN}in)`);
+		assert.ok(inches >= 6, `${inches}in shrinks every full-page figure needlessly`);
+		assert.match(rule.body, /(?<![\w-])max-height:[^;]*!important;/);
+	}
+});
+
+test('oversized images are scaled to a page instead of being clipped', () => {
+	const capped = printRulesSetting('max-height').filter((rule) => /(?<![\w-])img(?![\w-])/.test(rule.selector));
+	assert.equal(capped.length, 1, 'images need exactly one print height cap');
+});
+
+test('oversized mermaid diagrams are scaled to a page too', () => {
+	const capped = printRulesSetting('max-height').filter((rule) => /\.mermaid-diagram svg/.test(rule.selector));
+	assert.equal(capped.length, 1, 'diagrams need exactly one print height cap');
+});
+
+test('the cap preserves aspect ratio rather than squashing', () => {
+	assert.match(printBlock, /(?<![\w-])object-fit:\s*contain\s*!important;/);
+	// `height: auto` from the existing rhythm rule is what lets the cap scale
+	// the width down proportionally; it must stay.
+	assert.match(printBlock, /\.markdown-body img\s*\{[\s\S]*?height:\s*auto\s*!important;/);
+	assert.match(printBlock, /\.markdown-body img\s*\{[\s\S]*?max-width:\s*100%\s*!important;/);
+});
+
+test('the diagram container does not clip the capped diagram', () => {
+	// `.mermaid-diagram` carries `overflow-x: auto` for the screen, which
+	// computes overflow-y to `auto` as well and would crop on paper.
+	assert.match(printBlock, /\.markdown-body \.mermaid-diagram\s*\{[^}]*overflow:\s*visible\s*!important;/);
+});
+
+test('the media caps do not undo the existing print handling', () => {
+	// #359 moved diagram colours out of CSS into a light-theme re-render
+	// (utils/mermaidPrint.ts); the cap must not smuggle paint rules back in.
+	assert.doesNotMatch(printBlock, /\.mermaid-diagram svg[^{]*\{[^}]*fill:/);
+	assert.doesNotMatch(printBlock, /\.mermaid-diagram[^{]*\{[^}]*(?<![\w-])stroke:/);
+
+	// Now that they fit, `break-inside: avoid` can do its job and move them
+	// to the next page instead of cropping them.
+	assert.match(
+		printBlock,
+		/\.markdown-body img,\s*\n\s*\.markdown-body \.mermaid-diagram,[\s\S]*?break-inside:\s*avoid;/,
+	);
+});

--- a/src/lib/components/FindBar.svelte
+++ b/src/lib/components/FindBar.svelte
@@ -19,6 +19,19 @@
 	const MAX_MATCHES = 5000;
 	const DEBOUNCE_MS = 80;
 
+	// A collapsed fold keeps its text in the DOM behind `height: 0; overflow:
+	// hidden`, so matches inside one were counted but could never be shown —
+	// a state none of the reference implementations produce. VS Code unfolds
+	// the region it navigates into, and Chrome makes `hidden=until-found` and
+	// closed `<details>` content matchable precisely because it can reveal it
+	// (content the browser cannot reveal, `display: none`, is not matched at
+	// all). So the matches stay in the count and the fold opens on the way to
+	// them.
+	const FOLD_CONTENT_SELECTOR =
+		'.foldable-content-wrapper.is-collapsed, .markdown-alert-content.is-collapsed';
+	// styles.css animates the fold height for 0.25s.
+	const FOLD_TRANSITION_MS = 300;
+
 	let inputEl = $state<HTMLInputElement>();
 	let query = $state('');
 	let caseSensitive = $state(false);
@@ -51,6 +64,47 @@
 			curr = curr.parentNode;
 		}
 		return false;
+	}
+
+	/**
+	 * The control a user would click to open this fold.
+	 *
+	 * Expanding by clearing `is-collapsed` here would work for exactly one
+	 * frame: MarkdownViewer owns `collapsedHeaders`, re-applies the class on
+	 * every re-render and hands the same set to the table of contents. Going
+	 * through the affordance keeps that bookkeeping the single source of
+	 * truth — the same reason Chrome fires `beforematch` before it reveals
+	 * `hidden=until-found` content.
+	 */
+	function foldToggleFor(container: Element, root: HTMLElement): HTMLElement | null {
+		if (container.classList.contains('foldable-content-wrapper')) {
+			const header = container.id
+				? root.querySelector(`.foldable-header[data-fold-target="${CSS.escape(container.id)}"]`)
+				: null;
+			return (header?.querySelector('.header-fold-icon') as HTMLElement | null) ?? null;
+		}
+		return (container.closest('.callout-foldable')?.querySelector('.callout-toggle') as HTMLElement | null) ?? null;
+	}
+
+	/** Opens every collapsed fold between `mark` and the preview root. */
+	function revealFoldsAround(mark: HTMLElement): boolean {
+		const root = markdownBody as HTMLElement | null;
+		if (!root) return false;
+
+		const collapsed: Element[] = [];
+		let curr: Element | null = mark.parentElement;
+		while (curr && curr !== root) {
+			if (curr.matches(FOLD_CONTENT_SELECTOR)) collapsed.push(curr);
+			curr = curr.parentElement;
+		}
+		if (collapsed.length === 0) return false;
+
+		// Collected innermost first; open the outermost fold first so a nested
+		// one is already on screen by the time its own toggle fires.
+		for (const container of collapsed.reverse()) {
+			foldToggleFor(container, root)?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		}
+		return true;
 	}
 
 	export function clearHighlights() {
@@ -188,7 +242,20 @@
 		marks.forEach((m, i) => m.classList.toggle(FIND_MARK_ACTIVE_CLASS, i === safe));
 		activeIndex = safe;
 		if (scroll) {
-			marks[safe].scrollIntoView({ block: 'center', behavior: 'smooth' });
+			const target = marks[safe];
+			const revealed = revealFoldsAround(target);
+			target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+			if (revealed) {
+				// The fold animates its height open, so the scroll above aimed
+				// at a target that was still moving. Re-aim once it settles.
+				// A match that has since been cleared is detached, and the
+				// isConnected guard keeps the late timer from scrolling the
+				// preview for a search that is already gone.
+				setTimeout(() => {
+					if (!target.isConnected) return;
+					target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+				}, FOLD_TRANSITION_MS);
+			}
 		}
 	}
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1420,6 +1420,21 @@ body {
 		display: none !important;
 	}
 
+	/* The find bar is hidden above, but its marks wrap document text. Adding
+	   them to the list would delete the matched words from the export, so the
+	   highlight is neutralised instead of removed. `!important` is what
+	   decides here: FindBar.svelte paints the mark from a `:global()` rule of
+	   equal specificity, and the order between a component style and this
+	   sheet is not guaranteed. */
+	.markdown-body mark.markpad-find-match,
+	.markdown-body mark.markpad-find-match.active {
+		background-color: transparent !important;
+		box-shadow: none !important;
+		color: inherit !important;
+		border-radius: 0 !important;
+		padding: 0 !important;
+	}
+
 	html,
 	body,
 	#app,
@@ -1602,6 +1617,28 @@ body {
 		max-width: 100% !important;
 		height: auto !important;
 		margin: 1em auto;
+	}
+
+	/* Images and diagrams are replaced content: they cannot be fragmented, so
+	   the `break-inside: avoid` above crops anything taller than the printable
+	   column instead of moving it to the next page. Cap the height so they
+	   scale to fit — `height: auto` and the intrinsic ratio bring the width
+	   down with it.
+
+	   `@page` has no margin and `.markdown-body` adds 0.75in top and bottom,
+	   leaving 9.5in on Letter and 10.19in on A4. One absolute cap below both
+	   fits either sheet; viewport units would be shorter to write but resolve
+	   against the page box inconsistently across the platform webviews. */
+	.markdown-body img,
+	.markdown-body .mermaid-diagram svg {
+		max-height: 9in !important;
+		object-fit: contain !important;
+	}
+
+	/* `.mermaid-diagram` scrolls horizontally on screen, and that same overflow
+	   would clip on paper the diagram the cap just made fit. */
+	.markdown-body .mermaid-diagram {
+		overflow: visible !important;
 	}
 
 	.markdown-body table {


### PR DESCRIPTION
## Find counted matches nobody could reach

The tree walker skipped only `SCRIPT`, `STYLE`, `NOSCRIPT` and its own marks. Text inside a collapsed heading section (`.foldable-content-wrapper.is-collapsed`, `height: 0`) or a collapsed callout (`.markdown-alert-content.is-collapsed`, `grid-template-rows: 0fr`) stays in the DOM, so it was counted — but both clip to zero height, so pressing Enter onto one of those matches scrolled nowhere. The count said 7, three of them were unreachable, and nothing said why.

Landing on a match now reveals its folds.

### Why reveal rather than skip

Both options restore the invariant "a counted match is reachable", so the reference frame decided it:

- **Chrome** — `display:none` and `hidden` content is not findable, but `hidden=until-found` and closed `<details>` are findable **and auto-revealed**. The `beforematch` event exists precisely so a page can sync its own state before the browser reveals.
- **VS Code** — finds inside folded regions and unfolds when navigating to a match ([#59776](https://github.com/Microsoft/vscode/issues/59776) asks for re-folding afterwards, which confirms it unfolds).
- **Obsidian** — "counted but never revealed" is filed as a bug ([forum 41975](https://forum.obsidian.md/t/search-highlight-inside-folded-callout-blocks/41975)), with the expected behaviour stated as unfolding.

Markpad's behaviour matched none of them. Skipping folded text would be internally consistent, but it makes folding silently remove text from search with no signal — a usability cliff nothing else has.

### Why it goes through the fold toggle

`collapsedHeaders` in the viewer is the source of truth: `processMarkdownHtml` re-applies `is-collapsed` from it on every render, and the same Set feeds the table of contents. Stripping the class from the find bar would create a second source of truth that the next render silently reverts, with the ToC disagreeing in the meantime. Dispatching the toggle's own click routes through the existing handler so the DOM and that Set stay in step — and `MarkdownViewer.svelte` needed no change.

## Find highlights were printed into exported PDFs

Nothing cleared them before printing, and `.markdown-body` sets `print-color-adjust: exact`, so the orange blocks came through.

They cannot simply join the print block's `display: none` list — that `mark` wraps **document text**, so hiding it would delete the matched words from the printed page. Its background, shadow, colour, radius and padding are neutralised instead, and the text survives. Highlights authored with `==…==` are untouched. `!important` is required because the find bar's `:global()` rule has equal specificity and the order between a component stylesheet and `styles.css` is not guaranteed; a test locks the find bar's own rules `!important`-free so the two cannot start fighting.

## Images and diagrams taller than a page were clipped

`break-inside: avoid` was set with no height cap. A replaced element cannot fragment, so anything taller than the printable area simply lost its bottom rather than scaling or moving to the next page.

Capped at `9in` with `object-fit: contain` — `@page { margin: 0 }` plus the body's `0.75in` padding leaves 9.5in printable on Letter and 10.19in on A4, so 9in fits both. Absolute units deliberately, not `vh`: page-box resolution differs across the three platform webviews. Mermaid containers also need `overflow: visible` in print, because their on-screen `overflow-x: auto` computes `overflow-y` to `auto` and would re-crop what the cap just fixed.

## Not conflicting with #359

Checked before editing: #359's mermaid work is a light-theme **re-render** in `utils/mermaidPrint.ts`, carrying deliberately zero mermaid print CSS — so a size cap is purely additive. Only new rules were appended; no existing declaration changed, and the paper layout, table word-breaking and alert/`tr` break rules are byte-identical. The new tests additionally re-assert #359's `doesNotMatch(/\.mermaid-diagram svg[^{]*\{[^}]*fill:/)` and add a `stroke:` counterpart, so a future size rule cannot smuggle paint rules back in.

## Validation

- `npm run check` — 0 errors, 0 warnings
- `npm test` — 223/223 (18 new); #359's regression net in `issue261EditorPdf.test.ts` still green

**Baseline counter-proof:** 12 of 16 failed on unmodified source; the 4 that passed are deliberate guards (the find bar is already print-hidden, find-match is *not* in the `display:none` list, #359's rules intact). After tightening the print-block extraction to brace-match the real `@media print` block rather than slicing to EOF, the two print files were re-run on still-unmodified source: 9 of 12 failed. 18/18 after the fixes. Every property lookup uses a `(?<![\w-])` lookbehind so `box-shadow` cannot be satisfied by `-webkit-box-shadow`.

## Adjacent gap, deliberately left

A document containing raw `<details>` (comrak runs `unsafe_ = true`) renders a real disclosure whose closed children are `display: none` but still in the DOM — the same "counted, unreachable" symptom, and Chrome auto-opens `<details>` on find. Closing it is roughly three lines, but it brings a `<summary>`-match edge case and was outside this scope, so it is flagged rather than folded in.