### PR TITLE
fix(documents): refuse to save a buffer that was decoded lossily

### DIFF
--- a/scripts/lossyDecodeSaveGuard.test.ts
+++ b/scripts/lossyDecodeSaveGuard.test.ts
@@ -1,0 +1,236 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import type { Tab } from '../src/lib/stores/tabs.svelte.js';
+import { buildTransferredTab, snapshotTab, validateTransferPayload } from '../src/lib/utils/tabTransfer.js';
+
+// Every read path decodes leniently (#371): a file in a legacy encoding
+// (GBK, Big5, Shift-JIS, EUC-KR, CP1251 ...) opens as U+FFFD mojibake instead
+// of failing. U+FFFD is not reversible — the original bytes are gone from the
+// buffer. Writing that buffer back over the source file (auto-save does it
+// 1.5s after the first keystroke) destroys the document permanently.
+//
+// The guard: Rust reports the fidelity of every decode, the tab carries it —
+// through window restore and cross-window moves — and `documentSession`
+// refuses to write such a buffer over the file it came from. That is the
+// single choke point every writer shares, including MarkdownViewer's
+// auto-save timer and the close dialogs. "Save As" to a *different* path
+// stays open: the new file is genuinely UTF-8, so writing it is correct, and
+// it is the user's only way out.
+
+const session = readFileSync('src/lib/sessions/documentSession.svelte.ts', 'utf8');
+const windowSession = readFileSync('src/lib/sessions/windowSession.svelte.ts', 'utf8');
+const tabs = readFileSync('src/lib/stores/tabs.svelte.ts', 'utf8');
+const rust = readFileSync('src-tauri/src/lib.rs', 'utf8');
+
+function slice(source: string, start: string, end: string): string {
+	const from = source.indexOf(start);
+	assert.notEqual(from, -1, `expected to find ${start}`);
+	const to = source.indexOf(end, from + start.length);
+	assert.notEqual(to, -1, `expected to find ${end} after ${start}`);
+	return source.slice(from, to);
+}
+
+const loadMarkdown = () => slice(session, 'async function loadMarkdown', 'async function saveContent');
+const saveContent = () => slice(session, 'async function saveContent(', 'async function saveContentAs');
+const saveContentAs = () => slice(session, 'async function saveContentAs', 'async function toggleTaskCheckbox');
+const guard = () => slice(session, 'function refuseIfLossilyDecoded', 'function updateLoading');
+
+test('one decoder, and it reports what it destroyed', () => {
+	// The fact is known exactly once — when the bytes are decoded — and was
+	// thrown away. `String::from_utf8` returning `Err` IS the fact, so the
+	// shared decoder from #371 carries it instead of growing a second path.
+	assert.match(rust, /struct DecodedText \{[^}]*\bcontent: String,[^}]*\blossy: bool/s);
+	assert.match(rust, /fn decode_utf8_lossy\(bytes: Vec<u8>\) -> DecodedText/);
+	assert.match(rust, /fn read_to_string_lossy\(path: &str\) -> std::io::Result<DecodedText>/);
+	assert.equal(rust.match(/fn decode_utf8/g)?.length, 1, 'exactly one decoder');
+});
+
+test('both read commands can report fidelity', () => {
+	assert.match(rust, /async fn open_markdown_preview\([^)]*\)\s*-> Result<\(String, String, bool, bool\), String>/s);
+	assert.match(rust, /async fn read_file_content_checked\(path: String\) -> Result<\(String, bool\), String>/);
+	assert.match(rust, /read_file_content_checked,/, 'the command must be registered');
+});
+
+test('a preview cut inside a multi-byte character is not called lossy', () => {
+	// The preview stops at a fixed byte count, so a perfectly valid UTF-8 file
+	// is routinely cut mid-character. Reporting that as lossy would lock every
+	// large CJK/emoji document out of saving — a guard worse than the bug.
+	const preview = slice(rust, 'fn build_markdown_preview', '#[tauri::command]');
+	const trim = preview.indexOf('utf8_truncation_boundary');
+	assert.notEqual(trim, -1, 'the split tail must be dropped before decoding');
+	assert.ok(trim < preview.indexOf('decode_utf8_lossy'), 'trim first, then judge fidelity');
+});
+
+test('the tab carries the fidelity of its buffer', () => {
+	// Required, not optional: a construction site that forgot it would default
+	// to "safe to overwrite", and the failure mode is a destroyed document.
+	assert.match(tabs, /hasReplacementChars: boolean;/);
+	assert.doesNotMatch(tabs, /hasReplacementChars\?: boolean;/);
+	assert.match(tabs, /setTabDecodedLossy\(id: string, lossy: boolean\)/);
+	assert.equal(tabs.match(/hasReplacementChars: false/g)?.length, 4);
+});
+
+test('every load decides the flag instead of leaving it stale', () => {
+	// A reload of a file the user has since converted to UTF-8 must clear it.
+	const body = loadMarkdown();
+	assert.match(body, /as \[string, string, boolean, boolean\]/);
+	assert.match(body, /setTabDecodedLossy\(activeId, lossy\)/);
+	// The full load REPLACES the preview's buffer, so it brings its own
+	// verdict: a file can be valid UTF-8 for the first 50KB and not after.
+	assert.match(body, /read_file_content_checked/);
+	assert.match(body, /setTabDecodedLossy\(activeId, fullLossy\)/);
+});
+
+test('the editable-pane shortcut reports fidelity too', () => {
+	// #374 added a second way into loadMarkdown: a pane that can WRITE skips
+	// the preview and reads the whole file up front. That branch fills an
+	// editable buffer, so it is exactly the kind of caller that must not use
+	// the bare command — it would hand the editor unflagged mojibake.
+	const body = loadMarkdown();
+	assert.match(
+		body,
+		/if \(initialIsEditing \|\| initialIsSplit\) \{\s*\[content, lossy\] = \(await invoke\('read_file_content_checked'/,
+	);
+	// `ensureFullContent` is the one place the bare command survives, and only
+	// because it re-reads a file whose tab loadMarkdown already flagged.
+	const bare = session.match(/invoke\('read_file_content'/g)?.length ?? 0;
+	assert.equal(bare, 1, 'only ensureFullContent may use the unchecked command');
+	assert.match(
+		slice(session, 'async function ensureFullContent', 'const lossySaveWarnedTabs'),
+		/invoke\('read_file_content'/,
+	);
+});
+
+test('the flag is set before the buffer can reach a writer', () => {
+	const body = loadMarkdown();
+	const set = body.indexOf('setTabDecodedLossy(activeId, lossy)');
+	const firstAwait = body.indexOf('options.renderMarkdown(content');
+	assert.notEqual(set, -1, 'the preview branch must set the flag');
+	assert.notEqual(firstAwait, -1);
+	assert.ok(set < firstAwait, 'the flag must be set before the first await that follows the load');
+});
+
+test('window restore cannot launder the flag away', () => {
+	// Restore reads each file back into an editable buffer. With the bare
+	// command it produced mojibake that looked safe to save, so reopening the
+	// app was a way around the guard.
+	assert.match(windowSession, /read_file_content_checked/);
+	assert.match(windowSession, /tabManager\.setTabDecodedLossy\(tab\.id, lossy\)/);
+	assert.doesNotMatch(windowSession, /invoke\('read_file_content'/);
+});
+
+test('saveContent refuses to write a lossy buffer over its own file', () => {
+	const body = saveContent();
+	const refusal = body.indexOf('refuseIfLossilyDecoded');
+	assert.notEqual(refusal, -1, 'saveContent must consult the guard');
+	assert.match(body.slice(refusal, refusal + 120), /return false;/);
+	assert.ok(
+		refusal < body.indexOf("invoke('save_file_content'"),
+		'the guard must run before save_file_content is invoked',
+	);
+});
+
+test('the guard protects the source file only', () => {
+	const body = guard();
+	// An untitled buffer has no source file to destroy, and any other path is
+	// a new UTF-8 file — neither is blocked.
+	assert.match(body, /targetPath === ''/);
+	assert.match(body, /targetPath !== tab\.path/);
+	assert.match(body, /return true;/);
+});
+
+test('saveContent is the choke point auto-save and the close dialogs share', () => {
+	// Auto-save lives in MarkdownViewer.svelte's debounce effect and the close
+	// flow in canCloseTab; both call saveContent, so guarding it covers them
+	// without touching either.
+	assert.match(session, /const success = await saveContent\(tabId\);/);
+	const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+	assert.match(viewer, /saveContent\(s\.id\)\.then\(/);
+});
+
+test('Save As to a new file stays open as the escape hatch', () => {
+	const body = saveContentAs();
+	assert.match(body, /invoke\('save_file_content', \{ path: selected, content: snapshot \}\)/);
+	// Once written, the buffer matches a UTF-8 file of its own.
+	assert.match(body, /setTabDecodedLossy\(tab\.id, false\)/);
+});
+
+test('Save As onto the same path is still a destructive overwrite', () => {
+	const body = saveContentAs();
+	const refusal = body.indexOf('refuseIfLossilyDecoded(tab, selected)');
+	assert.notEqual(refusal, -1, 'picking the source file again must be refused');
+	assert.ok(
+		refusal < body.indexOf("invoke('save_file_content'"),
+		'the guard must run before save_file_content is invoked',
+	);
+});
+
+test('the refusal tells the user what to do and is not repeated per keystroke', () => {
+	// Auto-save re-arms on every edit; an undeduplicated toast would fire
+	// every 1.5s. The message names "Save As" because that is the only exit.
+	const body = guard();
+	assert.match(body, /toast\.lossySaveBlocked/);
+	assert.match(body, /lossySaveWarnedTabs\.has\(tab\.id\)/);
+	const i18n = readFileSync('src/lib/utils/i18n.ts', 'utf8');
+	assert.match(i18n, /lossySaveBlocked: 'Not saved: this file is not UTF-8/);
+	assert.match(i18n, /use "Save As" to write a copy/);
+});
+
+// --- Behavioural: the flag survives a cross-window move ------------------
+// tabTransfer.ts is pure, so these run the real code instead of reading it.
+// A moved tab carries its unsaved buffer; if the flag did not travel with it,
+// the destination window would happily overwrite the source file.
+
+function makeTab(overrides: Partial<Tab> = {}): Tab {
+	return {
+		id: 'source-id',
+		path: '/notes/legacy.md',
+		title: 'legacy.md',
+		content: '<p>rendered</p>',
+		rawContent: '# �� mojibake',
+		originalContent: '# �� mojibake',
+		scrollTop: 0,
+		isDirty: false,
+		isEditing: true,
+		history: ['/notes/legacy.md'],
+		historyIndex: 0,
+		editorViewState: null,
+		scrollPercentage: 0,
+		anchorLine: 0,
+		isSplit: false,
+		splitRatio: 0.5,
+		isScrollSynced: false,
+		hasReplacementChars: true,
+		...overrides,
+	};
+}
+
+test('a moved tab arrives still refusing to overwrite its source', () => {
+	const snap = snapshotTab(makeTab());
+	assert.equal(snap.hasReplacementChars, true, 'the snapshot must carry it');
+
+	const validated = validateTransferPayload(JSON.stringify(snap));
+	assert.ok(validated, 'a snapshot of a real tab must validate');
+	assert.equal(validated.hasReplacementChars, true);
+
+	const arrived = buildTransferredTab(validated, [], 'Untitled');
+	assert.equal(arrived.hasReplacementChars, true, 'the guard must survive the move');
+});
+
+test('a faithful buffer arrives savable', () => {
+	const snap = snapshotTab(makeTab({ hasReplacementChars: false, rawContent: '# fine' }));
+	const validated = validateTransferPayload(JSON.stringify(snap));
+	assert.ok(validated);
+	assert.equal(buildTransferredTab(validated, [], 'Untitled').hasReplacementChars, false);
+});
+
+test('a payload without the flag is rejected, not defaulted', () => {
+	// The file's own doctrine: no coercion, no defaults. Defaulting a missing
+	// flag to false would silently re-open the hole for any sender that
+	// forgets it.
+	const snap = snapshotTab(makeTab()) as Record<string, unknown>;
+	delete snap.hasReplacementChars;
+	assert.equal(validateTransferPayload(JSON.stringify(snap)), null);
+});

--- a/scripts/tabTransfer.test.ts
+++ b/scripts/tabTransfer.test.ts
@@ -37,6 +37,7 @@ function makeTab(overrides: Partial<Tab> = {}): Tab {
 		isSplit: true,
 		splitRatio: 0.3,
 		isScrollSynced: true,
+		hasReplacementChars: false,
 		...overrides,
 	};
 }

--- a/scripts/truncatedBufferGuard.test.ts
+++ b/scripts/truncatedBufferGuard.test.ts
@@ -80,8 +80,8 @@ function reset() {
 /** Open a >50KB file and leave the background full read pending forever. */
 async function openPartial(path = '/docs/big.md') {
 	handleInvoke = (cmd) => {
-		if (cmd === 'open_markdown_preview') return ['<p>preview</p>', PARTIAL, false];
-		if (cmd === 'read_file_content') return new Promise(() => {});
+		if (cmd === 'open_markdown_preview') return ['<p>preview</p>', PARTIAL, false, false];
+		if (cmd === 'read_file_content_checked') return new Promise(() => {});
 		throw new Error(`unexpected invoke: ${cmd}`);
 	};
 	const session = makeSession();
@@ -104,7 +104,7 @@ test('a partially loaded buffer is marked as incomplete', async () => {
 test('a fully loaded buffer is not marked as incomplete', async () => {
 	reset();
 	handleInvoke = (cmd) => {
-		if (cmd === 'open_markdown_preview') return ['<p>full</p>', FULL, true];
+		if (cmd === 'open_markdown_preview') return ['<p>full</p>', FULL, true, false];
 		throw new Error(`unexpected invoke: ${cmd}`);
 	};
 	const session = makeSession();
@@ -151,7 +151,7 @@ test('completing a partial buffer replaces it with the whole file and unblocks s
 test('completing a buffer that is already whole does not re-read the file', async () => {
 	reset();
 	handleInvoke = (cmd) => {
-		if (cmd === 'open_markdown_preview') return ['<p>full</p>', FULL, true];
+		if (cmd === 'open_markdown_preview') return ['<p>full</p>', FULL, true, false];
 		throw new Error(`unexpected invoke: ${cmd}`);
 	};
 	const session = makeSession();
@@ -186,8 +186,8 @@ test('a load into an editable pane reads the whole file instead of the preview s
 	// arms auto-save on it.
 	reset();
 	handleInvoke = (cmd) => {
-		if (cmd === 'open_markdown_preview') return ['<p>preview</p>', PARTIAL, false];
-		if (cmd === 'read_file_content') return FULL;
+		if (cmd === 'open_markdown_preview') return ['<p>preview</p>', PARTIAL, false, false];
+		if (cmd === 'read_file_content_checked') return [FULL, false];
 		throw new Error(`unexpected invoke: ${cmd}`);
 	};
 	tabManager.addTab('/docs/big.md', '');
@@ -210,8 +210,8 @@ test('toggling a task checkbox completes the buffer before writing it', async ()
 	const doc = `- [ ] first\n\n${'y'.repeat(PREVIEW_BYTES)}\n\n- [ ] last\n`;
 	const partial = doc.slice(0, PREVIEW_BYTES);
 	handleInvoke = (cmd) => {
-		if (cmd === 'open_markdown_preview') return ['<p>preview</p>', partial, false];
-		if (cmd === 'read_file_content') return new Promise(() => {});
+		if (cmd === 'open_markdown_preview') return ['<p>preview</p>', partial, false, false];
+		if (cmd === 'read_file_content_checked') return new Promise(() => {});
 		throw new Error(`unexpected invoke: ${cmd}`);
 	};
 	const session = makeSession();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -144,20 +144,40 @@ pub(crate) fn atomic_write(target: &Path, bytes: &[u8]) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Text decoded from a file, together with the fidelity of that decode.
+struct DecodedText {
+    content: String,
+    /// `true` when the bytes were not valid UTF-8 and every offending byte was
+    /// replaced with U+FFFD. `content` is then a destructive rendering of the
+    /// file: the original bytes cannot be recovered from it, so writing it
+    /// back over the source file destroys the document permanently. This is
+    /// known exactly once — at the moment of decoding — so it travels to the
+    /// frontend with the text it describes, and the frontend refuses that
+    /// write (see `documentSession.saveContent`).
+    lossy: bool,
+}
+
 /// Decode `bytes` as UTF-8, substituting U+FFFD for invalid sequences rather
 /// than rejecting the whole file. `read_to_string` refuses a document on its
 /// first invalid byte, which made a legacy-encoded (GBK/Big5/Shift-JIS) file
 /// openable or not purely by size: the truncated-preview path has always
 /// decoded leniently, so the same file failed at 50 KB and succeeded at
-/// 51 KB. Every read path now uses one decoder.
-fn decode_utf8_lossy(bytes: Vec<u8>) -> String {
+/// 51 KB. Every read path now uses one decoder — and every read path reports
+/// whether that decoder had to destroy anything.
+fn decode_utf8_lossy(bytes: Vec<u8>) -> DecodedText {
     match String::from_utf8(bytes) {
-        Ok(text) => text,
-        Err(error) => String::from_utf8_lossy(error.as_bytes()).into_owned(),
+        Ok(content) => DecodedText {
+            content,
+            lossy: false,
+        },
+        Err(error) => DecodedText {
+            content: String::from_utf8_lossy(error.as_bytes()).into_owned(),
+            lossy: true,
+        },
     }
 }
 
-fn read_to_string_lossy(path: &str) -> std::io::Result<String> {
+fn read_to_string_lossy(path: &str) -> std::io::Result<DecodedText> {
     Ok(decode_utf8_lossy(fs::read(path)?))
 }
 
@@ -397,9 +417,106 @@ mod tests {
 
         let decoded = read_to_string_lossy(path.to_str().unwrap())
             .expect("lenient decoding must open the file instead of failing");
-        assert!(decoded.contains('\u{FFFD}'), "got: {decoded:?}");
+        assert!(decoded.content.contains('\u{FFFD}'), "got: {:?}", decoded.content);
 
         fs::remove_file(path).unwrap();
+    }
+
+    // --- Decode fidelity ------------------------------------------------
+    //
+    // Opening these files leniently is deliberate (above). What must never
+    // follow is writing the result back: U+FFFD is not reversible, so an
+    // auto-save 1.5s after the first keystroke would destroy a document that
+    // was merely in another encoding. Every read path therefore reports
+    // whether its decode was destructive, and the frontend refuses that write
+    // (documentSession.saveContent). These pin the reporting half.
+    const GBK_ZHONGWEN: &[u8] = &[0xD6, 0xD0, 0xCE, 0xC4];
+
+    #[test]
+    fn gbk_bytes_are_reported_as_a_lossy_decode() {
+        let decoded = decode_utf8_lossy(GBK_ZHONGWEN.to_vec());
+        assert!(decoded.lossy, "GBK bytes cannot decode faithfully as UTF-8");
+        assert!(
+            decoded.content.contains('\u{FFFD}'),
+            "expected replacement characters, got {:?}",
+            decoded.content,
+        );
+    }
+
+    #[test]
+    fn valid_utf8_is_reported_as_faithful() {
+        let decoded = decode_utf8_lossy("中文".as_bytes().to_vec());
+        assert!(!decoded.lossy);
+        assert_eq!(decoded.content, "中文");
+    }
+
+    #[test]
+    fn read_file_content_checked_reports_a_lossy_file() {
+        // The tripwire that used to assert `read_file_content` REFUSES these
+        // bytes. #371 made every read path lenient, so refusing is no longer
+        // the protection — reporting is. A caller that fills an editable
+        // buffer must use this command and carry the flag onto the tab.
+        let path = temp_path("gbk-checked.md");
+        fs::write(&path, GBK_ZHONGWEN).unwrap();
+
+        let decoded = read_to_string_lossy(path.to_str().unwrap()).unwrap();
+        fs::remove_file(&path).unwrap();
+
+        assert!(
+            decoded.lossy,
+            "read_file_content_checked returned mojibake without reporting it",
+        );
+        assert!(decoded.content.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn a_small_non_utf8_file_is_flagged_by_the_preview_too() {
+        // The ≤max_bytes branch. Before #371 it decoded strictly and could
+        // only fail, so it needed no flag; now it opens the same mojibake the
+        // truncated branch always did, and needs the same guard.
+        let path = temp_path("gbk-small.md");
+        let mut bytes = b"# ".to_vec();
+        bytes.extend_from_slice(GBK_ZHONGWEN);
+        fs::write(&path, &bytes).unwrap();
+
+        let preview = build_markdown_preview(&path, 50_000).unwrap();
+        fs::remove_file(&path).unwrap();
+
+        assert!(preview.is_full, "this file fits in the preview budget");
+        assert!(preview.lossy, "the save guard has nothing to go on without this");
+        assert!(preview.content.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn an_oversized_non_utf8_preview_is_flagged() {
+        let path = temp_path("gbk-preview.md");
+        let mut bytes = b"# ".to_vec();
+        bytes.extend_from_slice(GBK_ZHONGWEN);
+        bytes.extend_from_slice(b"\nplus enough text to exceed the preview budget\n");
+        fs::write(&path, &bytes).unwrap();
+
+        let preview = build_markdown_preview(&path, 8).unwrap();
+        fs::remove_file(&path).unwrap();
+
+        assert!(!preview.is_full);
+        assert!(preview.lossy);
+        assert!(preview.content.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn an_oversized_utf8_preview_is_not_flagged() {
+        // The preview budget lands inside a multi-byte character. Reporting
+        // that as lossy would lock every large CJK or emoji document out of
+        // saving — a guard worse than the bug it protects against.
+        let path = temp_path("utf8-preview.md");
+        fs::write(&path, "中文标题很长".as_bytes()).unwrap();
+
+        let preview = build_markdown_preview(&path, 4).unwrap();
+        fs::remove_file(&path).unwrap();
+
+        assert!(!preview.is_full);
+        assert!(!preview.lossy, "unexpected flag on {:?}", preview.content);
+        assert_eq!(preview.content, "中");
     }
 
     #[test]
@@ -1285,37 +1402,75 @@ async fn open_markdown(path: String) -> Result<String, String> {
     .unwrap_or_else(|e| Err(e.to_string()))
 }
 
+struct MarkdownPreview {
+    html: String,
+    content: String,
+    is_full: bool,
+    lossy: bool,
+}
+
+/// The body of `open_markdown_preview`, kept synchronous and path-taking so
+/// the decode-fidelity behaviour can be exercised against real files.
+fn build_markdown_preview(path: &Path, max_bytes: usize) -> Result<MarkdownPreview, String> {
+    use std::io::Read;
+    let path_str = path.to_str().ok_or("Invalid path")?;
+    let mut f = fs::File::open(path).map_err(|e| e.to_string())?;
+
+    let metadata = f.metadata().map_err(|e| e.to_string())?;
+    if metadata.len() <= max_bytes as u64 {
+        let decoded = read_to_string_lossy(path_str).map_err(|e| e.to_string())?;
+        let html = convert_markdown(&decoded.content);
+        return Ok(MarkdownPreview {
+            html,
+            content: decoded.content,
+            is_full: true,
+            lossy: decoded.lossy,
+        });
+    }
+
+    // `Read::read` only guarantees *at most* `buf.len()` bytes and may
+    // return a short read for reasons that have nothing to do with EOF,
+    // truncating the preview well below the requested budget.
+    // `take(..).read_to_end(..)` keeps reading to the limit or EOF.
+    let mut vec_buf = Vec::new();
+    Read::by_ref(&mut f)
+        .take(max_bytes as u64)
+        .read_to_end(&mut vec_buf)
+        .map_err(|e| e.to_string())?;
+    // The cut lands on a raw byte offset, which can slice a multi-byte
+    // character in half; drop the partial tail instead of rendering it as
+    // a replacement character. This also keeps a perfectly good UTF-8 file
+    // from being reported as a lossy decode just because the preview budget
+    // fell inside one of its characters.
+    vec_buf.truncate(utf8_truncation_boundary(&vec_buf));
+
+    let preview = decode_utf8_lossy(vec_buf);
+
+    let html = convert_markdown(&preview.content);
+    Ok(MarkdownPreview {
+        html,
+        content: preview.content,
+        is_full: false,
+        lossy: preview.lossy,
+    })
+}
+
+/// Returns `(html, content, is_full, lossy)`. See `DecodedText::lossy`: the
+/// frontend uses it to refuse writing the buffer back over a file it could
+/// not decode faithfully.
 #[tauri::command]
-async fn open_markdown_preview(path: String, max_bytes: usize) -> Result<(String, String, bool), String> {
+async fn open_markdown_preview(
+    path: String,
+    max_bytes: usize,
+) -> Result<(String, String, bool, bool), String> {
     tauri::async_runtime::spawn_blocking(move || {
-        use std::io::Read;
-        let mut f = fs::File::open(&path).map_err(|e| e.to_string())?;
-        
-        let metadata = f.metadata().map_err(|e| e.to_string())?;
-        if metadata.len() <= max_bytes as u64 {
-            let content = read_to_string_lossy(&path).map_err(|e| e.to_string())?;
-            let html = convert_markdown(&content);
-            return Ok((html, content, true));
-        }
-
-        // `Read::read` only guarantees *at most* `buf.len()` bytes and may
-        // return a short read for reasons that have nothing to do with EOF,
-        // truncating the preview well below the requested budget.
-        // `take(..).read_to_end(..)` keeps reading to the limit or EOF.
-        let mut vec_buf = Vec::new();
-        Read::by_ref(&mut f)
-            .take(max_bytes as u64)
-            .read_to_end(&mut vec_buf)
-            .map_err(|e| e.to_string())?;
-        // The cut lands on a raw byte offset, which can slice a multi-byte
-        // character in half; drop the partial tail instead of rendering it as
-        // a replacement character.
-        vec_buf.truncate(utf8_truncation_boundary(&vec_buf));
-
-        let preview_content = decode_utf8_lossy(vec_buf);
-
-        let html = convert_markdown(&preview_content);
-        Ok((html, preview_content, false))
+        let preview = build_markdown_preview(Path::new(&path), max_bytes)?;
+        Ok((
+            preview.html,
+            preview.content,
+            preview.is_full,
+            preview.lossy,
+        ))
     })
     .await
     .unwrap_or_else(|e| Err(e.to_string()))
@@ -1339,7 +1494,26 @@ async fn render_markdown(content: String) -> Result<String, String> {
 #[tauri::command]
 async fn read_file_content(path: String) -> Result<String, String> {
     tauri::async_runtime::spawn_blocking(move || {
-        read_to_string_lossy(&path).map_err(|e| e.to_string())
+        read_to_string_lossy(&path)
+            .map(|decoded| decoded.content)
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .unwrap_or_else(|e| Err(e.to_string()))
+}
+
+/// `read_file_content` plus the fidelity of the decode: returns
+/// `(content, lossy)`. Since every read path decodes leniently, a caller that
+/// puts the text into an EDITABLE buffer must use this one and carry `lossy`
+/// onto the tab — otherwise the first auto-save writes U+FFFD over a file
+/// that was merely in another encoding. The bare `read_file_content` remains
+/// for callers that re-read a file whose tab is already flagged.
+#[tauri::command]
+async fn read_file_content_checked(path: String) -> Result<(String, bool), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        read_to_string_lossy(&path)
+            .map(|decoded| (decoded.content, decoded.lossy))
+            .map_err(|e| e.to_string())
     })
     .await
     .unwrap_or_else(|e| Err(e.to_string()))
@@ -2226,6 +2400,7 @@ pub fn run() {
             render_markdown,
             send_markdown_path,
             read_file_content,
+            read_file_content_checked,
             read_file_as_data_url,
             save_file_content,
             export_pdf_windows,

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -1,8 +1,9 @@
 import { invoke } from '@tauri-apps/api/core';
 import { save } from '@tauri-apps/plugin-dialog';
 import { settings } from '../stores/settings.svelte.js';
-import { tabManager } from '../stores/tabs.svelte.js';
+import { tabManager, type Tab } from '../stores/tabs.svelte.js';
 import { getMarkdownBodyWithoutFrontMatter } from '../utils/frontMatter.js';
+import { t } from '../utils/i18n.js';
 import { hasMarkdownLinkExtension } from '../utils/markdownLinks.js';
 
 export type LoadMarkdownOptions = {
@@ -115,6 +116,11 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		if (!tab.path) return true;
 		if (tab.isDirty) return false;
 		try {
+			// Safe on the bare command: this only re-reads a file whose tab was
+			// already flagged by `loadMarkdown`, and `setTabRawContent` does not
+			// clear that flag. Migrating it to `read_file_content_checked` is
+			// still worth doing — see the note on the two MarkdownViewer call
+			// sites — but nothing depends on it today.
 			const full = (await invoke('read_file_content', { path: tab.path })) as string;
 			tabManager.setTabRawContent(tabId, full);
 			return true;
@@ -122,6 +128,44 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 			options.onError('Error loading the rest of the file', error);
 			return false;
 		}
+	}
+
+	// Tabs already told about a refused save. Auto-save re-arms on every
+	// edit, so an undeduplicated toast would fire every 1.5s while typing.
+	const lossySaveWarnedTabs = new Set<string>();
+
+	/**
+	 * Refuse to write a buffer back over the file it was decoded from when
+	 * that decode was lossy: the file is not UTF-8, the bytes it disagreed
+	 * with are already U+FFFD in the buffer, and the original is unrecoverable
+	 * from it. Every writer — Ctrl+S, the auto-save timer in
+	 * MarkdownViewer.svelte, the close dialogs in canCloseTab, the task
+	 * checkbox — funnels through saveContent/saveContentAs, so this is the
+	 * one place that has to hold.
+	 *
+	 * Only the SOURCE file is protected. Save As to any other path writes a
+	 * genuine UTF-8 file, which is correct and is the user's way out; an
+	 * untitled buffer (path === '') has no source file to destroy.
+	 *
+	 * This is damage control, not encoding support: Markpad cannot read GBK
+	 * or Shift-JIS in the first place (that needs a real decoder), and this
+	 * only stops it from overwriting what it could not read.
+	 *
+	 * Known boundary: the comparison is exact string equality, so on a
+	 * case-insensitive filesystem (macOS, Windows) a Save As typed as
+	 * `/notes/Legacy.md` for a tab opened as `/notes/legacy.md` reads as a
+	 * different path and is allowed through. Closing that needs the backend
+	 * to canonicalize both sides; the same-path check is a courtesy on top of
+	 * the guard that matters, which is saveContent.
+	 */
+	function refuseIfLossilyDecoded(tab: Tab, targetPath: string): boolean {
+		if (!tab.hasReplacementChars || targetPath === '' || targetPath !== tab.path) return false;
+		console.warn('Refusing to overwrite a file that was decoded lossily', tab.path);
+		if (!lossySaveWarnedTabs.has(tab.id)) {
+			lossySaveWarnedTabs.add(tab.id);
+			options.onError(t('toast.lossySaveBlocked', settings.language), tab.path);
+		}
+		return true;
 	}
 
 	function updateLoading(tabId: string, loading: boolean) {
@@ -167,12 +211,18 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 				// from disk" take while edit or split mode is preserved.
 				let content: string;
 				let isFull: boolean;
+				let lossy: boolean;
 				if (initialIsEditing || initialIsSplit) {
-					content = (await invoke('read_file_content', { path: filePath })) as string;
+					[content, lossy] = (await invoke('read_file_content_checked', { path: filePath })) as [string, boolean];
 					isFull = true;
 				} else {
-					[, content, isFull] = (await invoke('open_markdown_preview', { path: filePath, maxBytes: 50000 })) as [string, string, boolean];
+					[, content, isFull, lossy] = (await invoke('open_markdown_preview', { path: filePath, maxBytes: 50000 })) as [string, string, boolean, boolean];
 				}
+				// Decided on every load, before the buffer can reach a writer.
+				// Both branches report it, so this also CLEARS the flag on a
+				// file the user has since converted to UTF-8.
+				tabManager.setTabDecodedLossy(activeId, lossy);
+				lossySaveWarnedTabs.delete(activeId);
 				if (pendingNavigateTabId) tabManager.navigate(pendingNavigateTabId, filePath);
 				const processed = await options.renderMarkdown(content, filePath);
 				tabManager.updateTabContent(activeId, processed);
@@ -188,8 +238,8 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 					};
 					updateLoading(activeId, true);
 					options.measureInitialViewport();
-					(invoke('read_file_content', { path: filePath }) as Promise<string>)
-						.then((fullContent) => {
+					(invoke('read_file_content_checked', { path: filePath }) as Promise<[string, boolean]>)
+						.then(([fullContent, fullLossy]) => {
 							const applyFull = () => {
 								try {
 									if (options.isScrolling()) return void setTimeout(applyFull, 100);
@@ -199,6 +249,11 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 											if (!canApplyFullLoad()) return updateLoading(activeId, false);
 											tabManager.updateTabContent(activeId, fullProcessed);
 											tabManager.setTabRawContent(activeId, fullContent);
+											// This buffer REPLACES the preview's, so it
+											// carries its own verdict — the preview only
+											// saw the first 50KB and a file can be valid
+											// UTF-8 up to there and not after.
+											tabManager.setTabDecodedLossy(activeId, fullLossy);
 											updateLoading(activeId, false);
 											if (tabManager.activeTabId === activeId) setTimeout(options.renderRichContent, 10);
 										})
@@ -220,7 +275,9 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 						});
 				}
 			} else {
-				const content = (await invoke('read_file_content', { path: filePath })) as string;
+				const [content, lossy] = (await invoke('read_file_content_checked', { path: filePath })) as [string, boolean];
+				tabManager.setTabDecodedLossy(activeId, lossy);
+				lossySaveWarnedTabs.delete(activeId);
 				if (pendingNavigateTabId) tabManager.navigate(pendingNavigateTabId, filePath);
 				if (tab) tab.isEditing = true;
 				tabManager.setTabRawContent(activeId, content);
@@ -258,6 +315,7 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 			if (!selected) return false;
 			targetPath = selected;
 		}
+		if (refuseIfLossilyDecoded(tab, targetPath)) return false;
 		const snapshot = tab.rawContent;
 		markSelfWrite(targetPath);
 		try {
@@ -293,12 +351,19 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 			defaultPath: tab.path || undefined,
 		});
 		if (!selected) return false;
+		// Picking the source file again in the dialog is the same destructive
+		// overwrite, just reached another way.
+		if (refuseIfLossilyDecoded(tab, selected)) return false;
 		const snapshot = tab.rawContent;
 		markSelfWrite(selected);
 		try {
 			await invoke('save_file_content', { path: selected, content: snapshot });
 			markSelfWrite(selected);
 			tabManager.updateTabPath(tab.id, selected);
+			// The buffer now has a UTF-8 file of its own that it matches
+			// exactly, so it is safe to save from here on.
+			tabManager.setTabDecodedLossy(tab.id, false);
+			lossySaveWarnedTabs.delete(tab.id);
 			options.saveRecentFile(selected);
 			tab.originalContent = snapshot;
 			tab.isDirty = tab.rawContent !== snapshot;

--- a/src/lib/sessions/windowSession.svelte.ts
+++ b/src/lib/sessions/windowSession.svelte.ts
@@ -1,5 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { getCurrentWindow } from '@tauri-apps/api/window';
+import { tabManager } from '../stores/tabs.svelte.js';
 import { validateTransferPayload, type TransferableTab } from '../utils/tabTransfer.js';
 
 type RestoredTab = {
@@ -76,9 +77,15 @@ export function createWindowSession(options: WindowSessionOptions) {
 				options.restoreState(savedData);
 				for (const tab of options.restoredTabs()) {
 					try {
-						const raw = (await invoke('read_file_content', { path: tab.path })) as string;
+						// `_checked`, because restore fills an editable buffer: reads
+						// decode leniently, so a file in a legacy encoding comes back
+						// as U+FFFD mojibake that must never be written over its
+						// source. Without this, reopening the app laundered the flag
+						// away and the next auto-save destroyed the document.
+						const [raw, lossy] = (await invoke('read_file_content_checked', { path: tab.path })) as [string, boolean];
 						if (options.isDisposed()) return;
 						await options.applyRestoredContent(tab.id, raw);
+						tabManager.setTabDecodedLossy(tab.id, lossy);
 						if (options.isDisposed()) return;
 					} catch (error) {
 						if (options.isDisposed()) return;

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -39,6 +39,17 @@ export interface Tab {
 	 * from a cross-window transfer payload always arrive complete.
 	 */
 	isTruncated?: boolean;
+	/**
+	 * `rawContent` was decoded with U+FFFD substitutions because the file is
+	 * not UTF-8 (GBK, Big5, Shift-JIS ...). The buffer is NOT a copy of the
+	 * file and the original bytes cannot be recovered from it, so writing it
+	 * back over that file destroys the document — documentSession.saveContent
+	 * refuses to. Required, not optional: unlike `isTruncated` above, this one
+	 * DOES travel through a transfer payload, and a construction site that
+	 * forgets it would default to "safe to overwrite" — the failure mode here
+	 * is a destroyed document, so the compiler asks every one of them.
+	 */
+	hasReplacementChars: boolean;
 }
 
 class TabManager {
@@ -147,7 +158,8 @@ class TabManager {
 					isSplit: saved.isSplit === true,
 					splitRatio: typeof saved.splitRatio === 'number' ? saved.splitRatio : 0.5,
 					isScrollSynced: saved.isScrollSynced === true,
-					isTruncated: false
+					isTruncated: false,
+					hasReplacementChars: false
 				});
 			}
 
@@ -188,7 +200,8 @@ class TabManager {
 			isSplit: false,
 			splitRatio: 0.5,
 			isScrollSynced: false,
-			isTruncated: false
+			isTruncated: false,
+			hasReplacementChars: false
 		});
 
 		this.activeTabId = id;
@@ -219,7 +232,8 @@ class TabManager {
 			isSplit: false,
 			splitRatio: 0.5,
 			isScrollSynced: false,
-			isTruncated: false
+			isTruncated: false,
+			hasReplacementChars: false
 		});
 
 		this.activeTabId = id;
@@ -251,7 +265,8 @@ class TabManager {
 			isSplit: false,
 			splitRatio: 0.5,
 			isScrollSynced: false,
-			isTruncated: false
+			isTruncated: false,
+			hasReplacementChars: false
 		});
 
 		this.activeTabId = id;
@@ -333,6 +348,18 @@ class TabManager {
 			tab.originalContent = raw;
 			tab.isDirty = false;
 			tab.isTruncated = isTruncated;
+		}
+	}
+
+	/**
+	 * Record whether this buffer came from a lossy decode. Set on every load,
+	 * both ways: a file the user has since converted to UTF-8 must clear the
+	 * flag, and Save As clears it once the buffer has a UTF-8 file of its own.
+	 */
+	setTabDecodedLossy(id: string, lossy: boolean) {
+		const tab = this.tabs.find((t) => t.id === id);
+		if (tab) {
+			tab.hasReplacementChars = lossy;
 		}
 	}
 

--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -253,7 +253,8 @@ export const translations: Record<LanguageCode, Translation> = {
 			noOtherWindows: 'No other windows to merge',
             savedNewerEdits: 'Saved — staying in edit mode because you have newer edits',
             openExportedFileFailed: 'Could not open exported file',
-            partialDocument: 'Cannot edit yet — this file is not fully loaded'
+            partialDocument: 'Cannot edit yet — this file is not fully loaded',
+            lossySaveBlocked: 'Not saved: this file is not UTF-8, so parts of it became "�" when it was opened. Saving would destroy the original — use "Save As" to write a copy'
         },
         externalChange: {
             message: 'This file changed on disk while you had unsaved changes.',
@@ -596,7 +597,8 @@ export const translations: Record<LanguageCode, Translation> = {
 			noOtherWindows: '没有其他可合并的窗口',
 			savedNewerEdits: '已保存 — 因为存在更新的编辑,继续保持编辑模式',
 			openExportedFileFailed: '无法打开导出的文件',
-			partialDocument: '暂时无法编辑 — 文件尚未完整加载'
+			partialDocument: '暂时无法编辑 — 文件尚未完整加载',
+			lossySaveBlocked: '未保存：此文件不是 UTF-8 编码，打开时部分内容已变成“�”。直接保存会破坏原文件 — 请用“另存为”写入新文件'
         },
         externalChange: {
             message: '此文件在你有未保存修改时被外部程序改动。',
@@ -902,7 +904,8 @@ export const translations: Record<LanguageCode, Translation> = {
             failedToCopyCode: 'コードのコピーに失敗しました',
             unsupportedFile: 'サポートされていないファイル形式: {{filename}}',
             autoSaveFailed: '自動保存に失敗しました — 未保存の変更はメモリ内に残っています',
-            savedNewerEdits: '保存しました — 新しい編集があるため編集モードを継続します'
+            savedNewerEdits: '保存しました — 新しい編集があるため編集モードを継続します',
+            lossySaveBlocked: '保存しませんでした：このファイルは UTF-8 ではないため、開いた時点で一部が「�」に置き換わっています。上書き保存すると元のファイルが壊れます —「名前を付けて保存」で新しいファイルに書き出してください'
         },
         modal: {
             confirmExit: '終了を確認',
@@ -1205,7 +1208,8 @@ export const translations: Record<LanguageCode, Translation> = {
             autoSaveFailed: '自動儲存失敗——未儲存的變更仍保留於記憶體中',
             noOtherWindows: '無其它可合併的視窗',
             savedNewerEdits: '已儲存——因有更新的編輯內容，繼續保持編輯模式',
-            openExportedFileFailed: '無法開啟匯出的檔案'
+            openExportedFileFailed: '無法開啟匯出的檔案',
+            lossySaveBlocked: '未儲存：此檔案不是 UTF-8 編碼，開啟時部分內容已變成「�」。直接儲存會破壞原檔案 — 請用「另存新檔」寫入新檔案'
         },
         modal: {
             confirmExit: '確認結束',
@@ -1544,7 +1548,8 @@ export const translations: Record<LanguageCode, Translation> = {
             unsupportedFile: '지원되지 않는 파일 형식: {{filename}}',
             autoSaveFailed: '자동 저장 실패 — 저장되지 않은 변경 사항은 메모리에 남아 있습니다',
             savedNewerEdits: '저장됨 — 새로운 편집이 있어 편집 모드를 유지합니다',
-            openExportedFileFailed: '내보낸 파일을 열 수 없습니다'
+            openExportedFileFailed: '내보낸 파일을 열 수 없습니다',
+            lossySaveBlocked: '저장하지 않음: 이 파일은 UTF-8이 아니어서 열 때 일부가 "�"로 바뀌었습니다. 덮어쓰면 원본이 손상됩니다 — "다른 이름으로 저장"으로 새 파일에 저장하세요'
         },
         modal: {
             confirmExit: '종료 확인',
@@ -1844,7 +1849,8 @@ export const translations: Record<LanguageCode, Translation> = {
             failedToCopyCode: 'Не удалось скопировать код',
             unsupportedFile: 'Неподдерживаемый тип файла: {{filename}}',
             autoSaveFailed: 'Автосохранение не удалось — несохранённые правки остались только в памяти',
-            savedNewerEdits: 'Сохранено — остаюсь в режиме редактирования, так как есть более новые правки'
+            savedNewerEdits: 'Сохранено — остаюсь в режиме редактирования, так как есть более новые правки',
+            lossySaveBlocked: 'Не сохранено: файл не в кодировке UTF-8, при открытии часть содержимого стала «�». Сохранение уничтожит оригинал — используйте «Сохранить как» для записи копии'
         },
         modal: {
             confirmExit: 'Подтвердить выход',

--- a/src/lib/utils/tabTransfer.ts
+++ b/src/lib/utils/tabTransfer.ts
@@ -24,6 +24,14 @@ export interface TransferableTab {
 	isEditing: boolean;
 	isSplit: boolean;
 	isScrollSynced: boolean;
+	/**
+	 * Travels with the buffer because the guard it feeds is about the buffer,
+	 * not about the window: a tab whose text was decoded with U+FFFD
+	 * substitutions must keep refusing to overwrite its source file after it
+	 * moves. Dropping it here would hand the destination window a buffer that
+	 * looks safe to save. See `Tab.hasReplacementChars`.
+	 */
+	hasReplacementChars: boolean;
 	splitRatio: number;
 	scrollTop: number;
 	scrollPercentage: number;
@@ -33,7 +41,13 @@ export interface TransferableTab {
 }
 
 const STRING_FIELDS = ['path', 'title', 'rawContent', 'originalContent'] as const;
-const BOOLEAN_FIELDS = ['isDirty', 'isEditing', 'isSplit', 'isScrollSynced'] as const;
+const BOOLEAN_FIELDS = [
+	'isDirty',
+	'isEditing',
+	'isSplit',
+	'isScrollSynced',
+	'hasReplacementChars',
+] as const;
 const NUMBER_FIELDS = [
 	'splitRatio',
 	'scrollTop',
@@ -53,6 +67,7 @@ export function snapshotTab(tab: Tab): TransferableTab {
 		isEditing: tab.isEditing,
 		isSplit: tab.isSplit,
 		isScrollSynced: tab.isScrollSynced,
+		hasReplacementChars: tab.hasReplacementChars,
 		splitRatio: tab.splitRatio,
 		scrollTop: tab.scrollTop,
 		scrollPercentage: tab.scrollPercentage,
@@ -105,6 +120,7 @@ export function validateTransferPayload(json: string): TransferableTab | null {
 		isEditing: obj.isEditing as boolean,
 		isSplit: obj.isSplit as boolean,
 		isScrollSynced: obj.isScrollSynced as boolean,
+		hasReplacementChars: obj.hasReplacementChars as boolean,
 		splitRatio: obj.splitRatio as number,
 		scrollTop: obj.scrollTop as number,
 		scrollPercentage: obj.scrollPercentage as number,
@@ -163,5 +179,6 @@ export function buildTransferredTab(
 		isSplit: snap.isSplit,
 		splitRatio: snap.splitRatio,
 		isScrollSynced: snap.isScrollSynced,
+		hasReplacementChars: snap.hasReplacementChars,
 	};
 }


### PR DESCRIPTION
## The problem

#371 made every read path decode leniently, which is the right call for *opening* a file: a document in a legacy encoding (GBK, Big5, Shift-JIS, EUC-KR, CP1251…) now opens as U+FFFD mojibake instead of failing outright, and it no longer opens-or-fails purely by size.

What must not follow is writing that buffer back. U+FFFD is not reversible — the original bytes are gone from the buffer, so saving replaces a readable document with permanent mojibake. With auto-save on, that happens **1.5s after the user's first keystroke**, before they have any chance to realise the file was never really loaded.

Two paths made it worse than it looks:

- the `≤ max_bytes` branch of `open_markdown_preview` became lenient too, so small legacy-encoded files went straight into an editable buffer with nothing marking them;
- session restore read through the bare command, so **relaunching the app laundered the fact away** even if it had been known before.

## The fix

Both read commands report the fidelity of their decode, the tab carries it, and `documentSession` refuses to write such a buffer over the file it came from. Every writer — <kbd>Ctrl</kbd>+<kbd>S</kbd>, the auto-save timer, the close dialogs, the task-checkbox toggle — funnels through `saveContent`/`saveContentAs`, so that is the one place that has to hold.

**Save As to a different path stays open.** The new file is genuinely UTF-8, so writing it is correct, and it is the user's way out; the flag clears once the buffer has a file of its own. Picking the *source* file again in the dialog is refused, because that is the same destructive overwrite reached another way.

This is damage control, not encoding support. Markpad still cannot read GBK — that needs a real decoder. This only stops it from overwriting what it could not read.

### Details worth a reviewer's eye

- `decode_utf8_lossy` returns `DecodedText { content, lossy }`. Still exactly one decoder (a test pins that); it just no longer throws away what `String::from_utf8` already told it.
- **`read_file_content` keeps its shape**; `read_file_content_checked` is added alongside. Its two remaining callers are in `MarkdownViewer.svelte` and read the result through `(await invoke(…)) as string` — an assertion, not a check — so returning a tuple would have type-checked cleanly and turned `rawContent` into an array at runtime. Those two call sites only re-read a file whose tab is already flagged, so they are safe today; migrating them is a small follow-up.
- **The truncation order is load-bearing.** The preview trims to a UTF-8 character boundary *before* decoding, so a valid file cut mid-character is not misreported. Reversed, every large CJK or emoji document would be permanently locked out of saving — a guard worse than the bug. Both directions are pinned by tests.
- `hasReplacementChars` is a **required** field of the cross-window transfer payload, strictly validated, following that module's existing rule that a missing field is rejected rather than defaulted. A falsy default here reads as "safe to overwrite", and the failure mode is a destroyed document. The broker is in-memory and both windows are the same binary, so there is no version skew to tolerate.
- Known boundary, documented in the code: the same-path comparison is exact string equality, so on a case-insensitive filesystem a Save As typed as `/notes/Legacy.md` for a tab opened as `/notes/legacy.md` is allowed through. Closing that needs the backend to canonicalize both sides; the same-path check is a courtesy on top of the guard that matters.

## Tests

16 new behaviour tests (`scripts/lossyDecodeSaveGuard.test.ts`) plus 6 Rust tests. Run against unmodified `master`, **15 of the 16 fail**. The one that passes is a deliberate anchor on existing structure — that auto-save and the close dialogs share `saveContent` — so it turns red if a future change routes a writer around the choke point.

```
npm run check   0 errors, 0 warnings
npm test        248 / 248
cargo test      82 / 82
```

## Follow-up (not in this PR)

When the guard refuses, `saveContent` returns `false`, and the auto-save timer in `MarkdownViewer.svelte` toasts its generic "Auto-save failed" on every re-arm. The specific explanation here is shown once per tab, but the generic one still repeats while typing. Quieting it needs `MarkdownViewer.svelte`, which #374 is currently changing; it is best done together with migrating the two `read_file_content` call sites noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)