### PR TITLE
refactor(preview): drop the dead YouTube iframe copy from the viewer

### DIFF
--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -1635,28 +1635,6 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		if (currentFile === path) tabManager.closeTab(tabManager.activeTabId!);
 	}
 
-	function isYoutubeLink(url: string) {
-		return url.includes('youtube.com/watch') || url.includes('youtu.be/');
-	}
-
-	function getYoutubeId(url: string) {
-		const match = url.match(/^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/);
-		return match && match[2].length === 11 ? match[2] : null;
-	}
-
-	function replaceWithYoutubeEmbed(element: Element, videoId: string) {
-		const container = element.ownerDocument.createElement('div');
-		container.className = 'video-container';
-		const iframe = element.ownerDocument.createElement('iframe');
-		iframe.src = `https://www.youtube.com/embed/${videoId}`;
-		iframe.title = 'YouTube video player';
-		iframe.frameBorder = '0';
-		iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';
-		iframe.allowFullscreen = true;
-		container.appendChild(iframe);
-		element.replaceWith(container);
-	}
-
 	async function canCloseTab(tabId: string): Promise<boolean> {
 		return documentSession.canCloseTab(tabId);
 	}


### PR DESCRIPTION
`MarkdownViewer.svelte` still carried a pre-fix copy of the YouTube handling — `isYoutubeLink`, `getYoutubeId` and `replaceWithYoutubeEmbed`. The live implementation is in `src/lib/utils/markdown.ts`, where `replaceWithYoutubeLink` renders a thumbnail anchor that opens the system browser instead of an embed.

The copy was dead twice over:

- **No callers.** `grep -rn 'replaceWithYoutubeEmbed\|isYoutubeLink\|getYoutubeId\|video-container' src scripts` matched only the definitions themselves.
- **Could not have worked if called.** It builds an `<iframe src="https://www.youtube.com/embed/...">`, but `frame-src` is no longer in the app CSP (`src-tauri/tauri.conf.json`), so the frame cannot load at all.

Its `isYoutubeLink` had also drifted narrower than the live one, missing the `youtube.com/embed/`, `/v/` and `/u/` forms.

`scripts/youtubeExternalFallback.test.ts` asserts that `createElement("iframe")` is absent, but reads only `markdown.ts` — so this second copy sat outside the test's field of view.

No `.video-container` CSS exists anywhere in the repo, so nothing else went stale alongside it.

## Verification

- `npm run check` — 432 files, 0 errors, 0 warnings
- `npm test` — 375 pass, 0 fail
- `cd src-tauri && cargo test` — 98 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)