### PR TITLE
fix(export): carry the theme into exported HTML, and stop cutting collapsed sections

### DIFF
--- a/scripts/exportFoldParity.test.ts
+++ b/scripts/exportFoldParity.test.ts
@@ -1,0 +1,317 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import { buildExportDocument } from '../src/lib/utils/export.js';
+
+const styles = readFileSync('src/styles.css', 'utf8');
+const exportSource = readFileSync('src/lib/utils/export.ts', 'utf8');
+
+// Both export routes have to agree on what is in the file. The HTML route
+// decides in TypeScript (it renders every fold open); the print/PDF route
+// decides in CSS, because it prints the live DOM with its folds still
+// collapsed. So the question "does a collapsed section survive the export" is,
+// on the print side, a cascade question — and it is answered here by resolving
+// the cascade rather than by grepping for a declaration, so that a later rule
+// re-hiding the section fails this file no matter how it is spelled.
+
+type Declaration = { property: string; value: string; important: boolean };
+type Rule = { selector: string; declarations: Declaration[]; order: number; media: 'all' | 'print' | 'other' };
+type Element = { tag: string; classes: string[] };
+
+function stripComments(css: string): string {
+	return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+function parseDeclarations(body: string): Declaration[] {
+	const declarations: Declaration[] = [];
+	for (const piece of body.split(';')) {
+		const colon = piece.indexOf(':');
+		if (colon === -1) continue;
+		const property = piece.slice(0, colon).trim().toLowerCase();
+		let value = piece.slice(colon + 1).trim();
+		if (!property || !value) continue;
+		const important = /!important$/i.test(value);
+		if (important) value = value.replace(/!important$/i, '').trim();
+		declarations.push({ property, value, important });
+	}
+	return declarations;
+}
+
+/** Flattens the sheet into style rules, remembering which @media block each came from. */
+function parseRules(css: string): Rule[] {
+	const rules: Rule[] = [];
+	let order = 0;
+
+	const walk = (source: string, media: Rule['media']) => {
+		let index = 0;
+		while (index < source.length) {
+			const open = source.indexOf('{', index);
+			if (open === -1) return;
+			const prelude = source.slice(index, open).trim();
+
+			let depth = 0;
+			let close = open;
+			for (; close < source.length; close += 1) {
+				if (source[close] === '{') depth += 1;
+				else if (source[close] === '}') {
+					depth -= 1;
+					if (depth === 0) break;
+				}
+			}
+			assert.ok(close < source.length, `unterminated block after ${prelude.slice(0, 40)}`);
+			const body = source.slice(open + 1, close);
+
+			if (prelude.startsWith('@')) {
+				const nested = /^@(media|supports|layer|container)\b/.test(prelude);
+				if (nested) {
+					const isPrint = /@media[^{]*\bprint\b/.test(prelude);
+					walk(body, isPrint ? 'print' : media === 'print' ? 'print' : 'other');
+				}
+			} else {
+				const declarations = parseDeclarations(body);
+				for (const selector of prelude.split(',')) {
+					const trimmed = selector.trim();
+					if (trimmed) rules.push({ selector: trimmed, declarations, order: order++, media });
+				}
+			}
+			index = close + 1;
+		}
+	};
+
+	walk(css, 'all');
+	return rules;
+}
+
+// The elements below are modelled as they exist while printing a document:
+// classed, attribute-free, and never hovered or focused. That is what lets a
+// compound the matcher cannot fully parse still be answered definitively —
+// `[open]`, `:hover` and `::selection` simply cannot apply to them.
+const NEVER_IN_PRINT =
+	/:(?:hover|focus|focus-visible|focus-within|active|target|before|after|marker|placeholder|selection|backdrop|first-line|first-letter)\b|::/;
+const NEEDS_SIBLINGS = /[+~]/;
+const STRUCTURAL = /:(?:first|last|only|nth)-[a-z-]+/;
+
+/** false: cannot match this element. 'unsupported': the matcher cannot tell. */
+function compoundMatches(compound: string, element: Element): boolean | 'unsupported' {
+	if (NEVER_IN_PRINT.test(compound)) return false;
+	if (/\[/.test(compound)) return false;
+	// The app chrome (`#app`) is an id; the fold wrapper's own generated id
+	// (`wrap-N`) is never styled. Either way an id selector cannot match here.
+	if (/#/.test(compound)) return false;
+
+	const withoutNot = compound.replace(/:not\(([^()]*)\)/g, (_, inner: string) => {
+		const negated = inner.trim();
+		const matchesNegated = /^\.[A-Za-z0-9_-]+$/.test(negated)
+			? element.classes.includes(negated.slice(1))
+			: /^[a-z][a-z0-9]*$/i.test(negated)
+				? negated.toLowerCase() === element.tag
+				: null;
+		return matchesNegated === null ? ':unsupported' : matchesNegated ? ':fails' : '';
+	});
+	if (withoutNot.includes(':fails')) return false;
+	if (withoutNot.includes(':unsupported')) return 'unsupported';
+
+	const bare = withoutNot.replace(STRUCTURAL, '');
+	if (!/^\*?(?:[a-z][a-z0-9]*)?(?:\.[A-Za-z0-9_-]+)*$/i.test(bare)) return 'unsupported';
+
+	const classes = [...bare.matchAll(/\.([A-Za-z0-9_-]+)/g)].map((m) => m[1]);
+	const tag = bare.replace(/[.*].*$/, '').toLowerCase();
+	if (tag && tag !== element.tag) return false;
+	if (!classes.every((cls) => element.classes.includes(cls))) return false;
+	// Only now, with everything else matching, does the unmodelled part bite.
+	return STRUCTURAL.test(withoutNot) ? 'unsupported' : true;
+}
+
+/** Right-to-left matching against an ancestor chain (root first). */
+function selectorMatches(selector: string, chain: Element[]): boolean | 'unsupported' {
+	const subjectCompound = selector.split(/[\s>+~]+/).filter(Boolean).pop() || '';
+	const subject = compoundMatches(subjectCompound, chain[chain.length - 1]);
+	if (subject !== true) return subject;
+
+	// No sibling is modelled, so a rule that survived the subject test and
+	// needs one cannot be decided here.
+	if (NEEDS_SIBLINGS.test(selector)) return 'unsupported';
+
+	const parts = selector.replace(/\s*>\s*/g, ' > ').split(/\s+/).filter(Boolean);
+	let part = parts.length - 2;
+	let index = chain.length - 1;
+
+	while (part >= 0) {
+		const isChild = parts[part] === '>';
+		if (isChild) part -= 1;
+		if (part < 0) return 'unsupported';
+
+		let matched = false;
+		while (index > 0) {
+			index -= 1;
+			const result = compoundMatches(parts[part], chain[index]);
+			if (result === 'unsupported') return 'unsupported';
+			if (result) {
+				matched = true;
+				break;
+			}
+			if (isChild) break;
+		}
+		if (!matched) return false;
+		part -= 1;
+	}
+	return true;
+}
+
+function specificity(selector: string): number {
+	const ids = (selector.match(/#[A-Za-z0-9_-]+/g) || []).length;
+	const classes = (selector.match(/\.[A-Za-z0-9_-]+/g) || []).length;
+	const tags = selector.split(/\s+/).filter((part) => /^[a-z]/.test(part)).length;
+	return ids * 10000 + classes * 100 + tags;
+}
+
+const appRules = parseRules(stripComments(styles));
+
+/**
+ * The value a property resolves to for `chain`'s last element, resolved by
+ * !important, then specificity, then document order — the real cascade.
+ * `media` selects which blocks are live: `all` alone is the screen, `all` plus
+ * `print` is the sheet a PDF is rendered from.
+ */
+function resolve(rules: Rule[], chain: Element[], property: string, media: Set<Rule['media']>): string | undefined {
+	let winner: { important: boolean; specificity: number; order: number; value: string } | undefined;
+
+	for (const rule of rules) {
+		if (!media.has(rule.media)) continue;
+		// Only rules that could change the answer are resolved — and every one
+		// of those has to be resolvable, so a selector this matcher cannot
+		// decide fails the test instead of quietly dropping out of the cascade.
+		if (!rule.declarations.some((declaration) => declaration.property === property)) continue;
+		const match = selectorMatches(rule.selector, chain);
+		assert.notEqual(
+			match,
+			'unsupported',
+			`this test cannot resolve "${rule.selector}" against .${chain[chain.length - 1].classes.join('.')}; extend the matcher rather than leaving the rule unchecked`,
+		);
+		if (!match) continue;
+
+		for (const declaration of rule.declarations) {
+			if (declaration.property !== property) continue;
+			const candidate = { important: declaration.important, specificity: specificity(rule.selector), order: rule.order, value: declaration.value };
+			if (
+				!winner ||
+				(candidate.important && !winner.important) ||
+				(candidate.important === winner.important &&
+					(candidate.specificity > winner.specificity ||
+						(candidate.specificity === winner.specificity && candidate.order > winner.order)))
+			) {
+				winner = candidate;
+			}
+		}
+	}
+
+	return winner?.value;
+}
+
+const SCREEN: Set<Rule['media']> = new Set(['all']);
+const PAPER: Set<Rule['media']> = new Set(['all', 'print']);
+
+/** What a PDF of the live viewer DOM shows. */
+const printedValue = (chain: Element[], property: string) => resolve(appRules, chain, property, PAPER);
+/** What the app itself shows. */
+const screenValue = (chain: Element[], property: string) => resolve(appRules, chain, property, SCREEN);
+
+// The exported file is a different stylesheet: the app's sheets copied in
+// verbatim, then the export's own rules appended. Resolving against that is
+// what says whether the recipient can read a section — and in an exported file
+// there is no toggle and no script, so anything hidden is hidden for good.
+const exportedStyles = (() => {
+	const document_ = buildExportDocument({ theme: 'light', title: 'T', styles, articleHtml: '' });
+	const match = document_.match(/<style>([\s\S]*)<\/style>/);
+	assert.ok(match, 'the export must carry a stylesheet');
+	return parseRules(stripComments(match[1]));
+})();
+const exportedValue = (chain: Element[], property: string) => resolve(exportedStyles, chain, property, SCREEN);
+
+const body: Element = { tag: 'body', classes: [] };
+const article: Element = { tag: 'article', classes: ['markdown-body'] };
+
+const collapsedSection: Element[] = [body, article, { tag: 'div', classes: ['foldable-content-wrapper', 'is-collapsed'] }];
+const collapsedSectionInner: Element[] = [...collapsedSection, { tag: 'div', classes: ['content-inner'] }];
+const collapsedCallout: Element[] = [
+	body,
+	article,
+	{ tag: 'div', classes: ['markdown-alert', 'is-collapsed'] },
+	{ tag: 'div', classes: ['markdown-alert-content', 'is-collapsed'] },
+];
+const collapsedCalloutInner: Element[] = [...collapsedCallout, { tag: 'div', classes: ['content-inner'] }];
+const openSection: Element[] = [body, article, { tag: 'div', classes: ['foldable-content-wrapper'] }];
+
+test('a collapsed heading section is printed, not clipped away', () => {
+	// The PDF is the copy the reader gets. Clipping a fold to zero height
+	// deletes text from it that the author can still reach in two clicks, and
+	// leaves no sign in the file that anything is missing.
+	assert.notEqual(printedValue(collapsedSection, 'height'), '0');
+	assert.equal(printedValue(collapsedSection, 'height'), 'auto');
+	assert.notEqual(printedValue(collapsedSection, 'overflow'), 'hidden');
+	// Height alone is not enough: the screen rule pairs it with opacity: 0.
+	assert.notEqual(printedValue(collapsedSection, 'opacity'), '0');
+	assert.notEqual(printedValue(collapsedSectionInner, 'overflow'), 'hidden');
+});
+
+test('a collapsed callout is printed too', () => {
+	// Same defect, second mechanism: callouts collapse with a 0fr grid track
+	// instead of a height, so a fix aimed only at headings leaves half the
+	// document still disappearing.
+	assert.notEqual(printedValue(collapsedCallout, 'grid-template-rows'), '0fr');
+	assert.equal(printedValue(collapsedCallout, 'grid-template-rows'), '1fr');
+	assert.notEqual(printedValue(collapsedCallout, 'opacity'), '0');
+	assert.notEqual(printedValue(collapsedCalloutInner, 'overflow'), 'hidden');
+});
+
+test('folding still works on screen', () => {
+	// The print rules must reveal the fold, not disable the feature: the same
+	// element on screen has to stay collapsed.
+	assert.equal(screenValue(collapsedSection, 'height'), '0');
+	assert.equal(screenValue(collapsedSection, 'opacity'), '0');
+	assert.equal(screenValue(collapsedCallout, 'grid-template-rows'), '0fr');
+});
+
+test('an expanded section is unaffected by the reveal', () => {
+	assert.equal(printedValue(openSection, 'height'), 'auto');
+	assert.notEqual(printedValue(openSection, 'opacity'), '0');
+});
+
+test('the fold controls do not print as misleading decoration', () => {
+	// A collapsed chevron is rotated to point at content that now prints
+	// expanded, and it is a control for an interaction paper does not have.
+	const chevron = [body, article, { tag: 'div', classes: ['foldable-header', 'is-collapsed'] }, { tag: 'span', classes: ['header-fold-icon'] }];
+	assert.equal(printedValue(chevron, 'display'), 'none');
+});
+
+test('the HTML export renders every heading fold open', () => {
+	// The HTML route never sees the live DOM, it re-renders from source, and
+	// the Set it passes is the fold state that render is given. An empty one is
+	// what makes every section expanded.
+	assert.match(exportSource, /processMarkdownHtml\(safeHtml, ctx\.tabPath, new Set\(\)\)/);
+	assert.doesNotMatch(exportSource, /processMarkdownHtml\([^)]*collapsedHeaders/);
+});
+
+test('a callout collapsed in the source is still readable in an exported file', () => {
+	// The empty Set only governs heading folds. `> [!note]-` puts `is-collapsed`
+	// in the markup itself, so it survives the re-render — and an exported file
+	// has no toggle to undo it and a policy that forbids the script one, so the
+	// text ships present, clipped to nothing, and unreachable forever. Verified
+	// in Chrome against a real exported file before the fix: the collapsed
+	// callout's content box measured 0px at opacity 0.
+	assert.notEqual(exportedValue(collapsedCallout, 'grid-template-rows'), '0fr');
+	assert.equal(exportedValue(collapsedCallout, 'grid-template-rows'), '1fr');
+	assert.notEqual(exportedValue(collapsedCallout, 'opacity'), '0');
+	assert.notEqual(exportedValue(collapsedCalloutInner, 'overflow'), 'hidden');
+
+	// The same guarantee for a heading fold, whatever fold state a future
+	// caller hands the renderer.
+	assert.notEqual(exportedValue(collapsedSection, 'height'), '0');
+	assert.notEqual(exportedValue(collapsedSection, 'opacity'), '0');
+});
+
+test('an exported file does not offer controls it cannot honour', () => {
+	const chevron = [body, article, { tag: 'div', classes: ['markdown-alert', 'is-collapsed'] }, { tag: 'svg', classes: ['callout-fold-icon'] }];
+	assert.equal(exportedValue(chevron, 'display'), 'none');
+});

--- a/scripts/exportedThemeFidelity.test.ts
+++ b/scripts/exportedThemeFidelity.test.ts
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import { buildExportDocument, exportThemeAttribute } from '../src/lib/utils/export.js';
+
+const styles = readFileSync('src/styles.css', 'utf8');
+const exportSource = readFileSync('src/lib/utils/export.ts', 'utf8');
+
+/** The opening `<html …>` tag of a built export. */
+function htmlTag(document: string): string {
+	const match = document.match(/<html[^>]*>/);
+	assert.ok(match, 'the export must contain an <html> tag');
+	return match[0];
+}
+
+/** Does `<html …>` satisfy a `[data-theme="…"]` attribute selector? */
+function matchesThemeSelector(document: string, theme: string): boolean {
+	return new RegExp(`<html[^>]*\\sdata-theme="${theme}"`).test(htmlTag(document));
+}
+
+function build(theme: string | null | undefined, extra: Partial<{ styles: string; title: string; articleHtml: string }> = {}) {
+	return buildExportDocument({
+		theme,
+		title: extra.title ?? 'Notes',
+		styles: extra.styles ?? '',
+		articleHtml: extra.articleHtml ?? '<p>body</p>',
+	});
+}
+
+test('an explicitly themed window exports a document wearing that theme', () => {
+	// Every dark variable in the app hangs off `:root[data-theme="dark"]`. The
+	// rule is copied into the export with the rest of the stylesheet, so
+	// without the attribute the copied rule is dead weight and the file falls
+	// back to the light `:root` block (or, on a dark machine, to the
+	// `prefers-color-scheme` block) — never to what the exporter was looking at.
+	for (const theme of ['dark', 'light']) {
+		assert.ok(matchesThemeSelector(build(theme), theme), `an export from the ${theme} theme must carry data-theme="${theme}"`);
+	}
+});
+
+test('an imported VS Code theme survives the export', () => {
+	// `parseAndApplyVscodeTheme` writes `:root[data-theme="vscode"] { … }` into a
+	// <style> tag, which `document.styleSheets` hands to the export like any
+	// other sheet. The attribute is the only thing that can make it match.
+	const doc = build('vscode', { styles: ':root[data-theme="vscode"] { --color-canvas-default: #1e1e1e; }' });
+	assert.ok(matchesThemeSelector(doc, 'vscode'));
+	assert.match(doc, /:root\[data-theme="vscode"\]/);
+});
+
+test('every theme selector the stylesheet defines can be reproduced by an export', () => {
+	// Pins the two halves together: a new `:root[data-theme="…"]` block in
+	// styles.css must be a value the export is willing to write out, or that
+	// theme silently becomes unexportable.
+	const declared = [...styles.matchAll(/:root\[data-theme="([^"]+)"\]/g)].map((m) => m[1]);
+	assert.ok(declared.length >= 2, 'expected styles.css to select themes by data-theme');
+
+	for (const theme of new Set(declared)) {
+		assert.equal(exportThemeAttribute(theme), ` data-theme="${theme}"`, `${theme} must survive an export`);
+		assert.ok(matchesThemeSelector(build(theme), theme));
+	}
+});
+
+test('the system theme is exported as "follow the reader", not as a frozen colour', () => {
+	// `system` is the one theme that is not a colour: MarkdownViewer deletes
+	// `data-theme` for it and lets `@media (prefers-color-scheme: dark)` decide.
+	// An export with no attribute reproduces that same cascade wherever it is
+	// opened, which is the instruction the user actually gave. Baking in the
+	// exporter's momentary system colour would make the file disagree with the
+	// author's own screen the next time their machine switches.
+	for (const absent of [undefined, null, '']) {
+		const doc = build(absent);
+		assert.doesNotMatch(htmlTag(doc), /data-theme/, `system theme must not pin a colour (${String(absent)})`);
+		assert.match(htmlTag(doc), /^<html lang="en">$/);
+	}
+
+	// And the mechanism it delegates to has to still be in the sheet that gets copied.
+	assert.match(styles, /@media \(prefers-color-scheme: dark\)/);
+});
+
+test('the theme attribute cannot break out of the tag', () => {
+	// `data-theme` is a string read back off the DOM and interpolated into
+	// markup. Nothing writes a hostile one today; the export must not be the
+	// place that finds out when something does.
+	const hostile = ['x" onload="alert(1)', '"><script>alert(1)</script>', "dark'", 'dark theme', 'a'.repeat(33), '../../etc'];
+	for (const theme of hostile) {
+		assert.equal(exportThemeAttribute(theme), '', `${theme} must not reach the markup`);
+		assert.match(htmlTag(build(theme)), /^<html lang="en">$/);
+	}
+	assert.equal(exportThemeAttribute(42 as unknown as string), '');
+});
+
+test('the export reads the theme off the same element the app themes', () => {
+	assert.match(exportSource, /theme: document\.documentElement\.dataset\.theme/);
+});
+
+test('theming the document did not cost it any of its other protections', () => {
+	// #376 put a CSP and a title escape in this template; extracting the
+	// template must carry both across unchanged.
+	const doc = build('dark', { title: '<script>alert(1)</script>' });
+	assert.match(doc, /<meta http-equiv="Content-Security-Policy" content="default-src 'none'; /);
+	assert.doesNotMatch(doc, /script-src/);
+	assert.match(doc, /<title>&lt;script&gt;alert\(1\)&lt;\/script&gt;<\/title>/);
+	assert.doesNotMatch(doc, /<title><script>/);
+	assert.match(build('dark', { title: '' }), /<title>Export<\/title>/);
+});
+
+test('the copied stylesheet and the article still land in the document', () => {
+	const doc = build('dark', { styles: '.sentinel { color: red; }', articleHtml: '<p id="sentinel">hello</p>' });
+	assert.match(doc, /<style>[\s\S]*\.sentinel \{ color: red; \}/);
+	assert.match(doc, /<article class="markdown-body">\n<p id="sentinel">hello<\/p>/);
+	assert.match(doc, /^<!DOCTYPE html>\n/);
+});

--- a/scripts/issue261EditorPdf.test.ts
+++ b/scripts/issue261EditorPdf.test.ts
@@ -20,9 +20,20 @@ test('print layout releases measured fold heights before text reflows', () => {
 		styles,
 		/@media print\s*\{[\s\S]*?\.foldable-content-wrapper\s*\{[\s\S]*?height:\s*auto\s*!important;/,
 	);
+	// This test used to require the opposite of the line below: a collapsed
+	// fold was pinned to `height: 0 !important` on paper, which is how a
+	// collapsed section came to be missing from the PDF entirely while the
+	// HTML export of the same document contained it. The two export routes now
+	// both hand over the whole document; scripts/exportFoldParity.test.ts
+	// resolves the cascade to prove the section is actually visible rather than
+	// merely un-pinned here.
 	assert.match(
 		styles,
-		/@media print\s*\{[\s\S]*?\.foldable-content-wrapper\.is-collapsed\s*\{[\s\S]*?height:\s*0\s*!important;/,
+		/@media print\s*\{[\s\S]*?\.foldable-content-wrapper\.is-collapsed\s*\{[\s\S]*?height:\s*auto\s*!important;/,
+	);
+	assert.doesNotMatch(
+		styles,
+		/@media print\s*\{[\s\S]*?\.foldable-content-wrapper\.is-collapsed\s*\{[^}]*height:\s*0/,
 	);
 });
 

--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -57,6 +57,142 @@ const EXPORT_CSP = [
 	"form-action 'none'",
 ].join('; ');
 
+// The app paints itself from CSS variables that are selected by an attribute on
+// the root element: `:root[data-theme="dark"]`, `:root[data-theme="light"]` and
+// — for an imported VS Code theme — `:root[data-theme="vscode"]`, whose rule is
+// generated into a `<style>` tag and therefore travels with the copied
+// stylesheet. Without the attribute on the exported document none of those
+// selectors can ever match, so a file exported from a dark or an imported theme
+// arrived looking like neither.
+//
+// `system` is the deliberate exception. It is not a colour, it is the
+// instruction "use the colours of the machine I am reading this on", and the
+// app implements it by removing the attribute and letting
+// `@media (prefers-color-scheme: dark)` decide. An export carrying no attribute
+// reproduces exactly that: the same document, the same cascade, resolved
+// wherever it is opened. Freezing the exporter's momentary system colour
+// instead would produce a file that disagrees with the author's own screen the
+// next time their machine switches at sunset.
+//
+// The value is validated rather than trusted: it is interpolated into markup,
+// and `data-theme` is a plain string that a future import path could take from
+// a theme file. Anything unexpected degrades to the no-attribute (viewer's
+// system) case rather than escaping the attribute's quotes.
+const SAFE_EXPORT_THEME = /^[A-Za-z0-9_-]{1,32}$/;
+
+export function exportThemeAttribute(theme: string | null | undefined): string {
+	if (typeof theme !== 'string' || !SAFE_EXPORT_THEME.test(theme)) return '';
+	return ` data-theme="${theme}"`;
+}
+
+export interface ExportDocumentInput {
+	/** `document.documentElement.dataset.theme`, i.e. undefined for `system`. */
+	theme: string | null | undefined;
+	title: string;
+	/** The app's own stylesheets, already serialised. */
+	styles: string;
+	/** The finished `.markdown-body` content. */
+	articleHtml: string;
+}
+
+/**
+ * Assembles the single file that leaves the app. Kept separate from
+ * `exportAsHtml` (which owns the file dialog, the renderer round trip and the
+ * image embedding) so the shape of the artefact can be asserted directly.
+ */
+export function buildExportDocument(input: ExportDocumentInput): string {
+	return `<!DOCTYPE html>
+<html lang="en"${exportThemeAttribute(input.theme)}>
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="${EXPORT_CSP}">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>${escapeHtmlText(input.title || 'Export')}</title>
+<style>
+${input.styles}
+html, body {
+	overflow: auto !important;
+	height: auto !important;
+	min-height: 100vh;
+	background-color: var(--color-canvas-default, #ffffff);
+	margin: 0;
+	padding: 0;
+}
+.markdown-body {
+	padding: 40px !important;
+	max-width: 900px;
+	margin: 0 auto;
+	height: auto !important;
+	overflow: visible !important;
+	min-height: 100%;
+}
+.lang-label {
+	display: none !important;
+}
+.export-frontmatter-panel {
+	margin: 0 0 24px 0;
+}
+.export-frontmatter-panel .frontmatter-grid {
+	display: grid;
+	grid-template-columns: max-content minmax(0, 1fr);
+	gap: 8px 16px;
+	padding: 12px 0 0 0;
+}
+.export-frontmatter-panel .frontmatter-key {
+	color: var(--color-fg-muted, #57606a);
+	font-weight: 600;
+}
+.export-frontmatter-panel .frontmatter-tags {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+}
+.export-frontmatter-panel .frontmatter-tag {
+	border: 1px solid var(--color-border-default, #d0d7de);
+	border-radius: 999px;
+	padding: 2px 8px;
+	background: var(--color-neutral-muted, rgba(175, 184, 193, 0.2));
+}
+.markdown-body pre {
+	white-space: pre-wrap !important;
+	word-break: break-word !important;
+}
+/* Nothing in an exported file can open a fold: the policy above forbids
+   script, and the app's toggles are not there to click. A section that ships
+   collapsed therefore ships unreadable — its text is in the file, clipped to
+   zero height at zero opacity, with nothing that could ever reveal it.
+   Heading folds arrive open already (the render above is handed an empty fold
+   state); a callout written as "> [!note]-" carries its collapsed state in the
+   markup itself and has to be opened here. The print/PDF route takes the same
+   position from the other side, in the @media print block of styles.css. */
+.foldable-content-wrapper.is-collapsed {
+	height: auto !important;
+	opacity: 1 !important;
+	overflow: visible !important;
+}
+.markdown-alert-content.is-collapsed {
+	grid-template-rows: 1fr !important;
+	opacity: 1 !important;
+	overflow: visible !important;
+}
+.foldable-content-wrapper .content-inner,
+.markdown-alert-content .content-inner {
+	overflow: visible !important;
+}
+.header-fold-icon,
+.callout-fold-icon {
+	display: none !important;
+}
+</style>
+</head>
+<body>
+<article class="markdown-body">
+${input.articleHtml}
+</article>
+</body>
+</html>`;
+}
+
 async function buildExportArticle(ctx: ExportContext): Promise<{ html: string; embeddedImages: number; missingImages: number }> {
 	const body = getMarkdownBodyWithoutFrontMatter(ctx.rawContent);
 	const rendered = (await invoke('render_markdown', { content: body })) as string;
@@ -75,6 +211,13 @@ async function buildExportArticle(ctx: ExportContext): Promise<{ html: string; e
 	// DOMParser (inert — no script execution, no resource loads) and only ever
 	// assigns `innerHTML` from its own constant SVG strings.
 	const safeHtml = sanitizeMarkdownHtml(rendered);
+	// No collapsed headers, ever. An export is the act of handing the document
+	// to someone who does not have the app, the fold state or a way to open one,
+	// so every section ships expanded — a fold is a reading convenience of this
+	// session, not part of the document. The print/PDF path is held to the same
+	// rule from the other end (see the `@media print` block in styles.css, which
+	// un-collapses folds instead of clipping them to zero height), so the two
+	// export routes cannot disagree about what is in the file.
 	const processed = processMarkdownHtml(safeHtml, ctx.tabPath, new Set());
 	const wrapper = document.createElement('div');
 	wrapper.innerHTML = renderStaticFrontMatterPanel(parseFrontMatter(ctx.rawContent)) + processed;
@@ -136,70 +279,12 @@ export async function exportAsHtml(ctx: ExportContext): Promise<ExportHtmlResult
 
 	const article = await buildExportArticle(ctx);
 
-	const fullHtml = `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta http-equiv="Content-Security-Policy" content="${EXPORT_CSP}">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>${escapeHtmlText(ctx.tabTitle || 'Export')}</title>
-<style>
-${styles}
-html, body {
-	overflow: auto !important;
-	height: auto !important;
-	min-height: 100vh;
-	background-color: var(--color-canvas-default, #ffffff);
-	margin: 0;
-	padding: 0;
-}
-.markdown-body {
-	padding: 40px !important;
-	max-width: 900px;
-	margin: 0 auto;
-	height: auto !important;
-	overflow: visible !important;
-	min-height: 100%;
-}
-.lang-label {
-	display: none !important;
-}
-.export-frontmatter-panel {
-	margin: 0 0 24px 0;
-}
-.export-frontmatter-panel .frontmatter-grid {
-	display: grid;
-	grid-template-columns: max-content minmax(0, 1fr);
-	gap: 8px 16px;
-	padding: 12px 0 0 0;
-}
-.export-frontmatter-panel .frontmatter-key {
-	color: var(--color-fg-muted, #57606a);
-	font-weight: 600;
-}
-.export-frontmatter-panel .frontmatter-tags {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 6px;
-}
-.export-frontmatter-panel .frontmatter-tag {
-	border: 1px solid var(--color-border-default, #d0d7de);
-	border-radius: 999px;
-	padding: 2px 8px;
-	background: var(--color-neutral-muted, rgba(175, 184, 193, 0.2));
-}
-.markdown-body pre {
-	white-space: pre-wrap !important;
-	word-break: break-word !important;
-}
-</style>
-</head>
-<body>
-<article class="markdown-body">
-${article.html}
-</article>
-</body>
-</html>`;
+	const fullHtml = buildExportDocument({
+		theme: document.documentElement.dataset.theme,
+		title: ctx.tabTitle,
+		styles,
+		articleHtml: article.html,
+	});
 
 	try {
 		await invoke('save_file_content', { path: selected, content: fullHtml });

--- a/src/styles.css
+++ b/src/styles.css
@@ -1386,6 +1386,18 @@ body {
 		size: auto;
 	}
 
+	/* A fold is a reading convenience of this session, not part of the
+	   document. Exporting is the act of handing the document to someone who
+	   has neither the app nor a way to open a collapsed section, so a print
+	   that clips one to zero height silently deletes text the author can
+	   still see two clicks away — and it disagreed with the HTML export,
+	   which renders every fold open (see utils/export.ts). Both routes now
+	   ship the whole document.
+
+	   Both collapse mechanisms have to be undone, and `opacity` matters as
+	   much as the size: the screen rules pair `height: 0` /
+	   `grid-template-rows: 0fr` with `opacity: 0`, so restoring only the
+	   size would print blank space where the section is. */
 	.foldable-content-wrapper {
 		height: auto !important;
 		transition: none !important;
@@ -1393,8 +1405,33 @@ body {
 	}
 
 	.foldable-content-wrapper.is-collapsed {
-		height: 0 !important;
-		overflow: hidden !important;
+		height: auto !important;
+		overflow: visible !important;
+		opacity: 1 !important;
+	}
+
+	.markdown-alert-content {
+		transition: none !important;
+		overflow: visible !important;
+	}
+
+	.markdown-alert-content.is-collapsed {
+		grid-template-rows: 1fr !important;
+		overflow: visible !important;
+		opacity: 1 !important;
+	}
+
+	.foldable-content-wrapper .content-inner,
+	.markdown-alert-content .content-inner {
+		overflow: visible !important;
+	}
+
+	/* The chevrons are the control for that fold. On paper they control
+	   nothing, and a collapsed one is rotated to point at content that is
+	   now printed open, so it would be actively misleading. */
+	.markdown-body .header-fold-icon,
+	.markdown-body .callout-fold-icon {
+		display: none !important;
 	}
 
 	.custom-title-bar,


### PR DESCRIPTION
Two ways an export failed to be a faithful copy of the document.

## 1. The exported file lost the theme

The template hardcoded `<html lang="en">` and never reproduced `document.documentElement.dataset.theme`. Every theme rule the export copies in — the dark variables, an imported VS Code theme — hangs off a `:root[data-theme=…]` selector, so **none of them could match**. A document authored and exported in a dark theme rendered in whatever colours the *reader's* machine happened to prefer.

The template is now a pure function `buildExportDocument()`, and `<html>` carries `data-theme`. The value is allowlisted (`^[A-Za-z0-9_-]{1,32}$`); anything else degrades to omitting the attribute rather than breaking out of the quotes.

**`system` is deliberately not frozen in.** It is not a colour — it is the instruction *"use the colours of the machine reading this"*. The app implements it by dropping `data-theme` and letting `prefers-color-scheme` take over, so an export without the attribute reproduces the same cascade verbatim. Freezing the exporter's momentary system colour would produce a file that the author's own machine disagrees with after dark mode kicks in that evening. Only an explicitly chosen light/dark/vscode is frozen — that is the one the user actually expressed.

Verified in a real browser: exported with the dark theme, the product opens as `<html lang="en" data-theme="dark">` with background `rgb(24,24,24)` and text `rgb(230,237,243)` — matching the app.

## 2. Collapsed sections were cut out of the PDF but kept in the HTML

The print block pinned `.foldable-content-wrapper.is-collapsed { height: 0 !important }`, so a collapsed section **disappeared from the PDF**, while the HTML export of the same document expanded everything. Same document, two export routes, two different sets of content.

Both routes now hand over the whole document. The principle: **an export exists to hand the content to someone else.**

**The half the audit missed:** a collapsed *callout* (`> [!note]-`) carries `is-collapsed` in the markup itself, so passing an empty collapsed-header set does not expand it — and the exported file has **no script and no toggle**, so that text can never be reached at all. Measured on the real artifact in a browser: content box `0px / opacity 0` before, `34px / opacity 1` after.

Restoring only the height would print blank space, so `opacity` is restored too, and both collapse mechanisms (height and `grid-template-rows`) are covered. The fold chevrons are hidden in print — on paper they control nothing, and a collapsed-state arrow pointing at now-expanded content is actively misleading. #377's find-mark neutralisation and the 9in size cap are untouched.

## Not done: inlining KaTeX fonts (E-2 was a misdiagnosis)

The audit claimed exported formulas fall back to a serif face because KaTeX `@font-face` URLs point at bundle paths. **There is no KaTeX output in the HTML export at all.** `exportAsHtml` does not read the live DOM — it re-renders from raw markdown through `render_markdown` (comrak, math extension not enabled) → sanitize → `processMarkdownHtml`, none of which invoke KaTeX. Exported formulas come out as `<p data-math="display" data-math-source="E = mc^2">`. No element uses a KaTeX font family, so **the browser never requests those fonts**: no 404, no fallback.

Measured, as the basis for not doing it: the full woff2 set is 253.7 KB → **+338.3 KB** base64 per exported file (1.17 MB with woff/ttf), against a current CSS payload of 281 KB. Subsetting would not help either, because zero glyphs are used. Cost is large, benefit is exactly zero.

**The real defect this uncovered is bigger and is not in this PR:** the exported HTML has *no rendered math, no syntax highlighting, and mermaid diagrams left as source blocks*, because `renderRichContent` only ever runs in the viewer. Fixing that means pre-rendering that chain at export time (the export forbids scripts), which touches `MarkdownViewer.svelte` — out of this PR's scope, and worth its own.

## Tests

16 new tests across two files, both **importing and executing** the real code rather than matching source text.

`scripts/exportFoldParity.test.ts` contains a small cascade resolver (`!important` → specificity → document order) that computes what `height` / `opacity` / `grid-template-rows` / `display` a collapsed element actually ends up with under the screen, print, and exported-file stylesheets. A selector it cannot resolve **fails the test** if it touches a queried property, so there is no silent blind spot.

| Configuration | Result |
|---|---|
| `master` implementation + these tests | **286 pass / 3 fail** |
| Only `styles.css` reverted | **19 pass / 4 fail** — collapsed section cut, collapsed callout cut, misleading chevron, and the pinning test below |
| Only the export template's fold CSS reverted | **6 pass / 2 fail** — collapsed callout unreadable in the exported file, and a control the reader cannot operate |
| Final | 303 pass / 0 fail |

```
npm run check   0 errors, 0 warnings
npm test        303 / 303
cargo test       76 / 76   (Rust untouched)
npm run build   ok
```

## One existing test asserted the bug

`scripts/issue261EditorPdf.test.ts` pinned `@media print … .is-collapsed { height: 0 !important }` — the defect itself, written as a requirement. That assertion is inverted (now `height: auto`, plus a `doesNotMatch` guard so it cannot creep back), with an in-place comment recording why it flipped and pointing at the cascade test that proves the section is *visible* rather than merely un-pinned. The file's other assertion is untouched; the CSS was split into separate rules specifically so it keeps passing unchanged.

## Known boundaries

- The front matter panel is a `<details>` in the app and a static always-expanded panel in the HTML export. Same class of divergence, but fixing it means overriding `<details>` UA behaviour — out of scope here.
- A `<details>` the *author* wrote stays collapsed in print. That is document content, not session UI state.
- PDFs remain white-background regardless of theme. Screen and paper diverging there is intentional.
- If the export ever does pre-render KaTeX, the font question becomes real and the 338 KB number needs re-weighing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)