### PR TITLE
fix(test): master is red — retire the iframe allowlist entry #388 made stale

### DIFF
--- a/scripts/singleImplementationConvention.test.ts
+++ b/scripts/singleImplementationConvention.test.ts
@@ -56,11 +56,12 @@ const RULES: Rule[] = [
 		name: 'YouTube links never become embedded frames',
 		why: 'The app dropped frame-src from its CSP and renders YouTube as a thumbnail anchor that opens the browser; an iframe path is the pre-fix version and cannot load.',
 		marker: /createElement\((['"])iframe\1\)/g,
-		// KNOWN STALE COPY — replaceWithYoutubeEmbed in MarkdownViewer.svelte is
-		// an uncalled pre-fix leftover. Delete it and this allowlist entry
-		// together; the entry exists only so this rule can guard the rest of the
-		// tree today.
-		allowed: ['src/lib/MarkdownViewer.svelte'],
+		// Allowed nowhere. The entry that used to sit here covered
+		// `replaceWithYoutubeEmbed` in MarkdownViewer.svelte, an uncalled
+		// pre-fix leftover, and said to delete the two together — #388 deleted
+		// the copy, so the entry goes with it and the rule now guards the
+		// whole tree.
+		allowed: [],
 	},
 	{
 		name: 'DOMPurify is configured in one place',


### PR DESCRIPTION
`master` currently fails `npm test`:

```
✖ every rule keeps at least one live implementation
  rule "YouTube links never become embedded frames" matches nothing in src
```

**This is my mistake, and the mechanism is worth naming.** #397 shipped that rule with one allowlist entry covering `replaceWithYoutubeEmbed` in `MarkdownViewer.svelte` — an uncalled pre-fix leftover it could not delete, because #388 owned that file. Its comment said to delete the copy and the entry together. #388 deleted the copy; the entry stayed.

#397's CI was green **before #388 landed**, and it merged without re-running against the newer base. A green measured on an older base is not a green for the merge.

The rule was always meant to be "allowed nowhere" — that is now literally true, so the entry goes and the rule joins the other nowhere-rule, which the meta-test correctly skips. The rule now guards the whole tree instead of all-but-one file.

```
npm test       401 / 401
npm run check  432 files, 0 errors, 0 warnings
```