### PR TITLE
chore: delete pre-fix copies that survived their own fixes

### DIFF
--- a/scripts/previewSanitize.test.ts
+++ b/scripts/previewSanitize.test.ts
@@ -86,9 +86,6 @@ const SANITIZE_CALL_SITES: Record<string, number> = {
 	// DOMPurify keeps mermaid's `<style>` under the diagram config and strips it
 	// under MARKDOWN_SANITIZE_CONFIG, which would flatten every diagram.
 	'src/lib/MarkdownViewer.svelte': 1,
-	// Dead export kept in step with the viewer's copy of the same diagram
-	// sanitizer; nothing imports it (see markdown.ts renderRichContent).
-	'src/lib/utils/markdown.ts': 1,
 };
 
 function walk(dir: string): string[] {

--- a/scripts/singleImplementationConvention.test.ts
+++ b/scripts/singleImplementationConvention.test.ts
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+// A fixed behavior must have exactly one implementation.
+//
+// The bug class this catches: a behavior gets fixed in file A while a stale
+// pre-fix copy of the same logic survives in file B. Nothing type-checks the
+// copy, nothing imports it, and it looks like a reusable shared helper — so the
+// next person to "reuse" or "sync" it silently reverts a merged fix.
+//
+// The existing behavior tests cannot see this. youtubeExternalFallback.test.ts,
+// taskToggleMemory.test.ts, mermaidPrintTheme.test.ts and previewScrollSync.ts
+// each read one hard-coded file, so a second copy living anywhere else is
+// invisible to them. Every rule below therefore scans the whole `src` tree and
+// pins *which files* are allowed to contain the marker.
+//
+// To add a behavior: append a row. `allowed` is the complete set of src-relative
+// paths permitted to match `marker`; anything else is a duplicate implementation.
+
+type Rule = {
+	name: string;
+	// What breaks if a second copy of this appears.
+	why: string;
+	marker: RegExp;
+	allowed: string[];
+	// Optional: every allowed file that matches `marker` must also match this.
+	requires?: { pattern: RegExp; message: string };
+};
+
+const RULES: Rule[] = [
+	{
+		name: 'mermaid rendering remembers the diagram source',
+		why: 'PDF/HTML export re-renders Mermaid in the light theme from data-mermaid-source; a render path without rememberDiagramSource exports blank or dark-themed diagrams (#359).',
+		marker: /mermaid\.render\(/g,
+		allowed: ['src/lib/MarkdownViewer.svelte', 'src/lib/utils/mermaidPrint.ts'],
+		requires: {
+			pattern: /rememberDiagramSource/,
+			message: 'a Mermaid render site must record the source via rememberDiagramSource',
+		},
+	},
+	{
+		name: 'Mermaid theme resolution has one implementation',
+		why: 'resolveMermaidTheme in mermaidPrint.ts is shared by the on-screen render and the print restore so the two cannot drift; a hand-rolled dark/neutral ternary is that drift.',
+		marker: /["']dark["']\s*:\s*["']neutral["']/g,
+		allowed: ['src/lib/utils/mermaidPrint.ts'],
+	},
+	{
+		name: 'editor scroll-sync max is measured from content height',
+		why: 'Split-view scroll sync must not count the editor bottom padding; the pre-fix form subtracted the viewport height from getScrollHeight() (#316).',
+		marker: /getScrollHeight\(\)\s*-\s*[^;\n)]*height/gi,
+		allowed: [],
+	},
+	{
+		name: 'YouTube links never become embedded frames',
+		why: 'The app dropped frame-src from its CSP and renders YouTube as a thumbnail anchor that opens the browser; an iframe path is the pre-fix version and cannot load.',
+		marker: /createElement\((['"])iframe\1\)/g,
+		// KNOWN STALE COPY — replaceWithYoutubeEmbed in MarkdownViewer.svelte is
+		// an uncalled pre-fix leftover. Delete it and this allowlist entry
+		// together; the entry exists only so this rule can guard the rest of the
+		// tree today.
+		allowed: ['src/lib/MarkdownViewer.svelte'],
+	},
+	{
+		name: 'DOMPurify is configured in one place',
+		why: 'The sanitize contract lives in utils/sanitize.ts; an inline DOMPurify config elsewhere is a second, unreviewed sanitizer.',
+		marker: /from\s+["']dompurify["']/g,
+		allowed: ['src/lib/utils/sanitize.ts', 'src/lib/MarkdownViewer.svelte'],
+	},
+	{
+		name: 'rich-content rendering has one implementation',
+		why: 'The viewer owns the render pipeline (highlight.js + KaTeX + Mermaid); a second renderRichContent is a fork that drifts from it.',
+		marker: /function\s+renderRichContent\s*\(/g,
+		allowed: ['src/lib/MarkdownViewer.svelte'],
+	},
+	{
+		name: 'editor language mapping has one implementation',
+		why: 'A second extension-to-language table drifts from the one the editor actually uses.',
+		marker: /function\s+getLanguage\s*\(/g,
+		allowed: ['src/lib/MarkdownViewer.svelte'],
+	},
+	{
+		name: 'highlight color palette has one definition',
+		why: 'A second palette drifts from the one bound to the --highlight-color custom property.',
+		marker: /(?:const|let)\s+highlightColorMap\b/g,
+		allowed: ['src/lib/MarkdownViewer.svelte'],
+	},
+];
+
+function walk(dir: string): string[] {
+	const out: string[] = [];
+	for (const name of readdirSync(dir)) {
+		const path = join(dir, name);
+		if (statSync(path).isDirectory()) out.push(...walk(path));
+		else if (/\.(ts|svelte|js)$/.test(name)) out.push(path);
+	}
+	return out;
+}
+
+const SOURCES = walk('src').map((path) => ({
+	path: path.replace(/\\/g, '/'),
+	text: readFileSync(path, 'utf8'),
+}));
+
+for (const rule of RULES) {
+	test(`single implementation: ${rule.name}`, () => {
+		const matched = SOURCES.filter(({ text }) => new RegExp(rule.marker.source, rule.marker.flags).test(text));
+
+		const unexpected = matched.map(({ path }) => path).filter((path) => !rule.allowed.includes(path));
+		assert.deepEqual(
+			unexpected,
+			[],
+			`second implementation found — ${rule.why}\nReuse the existing one instead of copying it. If this really is a new legitimate site, add it to \`allowed\` with a reason.`,
+		);
+
+		if (rule.requires) {
+			for (const { path, text } of matched) {
+				assert.match(text, rule.requires.pattern, `${path}: ${rule.requires.message}`);
+			}
+		}
+	});
+}
+
+test('every rule keeps at least one live implementation', () => {
+	// Guards the rules themselves: a marker that matches nothing has gone stale
+	// (renamed symbol, deleted feature) and is silently no longer guarding.
+	for (const rule of RULES) {
+		if (rule.allowed.length === 0) continue;
+		const matched = SOURCES.some(({ text }) => new RegExp(rule.marker.source, rule.marker.flags).test(text));
+		assert.ok(matched, `rule "${rule.name}" matches nothing in src — update its marker or drop the rule`);
+	}
+});

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -1180,13 +1180,6 @@
 		return 1;
 	}
 
-	function getEditorScrollMax() {
-		if (!editor) return 0;
-
-		const layout = editor.getLayoutInfo();
-		return Math.max(0, editor.getScrollHeight() - layout.height);
-	}
-
 	function getEditorContentScrollMax() {
 		if (!editor) return 0;
 
@@ -1525,9 +1518,7 @@
 	export const getValue = () => editor?.getValue() || "";
 	export const setValue = (val: string) => editor?.setValue(val);
 	export const focus = () => editor?.focus();
-	export const getViewState = () => editor?.saveViewState();
 	export const restoreViewState = (state: any) => editor?.restoreViewState(state);
-	export const revealLine = (line: number) => editor?.revealLineInCenter(line);
 </script>
 
 <div class="editor-outer">

--- a/src/lib/components/Toc.svelte
+++ b/src/lib/components/Toc.svelte
@@ -169,9 +169,14 @@
 	}
 
 	$effect(() => {
-		if (markdownBody) {
-			markdownBody.addEventListener('scroll', handleScroll, { passive: true });
-			return () => markdownBody.removeEventListener('scroll', handleScroll);
+		// Capture the element the listener was attached to: the cleanup must
+		// detach from that same node, not from whatever `markdownBody` points at
+		// when the effect re-runs (a changed prop would leak the old listener, a
+		// null prop would throw).
+		const el: HTMLElement | null = markdownBody;
+		if (el) {
+			el.addEventListener('scroll', handleScroll, { passive: true });
+			return () => el.removeEventListener('scroll', handleScroll);
 		}
 	});
 

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -1,17 +1,4 @@
 import { convertFileSrc } from "@tauri-apps/api/core";
-import DOMPurify from "dompurify";
-
-export const highlightColorMap: Record<string, string> = {
-	default: "color-mix(in srgb, var(--color-accent-fg) 40%, transparent)",
-	yellow: "rgba(255, 208, 0, 0.4)",
-	orange: "rgba(255, 140, 0, 0.4)",
-	red: "rgba(255, 60, 60, 0.4)",
-	pink: "rgba(255, 105, 180, 0.4)",
-	purple: "rgba(164, 108, 244, 0.4)",
-	blue: "rgba(67, 138, 243, 0.4)",
-	cyan: "rgba(43, 185, 178, 0.4)",
-	green: "rgba(77, 177, 88, 0.4)",
-};
 
 const alertIcons: Record<string, string> = {
 	note: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-pencil"><path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/><path d="m15 5 4 4"/></svg>',
@@ -39,7 +26,7 @@ export function resolvePath(basePath: string, relativePath: string): string {
 	return parts.join("/");
 }
 
-export function isYoutubeLink(url: string): boolean {
+function isYoutubeLink(url: string): boolean {
 	return (
 		url.includes("youtube.com/watch") ||
 		url.includes("youtube.com/embed/") ||
@@ -49,7 +36,7 @@ export function isYoutubeLink(url: string): boolean {
 	);
 }
 
-export function getYoutubeId(url: string): string | null {
+function getYoutubeId(url: string): string | null {
 	const match = url.match(
 		/^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/,
 	);
@@ -68,32 +55,6 @@ function replaceWithYoutubeLink(element: Element, videoId: string, href: string)
 	link.appendChild(thumbnail);
 
 	element.replaceWith(link);
-}
-
-export function getLanguage(path: string): string {
-	if (!path) return "markdown";
-	const ext = path.split(".").pop()?.toLowerCase();
-	switch (ext) {
-		case "js":
-		case "jsx":
-			return "javascript";
-		case "ts":
-		case "tsx":
-			return "typescript";
-		case "html":
-			return "html";
-		case "css":
-			return "css";
-		case "json":
-			return "json";
-		case "md":
-		case "markdown":
-		case "mdown":
-		case "mkd":
-			return "markdown";
-		default:
-			return "plaintext";
-	}
 }
 
 function processInlineMath(root: Element) {
@@ -723,146 +684,4 @@ export function processMarkdownHtml(
 	});
 
 	return doc.body.innerHTML;
-}
-
-export async function renderRichContent(
-	markdownBody: HTMLElement,
-	hljs: any,
-	katex: any,
-	renderMathInElement: any,
-	mermaid: any,
-	theme: string,
-	invoke: (cmd: string, args?: any) => Promise<any>,
-) {
-	if (!hljs || !renderMathInElement || !mermaid) return;
-
-	const isSystemDark = window.matchMedia(
-		"(prefers-color-scheme: dark)",
-	).matches;
-	const datasetThemeType = document.documentElement.dataset.themeType;
-	const isDark =
-		datasetThemeType === "dark" ||
-		theme === "dark" ||
-		(theme === "system" && isSystemDark);
-	const effectiveTheme = isDark ? "dark" : "neutral";
-	mermaid.initialize({ startOnLoad: false, theme: effectiveTheme });
-
-	const codeBlocks = Array.from(markdownBody.querySelectorAll("pre code"));
-	for (const block of codeBlocks) {
-		const codeEl = block as HTMLElement;
-		const preEl = codeEl.parentElement as HTMLPreElement;
-
-		if (codeEl.classList.contains("language-mermaid")) {
-			try {
-				const mermaidCode = codeEl.textContent || "";
-				const id = `mermaid-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
-				const { svg } = await mermaid.render(id, mermaidCode);
-				const container = document.createElement("div");
-				container.className = "mermaid-diagram";
-				container.innerHTML = DOMPurify.sanitize(svg, {
-					ADD_TAGS: ["foreignObject"],
-					ADD_ATTR: ["dominant-baseline", "text-anchor"],
-				});
-				preEl.replaceWith(container);
-			} catch (error) {
-				console.error("Failed to render Mermaid diagram:", error);
-				const errorDiv = document.createElement("div");
-				errorDiv.className = "mermaid-error";
-				errorDiv.style.color = "red";
-				errorDiv.style.padding = "1em";
-				errorDiv.textContent = `Error rendering Mermaid diagram: ${error}`;
-				preEl.replaceWith(errorDiv);
-			}
-			continue;
-		}
-
-		const hasExplicitLang = Array.from(codeEl.classList).some((c) =>
-			c.startsWith("language-"),
-		);
-
-		if (hasExplicitLang) {
-			hljs.highlightElement(codeEl);
-		}
-
-		const langClass = Array.from(codeEl.classList).find((c) =>
-			c.startsWith("language-"),
-		);
-
-		if (preEl && preEl.tagName === "PRE") {
-			preEl.querySelectorAll(".lang-label").forEach((l) => l.remove());
-			const codeContent = codeEl.textContent || "";
-			const existingWrapper = preEl.parentElement?.classList.contains(
-				"code-block-shell",
-			)
-				? (preEl.parentElement as HTMLDivElement)
-				: null;
-			existingWrapper
-				?.querySelectorAll(":scope > .lang-label")
-				.forEach((l) => l.remove());
-
-			const wrapper = existingWrapper ?? document.createElement("div");
-			if (!existingWrapper) {
-				wrapper.className = "code-block-shell";
-				preEl.replaceWith(wrapper);
-				wrapper.appendChild(preEl);
-			}
-
-			const copyCode = () => {
-				const codeToCopy = codeContent.replace(/\n$/, "");
-				invoke("clipboard_write_text", { text: codeToCopy })
-					.then(() => {
-						const originalContent = label.innerHTML;
-						label.innerHTML = "Copied!";
-						label.classList.add("copied");
-						setTimeout(() => {
-							label.innerHTML = originalContent;
-							label.classList.remove("copied");
-						}, 1500);
-					})
-					.catch((err) => {
-						console.error("Failed to copy code:", err);
-					});
-			};
-
-			const label = document.createElement("button");
-			label.className = "lang-label";
-			label.title = "Click to copy code";
-			label.onclick = copyCode;
-
-			if (hasExplicitLang && langClass) {
-				label.textContent = langClass.replace("language-", "");
-				wrapper.appendChild(label);
-			} else {
-				label.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>`;
-				wrapper.appendChild(label);
-			}
-		}
-	}
-
-	if (katex) {
-		const mathElements = markdownBody.querySelectorAll("[data-math]");
-		for (const el of Array.from(mathElements)) {
-			const isDisplay = el.getAttribute("data-math") === "display";
-			const mathSource = el.getAttribute("data-math-source") || el.textContent || "";
-			try {
-				katex.render(mathSource, el as HTMLElement, {
-					displayMode: isDisplay,
-					throwOnError: false,
-				});
-			} catch (e) {
-				console.error("KaTeX rendering error:", e);
-			}
-		}
-	}
-
-	if (renderMathInElement) {
-		renderMathInElement(markdownBody, {
-			delimiters: [
-				{ left: "$$", right: "$$", display: true },
-				{ left: "\\(", right: "\\)", display: false },
-				{ left: "\\[", right: "\\]", display: true },
-			],
-			throwOnError: false,
-		});
-	}
 }


### PR DESCRIPTION
A pure deletion — 186 lines — plus one guardrail so this cannot recur silently.

## These are not idle leftovers

Four already-fixed behaviours each left a copy behind, and every copy **looks like a reusable shared implementation**. The danger is not that they take up space; it is that a future "the viewer is too big, let's use the shared version" reverts a merged fix, with no test going red.

| Deleted | Zero-call evidence | How it had drifted |
|---|---|---|
| `markdown.ts::renderRichContent` (141 lines, **exported**) | `grep -rn "utils/markdown" src scripts src-tauri/src` — only `processMarkdownHtml` is ever imported | **Missing `rememberDiagramSource`.** Without that attribute, the light-theme Mermaid re-render that PDF/HTML export depends on (#359) finds nothing to restore. It also hand-rolls `isDark ? "dark" : "neutral"` instead of `resolveMermaidTheme` — whose own comment says it exists "so the two cannot drift" — and carries an inline DOMPurify config instead of the shared contract |
| `markdown.ts::getLanguage` | one definition, no importer; the viewer calls its own copy | — |
| `markdown.ts::highlightColorMap` | same | — |
| `Editor.svelte::getEditorScrollMax` | one hit in the whole tree: the definition | Pre-#316 version using `getScrollHeight()`; the live `getEditorContentScrollMax` uses `getContentHeight()`. Reviving it re-introduces the editor's bottom padding into split scroll sync |
| `Editor.svelte::getViewState`, `::revealLine` | component exports with no caller; the viewer's `editorPane` type declares neither | — |

`isYoutubeLink` / `getYoutubeId` are **kept** — still called inside `processMarkdownHtml` — but their now-pointless `export` is dropped.

## Why nothing caught them

`youtubeExternalFallback.test.ts`, `taskToggleMemory.test.ts`, `mermaidPrintTheme.test.ts` and `previewScrollSync.test.ts` each `readFileSync` **one hard-coded path**. A second copy living anywhere else is invisible to all of them.

`scripts/singleImplementationConvention.test.ts` generalises the allowlist idea already used by `renderPipelineConvention.test.ts`: a data-driven table where each row is `{ marker, allowed paths, optional requires }`, scanned across the **whole `src` tree**. Adding a newly-fixed behaviour is a one-row append. Eight rules ship, including:

- `mermaid.render(` may appear only in `MarkdownViewer.svelte` / `mermaidPrint.ts`, **and each such file must also contain `rememberDiagramSource`** — that is #359 pinned
- `getScrollHeight() - …height` is allowed **nowhere** — #316 pinned
- `createElement('iframe')`, `from 'dompurify'`, `renderRichContent`, `getLanguage`, `highlightColorMap` each pinned to their one legitimate owner

Plus a meta-test asserting every rule still matches something, so a renamed symbol cannot turn a rule into a silent no-op.

**Negative control:** with the two edited source files stashed, **7 of the 9 tests fail**, then pass again. It catches precisely the copies this PR removes.

## One unrelated fix rode along

`Toc.svelte`'s scroll `$effect` returned a cleanup that called `removeEventListener` on the **current value of a prop** rather than the node it had attached to. The element is stable today so it does not misbehave, but if the prop ever changed the listener would leak, and if it became `null` the cleanup would throw. Now captures the node.

## Checks

```
npm run check   432 files, 0 errors, 0 warnings
npm test        391 / 391
cargo test       98 / 98
```

No test lost coverage — none of the deleted symbols had a test referencing it, and `previewScrollSync.test.ts` pins the *live* `getEditorContentScrollMax`, untouched.

**One line in another test:** #384's `DOMPurify.sanitize` call-site allowlist listed `markdown.ts`, whose only call site was inside the dead `renderRichContent`. That allowlist must be *exactly* consumed, so deleting the call site correctly failed it. The entry is removed. This is the allowlist doing its job, not a workaround.

## Not deleted, and why

- `onDestroy` in `Editor.svelte` — **it is used**; an earlier scan claimed otherwise and was wrong.
- `exportHtml.ts::escapeHtmlText`, a zero-increment `return escapeHtml(v)` wrapper — it still has a live caller in `export.ts`. Worth inlining separately.
- `Editor.svelte`'s `getValue` / `setValue` / `focus` / `restoreViewState` component exports also appear to have no callers (every in-file hit is on the Monaco object, not the component export). Left alone to keep this a scoped deletion; worth a follow-up.
- **A live pre-fix copy in `MarkdownViewer.svelte`** — `replaceWithYoutubeEmbed` builds the very `<iframe src="youtube.com/embed/…">` that a merged fix replaced with a browser-opening thumbnail, and `frame-src` is gone from the CSP so it could not even load. It is zero-caller, and `youtubeExternalFallback.test.ts` asserts no iframe — but only against `markdown.ts`, so this copy was invisible: **exactly the failure mode this PR exists to close.** It is handled in #388; until that lands, the iframe rule ships with that one path allowlisted under a `KNOWN STALE COPY` comment telling the next person to delete the copy and the allowlist entry together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)