### PR TITLE
test: pin the render protocol between Rust and the preview

### DIFF
--- a/scripts/renderProtocol.test.ts
+++ b/scripts/renderProtocol.test.ts
@@ -1,0 +1,522 @@
+/**
+ * Render protocol contract: Markdown → `convert_markdown` HTML →
+ * `processMarkdownHtml` DOM.
+ *
+ * Every assertion here runs the real `processMarkdownHtml` over real
+ * `convert_markdown` output (see `renderProtocolFixtures.ts` for provenance)
+ * and inspects the resulting DOM. Nothing in this file asserts on the *text*
+ * of an implementation file, which is the point: renaming a helper or moving a
+ * statement must not turn these red, and changing what the preview actually
+ * produces must.
+ *
+ * The four protocols covered are the ones that have already regressed:
+ *   1. task-list markers and source positions (checkbox click → source line)
+ *   2. `$$…$$` underscore protection (issue #174)
+ *   3. heading ids and fold anchors (#371)
+ *   4. raw HTML checkboxes are not markdown tasks (#319)
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { installShimDom, parseHtml, type ShimElement } from './renderProtocolDom.ts';
+
+installShimDom();
+
+const { processMarkdownHtml } = await import('../src/lib/utils/markdown.ts');
+const { renderFixtures } = await import('./renderProtocolFixtures.ts');
+
+type FixtureName = keyof typeof renderFixtures;
+
+const FILE_PATH = '/documents/notes.md';
+
+function render(name: FixtureName, collapsedHeaders: Set<string> = new Set()) {
+	const html = processMarkdownHtml(renderFixtures[name].html, FILE_PATH, collapsedHeaders);
+	return parseHtml(html).body;
+}
+
+/**
+ * `src-tauri`'s `TASK_SOURCE_RE`, restated over the fixture's own Markdown so
+ * the expected line numbers are derived from the source document rather than
+ * copied out of the HTML they are supposed to validate.
+ */
+const TASK_SOURCE_RE = /^\s*(?:>\s*)*(?:[-+*]|\d+[.)])\s+\[[ xX]\](?:\s|$)/;
+const TASK_PREFIX_RE = /^\s*(?:>\s*)*(?:[-+*]|\d+[.)])\s+\[[ xX]\]\s*/;
+
+type SourceTask = { line: number; checked: boolean; text: string };
+
+/** Rust's `str::lines()`: split on `\n`, drop one trailing `\r`. */
+function sourceTasks(markdown: string): SourceTask[] {
+	return markdown
+		.split('\n')
+		.map((line) => line.replace(/\r$/, ''))
+		.flatMap((line, index) =>
+			TASK_SOURCE_RE.test(line)
+				? [
+						{
+							line: index + 1,
+							checked: /\[[xX]\]/.test(line),
+							text: line.replace(TASK_PREFIX_RE, ''),
+						},
+					]
+				: [],
+		);
+}
+
+/**
+ * The rule `MarkdownViewer.toggleTaskCheckbox` applies to decide which source
+ * line a click rewrites: first number of the enclosing `li`'s `data-sourcepos`.
+ */
+function clickedSourceLine(checkbox: ShimElement): number {
+	const sourcePosition = checkbox.closest('li')?.getAttribute('data-sourcepos');
+	return Number(sourcePosition?.match(/^(\d+):/)?.[1]);
+}
+
+function interactiveCheckboxes(root: ShimElement): ShimElement[] {
+	return root.querySelectorAll('li input[data-task-checkbox]');
+}
+
+const TASK_FIXTURES = [
+	'taskSimple',
+	'taskNested',
+	'taskQuoted',
+	'taskOrdered',
+	'taskSurrounded',
+	'taskCrlf',
+	'taskLoose',
+	'taskContinuation',
+	'taskParenOrdered',
+	'taskStarPlus',
+] as const satisfies readonly FixtureName[];
+
+// --- protocol 1: task markers and source positions -----------------------
+
+test('every rendered task checkbox resolves to its own Markdown task line', () => {
+	for (const name of TASK_FIXTURES) {
+		const body = render(name);
+		const expected = sourceTasks(renderFixtures[name].markdown);
+		const checkboxes = interactiveCheckboxes(body);
+
+		assert.equal(
+			checkboxes.length,
+			expected.length,
+			`${name}: rendered ${checkboxes.length} interactive checkboxes for ${expected.length} source tasks`,
+		);
+
+		const seen = checkboxes.map(clickedSourceLine);
+		assert.deepEqual(
+			[...seen].sort((a, b) => a - b),
+			expected.map((task) => task.line),
+			`${name}: checkbox → source line mapping drifted`,
+		);
+		assert.equal(new Set(seen).size, seen.length, `${name}: two checkboxes claim one source line`);
+
+		for (const checkbox of checkboxes) {
+			const line = clickedSourceLine(checkbox);
+			const task = expected.find((candidate) => candidate.line === line);
+			assert.ok(task, `${name}: checkbox mapped to non-task line ${line}`);
+			assert.equal(
+				checkbox.checked,
+				task.checked,
+				`${name}: line ${line} checked state disagrees with the source marker`,
+			);
+		}
+	}
+});
+
+test('task text is lifted into span.task-text next to the checkbox', () => {
+	for (const name of TASK_FIXTURES) {
+		const body = render(name);
+		for (const checkbox of interactiveCheckboxes(body)) {
+			const li = checkbox.closest('li');
+			assert.ok(li, `${name}: checkbox escaped its list item`);
+			assert.equal(
+				li.childNodes[0],
+				checkbox,
+				`${name}: the checkbox is no longer the first child of its li`,
+			);
+
+			const label = li.querySelectorAll('span.task-text')[0];
+			assert.ok(label, `${name}: no span.task-text was produced`);
+
+			const line = clickedSourceLine(checkbox);
+			const task = sourceTasks(renderFixtures[name].markdown).find(
+				(candidate) => candidate.line === line,
+			);
+			assert.ok(task);
+			assert.ok(
+				label.textContent.trim().startsWith(task.text.trim()),
+				`${name}: task text ${JSON.stringify(label.textContent)} does not start with the source text ${JSON.stringify(task.text)}`,
+			);
+		}
+	}
+});
+
+test('task checkboxes are made clickable and checked ones mark their item', () => {
+	for (const name of TASK_FIXTURES) {
+		const body = render(name);
+		for (const checkbox of interactiveCheckboxes(body)) {
+			assert.equal(
+				checkbox.hasAttribute('disabled'),
+				false,
+				`${name}: a task checkbox stayed disabled and cannot be clicked`,
+			);
+			assert.equal(checkbox.style.cursor, 'pointer', `${name}: task checkbox lost its cursor`);
+
+			const li = checkbox.closest('li');
+			assert.ok(li);
+			assert.equal(
+				li.classList.contains('task-done'),
+				checkbox.checked,
+				`${name}: task-done disagrees with the checkbox state`,
+			);
+		}
+	}
+});
+
+test('a nested task keeps its own source line and stays out of the parent label', () => {
+	const body = render('taskNested');
+	const [parent, nested] = interactiveCheckboxes(body);
+
+	assert.equal(clickedSourceLine(parent), 1);
+	assert.equal(clickedSourceLine(nested), 2);
+	assert.equal(nested.closest('li')?.closest('ul')?.closest('li'), parent.closest('li'));
+
+	const parentLabel = parent.closest('li')?.querySelectorAll('span.task-text')[0];
+	assert.equal(parentLabel?.textContent.trim(), 'parent');
+	assert.equal(parentLabel?.querySelectorAll('input').length, 0);
+});
+
+test('a task inside a block quote still reports the quoted source line', () => {
+	const body = render('taskQuoted');
+	const [checkbox] = interactiveCheckboxes(body);
+
+	assert.ok(checkbox.closest('blockquote'), 'the quoted task left its block quote');
+	assert.equal(clickedSourceLine(checkbox), 1);
+});
+
+test('CRLF documents report the same source lines as LF documents', () => {
+	const crlf = interactiveCheckboxes(render('taskCrlf')).map(clickedSourceLine);
+	const lf = interactiveCheckboxes(render('taskSimple')).map(clickedSourceLine);
+
+	assert.deepEqual(crlf, [1, 2]);
+	assert.deepEqual(crlf, lf);
+});
+
+test('prose before a task does not shift the reported source line', () => {
+	const lines = interactiveCheckboxes(render('taskSurrounded')).map(clickedSourceLine);
+
+	// `- [ ] after prose` is line 5 and `- [x] after blank` is line 9 of the
+	// fixture Markdown; heading folding must not renumber them.
+	assert.deepEqual(lines, [5, 9]);
+});
+
+// --- protocol 2: $$…$$ underscore protection (issue #174) ----------------
+
+const DISPLAY_MATH_FIXTURES = [
+	'mathBracedSubscripts',
+	'mathPlainSubscripts',
+	'mathBlockOwnLines',
+	'mathEscapedUnderscore',
+	'mathInsideListItem',
+] as const satisfies readonly FixtureName[];
+
+/** The text between the outermost `$$` pair of a fixture's Markdown. */
+function displayMathSource(markdown: string): string {
+	return markdown.slice(markdown.indexOf('$$') + 2, markdown.lastIndexOf('$$')).trim();
+}
+
+test('display math reaches KaTeX with its underscores intact', () => {
+	for (const name of DISPLAY_MATH_FIXTURES) {
+		const body = render(name);
+		const math = body.querySelectorAll('[data-math]');
+
+		assert.equal(math.length, 1, `${name}: expected exactly one display-math element`);
+		assert.equal(math[0].getAttribute('data-math'), 'display', `${name}: wrong math mode`);
+
+		const expected = displayMathSource(renderFixtures[name].markdown);
+		assert.equal(
+			math[0].getAttribute('data-math-source'),
+			expected,
+			`${name}: data-math-source drifted from the Markdown between the $$ delimiters`,
+		);
+		assert.equal(
+			math[0].textContent,
+			expected,
+			`${name}: the rendered text no longer matches the math source`,
+		);
+		assert.equal(
+			(math[0].getAttribute('data-math-source') || '').split('_').length - 1,
+			expected.split('_').length - 1,
+			`${name}: underscores were consumed on the way to KaTeX`,
+		);
+	}
+});
+
+test('paired underscores inside display math never become emphasis', () => {
+	for (const name of DISPLAY_MATH_FIXTURES) {
+		const body = render(name);
+		assert.equal(
+			body.querySelectorAll('em').length,
+			0,
+			`${name}: the renderer turned math subscripts into <em>, which breaks the KaTeX source`,
+		);
+		assert.equal(body.querySelectorAll('strong').length, 0, `${name}: unexpected <strong>`);
+	}
+});
+
+test('display math on its own lines is joined without the hard line breaks', () => {
+	const body = render('mathBlockOwnLines');
+	const math = body.querySelectorAll('[data-math]')[0];
+
+	assert.equal(math.getAttribute('data-math-source'), 'a_i = b_i + c_i');
+	assert.equal(math.querySelectorAll('br').length, 0, 'hard breaks leaked into the math source');
+});
+
+test('math mixed with prose stays literal instead of becoming a math block', () => {
+	// Two `$$` spans in a paragraph that also carries text: the block form does
+	// not apply, but the underscores still have to survive for the inline pass.
+	const mixed = render('mathTwoBlocksOneLine');
+	assert.equal(mixed.querySelectorAll('[data-math]').length, 0);
+	assert.equal(mixed.querySelectorAll('em').length, 0);
+	assert.equal(mixed.textContent.trim(), 'before $$a_1$$ middle $$b_2$$ after');
+
+	const withEmphasis = render('mathEmphasisOutsideStillWorks');
+	assert.deepEqual(
+		withEmphasis.querySelectorAll('em').map((element) => element.textContent),
+		['emphasis', 'more'],
+		'emphasis outside display math must keep working',
+	);
+	assert.ok(
+		withEmphasis.textContent.includes('$$p_1 + q_2$$'),
+		'underscores inside display math were emphasised away',
+	);
+});
+
+// --- protocol 3: heading ids and fold anchors (#371) ---------------------
+
+const HEADING_FIXTURES = [
+	'headingPunctuation',
+	'headingDuplicates',
+	'headingChinese',
+	'headingNumericDot',
+	'headingApostrophe',
+	'headingUnderscore',
+	'headingNesting',
+	'taskSurrounded',
+] as const satisfies readonly FixtureName[];
+
+const HEADING_SELECTOR = 'h1, h2, h3, h4, h5, h6';
+
+/** The ids comrak put on the inner `a.anchor` of each heading. */
+function rendererAnchorIds(name: FixtureName): string[] {
+	return parseHtml(renderFixtures[name].html)
+		.body.querySelectorAll(HEADING_SELECTOR)
+		.map((heading) => heading.querySelectorAll('a.anchor')[0]?.id ?? '');
+}
+
+test("each heading adopts comrak's anchor id and leaves the anchor without one", () => {
+	for (const name of HEADING_FIXTURES) {
+		const body = render(name);
+		const headings = body.querySelectorAll(HEADING_SELECTOR);
+		const expected = rendererAnchorIds(name);
+
+		assert.equal(headings.length, expected.length, `${name}: heading count changed`);
+		assert.deepEqual(
+			headings.map((heading) => heading.id),
+			expected,
+			`${name}: heading ids no longer match the ids comrak rendered`,
+		);
+
+		for (const heading of headings) {
+			const anchor = heading.querySelectorAll('a.anchor')[0];
+			assert.ok(anchor, `${name}: comrak's anchor disappeared`);
+			assert.equal(
+				anchor.hasAttribute('id'),
+				false,
+				`${name}: the id is duplicated on the heading and its anchor`,
+			);
+		}
+
+		const ids = body.querySelectorAll('[id]').map((element) => element.id);
+		assert.equal(new Set(ids).size, ids.length, `${name}: duplicate ids in the rendered document`);
+	}
+});
+
+test('anchorized heading ids are pinned for punctuation, duplicates and Chinese', () => {
+	// These values come from comrak's own `Anchorizer` (#371). They are pinned
+	// here so a regenerated fixture cannot quietly change the link targets that
+	// wikilinks and the table of contents resolve against.
+	const expected: Partial<Record<FixtureName, string[]>> = {
+		headingPunctuation: ['hello-world'],
+		headingDuplicates: ['title', 'title-1', 'title-2'],
+		headingChinese: ['中文标题'],
+		headingNumericDot: ['1-概述'],
+		headingApostrophe: ['ticks-arent-in'],
+		headingUnderscore: ['under_score-here'],
+	};
+
+	for (const [name, ids] of Object.entries(expected)) {
+		assert.deepEqual(
+			render(name as FixtureName)
+				.querySelectorAll(HEADING_SELECTOR)
+				.map((heading) => heading.id),
+			ids,
+			`${name}: heading anchor ids drifted`,
+		);
+	}
+});
+
+test('every heading gets a fold chevron and owns the wrapper it points at', () => {
+	for (const name of HEADING_FIXTURES) {
+		const body = render(name);
+		for (const heading of body.querySelectorAll(HEADING_SELECTOR)) {
+			assert.ok(heading.classList.contains('foldable-header'), `${name}: heading is not foldable`);
+			assert.equal(
+				heading.childNodes[0],
+				heading.querySelectorAll('span.header-fold-icon')[0],
+				`${name}: the fold chevron is not the heading's first child`,
+			);
+
+			const target = heading.getAttribute('data-fold-target');
+			assert.ok(target, `${name}: heading has no data-fold-target`);
+
+			const wrapper = heading.nextElementSibling;
+			assert.ok(wrapper, `${name}: heading has no following wrapper`);
+			assert.ok(
+				wrapper.classList.contains('foldable-content-wrapper'),
+				`${name}: the sibling after the heading is not the fold wrapper`,
+			);
+			assert.equal(wrapper.id, target, `${name}: data-fold-target does not address the wrapper`);
+			assert.ok(
+				wrapper.querySelectorAll('div.content-inner')[0],
+				`${name}: the fold wrapper has no content-inner`,
+			);
+		}
+	}
+});
+
+test('a deeper heading is folded inside its parent, a sibling heading is not', () => {
+	const body = render('headingNesting');
+	const [a, b, c] = body.querySelectorAll(HEADING_SELECTOR);
+
+	assert.deepEqual([a.id, b.id, c.id], ['a', 'b', 'c']);
+	assert.equal(
+		b.closest('div.foldable-content-wrapper')?.id,
+		a.getAttribute('data-fold-target'),
+		'the h2 must live inside the h1 fold wrapper',
+	);
+	assert.equal(
+		c.closest('div.foldable-content-wrapper'),
+		null,
+		'a sibling h1 must not be folded into the previous section',
+	);
+	assert.equal(
+		a.nextElementSibling?.textContent.includes('body b'),
+		true,
+		'the h1 wrapper must carry the nested section body',
+	);
+});
+
+test('collapsed state is keyed by heading id, so duplicate titles fold apart', () => {
+	// The heading id is promoted off comrak's anchor precisely so this key can
+	// tell "Title", "Title" and "Title" apart. Keying by text would collapse
+	// all three (or none) instead of the second one.
+	const body = render('headingDuplicates', new Set(['title-1']));
+	const headings = body.querySelectorAll(HEADING_SELECTOR);
+
+	assert.deepEqual(
+		headings.map((heading) => heading.classList.contains('is-collapsed')),
+		[false, true, false],
+		'the collapsed heading is not the one keyed by id',
+	);
+	assert.deepEqual(
+		headings.map((heading) => heading.nextElementSibling?.classList.contains('is-collapsed')),
+		[false, true, false],
+		'the collapsed wrapper does not follow its heading',
+	);
+});
+
+// --- protocol 4: raw HTML checkboxes (#319) ------------------------------
+
+const RAW_CHECKBOX_FIXTURES = [
+	'rawCheckboxListItem',
+	'rawCheckboxDisabled',
+	'rawCheckboxHtmlList',
+	'rawCheckboxMixedWithTask',
+	'rawCheckboxParagraph',
+] as const satisfies readonly FixtureName[];
+
+test('a hand-written checkbox is never treated as a Markdown task', () => {
+	for (const name of RAW_CHECKBOX_FIXTURES) {
+		const body = render(name);
+		const rendererTasks = sourceTasks(renderFixtures[name].markdown).length;
+
+		assert.equal(
+			interactiveCheckboxes(body).length,
+			rendererTasks,
+			`${name}: raw HTML controls were promoted to clickable tasks`,
+		);
+
+		for (const checkbox of body.querySelectorAll('input[type="checkbox"]')) {
+			if (checkbox.hasAttribute('data-task-checkbox')) continue;
+			assert.equal(
+				checkbox.closest('li') === null || checkbox.hasAttribute('disabled'),
+				true,
+				`${name}: a raw checkbox inside a list item stayed clickable`,
+			);
+			assert.equal(
+				checkbox.closest('li')?.classList.contains('task-done') ?? false,
+				false,
+				`${name}: a raw checkbox marked its list item done`,
+			);
+			assert.equal(
+				checkbox.closest('li')?.querySelectorAll('span.task-text').length ?? 0,
+				0,
+				`${name}: a raw checkbox got task-text treatment`,
+			);
+		}
+	}
+});
+
+test('a raw checkbox indistinguishable by markup is separated by the source line', () => {
+	// `- <input type="checkbox" disabled="" /> …` renders byte-identically to a
+	// real `- [ ]` item apart from the marker attribute the Rust side adds only
+	// when the source line really is a task.
+	const body = render('rawCheckboxDisabled');
+	const [checkbox] = body.querySelectorAll('input[type="checkbox"]');
+
+	assert.equal(checkbox.hasAttribute('data-task-checkbox'), false);
+	assert.equal(checkbox.hasAttribute('disabled'), true);
+	assert.equal(interactiveCheckboxes(body).length, 0);
+});
+
+test('a raw checkbox next to a real task cannot rewrite the task line', () => {
+	const body = render('rawCheckboxMixedWithTask');
+	const checkboxes = body.querySelectorAll('input[type="checkbox"]');
+
+	assert.equal(checkboxes.length, 2);
+	assert.deepEqual(
+		checkboxes.map((checkbox) => checkbox.hasAttribute('data-task-checkbox')),
+		[true, false],
+	);
+	assert.equal(clickedSourceLine(checkboxes[0]), 1);
+	assert.equal(checkboxes[1].hasAttribute('disabled'), true);
+});
+
+test('a raw HTML list has no source position for a click to resolve', () => {
+	const body = render('rawCheckboxHtmlList');
+	const [checkbox] = body.querySelectorAll('input[type="checkbox"]');
+
+	assert.equal(checkbox.closest('li')?.hasAttribute('data-sourcepos'), false);
+	assert.equal(Number.isInteger(clickedSourceLine(checkbox)), false);
+});
+
+test('a checkbox outside a list item is left alone by the task pass', () => {
+	const body = render('rawCheckboxParagraph');
+	const [checkbox] = body.querySelectorAll('input[type="checkbox"]');
+
+	assert.equal(checkbox.closest('li'), null);
+	assert.equal(checkbox.hasAttribute('data-task-checkbox'), false);
+	assert.equal(checkbox.closest('p')?.textContent.trim(), 'A paragraph with  inline.');
+});

--- a/scripts/renderProtocolDom.test.ts
+++ b/scripts/renderProtocolDom.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Self-checks for the fixture harness in `renderProtocolDom.ts`.
+ *
+ * `renderProtocol.test.ts` trusts that shim to represent what a browser would
+ * hand `processMarkdownHtml`. A shim bug would otherwise turn into a silently
+ * wrong contract test, so the pieces that carry the risk — the parser, the
+ * serializer, the selector engine and the tree walker — are exercised here on
+ * their own. If these fail, the protocol assertions mean nothing.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+	NODE_ELEMENT,
+	NODE_TEXT,
+	installShimDom,
+	parseHtml,
+	structureOf,
+	type ShimNode,
+} from './renderProtocolDom.ts';
+import { renderFixtures } from './renderProtocolFixtures.ts';
+
+installShimDom();
+
+test('parsing and reserializing every fixture is stable', () => {
+	for (const [name, fixture] of Object.entries(renderFixtures)) {
+		const once = parseHtml(fixture.html).body;
+		const twice = parseHtml(once.innerHTML).body;
+		assert.deepEqual(
+			structureOf(twice),
+			structureOf(once),
+			`${name}: the shim does not round-trip the renderer's HTML`,
+		);
+	}
+});
+
+test('parsing preserves the document text exactly', () => {
+	const decode = (value: string) =>
+		value
+			.replace(/&lt;/g, '<')
+			.replace(/&gt;/g, '>')
+			.replace(/&quot;/g, '"')
+			.replace(/&#39;/g, "'")
+			.replace(/&amp;/g, '&');
+
+	for (const [name, fixture] of Object.entries(renderFixtures)) {
+		assert.equal(
+			parseHtml(fixture.html).body.textContent,
+			decode(fixture.html.replace(/<[^>]*>/g, '')),
+			`${name}: text was lost or invented while parsing`,
+		);
+	}
+});
+
+test('the parser keeps attributes, nesting and void elements', () => {
+	const body = parseHtml(
+		'<ul class="a b"><li data-sourcepos="1:1-1:9"><input type="checkbox" disabled="" /> x<br />y</li></ul>',
+	).body;
+
+	assert.deepEqual(structureOf(body), {
+		tag: 'body',
+		attributes: [],
+		children: [
+			{
+				tag: 'ul',
+				attributes: [['class', 'a b']],
+				children: [
+					{
+						tag: 'li',
+						attributes: [['data-sourcepos', '1:1-1:9']],
+						children: [
+							{
+								tag: 'input',
+								attributes: [
+									['type', 'checkbox'],
+									['disabled', ''],
+								],
+								children: [],
+							},
+							{ text: ' x' },
+							{ tag: 'br', attributes: [], children: [] },
+							{ text: 'y' },
+						],
+					},
+				],
+			},
+		],
+	});
+});
+
+test('the parser decodes entities in text and attributes', () => {
+	const body = parseHtml('<p title="a &amp; b">1 &lt; 2 &amp;&amp; 3 &gt; 2 &#39;ok&#39;</p>').body;
+	const paragraph = body.querySelectorAll('p')[0];
+
+	assert.equal(paragraph.getAttribute('title'), 'a & b');
+	assert.equal(paragraph.textContent, "1 < 2 && 3 > 2 'ok'");
+	assert.equal(paragraph.innerHTML, '1 &lt; 2 &amp;&amp; 3 &gt; 2 \'ok\'');
+});
+
+test('the selector engine handles the shapes the render pipeline uses', () => {
+	const body = parseHtml(
+		'<ul><li><input type="checkbox" data-task-checkbox="" /></li></ul>' +
+			'<p><input type="radio" /></p>' +
+			'<h2><a class="anchor" id="x"></a>T</h2>' +
+			'<div class="block-id">^one</div>',
+	).body;
+
+	assert.equal(body.querySelectorAll('li input[type="checkbox"]').length, 1);
+	assert.equal(body.querySelectorAll('input[type="checkbox"]').length, 1);
+	assert.equal(body.querySelectorAll('li input[data-task-checkbox]').length, 1);
+	assert.equal(body.querySelectorAll('p, li').length, 2);
+	assert.equal(body.querySelectorAll('h1, h2, h3, h4, h5, h6').length, 1);
+	assert.equal(body.querySelectorAll('a.anchor')[0].id, 'x');
+	assert.equal(body.querySelectorAll('.block-id, [data-block-id]').length, 1);
+
+	const checkbox = body.querySelectorAll('input[type="checkbox"]')[0];
+	assert.equal(checkbox.closest('li')?.tagName, 'LI');
+	assert.equal(checkbox.closest('table'), null);
+});
+
+test('the tree walker skips rejected subtrees and yields only text', () => {
+	const body = parseHtml('<p>keep<code>drop<em>drop too</em></code>tail</p>').body;
+	const scope = globalThis as unknown as {
+		document: {
+			createTreeWalker(
+				root: ShimNode,
+				whatToShow: number,
+				filter?: { acceptNode(node: ShimNode): number },
+			): { nextNode(): ShimNode | null };
+		};
+		NodeFilter: { SHOW_TEXT: number; FILTER_ACCEPT: number; FILTER_REJECT: number };
+	};
+
+	const walker = scope.document.createTreeWalker(body, scope.NodeFilter.SHOW_TEXT, {
+		acceptNode(node) {
+			let current = node.parentElement;
+			while (current && current !== body) {
+				if (current.tagName === 'CODE') return scope.NodeFilter.FILTER_REJECT;
+				current = current.parentElement;
+			}
+			return scope.NodeFilter.FILTER_ACCEPT;
+		},
+	});
+
+	const seen: string[] = [];
+	let node: ShimNode | null;
+	while ((node = walker.nextNode())) {
+		assert.equal(node.nodeType, NODE_TEXT);
+		seen.push(node.textContent);
+	}
+	assert.deepEqual(seen, ['keep', 'tail']);
+});
+
+test('mutation keeps parent links and document order consistent', () => {
+	const doc = parseHtml('<div><span>a</span><span>b</span><span>c</span></div>');
+	const container = doc.body.querySelectorAll('div')[0];
+	const [a, b, c] = container.querySelectorAll('span');
+
+	const wrapper = doc.createElement('em');
+	b.replaceWith(wrapper);
+	wrapper.appendChild(b);
+	assert.equal(container.innerHTML, '<span>a</span><em><span>b</span></em><span>c</span>');
+	assert.equal(b.parentNode, wrapper);
+
+	container.insertBefore(doc.createTextNode('|'), c);
+	assert.equal(container.innerHTML, '<span>a</span><em><span>b</span></em>|<span>c</span>');
+
+	a.remove();
+	assert.equal(a.parentNode, null);
+	assert.equal(container.childNodes.length, 3);
+
+	container.replaceChildren(doc.createTextNode('only'));
+	assert.equal(container.innerHTML, 'only');
+	assert.equal(container.childNodes[0].nodeType, NODE_TEXT);
+
+	const heading = doc.createElement('h1');
+	heading.classList.add('one', 'two');
+	heading.classList.remove('one');
+	heading.id = 'h';
+	assert.equal(heading.outerHTML, '<h1 class="two" id="h"></h1>');
+	assert.equal(heading.nodeType, NODE_ELEMENT);
+});
+
+test('checked reflects the attribute the renderer emits', () => {
+	const body = parseHtml('<input type="checkbox" checked="" /><input type="checkbox" />').body;
+	const [checked, unchecked] = body.querySelectorAll('input');
+
+	assert.equal(checked.checked, true);
+	assert.equal(unchecked.checked, false);
+	unchecked.checked = true;
+	assert.equal(unchecked.hasAttribute('checked'), true);
+});

--- a/scripts/renderProtocolDom.ts
+++ b/scripts/renderProtocolDom.ts
@@ -1,0 +1,643 @@
+/**
+ * A minimal DOM used only by `renderProtocol.test.ts`, so that the render
+ * contract can be exercised by *running* `processMarkdownHtml` instead of
+ * grepping its source. Node has no `DOMParser`, and the project intentionally
+ * has no test-only DOM dependency, so the fixture carries its own.
+ *
+ * Scope is deliberately narrow: exactly the surface `processMarkdownHtml`
+ * touches, over the HTML shapes comrak actually emits (well nested, explicit
+ * close tags, `<input>`/`<br>`/`<img>` as the only void elements). It is not a
+ * general HTML parser and must not grow into one — `renderProtocol.test.ts`
+ * round-trips every fixture through it as a self-check so a shim bug shows up
+ * as a shim failure rather than as a silent pass.
+ */
+
+const VOID_TAGS = new Set([
+	'area',
+	'base',
+	'br',
+	'col',
+	'embed',
+	'hr',
+	'img',
+	'input',
+	'link',
+	'meta',
+	'param',
+	'source',
+	'track',
+	'wbr',
+]);
+
+const ENTITIES: Record<string, string> = {
+	amp: '&',
+	lt: '<',
+	gt: '>',
+	quot: '"',
+	apos: "'",
+	nbsp: ' ',
+};
+
+function decodeEntities(value: string): string {
+	return value.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (match, body: string) => {
+		if (body[0] === '#') {
+			const code =
+				body[1] === 'x' || body[1] === 'X'
+					? parseInt(body.slice(2), 16)
+					: parseInt(body.slice(1), 10);
+			return Number.isFinite(code) ? String.fromCodePoint(code) : match;
+		}
+		return ENTITIES[body.toLowerCase()] ?? match;
+	});
+}
+
+function escapeText(value: string): string {
+	return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function escapeAttribute(value: string): string {
+	return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+}
+
+export const NODE_ELEMENT = 1;
+export const NODE_TEXT = 3;
+export const NODE_COMMENT = 8;
+
+export class ShimNode {
+	nodeType: number;
+	childNodes: ShimNode[] = [];
+	parentNode: ShimNode | null = null;
+	ownerDocument: ShimDocument | null = null;
+
+	constructor(nodeType: number) {
+		this.nodeType = nodeType;
+	}
+
+	get parentElement(): ShimElement | null {
+		return this.parentNode && this.parentNode.nodeType === NODE_ELEMENT
+			? (this.parentNode as ShimElement)
+			: null;
+	}
+
+	get firstChild(): ShimNode | null {
+		return this.childNodes[0] ?? null;
+	}
+
+	get lastChild(): ShimNode | null {
+		return this.childNodes[this.childNodes.length - 1] ?? null;
+	}
+
+	private siblingAt(offset: number): ShimNode | null {
+		const siblings = this.parentNode?.childNodes;
+		if (!siblings) return null;
+		return siblings[siblings.indexOf(this) + offset] ?? null;
+	}
+
+	get nextSibling(): ShimNode | null {
+		return this.siblingAt(1);
+	}
+
+	get previousSibling(): ShimNode | null {
+		return this.siblingAt(-1);
+	}
+
+	get nextElementSibling(): ShimElement | null {
+		let candidate = this.nextSibling;
+		while (candidate && candidate.nodeType !== NODE_ELEMENT) candidate = candidate.nextSibling;
+		return (candidate as ShimElement) ?? null;
+	}
+
+	get textContent(): string {
+		return this.childNodes.map((child) => child.textContent).join('');
+	}
+
+	set textContent(value: string) {
+		const text = new ShimText(value);
+		text.ownerDocument = this.ownerDocument;
+		this.replaceChildren(text);
+	}
+
+	appendChild<T extends ShimNode>(node: T): T {
+		node.parentNode?.removeChild(node);
+		node.parentNode = this;
+		this.childNodes.push(node);
+		return node;
+	}
+
+	insertBefore<T extends ShimNode>(node: T, reference: ShimNode | null): T {
+		if (!reference) return this.appendChild(node);
+		const index = this.childNodes.indexOf(reference);
+		if (index === -1) return this.appendChild(node);
+		node.parentNode?.removeChild(node);
+		node.parentNode = this;
+		this.childNodes.splice(index, 0, node);
+		return node;
+	}
+
+	removeChild<T extends ShimNode>(node: T): T {
+		const index = this.childNodes.indexOf(node);
+		if (index !== -1) this.childNodes.splice(index, 1);
+		node.parentNode = null;
+		return node;
+	}
+
+	replaceChild<T extends ShimNode>(next: ShimNode, current: T): T {
+		const index = this.childNodes.indexOf(current);
+		if (index === -1) return current;
+		next.parentNode?.removeChild(next);
+		next.parentNode = this;
+		this.childNodes.splice(index, 1, next);
+		current.parentNode = null;
+		return current;
+	}
+
+	replaceWith(...nodes: ShimNode[]) {
+		const parent = this.parentNode;
+		if (!parent) return;
+		let anchor: ShimNode | null = this;
+		for (const node of nodes) parent.insertBefore(node, anchor);
+		anchor = null;
+		parent.removeChild(this);
+	}
+
+	replaceChildren(...nodes: ShimNode[]) {
+		for (const child of [...this.childNodes]) this.removeChild(child);
+		for (const node of nodes) this.appendChild(node);
+	}
+
+	remove() {
+		this.parentNode?.removeChild(this);
+	}
+
+	/** Pre-order descendants, self excluded. */
+	descendants(): ShimNode[] {
+		const out: ShimNode[] = [];
+		const visit = (node: ShimNode) => {
+			for (const child of node.childNodes) {
+				out.push(child);
+				visit(child);
+			}
+		};
+		visit(this);
+		return out;
+	}
+
+	querySelectorAll(selector: string): ShimElement[] {
+		const matchers = parseSelectorList(selector);
+		return this.descendants().filter(
+			(node): node is ShimElement =>
+				node.nodeType === NODE_ELEMENT &&
+				matchers.some((matcher) => matcher(node as ShimElement)),
+		);
+	}
+
+	querySelector(selector: string): ShimElement | null {
+		return this.querySelectorAll(selector)[0] ?? null;
+	}
+}
+
+export class ShimText extends ShimNode {
+	nodeValue: string;
+
+	constructor(value: string) {
+		super(NODE_TEXT);
+		this.nodeValue = value;
+	}
+
+	get textContent(): string {
+		return this.nodeValue;
+	}
+
+	set textContent(value: string) {
+		this.nodeValue = value;
+	}
+}
+
+export class ShimComment extends ShimNode {
+	nodeValue: string;
+
+	constructor(value: string) {
+		super(NODE_COMMENT);
+		this.nodeValue = value;
+	}
+
+	get textContent(): string {
+		return '';
+	}
+}
+
+class ShimClassList {
+	constructor(private readonly element: ShimElement) {}
+
+	private tokens(): string[] {
+		return (this.element.getAttribute('class') || '').split(/\s+/).filter(Boolean);
+	}
+
+	private write(tokens: string[]) {
+		if (tokens.length === 0) this.element.removeAttribute('class');
+		else this.element.setAttribute('class', tokens.join(' '));
+	}
+
+	add(...names: string[]) {
+		const tokens = this.tokens();
+		for (const name of names) if (!tokens.includes(name)) tokens.push(name);
+		this.write(tokens);
+	}
+
+	remove(...names: string[]) {
+		this.write(this.tokens().filter((token) => !names.includes(token)));
+	}
+
+	contains(name: string): boolean {
+		return this.tokens().includes(name);
+	}
+
+	toggle(name: string, force?: boolean) {
+		const present = this.contains(name);
+		const next = force ?? !present;
+		if (next) this.add(name);
+		else this.remove(name);
+	}
+}
+
+function styleProxy(element: ShimElement): Record<string, string> {
+	const declarations = new Map<string, string>();
+	for (const part of (element.getAttribute('style') || '').split(';')) {
+		const [name, ...rest] = part.split(':');
+		if (!name.trim() || rest.length === 0) continue;
+		declarations.set(name.trim(), rest.join(':').trim());
+	}
+	const flush = () => {
+		if (declarations.size === 0) element.removeAttribute('style');
+		else
+			element.setAttribute(
+				'style',
+				[...declarations].map(([name, value]) => `${name}: ${value}`).join('; '),
+			);
+	};
+	return new Proxy({} as Record<string, string>, {
+		get: (_target, property: string) =>
+			declarations.get(property.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`)) ?? '',
+		set: (_target, property: string, value: string) => {
+			const name = property.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`);
+			if (value === '') declarations.delete(name);
+			else declarations.set(name, value);
+			flush();
+			return true;
+		},
+	});
+}
+
+export class ShimElement extends ShimNode {
+	tagName: string;
+	attributes = new Map<string, string>();
+	readonly classList = new ShimClassList(this);
+
+	constructor(tagName: string) {
+		super(NODE_ELEMENT);
+		this.tagName = tagName.toUpperCase();
+	}
+
+	get localName(): string {
+		return this.tagName.toLowerCase();
+	}
+
+	getAttribute(name: string): string | null {
+		return this.attributes.has(name) ? (this.attributes.get(name) as string) : null;
+	}
+
+	setAttribute(name: string, value: string) {
+		this.attributes.set(name, value);
+	}
+
+	hasAttribute(name: string): boolean {
+		return this.attributes.has(name);
+	}
+
+	removeAttribute(name: string) {
+		this.attributes.delete(name);
+	}
+
+	get id(): string {
+		return this.getAttribute('id') || '';
+	}
+
+	set id(value: string) {
+		this.setAttribute('id', value);
+	}
+
+	get className(): string {
+		return this.getAttribute('class') || '';
+	}
+
+	set className(value: string) {
+		this.setAttribute('class', value);
+	}
+
+	get style(): Record<string, string> {
+		return styleProxy(this);
+	}
+
+	/** `HTMLInputElement.checked`, the only element property the pipeline reads. */
+	get checked(): boolean {
+		return this.hasAttribute('checked');
+	}
+
+	set checked(value: boolean) {
+		if (value) this.setAttribute('checked', '');
+		else this.removeAttribute('checked');
+	}
+
+	get type(): string {
+		return this.getAttribute('type') || '';
+	}
+
+	get dataset(): Record<string, string | undefined> {
+		const element = this;
+		return new Proxy({} as Record<string, string | undefined>, {
+			get: (_target, property: string) =>
+				element.getAttribute(
+					`data-${property.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`)}`,
+				) ?? undefined,
+		});
+	}
+
+	closest(selector: string): ShimElement | null {
+		const matchers = parseSelectorList(selector);
+		let current: ShimNode | null = this;
+		while (current) {
+			if (
+				current.nodeType === NODE_ELEMENT &&
+				matchers.some((matcher) => matcher(current as ShimElement))
+			)
+				return current as ShimElement;
+			current = current.parentNode;
+		}
+		return null;
+	}
+
+	get innerHTML(): string {
+		return this.childNodes.map(serializeNode).join('');
+	}
+
+	set innerHTML(html: string) {
+		const parsed = parseFragment(html, this.ownerDocument);
+		this.replaceChildren(...parsed);
+	}
+
+	get outerHTML(): string {
+		return serializeNode(this);
+	}
+}
+
+export class ShimDocument extends ShimNode {
+	documentElement: ShimElement;
+	body: ShimElement;
+
+	constructor() {
+		super(9);
+		this.ownerDocument = this;
+		this.documentElement = this.createElement('html');
+		this.body = this.createElement('body');
+		this.appendChild(this.documentElement);
+		this.documentElement.appendChild(this.body);
+	}
+
+	createElement(tagName: string): ShimElement {
+		const element = new ShimElement(tagName);
+		element.ownerDocument = this;
+		return element;
+	}
+
+	createTextNode(value: string): ShimText {
+		const text = new ShimText(value);
+		text.ownerDocument = this;
+		return text;
+	}
+
+	createTreeWalker(
+		root: ShimNode,
+		whatToShow = 0xffffffff,
+		filter?: { acceptNode(node: ShimNode): number } | null,
+	) {
+		const queue: ShimNode[] = [];
+		const visit = (node: ShimNode) => {
+			for (const child of node.childNodes) {
+				const shown = (whatToShow & (1 << (child.nodeType - 1))) !== 0;
+				if (!shown) {
+					visit(child);
+					continue;
+				}
+				const verdict = filter ? filter.acceptNode(child) : 1;
+				if (verdict === 2) continue; // FILTER_REJECT: skip the subtree
+				if (verdict === 1) queue.push(child);
+				visit(child);
+			}
+		};
+		visit(root);
+		let index = 0;
+		return {
+			nextNode(): ShimNode | null {
+				return index < queue.length ? queue[index++] : null;
+			},
+		};
+	}
+}
+
+// --- parsing -------------------------------------------------------------
+
+const TOKEN_RE = /<!--([\s\S]*?)-->|<\/([a-zA-Z][^\s>]*)\s*>|<([a-zA-Z][^\s/>]*)((?:[^>"']|"[^"]*"|'[^']*')*)>/g;
+const ATTRIBUTE_RE = /([^\s=/][^\s=]*)(?:\s*=\s*("([^"]*)"|'([^']*)'|([^\s"'>]+)))?/g;
+
+function parseAttributes(raw: string, element: ShimElement) {
+	ATTRIBUTE_RE.lastIndex = 0;
+	let match: RegExpExecArray | null;
+	while ((match = ATTRIBUTE_RE.exec(raw))) {
+		const name = match[1];
+		if (!name || name === '/') continue;
+		const value = match[3] ?? match[4] ?? match[5] ?? '';
+		element.setAttribute(name, decodeEntities(value));
+	}
+}
+
+function parseInto(html: string, container: ShimNode, doc: ShimDocument) {
+	const stack: ShimNode[] = [container];
+	const top = () => stack[stack.length - 1];
+	let cursor = 0;
+	TOKEN_RE.lastIndex = 0;
+	let match: RegExpExecArray | null;
+
+	const pushText = (raw: string) => {
+		if (!raw) return;
+		const text = new ShimText(decodeEntities(raw));
+		text.ownerDocument = doc;
+		top().appendChild(text);
+	};
+
+	while ((match = TOKEN_RE.exec(html))) {
+		pushText(html.slice(cursor, match.index));
+		cursor = TOKEN_RE.lastIndex;
+
+		if (match[1] !== undefined) {
+			const comment = new ShimComment(match[1]);
+			comment.ownerDocument = doc;
+			top().appendChild(comment);
+			continue;
+		}
+
+		if (match[2] !== undefined) {
+			const name = match[2].toUpperCase();
+			for (let depth = stack.length - 1; depth >= 1; depth -= 1) {
+				if ((stack[depth] as ShimElement).tagName === name) {
+					stack.length = depth;
+					break;
+				}
+			}
+			continue;
+		}
+
+		const tagName = match[3];
+		const element = doc.createElement(tagName);
+		parseAttributes(match[4] || '', element);
+		top().appendChild(element);
+		const selfClosing = /\/\s*$/.test(match[4] || '');
+		if (!selfClosing && !VOID_TAGS.has(tagName.toLowerCase())) stack.push(element);
+	}
+	pushText(html.slice(cursor));
+}
+
+function parseFragment(html: string, doc: ShimDocument | null): ShimNode[] {
+	const document = doc ?? new ShimDocument();
+	const holder = document.createElement('template');
+	parseInto(html, holder, document);
+	return [...holder.childNodes].map((child) => {
+		holder.removeChild(child);
+		return child;
+	});
+}
+
+export class ShimDOMParser {
+	parseFromString(html: string, _type: string): ShimDocument {
+		const doc = new ShimDocument();
+		parseInto(html, doc.body, doc);
+		return doc;
+	}
+}
+
+// --- serialization -------------------------------------------------------
+
+function serializeNode(node: ShimNode): string {
+	if (node.nodeType === NODE_TEXT) return escapeText((node as ShimText).nodeValue);
+	if (node.nodeType === NODE_COMMENT) return `<!--${(node as ShimComment).nodeValue}-->`;
+	const element = node as ShimElement;
+	const name = element.localName;
+	const attributes = [...element.attributes]
+		.map(([key, value]) => ` ${key}="${escapeAttribute(value)}"`)
+		.join('');
+	if (VOID_TAGS.has(name)) return `<${name}${attributes}>`;
+	return `<${name}${attributes}>${element.innerHTML}</${name}>`;
+}
+
+// --- selectors -----------------------------------------------------------
+
+type Matcher = (element: ShimElement) => boolean;
+
+function parseCompound(source: string): Matcher {
+	const checks: Matcher[] = [];
+	const pattern = /^([a-zA-Z][\w-]*)|^\.([\w-]+)|^#([\w-]+)|^\[([\w-]+)(?:=("([^"]*)"|'([^']*)'|[^\]]+))?\]/;
+	let rest = source.trim();
+	while (rest.length > 0) {
+		const match = pattern.exec(rest);
+		if (!match) throw new Error(`unsupported selector fragment: ${source}`);
+		if (match[1]) {
+			const tag = match[1].toUpperCase();
+			checks.push((element) => element.tagName === tag);
+		} else if (match[2]) {
+			const className = match[2];
+			checks.push((element) => element.classList.contains(className));
+		} else if (match[3]) {
+			const id = match[3];
+			checks.push((element) => element.id === id);
+		} else if (match[4]) {
+			const name = match[4];
+			const raw = match[5];
+			if (raw === undefined) checks.push((element) => element.hasAttribute(name));
+			else {
+				const value = match[6] ?? match[7] ?? raw;
+				checks.push((element) => element.getAttribute(name) === value);
+			}
+		}
+		rest = rest.slice(match[0].length);
+	}
+	if (checks.length === 0) throw new Error(`empty selector: ${source}`);
+	return (element) => checks.every((check) => check(element));
+}
+
+function parseComplex(source: string): Matcher {
+	const compounds = source.trim().split(/\s+/).map(parseCompound);
+	const subject = compounds[compounds.length - 1];
+	const ancestors = compounds.slice(0, -1).reverse();
+	return (element) => {
+		if (!subject(element)) return false;
+		let current: ShimNode | null = element.parentNode;
+		let index = 0;
+		while (current && index < ancestors.length) {
+			if (current.nodeType === NODE_ELEMENT && ancestors[index](current as ShimElement))
+				index += 1;
+			current = current.parentNode;
+		}
+		return index === ancestors.length;
+	};
+}
+
+const selectorCache = new Map<string, Matcher[]>();
+
+function parseSelectorList(selector: string): Matcher[] {
+	const cached = selectorCache.get(selector);
+	if (cached) return cached;
+	const matchers = selector.split(',').map(parseComplex);
+	selectorCache.set(selector, matchers);
+	return matchers;
+}
+
+// --- installation --------------------------------------------------------
+
+let installed = false;
+
+/**
+ * Publishes the globals `processMarkdownHtml` reaches for. It calls the bare
+ * `document.createTreeWalker` (not `doc.createTreeWalker`) in two places, so a
+ * global document has to exist even though the parsed document is separate.
+ */
+export function installShimDom() {
+	if (installed) return;
+	installed = true;
+	const scope = globalThis as unknown as Record<string, unknown>;
+	scope.DOMParser = ShimDOMParser;
+	scope.document = new ShimDocument();
+	scope.Node = { ELEMENT_NODE: NODE_ELEMENT, TEXT_NODE: NODE_TEXT, COMMENT_NODE: NODE_COMMENT };
+	scope.NodeFilter = {
+		SHOW_ALL: 0xffffffff,
+		SHOW_ELEMENT: 1,
+		SHOW_TEXT: 4,
+		FILTER_ACCEPT: 1,
+		FILTER_REJECT: 2,
+		FILTER_SKIP: 3,
+	};
+}
+
+export function parseHtml(html: string): ShimDocument {
+	return new ShimDOMParser().parseFromString(html, 'text/html');
+}
+
+/** Tag / attribute / text tree, for shim round-trip self-checks. */
+export function structureOf(node: ShimNode): unknown {
+	if (node.nodeType === NODE_TEXT) return { text: (node as ShimText).nodeValue };
+	if (node.nodeType === NODE_COMMENT) return { comment: (node as ShimComment).nodeValue };
+	const element = node as ShimElement;
+	return {
+		tag: element.localName,
+		attributes: [...element.attributes],
+		children: element.childNodes.map(structureOf),
+	};
+}

--- a/scripts/renderProtocolFixtures.ts
+++ b/scripts/renderProtocolFixtures.ts
@@ -1,0 +1,152 @@
+/**
+ * Markdown input → `convert_markdown` output, captured from a real comrak run.
+ *
+ * These are INPUTS, not expected values: `renderProtocol.test.ts` feeds the
+ * `html` of each case to the frontend's `processMarkdownHtml` and asserts what
+ * the frontend does with it. Nothing here re-asserts comrak's own behaviour —
+ * that is `src-tauri/src/lib.rs`'s `mod tests` job, and it already covers it.
+ *
+ * Provenance: produced by running comrak 0.18 with the exact
+ * `ComrakOptions`/`ComrakExtensionOptions` of `convert_markdown`, followed by
+ * verbatim copies of `protect_display_math_underscores` and
+ * `annotate_task_checkboxes`. The capture harness was validated by reproducing,
+ * byte for byte, the HTML literals asserted in the Rust test module (for
+ * example `task_list_checkbox_is_emitted_at_the_start_of_its_list_item`).
+ * The wikilink/embed/autolink pre-passes are no-ops on every input below.
+ *
+ * To refresh after a comrak upgrade or a renderer change, re-run the pipeline
+ * over `markdown` and replace `html`. Do not hand-edit `html`: a fixture that
+ * no longer matches the renderer makes every assertion here a lie.
+ */
+
+export type RenderFixture = {
+	/** Markdown handed to `convert_markdown`. */
+	markdown: string;
+	/** Exactly what `convert_markdown` returned. */
+	html: string;
+};
+
+export const renderFixtures = {
+	// --- protocol 1 — task-list markers and source positions ---
+	taskSimple: {
+		markdown: "- [ ] open task\n- [x] completed task\n",
+		html: "<ul data-sourcepos=\"1:1-2:20\">\n<li data-sourcepos=\"1:1-1:15\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> open task</li>\n<li data-sourcepos=\"2:1-2:20\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" checked=\"\" /> completed task</li>\n</ul>\n",
+	},
+	taskNested: {
+		markdown: "- [ ] parent\n  - [x] nested\n",
+		html: "<ul data-sourcepos=\"1:1-2:14\">\n<li data-sourcepos=\"1:1-2:14\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> parent\n<ul data-sourcepos=\"2:3-2:14\">\n<li data-sourcepos=\"2:3-2:14\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" checked=\"\" /> nested</li>\n</ul>\n</li>\n</ul>\n",
+	},
+	taskQuoted: {
+		markdown: "> - [ ] quoted task\n",
+		html: "<blockquote data-sourcepos=\"1:1-1:19\">\n<ul data-sourcepos=\"1:3-1:19\">\n<li data-sourcepos=\"1:3-1:19\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> quoted task</li>\n</ul>\n</blockquote>\n",
+	},
+	taskOrdered: {
+		markdown: "1. [ ] ordered open\n2. [x] ordered done\n",
+		html: "<ol data-sourcepos=\"1:1-2:19\">\n<li data-sourcepos=\"1:1-1:19\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> ordered open</li>\n<li data-sourcepos=\"2:1-2:19\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" checked=\"\" /> ordered done</li>\n</ol>\n",
+	},
+	taskSurrounded: {
+		markdown: "# Title\n\nIntro paragraph.\n\n- [ ] after prose\n\nTrailing prose.\n\n- [x] after blank\n",
+		html: "<h1 data-sourcepos=\"1:1-1:7\"><a href=\"#title\" aria-hidden=\"true\" class=\"anchor\" id=\"title\"></a>Title</h1>\n<p data-sourcepos=\"3:1-3:16\">Intro paragraph.</p>\n<ul data-sourcepos=\"5:1-6:0\">\n<li data-sourcepos=\"5:1-6:0\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> after prose</li>\n</ul>\n<p data-sourcepos=\"7:1-7:15\">Trailing prose.</p>\n<ul data-sourcepos=\"9:1-9:17\">\n<li data-sourcepos=\"9:1-9:17\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" checked=\"\" /> after blank</li>\n</ul>\n",
+	},
+	taskCrlf: {
+		markdown: "- [ ] crlf open\r\n- [x] crlf done\r\n",
+		html: "<ul data-sourcepos=\"1:1-2:15\">\n<li data-sourcepos=\"1:1-1:15\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> crlf open</li>\n<li data-sourcepos=\"2:1-2:15\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" checked=\"\" /> crlf done</li>\n</ul>\n",
+	},
+	taskLoose: {
+		markdown: "- [ ] loose one\n\n- [x] loose two\n",
+		html: "<ul data-sourcepos=\"1:1-3:15\">\n<li data-sourcepos=\"1:1-2:0\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> \n<p data-sourcepos=\"1:7-1:15\">loose one</p>\n</li>\n<li data-sourcepos=\"3:1-3:15\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" checked=\"\" /> \n<p data-sourcepos=\"3:7-3:15\">loose two</p>\n</li>\n</ul>\n",
+	},
+	taskContinuation: {
+		markdown: "- [ ] first line\n  continued line\n- [x] second task\n",
+		html: "<ul data-sourcepos=\"1:1-3:17\">\n<li data-sourcepos=\"1:1-2:16\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> first line<br data-sourcepos=\"1:17-1:17\" />\ncontinued line</li>\n<li data-sourcepos=\"3:1-3:17\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" checked=\"\" /> second task</li>\n</ul>\n",
+	},
+	taskParenOrdered: {
+		markdown: "1) [ ] paren marker\n",
+		html: "<ol data-sourcepos=\"1:1-1:19\">\n<li data-sourcepos=\"1:1-1:19\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> paren marker</li>\n</ol>\n",
+	},
+	taskStarPlus: {
+		markdown: "* [ ] star marker\n+ [x] plus marker\n",
+		html: "<ul data-sourcepos=\"1:1-1:17\">\n<li data-sourcepos=\"1:1-1:17\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> star marker</li>\n</ul>\n<ul data-sourcepos=\"2:1-2:17\">\n<li data-sourcepos=\"2:1-2:17\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" checked=\"\" /> plus marker</li>\n</ul>\n",
+	},
+	// --- protocol 2 — $$…$$ underscore protection (issue #174 shapes) ---
+	mathBracedSubscripts: {
+		markdown: "$$\\bar{b}_{1} + \\bar{b}_{2}$$\n",
+		html: "<p data-sourcepos=\"1:1-1:33\">$$\\bar{b}_{1} + \\bar{b}_{2}$$</p>\n",
+	},
+	mathPlainSubscripts: {
+		markdown: "$$x_1 + y_2 + z_3$$\n",
+		html: "<p data-sourcepos=\"1:1-1:25\">$$x_1 + y_2 + z_3$$</p>\n",
+	},
+	mathBlockOwnLines: {
+		markdown: "$$\na_i = b_i + c_i\n$$\n",
+		html: "<p data-sourcepos=\"1:1-3:2\">$$<br data-sourcepos=\"1:3-1:3\" />\na_i = b_i + c_i<br data-sourcepos=\"2:22-2:22\" />\n$$</p>\n",
+	},
+	mathTwoBlocksOneLine: {
+		markdown: "before $$a_1$$ middle $$b_2$$ after\n",
+		html: "<p data-sourcepos=\"1:1-1:39\">before $$a_1$$ middle $$b_2$$ after</p>\n",
+	},
+	mathEscapedUnderscore: {
+		markdown: "$$x\\_y_z$$\n",
+		html: "<p data-sourcepos=\"1:1-1:14\">$$x\\_y_z$$</p>\n",
+	},
+	mathEmphasisOutsideStillWorks: {
+		markdown: "_emphasis_ then $$p_1 + q_2$$ then _more_\n",
+		html: "<p data-sourcepos=\"1:1-1:45\"><em data-sourcepos=\"1:1-1:10\">emphasis</em> then $$p_1 + q_2$$ then <em data-sourcepos=\"1:40-1:45\">more</em></p>\n",
+	},
+	mathInsideListItem: {
+		markdown: "- $$u_1 + v_2$$\n",
+		html: "<ul data-sourcepos=\"1:1-1:19\">\n<li data-sourcepos=\"1:1-1:19\">$$u_1 + v_2$$</li>\n</ul>\n",
+	},
+	// --- protocol 3 — heading ids and fold anchors (#371) ---
+	headingPunctuation: {
+		markdown: "## Hello, World!\n",
+		html: "<h2 data-sourcepos=\"1:1-1:16\"><a href=\"#hello-world\" aria-hidden=\"true\" class=\"anchor\" id=\"hello-world\"></a>Hello, World!</h2>\n",
+	},
+	headingDuplicates: {
+		markdown: "# Title\n\nfirst\n\n# Title\n\nsecond\n\n# Title\n\nthird\n",
+		html: "<h1 data-sourcepos=\"1:1-1:7\"><a href=\"#title\" aria-hidden=\"true\" class=\"anchor\" id=\"title\"></a>Title</h1>\n<p data-sourcepos=\"3:1-3:5\">first</p>\n<h1 data-sourcepos=\"5:1-5:7\"><a href=\"#title-1\" aria-hidden=\"true\" class=\"anchor\" id=\"title-1\"></a>Title</h1>\n<p data-sourcepos=\"7:1-7:6\">second</p>\n<h1 data-sourcepos=\"9:1-9:7\"><a href=\"#title-2\" aria-hidden=\"true\" class=\"anchor\" id=\"title-2\"></a>Title</h1>\n<p data-sourcepos=\"11:1-11:5\">third</p>\n",
+	},
+	headingChinese: {
+		markdown: "## 中文标题\n",
+		html: "<h2 data-sourcepos=\"1:1-1:15\"><a href=\"#中文标题\" aria-hidden=\"true\" class=\"anchor\" id=\"中文标题\"></a>中文标题</h2>\n",
+	},
+	headingNumericDot: {
+		markdown: "## 1. 概述\n",
+		html: "<h2 data-sourcepos=\"1:1-1:12\"><a href=\"#1-概述\" aria-hidden=\"true\" class=\"anchor\" id=\"1-概述\"></a>1. 概述</h2>\n",
+	},
+	headingApostrophe: {
+		markdown: "## Ticks aren't in\n",
+		html: "<h2 data-sourcepos=\"1:1-1:18\"><a href=\"#ticks-arent-in\" aria-hidden=\"true\" class=\"anchor\" id=\"ticks-arent-in\"></a>Ticks aren't in</h2>\n",
+	},
+	headingUnderscore: {
+		markdown: "## under_score here\n",
+		html: "<h2 data-sourcepos=\"1:1-1:19\"><a href=\"#under_score-here\" aria-hidden=\"true\" class=\"anchor\" id=\"under_score-here\"></a>under_score here</h2>\n",
+	},
+	headingNesting: {
+		markdown: "# A\n\nbody a\n\n## B\n\nbody b\n\n# C\n\nbody c\n",
+		html: "<h1 data-sourcepos=\"1:1-1:3\"><a href=\"#a\" aria-hidden=\"true\" class=\"anchor\" id=\"a\"></a>A</h1>\n<p data-sourcepos=\"3:1-3:6\">body a</p>\n<h2 data-sourcepos=\"5:1-5:4\"><a href=\"#b\" aria-hidden=\"true\" class=\"anchor\" id=\"b\"></a>B</h2>\n<p data-sourcepos=\"7:1-7:6\">body b</p>\n<h1 data-sourcepos=\"9:1-9:3\"><a href=\"#c\" aria-hidden=\"true\" class=\"anchor\" id=\"c\"></a>C</h1>\n<p data-sourcepos=\"11:1-11:6\">body c</p>\n",
+	},
+	// --- protocol 4 — raw HTML checkboxes are not markdown tasks (#319) ---
+	rawCheckboxListItem: {
+		markdown: "- <input type=\"checkbox\" /> raw control\n",
+		html: "<ul data-sourcepos=\"1:1-1:39\">\n<li data-sourcepos=\"1:1-1:39\"><input type=\"checkbox\" /> raw control</li>\n</ul>\n",
+	},
+	rawCheckboxDisabled: {
+		markdown: "- <input type=\"checkbox\" disabled=\"\" /> raw disabled control\n",
+		html: "<ul data-sourcepos=\"1:1-1:60\">\n<li data-sourcepos=\"1:1-1:60\"><input type=\"checkbox\" disabled=\"\" /> raw disabled control</li>\n</ul>\n",
+	},
+	rawCheckboxHtmlList: {
+		markdown: "<ul>\n<li><input type=\"checkbox\" disabled=\"\" /> hand written</li>\n</ul>\n",
+		html: "<ul>\n<li><input type=\"checkbox\" disabled=\"\" /> hand written</li>\n</ul>\n",
+	},
+	rawCheckboxMixedWithTask: {
+		markdown: "- [ ] real task\n- <input type=\"checkbox\" /> raw control\n",
+		html: "<ul data-sourcepos=\"1:1-2:39\">\n<li data-sourcepos=\"1:1-1:15\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> real task</li>\n<li data-sourcepos=\"2:1-2:39\"><input type=\"checkbox\" /> raw control</li>\n</ul>\n",
+	},
+	rawCheckboxParagraph: {
+		markdown: "A paragraph with <input type=\"checkbox\" /> inline.\n",
+		html: "<p data-sourcepos=\"1:1-1:50\">A paragraph with <input type=\"checkbox\" /> inline.</p>\n",
+	},
+} as const satisfies Record<string, RenderFixture>;
+
+export type RenderFixtureName = keyof typeof renderFixtures;


### PR DESCRIPTION
## Summary

The Rust renderer's output is a behavioural contract the frontend depends on. Four parts of it have regressed before:

- task markers and the source positions clicks resolve through
- the raw text kept inside `$$…$$` so KaTeX still sees its own source
- heading ids, and the fold anchors keyed to them
- the difference between a Markdown task item and a hand-written HTML checkbox

`markpad提升.md` lists this fixture as the first item of the structural queue and as the safety net a later PreviewRenderer extraction would need. This is that net; it changes **no implementation code**.

## Why not more source-regex tests

Most of `scripts/` matches source text with regular expressions. That fails on rewrites which change nothing and stays green on behaviour changes that break users. Today alone: replacing `lock().unwrap()` with a recovering helper, and moving a `localStorage.setItem` into a persistence table, each turned an assertion red without altering behaviour.

These run `processMarkdownHtml` **for real** against 29 documents whose HTML is genuine `convert_markdown` output, then re-parse the result and query it structurally — so nothing depends on the harness's own serialisation conventions.

## The two halves, and their honest status

**Frontend: genuinely executed.** No DOM shim precedent existed in `scripts/` and no DOM library is in `node_modules` (adding one touches `package.json` and the lockfile, and `node_modules` is shared). So the harness ships a deliberately narrow parser, serializer, selector engine and TreeWalker. It is validated two ways: eight self-tests including parse→serialize→parse stability over all 29 fixtures, and a differential run against Python's `html.parser`, which yields identical trees for every fixture. That validates the tokenizer and tree builder — not browser DOM *semantics*, which only the targeted self-tests cover. The file is documented as "must not grow into a general parser".

**Renderer HTML: captured, not called.** `convert_markdown` is a private `fn`; `src-tauri/tests/` cannot reach it. The HTML was not hand-written — it came from a throwaway crate carrying comrak 0.18, verbatim copies of `protect_display_math_underscores`, `annotate_task_checkboxes`, both task regexps and the exact `ComrakOptions`, validated by reproducing byte-for-byte the HTML literals that `lib.rs`'s own passing tests assert.

**So these fixtures are inputs.** If comrak or `convert_markdown` drifts, nothing here goes red until someone regenerates them. Closing that gap needs the assertions to live in `lib.rs`'s `mod tests`, where several already do. The fixture file header states this and how to regenerate.

## Coverage

| Protocol | Notable cases |
|---|---|
| Task marker + sourcepos | nested, `> - [ ]`, `1. [ ]` and `1) [ ]`, `*`/`+`, prose either side, CRLF, loose lists, multi-line continuation. Expected lines are derived from the *Markdown* by the `TASK_SOURCE_RE` rule, then compared with what the viewer's own read (`closest('li')` → `/^(\d+):/`) produces |
| Display math | braced and plain subscripts, own-line blocks, escaped `\_`, inside a list item, two blocks on one line, math beside real emphasis. Asserts `data-math-source` equals the Markdown between delimiters, underscore count preserved, zero `<em>`, and that emphasis *outside* math still works |
| Heading id + fold anchor | id promoted off `a.anchor`, no duplicate ids, chevron ↔ wrapper pairing, nesting. The sharpest: three identical `# Title`s with `collapsedHeaders = {'title-1'}` — only the second collapses, which fails outright if #371's id keying regresses |
| Raw HTML checkbox | including `- <input type="checkbox" disabled="" />`, byte-identical to a real task item and separated only by source line; a raw `<ul>` whose `li` has no `data-sourcepos` at all; a checkbox inside a `<p>` |

## Failability, checked rather than argued

Sixteen mutations — frontend and simulated renderer drift — each turn the suite red: leaving checkboxes disabled, dropping id promotion, keying folds by text, dropping `data-math-source`, treating raw checkboxes as tasks, `li` losing `data-sourcepos`, `1.-概述` anchorization, `<em>` inside `$$`, duplicate headings sharing an id, an escaped underscore being eaten, and so on. Three initially came out green; all three were bugs in the mutation script (first-occurrence-only replace, or mutating markdown and HTML together) and went red once corrected.

## Not covered

- `documentSession.toggleTaskCheckbox` is **not executed** — the regex that rewrites the source line lives in a closure inside a runes module that cannot be imported under `tsx`. The tests stop at "a click resolves to line N"; that the rewrite of line N is correct is not covered. Prerequisite: extract that rewrite into a plain exported function.
- `MarkdownViewer.svelte`'s handlers are not executed either. Its `data-sourcepos` parse rule is *restated* here as the documented contract, so a change there will not red this suite.
- The DOM shim is not validated against a real browser — `localhost` and `file://` are both blocked by the browser pane in this environment.

## Validation

- `npm test` — 234/234 (29 new)
- `npm run check` — 0 errors, 0 warnings
- `git status` — only the four new files under `scripts/`

Worth knowing: `scripts/` sits outside svelte-check's tsconfig include, as the whole existing suite does, so these files are not type-checked by CI.