### PR TITLE
fix(i18n): make three keys reachable, and add a coverage test

### DIFF
--- a/scripts/i18nCoverage.test.ts
+++ b/scripts/i18nCoverage.test.ts
@@ -1,0 +1,404 @@
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+	getSupportedLanguages,
+	t,
+	translations,
+	type LanguageCode,
+	type Translation,
+} from '../src/lib/utils/i18n.js';
+
+// WHAT THIS FILE COVERS, AND WHY IT EXISTS
+//
+// `t(key: string)` takes a free-form string. Nothing — not tsc, not
+// `svelte-check`, not the rest of this suite — notices when that string names a
+// key no dictionary has, or when a translator files a key one level away from
+// where the code reads it. Both failure modes are silent: `t()` returns the key
+// itself, or falls back to English, and the app ships looking fine to whoever
+// wrote the code in English.
+//
+// Two real bugs motivated this file:
+//   * TitleBar's window-tag editor called `t('common.save')`. No language
+//     defines `common.save`, so the button read literally "common.save" —
+//     in English too.
+//   * 21 languages filed the tag colours under `settings.colors.*` while
+//     Settings.svelte reads `colors.*`. ~190 finished translations sat in the
+//     file and never reached a user.
+//
+// So: (1) every key the source asks for must exist in English, and (2) no
+// language may define a key English does not have. (2) is what catches
+// misfiled translations, because a misfiled key is by construction one English
+// never had.
+//
+// Per-locale completeness is REPORTED, never asserted. 19 locales are missing
+// >100 keys each; failing on that would mean nobody could add an English key
+// without translating it 25 times first.
+
+const SOURCE_ROOT = 'src';
+const DICTIONARY = 'src/lib/utils/i18n.ts';
+
+const languages = getSupportedLanguages().map((l) => l.code) as LanguageCode[];
+
+// ---------------------------------------------------------------- dictionary
+
+function flatten(node: Translation, prefix = ''): Map<string, string> {
+	const out = new Map<string, string>();
+	for (const [key, value] of Object.entries(node)) {
+		const path = prefix ? `${prefix}.${key}` : key;
+		if (typeof value === 'string') out.set(path, value);
+		else for (const [k, v] of flatten(value, path)) out.set(k, v);
+	}
+	return out;
+}
+
+const dictionaries = new Map<LanguageCode, Map<string, string>>(
+	languages.map((lang) => [lang, flatten(translations[lang])]),
+);
+const english = dictionaries.get('en')!;
+
+// ------------------------------------------------------------------- source
+
+function sourceFiles(dir: string, out: string[] = []): string[] {
+	for (const entry of readdirSync(dir)) {
+		const path = join(dir, entry);
+		if (statSync(path).isDirectory()) sourceFiles(path, out);
+		else if (path.endsWith('.svelte') || path.endsWith('.ts')) out.push(path);
+	}
+	return out;
+}
+
+// Prose in a doc comment can mention `t('foo')`. Drop whole comment lines
+// rather than trying to parse comments out of the middle of code — this only
+// ever removes candidates, and no real call site starts a line with `*` or `//`.
+function stripCommentLines(source: string): string {
+	return source
+		.split('\n')
+		.map((line) => {
+			const trimmed = line.trimStart();
+			const isComment =
+				trimmed.startsWith('*') ||
+				trimmed.startsWith('//') ||
+				trimmed.startsWith('/*') ||
+				trimmed.startsWith('<!--');
+			return isComment ? '' : line;
+		})
+		.join('\n');
+}
+
+/** Index just past the template literal that starts at `i`. */
+function endOfTemplate(src: string, i: number): number {
+	i++;
+	while (i < src.length) {
+		if (src[i] === '\\') i += 2;
+		else if (src[i] === '`') return i + 1;
+		else if (src[i] === '$' && src[i + 1] === '{') i = endOfInterpolation(src, i + 2);
+		else i++;
+	}
+	return i;
+}
+
+/** Index just past the `${ … }` whose body starts at `i`. */
+function endOfInterpolation(src: string, i: number): number {
+	let depth = 1;
+	while (i < src.length && depth > 0) {
+		const c = src[i];
+		if (c === '{') depth++;
+		else if (c === '}') depth--;
+		else if (c === '`') { i = endOfTemplate(src, i); continue; }
+		else if (c === "'" || c === '"') { i = endOfString(src, i); continue; }
+		i++;
+	}
+	return i;
+}
+
+/** Index just past the quoted string that starts at `i`. */
+function endOfString(src: string, i: number): number {
+	const quote = src[i++];
+	while (i < src.length && src[i] !== quote) i += src[i] === '\\' ? 2 : 1;
+	return i + 1;
+}
+
+/** The text of the first argument of the call whose `(` sits at `open`. */
+function firstArgument(src: string, open: number): string {
+	const start = open + 1;
+	let i = start;
+	let depth = 0;
+	while (i < src.length) {
+		const c = src[i];
+		if (c === "'" || c === '"') { i = endOfString(src, i); continue; }
+		if (c === '`') { i = endOfTemplate(src, i); continue; }
+		if (c === '(' || c === '[' || c === '{') { depth++; i++; continue; }
+		if (c === ')' && depth === 0) return src.slice(start, i);
+		if (c === ')' || c === ']' || c === '}') { depth--; i++; continue; }
+		if (c === ',' && depth === 0) return src.slice(start, i);
+		i++;
+	}
+	return src.slice(start);
+}
+
+type Reference = { key: string; file: string };
+
+const staticKeys: Reference[] = [];
+/** `t(`colors.${…}`)` → prefix `colors.`, which no scanner can resolve alone. */
+const dynamicPrefixes = new Map<string, Set<string>>();
+/** `t(someVariable, lang)` — the key is computed elsewhere. */
+const indirectCalls = new Set<string>();
+
+for (const file of sourceFiles(SOURCE_ROOT)) {
+	if (file === DICTIONARY) continue;
+	const src = stripCommentLines(readFileSync(file, 'utf8'));
+
+	// `t(` but not `format(`, `.at(`, `assert(` …
+	for (const match of src.matchAll(/(?<![\w$.])t\(/g)) {
+		const arg = firstArgument(src, match.index + 1).trim();
+		if (arg === '') continue; // `t()` does not type-check; nothing to resolve.
+		let i = 0;
+		let resolved = false;
+		while (i < arg.length) {
+			const c = arg[i];
+			if (c === "'" || c === '"') {
+				const end = endOfString(arg, i);
+				staticKeys.push({ key: arg.slice(i + 1, end - 1), file });
+				resolved = true;
+				i = end;
+				continue;
+			}
+			if (c === '`') {
+				const end = endOfTemplate(arg, i);
+				const literal = arg.slice(i + 1, end - 1);
+				const hole = literal.indexOf('${');
+				if (hole === -1) staticKeys.push({ key: literal, file });
+				else {
+					const prefix = literal.slice(0, hole);
+					dynamicPrefixes.set(prefix, (dynamicPrefixes.get(prefix) ?? new Set()).add(file));
+				}
+				resolved = true;
+				i = end;
+				continue;
+			}
+			i++;
+		}
+		if (!resolved) indirectCalls.add(`${file}: t(${arg.replace(/\s+/g, ' ')})`);
+	}
+
+	// Toolbar/menu descriptors carry their key as data and are handed to `t()`
+	// through `t(action.labelKey)`. Same exposure, different spelling.
+	for (const match of src.matchAll(/\blabelKey: '([^']+)'/g)) {
+		staticKeys.push({ key: match[1], file });
+	}
+}
+
+// ------------------------------------------------ declared dynamic families
+//
+// A template-literal key cannot be resolved by reading the call site, so each
+// family is declared here together with the source of truth that enumerates its
+// members at runtime. The members are re-derived from that source on every run,
+// so adding a swatch colour or an update-dialog string is checked like any
+// other key — this is not an exemption list.
+
+const DYNAMIC_FAMILIES: Record<string, { file: string; member: RegExp; why: string }> = {
+	'colors.': {
+		file: 'src/lib/components/Settings.svelte',
+		// Settings renders one swatch per `highlightColors` entry and labels it
+		// with t(`colors.${color.value}`).
+		member: /\{ value: '([a-z]+)', color: /g,
+		why: 'the highlight-colour swatch list',
+	},
+	'update.': {
+		file: 'src/lib/components/UpdateDialog.svelte',
+		// Every string in the dialog goes through `tk(key)`, i.e. t(`update.${key}`).
+		member: /\btk\('([A-Za-z0-9]+)'/g,
+		why: 'the update dialog’s tk() call sites',
+	},
+};
+
+// ------------------------------------------------------- known-orphan pins
+//
+// Three leaves exist in 22 locales and never existed in English. Unlike the
+// colour block they are not misfiled: nothing in the source reads them under
+// any path, so they are dead weight rather than lost translations. Deleting
+// dead keys is deliberately out of scope for the change that introduced this
+// test, so they are pinned here instead of being swept under a wildcard.
+//
+// Pinning them is safe because the two rules interlock: should anyone ever
+// point source code at one of these keys, "every referenced key exists in
+// English" fails immediately. An orphan can be tolerated OR reachable, never
+// both.
+const KNOWN_ORPHANS = new Set(['editor.status.lines', 'tooltip.zoomIn', 'tooltip.zoomOut']);
+
+// `t(action.labelKey, …)`: resolved by the `labelKey:` harvest above. Any new
+// unexplained indirection has to be added here consciously.
+const KNOWN_INDIRECT_CALLS = new Set([
+	'src/lib/components/Settings.svelte: t(action.labelKey)',
+	'src/lib/components/Tab.svelte: t(action.labelKey)',
+]);
+
+// ------------------------------------------------------------------- tests
+
+test('the scanner actually found the call sites', () => {
+	// Guards against the whole file silently passing because a regex stopped
+	// matching. Every assertion below is vacuous if this one is wrong.
+	assert.ok(staticKeys.length > 250, `found ${staticKeys.length} literal t() keys`);
+	assert.ok(english.size > 300, `English defines ${english.size} keys`);
+	assert.equal(languages.length, 26);
+});
+
+test('every key the source asks for exists in English', () => {
+	// TitleBar called t('common.save'); en.common has close/minimize/maximize/
+	// loadingFullDocument and no save, so the button rendered "common.save".
+	const missing = new Map<string, Set<string>>();
+	for (const { key, file } of staticKeys) {
+		if (english.has(key)) continue;
+		missing.set(key, (missing.get(key) ?? new Set()).add(file));
+	}
+	const report = [...missing]
+		.map(([key, files]) => `  ${key}  <- ${[...files].join(', ')}`)
+		.join('\n');
+	assert.equal(
+		missing.size,
+		0,
+		`t() references ${missing.size} key(s) English does not define; the UI shows the raw key:\n${report}`,
+	);
+});
+
+test('no language defines a key English does not have', () => {
+	// A translation filed one level away from where the code reads it is
+	// invisible: `settings.colors.blue` can never be reached by t('colors.blue').
+	// Since every reachable key must exist in English, "exists somewhere but not
+	// in English" is exactly the set of unreachable translations.
+	const orphans = new Map<string, string[]>();
+	for (const lang of languages) {
+		if (lang === 'en') continue;
+		for (const key of dictionaries.get(lang)!.keys()) {
+			if (english.has(key)) continue;
+			orphans.set(key, [...(orphans.get(key) ?? []), lang]);
+		}
+	}
+
+	const unexpected = [...orphans].filter(([key]) => !KNOWN_ORPHANS.has(key));
+	assert.equal(
+		unexpected.length,
+		0,
+		`translations that no code path can reach (present in a locale, absent in English):\n${unexpected
+			.map(([key, langs]) => `  ${key}  [${langs.length}] ${langs.join(', ')}`)
+			.join('\n')}`,
+	);
+
+	// The pin must not rot: a key that got cleaned up has to leave this list.
+	for (const key of KNOWN_ORPHANS) {
+		assert.ok(orphans.has(key), `${key} is no longer an orphan — drop it from KNOWN_ORPHANS`);
+	}
+});
+
+test('pinned orphans are unreachable, so pinning them hides nothing', () => {
+	for (const { key, file } of staticKeys) {
+		assert.ok(!KNOWN_ORPHANS.has(key), `${file} reads pinned orphan ${key}`);
+	}
+	for (const prefix of dynamicPrefixes.keys()) {
+		for (const key of KNOWN_ORPHANS) {
+			assert.ok(!key.startsWith(prefix), `dynamic family ${prefix}* can reach pinned orphan ${key}`);
+		}
+	}
+});
+
+test('every template-literal key family is declared and resolvable', () => {
+	assert.deepEqual(
+		[...dynamicPrefixes.keys()].sort(),
+		Object.keys(DYNAMIC_FAMILIES).sort(),
+		'a t(`prefix.${…}`) call site is undeclared (or a declared one disappeared); ' +
+			'declare it in DYNAMIC_FAMILIES together with whatever enumerates its members',
+	);
+
+	for (const [prefix, { file, member, why }] of Object.entries(DYNAMIC_FAMILIES)) {
+		const source = readFileSync(file, 'utf8');
+		// A member may legitimately appear at several call sites (`tk('close')`),
+		// so this is a set, not a list.
+		const members = new Set([...source.matchAll(member)].map((m) => m[1]));
+		assert.ok(members.size > 0, `${why} in ${file} no longer matches its pattern`);
+
+		for (const name of members) {
+			assert.ok(
+				english.has(`${prefix}${name}`),
+				`${prefix}${name} is rendered from ${why} but English does not define it`,
+			);
+		}
+	}
+});
+
+test('t() never echoes a key back for a reachable string', () => {
+	// The end-to-end statement of both bugs, expressed through t() itself
+	// rather than through the tables.
+	const reachable = new Set(staticKeys.map((r) => r.key));
+	for (const [prefix, { file, member }] of Object.entries(DYNAMIC_FAMILIES)) {
+		const source = readFileSync(file, 'utf8');
+		for (const m of source.matchAll(member)) reachable.add(`${prefix}${m[1]}`);
+	}
+	for (const key of reachable) {
+		for (const lang of languages) {
+			const value = t(key, lang);
+			assert.notEqual(value, key, `t('${key}', '${lang}') renders the key itself`);
+			assert.ok(value.length > 0, `t('${key}', '${lang}') is empty`);
+		}
+	}
+});
+
+test('the tag-colour names reach the UI in every language', () => {
+	// The regression pin for the misfiled block: English fallback would keep the
+	// previous test green, so require each locale to own the block outright.
+	const colourNames = Object.keys(translations.en.colors as Translation);
+	assert.ok(colourNames.length >= 9, 'English still defines the colour block');
+
+	for (const lang of languages) {
+		const own = dictionaries.get(lang)!;
+		for (const name of colourNames) {
+			assert.ok(own.has(`colors.${name}`), `${lang} defines colors.${name} at the top level`);
+			assert.ok(!own.has(`settings.colors.${name}`), `${lang} no longer hides it under settings.*`);
+		}
+	}
+});
+
+test('the window-tag editor’s Save button is translated', () => {
+	// The button that shipped reading "common.save".
+	const titleBar = readFileSync('src/lib/components/TitleBar.svelte', 'utf8');
+	const match = titleBar.match(/onclick=\{applyTag\}>\{t\('([^']+)', currentLanguage\)\}/);
+	assert.ok(match, 'the tag editor still labels its confirm button through t()');
+	assert.ok(english.has(match[1]), `${match[1]} is defined in English`);
+	for (const lang of languages) {
+		assert.notEqual(t(match[1], lang), match[1], `the Save button is translated in ${lang}`);
+	}
+});
+
+test('every t() call resolves to a literal, a declared family, or a known indirection', () => {
+	assert.deepEqual(
+		[...indirectCalls].sort(),
+		[...KNOWN_INDIRECT_CALLS].sort(),
+		'a t() call takes a key this scanner cannot see; either give it a literal ' +
+			'or add it here after making sure the key is checked some other way',
+	);
+});
+
+test('per-locale completeness (reported, never enforced)', () => {
+	// A worklist for translators, not a gate. Adding an English key must not
+	// turn 25 locales red.
+	const rows = languages
+		.filter((lang) => lang !== 'en')
+		.map((lang) => {
+			const own = dictionaries.get(lang)!;
+			const missing = [...english.keys()].filter((key) => !own.has(key));
+			return { lang, missing: missing.length };
+		})
+		.sort((a, b) => b.missing - a.missing);
+
+	const total = rows.reduce((sum, row) => sum + row.missing, 0);
+	console.log(`\n  i18n coverage — ${english.size} English keys, 25 other locales`);
+	for (const { lang, missing } of rows) {
+		const pct = (((english.size - missing) / english.size) * 100).toFixed(1);
+		console.log(`    ${lang.padEnd(6)} ${String(english.size - missing).padStart(3)}/${english.size}  ${pct.padStart(5)}%  ${missing} missing`);
+	}
+	console.log(`    ${'total'.padEnd(6)} ${total} untranslated key-slots (falling back to English)\n`);
+
+	assert.ok(total >= 0);
+});

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -557,7 +557,7 @@
 						<button class:selected={tagDraftColor === color} style:--tag-color={color} onclick={() => (tagDraftColor = color)} aria-label={color}></button>
 					{/each}
 				</div>
-				<button onclick={applyTag}>{t('common.save', currentLanguage)}</button>
+				<button onclick={applyTag}>{t('settings.save', currentLanguage)}</button>
 				{#if tabManager.windowTag}<button onclick={togglePinnedTag}>{t(tabManager.windowTag.pinned ? 'menu.unpinWindowTag' : 'menu.pinWindowTag', currentLanguage)}</button>{/if}
 				{#if tabManager.windowTag}<button onclick={clearTag}>{t('menu.windowTagClear', currentLanguage)}</button>{/if}
 			</div>

--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -189,6 +189,7 @@ export const translations: Record<LanguageCode, Translation> = {
             exit: 'Exit',
             zenMode: 'Zen Mode',
             tabs: '{{action}} Tabs',
+            openTabs: 'Open Tabs',
             back: 'Back',
             forward: 'Forward',
             openLocation: 'Open Location',
@@ -1465,17 +1466,6 @@ export const translations: Record<LanguageCode, Translation> = {
             resetToolbar: '툴바 초기화',
             moveUp: '위로 이동',
             moveDown: '아래로 이동',
-            colors: {
-                default: '기본',
-                yellow: '노란색',
-                orange: '주황색',
-                red: '빨간색',
-                pink: '분홍색',
-                purple: '볼라색',
-                blue: '파란색',
-                cyan: '청록색',
-                green: '초록색'
-            },
             files: '파일',
             fileSettings: '파일 설정',
             autoSave: '편집 내용 자동 저장',
@@ -1810,18 +1800,18 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefault: 'По умолчанию',
             themeDefaultLight: 'Светлая по умолчанию',
             themeDefaultDark: 'Тёмная по умолчанию',
-            themeFollowSystem: 'Системная',
-            colors: {
-                default: 'По умолчанию',
-                yellow: 'Жёлтый',
-                orange: 'Оранжевый',
-                red: 'Красный',
-                pink: 'Розовый',
-                purple: 'Фиолетовый',
-                blue: 'Синий',
-                cyan: 'Голубой',
-                green: 'Зелёный'
-            }
+            themeFollowSystem: 'Системная'
+        },
+        colors: {
+            default: 'По умолчанию',
+            yellow: 'Жёлтый',
+            orange: 'Оранжевый',
+            red: 'Красный',
+            pink: 'Розовый',
+            purple: 'Фиолетовый',
+            blue: 'Синий',
+            cyan: 'Голубой',
+            green: 'Зелёный'
         },
         menu: {
             file: 'Файл',
@@ -2035,21 +2025,21 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: 'Claro predeterminado',
             themeDefaultDark: 'Oscuro predeterminado',
             themeFollowSystem: 'Seguir sistema',
-            colors: {
-                default: 'Predeterminado',
-                yellow: 'Amarillo',
-                orange: 'Naranja',
-                red: 'Rojo',
-                pink: 'Rosa',
-                purple: 'Morado',
-                blue: 'Azul',
-                cyan: 'Cian',
-                green: 'Verde'
-            },
             files: 'Archivos',
             fileSettings: 'Configuración de archivos',
             autoSave: 'Guardar cambios automáticamente',
             confirmBeforeSave: 'Pedir confirmación antes de guardar'
+        },
+        colors: {
+            default: 'Predeterminado',
+            yellow: 'Amarillo',
+            orange: 'Naranja',
+            red: 'Rojo',
+            pink: 'Rosa',
+            purple: 'Morado',
+            blue: 'Azul',
+            cyan: 'Cian',
+            green: 'Verde'
         },
         menu: {
             file: 'Archivo',
@@ -2262,21 +2252,21 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: 'Clair par défaut',
             themeDefaultDark: 'Sombre par défaut',
             themeFollowSystem: 'Suivre le système',
-            colors: {
-                default: 'Par défaut',
-                yellow: 'Jaune',
-                orange: 'Orange',
-                red: 'Rouge',
-                pink: 'Rose',
-                purple: 'Violet',
-                blue: 'Bleu',
-                cyan: 'Cyan',
-                green: 'Vert'
-            },
             files: 'Fichiers',
             fileSettings: 'Paramètres des fichiers',
             autoSave: 'Enregistrement automatique des modifications',
             confirmBeforeSave: 'Demander confirmation avant d\'enregistrer'
+        },
+        colors: {
+            default: 'Par défaut',
+            yellow: 'Jaune',
+            orange: 'Orange',
+            red: 'Rouge',
+            pink: 'Rose',
+            purple: 'Violet',
+            blue: 'Bleu',
+            cyan: 'Cyan',
+            green: 'Vert'
         },
         menu: {
             file: 'Fichier',
@@ -2489,21 +2479,21 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: 'Hell Standard',
             themeDefaultDark: 'Dunkel Standard',
             themeFollowSystem: 'System folgen',
-            colors: {
-                default: 'Standard',
-                yellow: 'Gelb',
-                orange: 'Orange',
-                red: 'Rot',
-                pink: 'Rosa',
-                purple: 'Lila',
-                blue: 'Blau',
-                cyan: 'Cyan',
-                green: 'Grün'
-            },
             files: 'Dateien',
             fileSettings: 'Datei-Einstellungen',
             autoSave: 'Änderungen automatisch speichern',
             confirmBeforeSave: 'Vor dem Speichern bestätigen'
+        },
+        colors: {
+            default: 'Standard',
+            yellow: 'Gelb',
+            orange: 'Orange',
+            red: 'Rot',
+            pink: 'Rosa',
+            purple: 'Lila',
+            blue: 'Blau',
+            cyan: 'Cyan',
+            green: 'Grün'
         },
         menu: {
             file: 'Datei',
@@ -2716,21 +2706,21 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: 'Claro padrão',
             themeDefaultDark: 'Escuro padrão',
             themeFollowSystem: 'Seguir sistema',
-            colors: {
-                default: 'Padrão',
-                yellow: 'Amarelo',
-                orange: 'Laranja',
-                red: 'Vermelho',
-                pink: 'Rosa',
-                purple: 'Roxo',
-                blue: 'Azul',
-                cyan: 'Ciano',
-                green: 'Verde'
-            },
             files: 'Arquivos',
             fileSettings: 'Configurações de arquivos',
             autoSave: 'Salvar edições automaticamente',
             confirmBeforeSave: 'Pedir confirmação antes de salvar'
+        },
+        colors: {
+            default: 'Padrão',
+            yellow: 'Amarelo',
+            orange: 'Laranja',
+            red: 'Vermelho',
+            pink: 'Rosa',
+            purple: 'Roxo',
+            blue: 'Azul',
+            cyan: 'Ciano',
+            green: 'Verde'
         },
         menu: {
             file: 'Arquivo',
@@ -2943,21 +2933,21 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: 'Chiaro predefinito',
             themeDefaultDark: 'Scuro predefinito',
             themeFollowSystem: 'Segui sistema',
-            colors: {
-                default: 'Predefinito',
-                yellow: 'Giallo',
-                orange: 'Arancione',
-                red: 'Rosso',
-                pink: 'Rosa',
-                purple: 'Viola',
-                blue: 'Blu',
-                cyan: 'Ciano',
-                green: 'Verde'
-            },
             files: 'File',
             fileSettings: 'Impostazioni file',
             autoSave: 'Salvataggio automatico delle modifiche',
             confirmBeforeSave: 'Chiedi conferma prima di salvare'
+        },
+        colors: {
+            default: 'Predefinito',
+            yellow: 'Giallo',
+            orange: 'Arancione',
+            red: 'Rosso',
+            pink: 'Rosa',
+            purple: 'Viola',
+            blue: 'Blu',
+            cyan: 'Ciano',
+            green: 'Verde'
         },
         menu: {
             file: 'File',
@@ -3182,21 +3172,21 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: 'Jasny domyślny',
             themeDefaultDark: 'Ciemny domyślny',
             themeFollowSystem: 'Zgodny z systemem',
-            colors: {
-                default: 'Domyślny',
-                yellow: 'Żółty',
-                orange: 'Pomarańczowy',
-                red: 'Czerwony',
-                pink: 'Różowy',
-                purple: 'Fioletowy',
-                blue: 'Niebieski',
-                cyan: 'Cyjan',
-                green: 'Zielony'
-            },
             files: 'Pliki',
             fileSettings: 'Ustawienia plików',
             autoSave: 'Autozapis zmian',
             confirmBeforeSave: 'Pytaj o potwierdzenie przed zapisem'
+        },
+        colors: {
+            default: 'Domyślny',
+            yellow: 'Żółty',
+            orange: 'Pomarańczowy',
+            red: 'Czerwony',
+            pink: 'Różowy',
+            purple: 'Fioletowy',
+            blue: 'Niebieski',
+            cyan: 'Cyjan',
+            green: 'Zielony'
         },
         menu: {
             file: 'Plik',
@@ -3419,21 +3409,21 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: 'Licht standaard',
             themeDefaultDark: 'Donker standaard',
             themeFollowSystem: 'Volg systeem',
-            colors: {
-                default: 'Standaard',
-                yellow: 'Geel',
-                orange: 'Oranje',
-                red: 'Rood',
-                pink: 'Roze',
-                purple: 'Paars',
-                blue: 'Blauw',
-                cyan: 'Cyaan',
-                green: 'Groen'
-            },
             files: 'Bestanden',
             fileSettings: 'Bestandsinstellingen',
             autoSave: 'Wijzigingen automatisch opslaan',
             confirmBeforeSave: 'Bevestiging vragen voor opslaan'
+        },
+        colors: {
+            default: 'Standaard',
+            yellow: 'Geel',
+            orange: 'Oranje',
+            red: 'Rood',
+            pink: 'Roze',
+            purple: 'Paars',
+            blue: 'Blauw',
+            cyan: 'Cyaan',
+            green: 'Groen'
         },
         menu: {
             file: 'Bestand',
@@ -3646,21 +3636,21 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: 'Ljust standard',
             themeDefaultDark: 'Mörkt standard',
             themeFollowSystem: 'Följ systemet',
-            colors: {
-                default: 'Standard',
-                yellow: 'Gul',
-                orange: 'Orange',
-                red: 'Röd',
-                pink: 'Rosa',
-                purple: 'Lila',
-                blue: 'Blå',
-                cyan: 'Cyan',
-                green: 'Grön'
-            },
             files: 'Filer',
             fileSettings: 'Filinställningar',
             autoSave: 'Spara ändringar automatiskt',
             confirmBeforeSave: 'Fråga om bekräftelse innan sparande'
+        },
+        colors: {
+            default: 'Standard',
+            yellow: 'Gul',
+            orange: 'Orange',
+            red: 'Röd',
+            pink: 'Rosa',
+            purple: 'Lila',
+            blue: 'Blå',
+            cyan: 'Cyan',
+            green: 'Grön'
         },
         menu: {
             file: 'Arkiv',
@@ -3873,21 +3863,21 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: 'Sáng mặc định',
             themeDefaultDark: 'Tối mặc định',
             themeFollowSystem: 'Theo hệ thống',
-            colors: {
-                default: 'Mặc định',
-                yellow: 'Vàng',
-                orange: 'Cam',
-                red: 'Đỏ',
-                pink: 'Hồng',
-                purple: 'Tím',
-                blue: 'Xanh dương',
-                cyan: 'Xanh lam',
-                green: 'Xanh lá'
-            },
             files: 'Tệp',
             fileSettings: 'Cài đặt tệp',
             autoSave: 'Tự động lưu chỉnh sửa',
             confirmBeforeSave: 'Hỏi xác nhận trước khi lưu'
+        },
+        colors: {
+            default: 'Mặc định',
+            yellow: 'Vàng',
+            orange: 'Cam',
+            red: 'Đỏ',
+            pink: 'Hồng',
+            purple: 'Tím',
+            blue: 'Xanh dương',
+            cyan: 'Xanh lam',
+            green: 'Xanh lá'
         },
         menu: {
             file: 'Tệp',
@@ -4100,21 +4090,21 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: 'Claro predefinido',
             themeDefaultDark: 'Escuro predefinido',
             themeFollowSystem: 'Seguir sistema',
-            colors: {
-                default: 'Predefinição',
-                yellow: 'Amarelo',
-                orange: 'Laranja',
-                red: 'Vermelho',
-                pink: 'Rosa',
-                purple: 'Roxo',
-                blue: 'Azul',
-                cyan: 'Ciano',
-                green: 'Verde'
-            },
             files: 'Ficheiros',
             fileSettings: 'Definições de ficheiros',
             autoSave: 'Guardar edições automaticamente',
             confirmBeforeSave: 'Pedir confirmação antes de guardar'
+        },
+        colors: {
+            default: 'Predefinição',
+            yellow: 'Amarelo',
+            orange: 'Laranja',
+            red: 'Vermelho',
+            pink: 'Rosa',
+            purple: 'Roxo',
+            blue: 'Azul',
+            cyan: 'Ciano',
+            green: 'Verde'
         },
         menu: {
             file: 'Ficheiro',
@@ -4327,21 +4317,21 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: 'Luminos implicit',
             themeDefaultDark: 'Întunecat implicit',
             themeFollowSystem: 'Urmează sistemul',
-            colors: {
-                default: 'Implicit',
-                yellow: 'Galben',
-                orange: 'Portocaliu',
-                red: 'Roșu',
-                pink: 'Roz',
-                purple: 'Mov',
-                blue: 'Albastru',
-                cyan: 'Cyan',
-                green: 'Verde'
-            },
             files: 'Fișiere',
             fileSettings: 'Setări fișiere',
             autoSave: 'Salvare automată a modificărilor',
             confirmBeforeSave: 'Solicită confirmare înainte de salvare'
+        },
+        colors: {
+            default: 'Implicit',
+            yellow: 'Galben',
+            orange: 'Portocaliu',
+            red: 'Roșu',
+            pink: 'Roz',
+            purple: 'Mov',
+            blue: 'Albastru',
+            cyan: 'Cyan',
+            green: 'Verde'
         },
         menu: {
             file: 'Fișier',
@@ -4554,21 +4544,21 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: 'Alapértelmezett világos',
             themeDefaultDark: 'Alapértelmezett sötét',
             themeFollowSystem: 'Rendszer követése',
-            colors: {
-                default: 'Alapértelmezett',
-                yellow: 'Sárga',
-                orange: 'Narancssárga',
-                red: 'Piros',
-                pink: 'Rózsaszín',
-                purple: 'Lila',
-                blue: 'Kék',
-                cyan: 'Cián',
-                green: 'Zöld'
-            },
             files: 'Fájlok',
             fileSettings: 'Fájlbeállítások',
             autoSave: 'Módosítások automatikus mentése',
             confirmBeforeSave: 'Mentés előtt kérjen megerősítést'
+        },
+        colors: {
+            default: 'Alapértelmezett',
+            yellow: 'Sárga',
+            orange: 'Narancssárga',
+            red: 'Piros',
+            pink: 'Rózsaszín',
+            purple: 'Lila',
+            blue: 'Kék',
+            cyan: 'Cián',
+            green: 'Zöld'
         },
         menu: {
             file: 'Fájl',
@@ -4781,21 +4771,21 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: 'Výchozí světlý',
             themeDefaultDark: 'Výchozí tmavý',
             themeFollowSystem: 'Podle systému',
-            colors: {
-                default: 'Výchozí',
-                yellow: 'Žlutá',
-                orange: 'Oranžová',
-                red: 'Červená',
-                pink: 'Růžová',
-                purple: 'Fialová',
-                blue: 'Modrá',
-                cyan: 'Azurová',
-                green: 'Zelená'
-            },
             files: 'Soubory',
             fileSettings: 'Nastavení souborů',
             autoSave: 'Automaticky ukládat úpravy',
             confirmBeforeSave: 'Před uložením se zeptat na potvrzení'
+        },
+        colors: {
+            default: 'Výchozí',
+            yellow: 'Žlutá',
+            orange: 'Oranžová',
+            red: 'Červená',
+            pink: 'Růžová',
+            purple: 'Fialová',
+            blue: 'Modrá',
+            cyan: 'Azurová',
+            green: 'Zelená'
         },
         menu: {
             file: 'Soubor',
@@ -5014,21 +5004,21 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: 'Predvolené svetlé',
             themeDefaultDark: 'Predvolené tmavé',
             themeFollowSystem: 'Podľa systému',
-            colors: {
-                default: 'Predvolené',
-                yellow: 'Žltá',
-                orange: 'Oranžová',
-                red: 'Červená',
-                pink: 'Ružová',
-                purple: 'Fialová',
-                blue: 'Modrá',
-                cyan: 'Azúrová',
-                green: 'Zelená'
-            },
             files: 'Súbory',
             fileSettings: 'Nastavenia súborov',
             autoSave: 'Automaticky ukladať úpravy',
             confirmBeforeSave: 'Pred uložením sa opýtať na potvrdenie'
+        },
+        colors: {
+            default: 'Predvolené',
+            yellow: 'Žltá',
+            orange: 'Oranžová',
+            red: 'Červená',
+            pink: 'Ružová',
+            purple: 'Fialová',
+            blue: 'Modrá',
+            cyan: 'Azúrová',
+            green: 'Zelená'
         },
         menu: {
             file: 'Súbor',
@@ -5241,21 +5231,21 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: 'Προεπιλεγμένο φωτεινό',
             themeDefaultDark: 'Προεπιλεγμένο σκοτεινό',
             themeFollowSystem: 'Ακολούθηση συστήματος',
-            colors: {
-                default: 'Προεπιλογή',
-                yellow: 'Κίτρινο',
-                orange: 'Πορτοκαλί',
-                red: 'Κόκκινο',
-                pink: 'Ροζ',
-                purple: 'Μωβ',
-                blue: 'Μπλε',
-                cyan: 'Κυανό',
-                green: 'Πράσινο'
-            },
             files: 'Αρχεία',
             fileSettings: 'Ρυθμίσεις αρχείων',
             autoSave: 'Αυτόματη αποθήκευση αλλαγών',
             confirmBeforeSave: 'Ζήτηση επιβεβαίωσης πριν την αποθήκευση'
+        },
+        colors: {
+            default: 'Προεπιλογή',
+            yellow: 'Κίτρινο',
+            orange: 'Πορτοκαλί',
+            red: 'Κόκκινο',
+            pink: 'Ροζ',
+            purple: 'Μωβ',
+            blue: 'Μπλε',
+            cyan: 'Κυανό',
+            green: 'Πράσινο'
         },
         menu: {
             file: 'Αρχείο',
@@ -5468,21 +5458,21 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: 'Oletus vaalea',
             themeDefaultDark: 'Oletus tumma',
             themeFollowSystem: 'Seuraa järjestelmää',
-            colors: {
-                default: 'Oletus',
-                yellow: 'Keltainen',
-                orange: 'Oranssi',
-                red: 'Punainen',
-                pink: 'Vaaleanpunainen',
-                purple: 'Violetti',
-                blue: 'Sininen',
-                cyan: 'Syaani',
-                green: 'Vihreä'
-            },
             files: 'Tiedostot',
             fileSettings: 'Tiedostoasetukset',
             autoSave: 'Tallenna muutokset automaattisesti',
             confirmBeforeSave: 'Pyydä vahvistus ennen tallennusta'
+        },
+        colors: {
+            default: 'Oletus',
+            yellow: 'Keltainen',
+            orange: 'Oranssi',
+            red: 'Punainen',
+            pink: 'Vaaleanpunainen',
+            purple: 'Violetti',
+            blue: 'Sininen',
+            cyan: 'Syaani',
+            green: 'Vihreä'
         },
         menu: {
             file: 'Tiedosto',
@@ -5695,21 +5685,21 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: 'Standard lys',
             themeDefaultDark: 'Standard mørk',
             themeFollowSystem: 'Følg system',
-            colors: {
-                default: 'Standard',
-                yellow: 'Gul',
-                orange: 'Orange',
-                red: 'Rød',
-                pink: 'Lyserød',
-                purple: 'Lilla',
-                blue: 'Blå',
-                cyan: 'Cyan',
-                green: 'Grøn'
-            },
             files: 'Filer',
             fileSettings: 'Filindstillinger',
             autoSave: 'Gem ændringer automatisk',
             confirmBeforeSave: 'Bed om bekræftelse før der gemmes'
+        },
+        colors: {
+            default: 'Standard',
+            yellow: 'Gul',
+            orange: 'Orange',
+            red: 'Rød',
+            pink: 'Lyserød',
+            purple: 'Lilla',
+            blue: 'Blå',
+            cyan: 'Cyan',
+            green: 'Grøn'
         },
         menu: {
             file: 'Fil',
@@ -5922,21 +5912,21 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: 'Standard lys',
             themeDefaultDark: 'Standard mørk',
             themeFollowSystem: 'Følg system',
-            colors: {
-                default: 'Standard',
-                yellow: 'Gul',
-                orange: 'Oransje',
-                red: 'Rød',
-                pink: 'Rosa',
-                purple: 'Lilla',
-                blue: 'Blå',
-                cyan: 'Cyan',
-                green: 'Grønn'
-            },
             files: 'Filer',
             fileSettings: 'Filinnstillinger',
             autoSave: 'Lagre endringer automatisk',
             confirmBeforeSave: 'Be om bekreftelse før lagring'
+        },
+        colors: {
+            default: 'Standard',
+            yellow: 'Gul',
+            orange: 'Oransje',
+            red: 'Rød',
+            pink: 'Rosa',
+            purple: 'Lilla',
+            blue: 'Blå',
+            cyan: 'Cyan',
+            green: 'Grønn'
         },
         menu: {
             file: 'Fil',
@@ -6149,21 +6139,21 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: 'Default Terang',
             themeDefaultDark: 'Default Gelap',
             themeFollowSystem: 'Ikuti Sistem',
-            colors: {
-                default: 'Default',
-                yellow: 'Kuning',
-                orange: 'Oranye',
-                red: 'Merah',
-                pink: 'Merah Muda',
-                purple: 'Ungu',
-                blue: 'Biru',
-                cyan: 'Sian',
-                green: 'Hijau'
-            },
             files: 'Berkas',
             fileSettings: 'Pengaturan berkas',
             autoSave: 'Simpan otomatis perubahan',
             confirmBeforeSave: 'Minta konfirmasi sebelum menyimpan'
+        },
+        colors: {
+            default: 'Default',
+            yellow: 'Kuning',
+            orange: 'Oranye',
+            red: 'Merah',
+            pink: 'Merah Muda',
+            purple: 'Ungu',
+            blue: 'Biru',
+            cyan: 'Sian',
+            green: 'Hijau'
         },
         menu: {
             file: 'Berkas',
@@ -6376,21 +6366,21 @@ export const translations: Record<LanguageCode, Translation> = {
             themeDefaultLight: 'Varsayılan Açık',
             themeDefaultDark: 'Varsayılan Koyu',
             themeFollowSystem: 'Sistemi Takip Et',
-            colors: {
-                default: 'Varsayılan',
-                yellow: 'Sarı',
-                orange: 'Turuncu',
-                red: 'Kırmızı',
-                pink: 'Pembe',
-                purple: 'Mor',
-                blue: 'Mavi',
-                cyan: 'Camgöbeği',
-                green: 'Yeşil'
-            },
             files: 'Dosyalar',
             fileSettings: 'Dosya ayarları',
             autoSave: 'Düzenlemeleri otomatik kaydet',
             confirmBeforeSave: 'Kaydetmeden önce onay iste'
+        },
+        colors: {
+            default: 'Varsayılan',
+            yellow: 'Sarı',
+            orange: 'Turuncu',
+            red: 'Kırmızı',
+            pink: 'Pembe',
+            purple: 'Mor',
+            blue: 'Mavi',
+            cyan: 'Camgöbeği',
+            green: 'Yeşil'
         },
         menu: {
             file: 'Dosya',


### PR DESCRIPTION
Three keys the UI asks for that no locale can answer, plus a test that fails on either shape.

## 1. The window-tag Save button rendered `common.save`

`TitleBar.svelte` calls `t('common.save', …)`. `en.common` contains `close / minimize / maximize / loadingFullDocument` (+ `decrease / increase`) — **no locale defines `common.save`**, so `t()` echoes the key back and the button literally reads `common.save`. In all 26 languages, English included.

**Reused `settings.save` rather than adding a key.** I compared both existing candidates across all 26 locales and they are **byte-identical in 26/26** — both are the bare imperative verb with no object baked in, unlike `menu.saveAs`. So the feared "file-save verb ≠ dialog-confirm verb" split does not exist in this corpus, and a new `common.save` would be a third identical copy of one word across 26 locales, with permanent drift risk and no new information.

Between the two, `settings.save` on change-reason coupling: it is already the app's dialog-confirm Save, used by `Modal.svelte` next to `settings.cancel` / `settings.discard`, and the tag editor is a `role="dialog"` with a confirm button. `menu.save` is File ▸ Save and **already appears elsewhere in this same component** — reusing it would make one key label two unrelated controls in one file, so any future disambiguation of File ▸ Save would silently mutate the tag popover.

## 2. 21 locales filed the tab-colour names one level too deep

The code reads ``t(`colors.${…}`)``. `en / ja / zh-CN / zh-TW / ko` define top-level `colors`; the other **21 locales put the block inside `settings`**, where nothing reads it. Every non-CJK locale showed English colour names while finished translations sat in the file.

**Pure key-path relocation — 189 already-written translations become reachable, none are added.** Each 9-entry block was cut from inside `settings` and re-inserted at top level right after the `settings` block closes, matching where `colors` already sits in the five correct locales.

`ko` had the block in **both** places. The unreachable copy carried a typo (`볼라색` for `보라색`), and it is the one removed.

## 3. `menu.openTabs` — found by the test, not by a human

`titlebarToolbar.ts` declares `labelKey: 'menu.openTabs'`, which **no locale defines**. `Settings.svelte` masks it with a `fallbackName`, so the toolbar-customization list has been showing hard-coded English in all 26 languages. Added to `en.menu`; behaviour is byte-identical for every locale today (they fall back to English exactly as before), but the label is now translatable and appears on the translator worklist. `titlebarToolbar.ts` is untouched.

## The test

`scripts/i18nCoverage.test.ts`, 10 tests, picked up by the existing `npm test` glob. Two hard failures, matching the two shapes these bugs took:

1. **A key the source asks for that English does not define** → catches defects 1 and 3.
2. **A key a locale defines that English does not** → catches defect 2. A misfiled translation is by construction a key English never had, so "orphan" and "unreachable" are the same set.

**Dynamic keys are resolved, not exempted.** Both template families are declared together with the source of truth that enumerates their members, and members are re-derived on every run: ``t(`colors.${…}`)`` from the `highlightColors` array in `Settings.svelte`, ``t(`update.${…}`)`` from the 25 `tk('…')` call sites in `UpdateDialog.svelte`. The set of `prefix.` values found in source must `deepEqual` the declared list, so a new dynamic call site fails until someone declares how to enumerate it — and a 10th swatch colour without a translation is caught like any static key.

**Indirection is followed.** `t(action.labelKey, lang)` cannot be read at the call site, so a second pass harvests every `labelKey: '…'` literal in the tree and subjects those keys to the same rules — that is how defect 3 surfaced. The set of unresolvable call sites must `deepEqual` a 2-entry allowlist, so a new invisible indirection fails.

The argument parser is a real balancer (nested parens/brackets/braces, both quote styles, template literals with nested `${…}`), so the ternary form `t(cond ? 'menu.unpinWindowTag' : 'menu.pinWindowTag', lang)` is handled and `'default'` inside an interpolation is correctly ignored. Whole-line comments are stripped first, because one source comment mentions `` `t()` `` in prose.

**Per-locale completeness is reported, never enforced.** It prints a ranked worklist (327 English keys; 18 locales at 63.3%, `ru` 119 missing, `cs` 116, `pl` 105, `ja` 75, `ko` 21, `zh-TW` 11, `zh-CN` 1; 2608 untranslated slots). Making that a hard failure would mean nobody could add an English key without turning 25 locales red.

### Counter-proof

| State | Pass | Fail |
|---|---|---|
| Both fixes reverted — i.e. current `master` | **5** | **5** |
| Only the Save button reverted | 7 | 3 |
| Final | **10** | 0 |

The two defects fail **disjoint** test sets (1 → tests 1/3/5, 2 → tests 2/4), so neither masks the other. On `master` the failures name the bugs directly:

```
t() references 2 key(s) English does not define; the UI shows the raw key:
  common.save    <- src/lib/components/TitleBar.svelte
  menu.openTabs  <- src/lib/utils/titlebarToolbar.ts

translations that no code path can reach (present in a locale, absent in English):
  settings.colors.default  [22] cs, da, nl, fi, fr, de, el, hu, id, it, ko, no, pl, …
```

## Diff discipline

```
  1    1   src/lib/components/TitleBar.svelte
233  243   src/lib/utils/i18n.ts
+    404   scripts/i18nCoverage.test.ts   (new)
```

The `i18n.ts` numbers account exactly: 233 inserted = 21 × 11 (`colors: {` + 9 entries + `},`) + 1 (a trailing comma) + 1 (`menu.openTabs`); 243 deleted = 21 × 11 + 11 (`ko`'s nested block) + 1. **Filtering the diff for anything outside those lines returns zero rows** — no reindentation, no reflow, no unrelated lines.

```
npm run check   432 files, 0 errors, 0 warnings
npm test        385 / 385
cargo test       95 / 95
```

## Known limits

- The test proves keys **resolve**, not that the text is correct or well-placed.
- Three leaves (`editor.status.lines`, `tooltip.zoomIn`, `tooltip.zoomOut`) exist in 22 locales and never existed in English. Unlike the colour block they are not misfiled — nothing reads them under any path. They are pinned in a 3-entry `KNOWN_ORPHANS` that must be **exactly** consumed, so a stale entry fails as loudly as a new orphan, and a separate test asserts no source key or dynamic family can reach a pinned orphan. An orphan can be tolerated **or** reachable, never both. Deleting dead keys is out of scope here.
- A key assembled by string concatenation outside a template literal is invisible; it would surface as a literal ending in `.` failing rule 1, which is the right outcome.
- No translations were added for the 2608 missing slots, and the ~36 unreferenced English keys were left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)