### PR TITLE
fix(session): stop startup from throwing away tabs it could not read

### DIFF
--- a/scripts/homeSentinelSnapshot.test.ts
+++ b/scripts/homeSentinelSnapshot.test.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+// The home screen sits in a tab, and that tab's path is the sentinel string
+// `'HOME'` rather than a file. `serializeState` filtered on `path !== ''`, so
+// the sentinel was written into the session snapshot; `restoreState` accepted
+// any non-empty string, so it came back; and startup then asked the backend to
+// read a file called `HOME`. The failure left a phantom tab that can never be
+// read, and a window whose only tab was the home screen came back empty.
+//
+// `hasRealFilePath` in utils/tabFileActions.ts is the project's existing answer
+// to "is this path a file" — every other caller already used it.
+//
+// These tests drive the real TabManager, so they lock the behaviour rather than
+// the wording. The restore-loop half lives in sessionRestoreResilience.test.ts,
+// which already has the window-session harness.
+
+const g = globalThis as any;
+const runeEffect = (fn: () => void) => {
+	void fn;
+};
+runeEffect.root = (fn: () => unknown) => fn();
+g.$state = (value: unknown) => value;
+g.$state.raw = (value: unknown) => value;
+g.$state.snapshot = (value: unknown) => value;
+g.$derived = (value: unknown) => value;
+g.$derived.by = (fn: () => unknown) => fn();
+g.$effect = runeEffect;
+g.window = g.window ?? {};
+
+const localStore = new Map<string, string>();
+g.localStorage = {
+	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
+	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
+	removeItem: (key: string) => void localStore.delete(key),
+	clear: () => localStore.clear(),
+};
+g.window.__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+
+function reset() {
+	tabManager.closeAll();
+	localStore.clear();
+}
+
+test('a session snapshot never carries the home tab', () => {
+	reset();
+	tabManager.addTab('/notes/a.md');
+	tabManager.addHomeTab();
+
+	const snapshot = JSON.parse(tabManager.serializeState());
+
+	assert.deepEqual(
+		snapshot.tabs.map((tab: { path: string }) => tab.path),
+		['/notes/a.md'],
+	);
+});
+
+test('a window showing only the home tab writes an empty snapshot, not a HOME one', () => {
+	reset();
+	tabManager.addHomeTab();
+
+	assert.deepEqual(JSON.parse(tabManager.serializeState()).tabs, []);
+});
+
+test('untitled tabs are still excluded from the snapshot', () => {
+	// The filter this changes also carried the untitled rule; keep it honest.
+	reset();
+	tabManager.addTab('/notes/a.md');
+	tabManager.addNewTab();
+
+	assert.deepEqual(
+		JSON.parse(tabManager.serializeState()).tabs.map((tab: { path: string }) => tab.path),
+		['/notes/a.md'],
+	);
+});
+
+test('a HOME entry in an older snapshot is not restored as a tab', () => {
+	reset();
+	// Builds before this fix wrote the sentinel into the snapshot, and those
+	// snapshots are already on users' disks — so the read side has to reject it
+	// too, not just the write side.
+	tabManager.restoreState(
+		JSON.stringify({
+			version: 2,
+			activeTabId: 'home-id',
+			tabs: [
+				{ id: 'home-id', path: 'HOME', title: 'Home' },
+				{ id: 'doc-id', path: '/notes/a.md', title: 'a.md' },
+			],
+		}),
+	);
+
+	assert.deepEqual(
+		tabManager.tabs.map((tab) => tab.path),
+		['/notes/a.md'],
+	);
+	// The stale active id pointed at the rejected entry; the window must not
+	// come back with nothing selected.
+	assert.equal(tabManager.activeTabId, tabManager.tabs[0].id);
+});
+
+test('a snapshot of nothing but HOME restores no tabs at all', () => {
+	reset();
+	tabManager.restoreState(
+		JSON.stringify({ version: 2, activeTabId: 'home-id', tabs: [{ id: 'home-id', path: 'HOME', title: 'Home' }] }),
+	);
+
+	assert.deepEqual(tabManager.tabs, []);
+	assert.equal(tabManager.activeTabId, null);
+});

--- a/scripts/interruptedSessionRestore.test.ts
+++ b/scripts/interruptedSessionRestore.test.ts
@@ -2,20 +2,35 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+// The wiring behind the behaviour that `sessionRestoreResilience.test.ts`
+// exercises: the breadcrumb key exists, it is written before the work and
+// settled afterwards no matter how the pass ends, and an interrupted pass is
+// never answered by deleting the snapshot.
+
 const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
 const session = readFileSync('src/lib/sessions/windowSession.svelte.ts', 'utf8');
 
 test('session restore records work in progress before restoring tabs', () => {
 	assert.match(viewer, /const RESTORE_IN_PROGRESS_KEY = 'markpad-window-restore-in-progress';/);
-	assert.match(session, /localStorage\.setItem\(options\.restoreInProgressKey, 'true'\);/);
-	assert.match(session, /finally \{\s*localStorage\.removeItem\(options\.restoreInProgressKey\);/s);
+	assert.match(
+		session,
+		/const progress: RestoreProgress = \{ running: true, pending: null, deferred, interruptions \};\s*\n\s*writeProgress\(progress\);/,
+	);
+	// The record names the document being read, not just "a restore is running":
+	// that is what lets the next launch skip one document instead of all of them.
+	assert.match(session, /progress\.pending = tab\.path;\s*\n\s*writeProgress\(progress\);/);
+	assert.match(session, /finally \{\s*writeProgress\(\{ running: false,/s);
 });
 
-test('an interrupted restore discards saved tabs without deleting documents', () => {
-	assert.match(session, /if \(localStorage\.getItem\(options\.restoreInProgressKey\)\)/);
-	assert.match(session, /await discardPersistedState\(\);/);
-	assert.match(viewer, /await windowSession\.discardPersistedState\(\);/);
-	assert.match(session, /localStorage\.removeItem\(options\.windowStateKey\);/);
-	assert.match(session, /localStorage\.removeItem\(options\.legacyStateKey\);/);
+test('an interrupted restore keeps the snapshot instead of deleting it', () => {
+	const restore = session.slice(session.indexOf('async function restore'), session.indexOf('async function claimTransferredTab'));
+	assert.match(restore, /if \(previous\?\.running\)/);
+	// Deleting the whole snapshot is what made one document cost the user every
+	// tab they had open. Nothing in restore() may discard it.
+	assert.doesNotMatch(restore, /discardPersistedState/);
+	assert.doesNotMatch(restore, /clear_window_state/);
+	// Explicit exit is a different matter: the user chose it.
+	assert.match(session, /async function discardPersistedState/);
 	assert.match(session, /await invoke\('clear_window_state'\);/);
+	assert.match(viewer, /await windowSession\.discardPersistedState\(\);/);
 });

--- a/scripts/sessionRestoreResilience.test.ts
+++ b/scripts/sessionRestoreResilience.test.ts
@@ -1,0 +1,362 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+// Startup restore is a data-safety path: the snapshot is the only record of
+// which documents the user had open. Two ways it used to destroy that record:
+//
+// 1. A file that could not be read had its tab dropped, and the trimmed list
+//    was written straight back to disk. A share that was down for a minute, a
+//    drive that was not plugged in, a file another program had locked — the
+//    tab was gone for good.
+// 2. A restore that never finished left a breadcrumb, and the next launch
+//    reacted by deleting the whole snapshot. One document took the session
+//    down with it.
+//
+// These tests drive the real window session and the real TabManager against a
+// stubbed Tauri bridge and a stubbed localStorage, so they lock the behaviour
+// rather than the wording. What they cannot cover is the renderer actually
+// dying mid-restore; an interrupted launch is simulated by leaving behind
+// exactly the breadcrumb such a launch leaves.
+
+const g = globalThis as any;
+const runeEffect = (fn: () => void) => {
+	void fn;
+};
+runeEffect.root = (fn: () => unknown) => fn();
+g.$state = (value: unknown) => value;
+g.$state.raw = (value: unknown) => value;
+g.$state.snapshot = (value: unknown) => value;
+g.$derived = (value: unknown) => value;
+g.$derived.by = (fn: () => unknown) => fn();
+g.$effect = runeEffect;
+g.window = g.window ?? {};
+
+const localStore = new Map<string, string>();
+g.localStorage = {
+	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
+	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
+	removeItem: (key: string) => void localStore.delete(key),
+	clear: () => localStore.clear(),
+};
+
+const WINDOW_STATE_KEY = 'savedTabsDataV2';
+const LEGACY_STATE_KEY = 'savedTabsData';
+const RESTORE_IN_PROGRESS_KEY = 'markpad-window-restore-in-progress';
+
+let invokeCalls: Array<{ cmd: string; args: any }> = [];
+/** The window-state file the Rust side holds. */
+let storedSnapshot: string | null = null;
+/** Files the backend can read; anything else fails the way a real read does. */
+let disk = new Map<string, string>();
+/** Paths whose read should fail even though the file "exists". */
+let unreadable = new Set<string>();
+/** Called just before each read, to observe the breadcrumb mid-restore. */
+let onRead: (path: string) => void = () => {};
+
+g.window.__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string, args: any) => {
+		invokeCalls.push({ cmd, args });
+		switch (cmd) {
+			case 'get_os_type':
+				return Promise.resolve('macos');
+			case 'load_window_state':
+				return Promise.resolve(storedSnapshot);
+			case 'save_window_state':
+				storedSnapshot = args.json;
+				return Promise.resolve(null);
+			case 'clear_window_state':
+				storedSnapshot = null;
+				return Promise.resolve(null);
+			case 'read_file_content_checked': {
+				onRead(args.path);
+				if (unreadable.has(args.path) || !disk.has(args.path)) {
+					return Promise.reject(new Error(`cannot read ${args.path}`));
+				}
+				return Promise.resolve([disk.get(args.path), false]);
+			}
+			default:
+				return Promise.resolve(null);
+		}
+	},
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { createWindowSession } = await import('../src/lib/sessions/windowSession.svelte.js');
+
+const warnings: string[] = [];
+const errors: string[] = [];
+
+function makeSession() {
+	return createWindowSession({
+		isMainWindow: true,
+		windowStateKey: WINDOW_STATE_KEY,
+		legacyStateKey: LEGACY_STATE_KEY,
+		restoreInProgressKey: RESTORE_IN_PROGRESS_KEY,
+		serializeState: () => tabManager.serializeState(),
+		shouldRestoreState: () => true,
+		isDisposed: () => false,
+		restoreState: (json) => tabManager.restoreState(json),
+		restoredTabs: () => tabManager.tabs.map((tab) => ({ id: tab.id, path: tab.path })),
+		applyRestoredContent: async (tabId, raw) => {
+			const tab = tabManager.tabs.find((item) => item.id === tabId);
+			if (!tab) return;
+			tab.rawContent = raw;
+			tab.originalContent = raw;
+		},
+		dropRestoredTab: (tabId) => tabManager.closeTab(tabId),
+		canTransfer: () => true,
+		canDetach: () => true,
+		transferPayload: () => '',
+		onTransferClaimed: () => {},
+		acceptTransferredTab: async () => true,
+		onError: (message) => errors.push(message),
+		onWarning: (message) => warnings.push(message),
+	});
+}
+
+function snapshotOf(paths: string[]): string {
+	return JSON.stringify({
+		version: 2,
+		activeTabId: null,
+		tabs: paths.map((path, index) => ({ id: `tab-${index}`, path, title: path })),
+	});
+}
+
+function reset(paths: string[], contents: Record<string, string> = {}) {
+	tabManager.closeAll();
+	tabManager.recentlyClosed.length = 0;
+	localStore.clear();
+	invokeCalls = [];
+	warnings.length = 0;
+	errors.length = 0;
+	unreadable = new Set();
+	onRead = () => {};
+	disk = new Map(paths.map((path) => [path, contents[path] ?? `# ${path}`]));
+	storedSnapshot = snapshotOf(paths);
+}
+
+function breadcrumb(): any {
+	const raw = localStore.get(RESTORE_IN_PROGRESS_KEY);
+	return raw === undefined ? null : JSON.parse(raw);
+}
+
+function persistedPaths(): string[] {
+	return storedSnapshot ? JSON.parse(storedSnapshot).tabs.map((tab: { path: string }) => tab.path) : [];
+}
+
+const readsOf = () => invokeCalls.filter((call) => call.cmd === 'read_file_content_checked').map((call) => call.args.path);
+
+// --- a read that fails is not a decision to close the document ---
+
+test('a file that cannot be read keeps its tab', async () => {
+	reset(['/a.md', '/away.md', '/c.md']);
+	unreadable.add('/away.md');
+
+	await makeSession().restore();
+
+	assert.deepEqual(
+		tabManager.tabs.map((tab) => tab.path),
+		['/a.md', '/away.md', '/c.md'],
+	);
+	assert.ok(
+		warnings.some((message) => message.includes('could not be read')),
+		'the failure is reported, not silent',
+	);
+});
+
+test('the failed read is not written back into the snapshot', async () => {
+	reset(['/a.md', '/away.md']);
+	unreadable.add('/away.md');
+
+	await makeSession().restore();
+
+	// This is the whole bug: the trimmed list used to be persisted right after
+	// the loop, so the tab never came back even once the drive was plugged in.
+	assert.deepEqual(persistedPaths(), ['/a.md', '/away.md']);
+});
+
+test('the empty buffer of an unreadable tab is flagged so nothing can save it over the file', async () => {
+	reset(['/away.md']);
+	unreadable.add('/away.md');
+
+	await makeSession().restore();
+
+	const tab = tabManager.tabs[0];
+	assert.equal(tab.rawContent, '');
+	assert.equal(tab.isDirty, false);
+	// `isTruncated` is the existing "this buffer is not the whole file" flag:
+	// every writer already refuses it and `ensureFullContent` re-reads the file
+	// the next time the tab is opened for editing.
+	assert.equal(tab.isTruncated, true);
+});
+
+test('the documents that did read are restored normally', async () => {
+	reset(['/a.md', '/away.md'], { '/a.md': '# hello' });
+	unreadable.add('/away.md');
+
+	await makeSession().restore();
+
+	const readable = tabManager.tabs.find((tab) => tab.path === '/a.md')!;
+	assert.equal(readable.rawContent, '# hello');
+	assert.notEqual(readable.isTruncated, true);
+});
+
+// --- an interrupted restore costs one document, not the session ---
+
+test('an interrupted restore names the document it was on', async () => {
+	reset(['/a.md', '/big.md', '/c.md']);
+	const seen: Array<string | null> = [];
+	onRead = () => seen.push(breadcrumb()?.pending ?? null);
+
+	await makeSession().restore();
+
+	// The breadcrumb has to be updated per document; a flag that only says "a
+	// restore was running" cannot tell the next launch what to skip.
+	assert.deepEqual(seen, ['/a.md', '/big.md', '/c.md']);
+});
+
+test('the launch after an interruption restores everything except the suspect', async () => {
+	reset(['/a.md', '/big.md', '/c.md']);
+	localStore.set(
+		RESTORE_IN_PROGRESS_KEY,
+		JSON.stringify({ running: true, pending: '/big.md', deferred: [], interruptions: 0 }),
+	);
+
+	await makeSession().restore();
+
+	assert.deepEqual(readsOf(), ['/a.md', '/c.md'], 'the suspect is not read again');
+	assert.deepEqual(
+		tabManager.tabs.map((tab) => tab.path),
+		['/a.md', '/big.md', '/c.md'],
+		'every tab is still there, including the deferred one',
+	);
+	assert.deepEqual(persistedPaths(), ['/a.md', '/big.md', '/c.md']);
+	assert.equal(storedSnapshot !== null, true, 'the snapshot is never discarded');
+	assert.equal(
+		invokeCalls.some((call) => call.cmd === 'clear_window_state'),
+		false,
+	);
+});
+
+test('a breadcrumb from an older build no longer wipes the session', async () => {
+	reset(['/a.md', '/b.md']);
+	// Pre-fix builds wrote the string 'true' and the next launch deleted the
+	// entire snapshot on sight.
+	localStore.set(RESTORE_IN_PROGRESS_KEY, 'true');
+
+	await makeSession().restore();
+
+	assert.deepEqual(
+		tabManager.tabs.map((tab) => tab.path),
+		['/a.md', '/b.md'],
+	);
+	assert.equal(
+		invokeCalls.some((call) => call.cmd === 'clear_window_state'),
+		false,
+	);
+	// It names no suspect, so it costs one retry rather than one document.
+	assert.deepEqual(readsOf(), ['/a.md', '/b.md']);
+});
+
+test('a finished restore leaves no breadcrumb behind', async () => {
+	reset(['/a.md']);
+
+	await makeSession().restore();
+
+	assert.equal(breadcrumb(), null);
+});
+
+test('deferrals accumulate one document per interruption instead of retrying forever', async () => {
+	reset(['/a.md', '/one.md', '/two.md']);
+	localStore.set(
+		RESTORE_IN_PROGRESS_KEY,
+		JSON.stringify({ running: true, pending: '/one.md', deferred: [], interruptions: 0 }),
+	);
+	await makeSession().restore();
+	assert.deepEqual(breadcrumb().deferred, ['/one.md']);
+
+	// The next launch dies on a different document.
+	reset(['/a.md', '/one.md', '/two.md']);
+	localStore.set(
+		RESTORE_IN_PROGRESS_KEY,
+		JSON.stringify({ running: true, pending: '/two.md', deferred: ['/one.md'], interruptions: 1 }),
+	);
+
+	await makeSession().restore();
+
+	assert.deepEqual(readsOf(), ['/a.md']);
+	assert.deepEqual(
+		tabManager.tabs.map((tab) => tab.path),
+		['/a.md', '/one.md', '/two.md'],
+	);
+	assert.deepEqual(breadcrumb().deferred, ['/one.md', '/two.md']);
+});
+
+test('after repeated interruptions startup stops reading but still hands back every tab', async () => {
+	reset(['/a.md', '/b.md', '/c.md']);
+	localStore.set(
+		RESTORE_IN_PROGRESS_KEY,
+		JSON.stringify({ running: true, pending: null, deferred: [], interruptions: 2 }),
+	);
+
+	await makeSession().restore();
+
+	assert.deepEqual(readsOf(), [], 'a third interrupted launch stops opening documents by itself');
+	assert.deepEqual(
+		tabManager.tabs.map((tab) => tab.path),
+		['/a.md', '/b.md', '/c.md'],
+	);
+	assert.deepEqual(persistedPaths(), ['/a.md', '/b.md', '/c.md']);
+	for (const tab of tabManager.tabs) assert.equal(tab.isTruncated, true);
+});
+
+// --- the HOME sentinel never reaches the backend ---
+
+test('a HOME entry in an older snapshot is never read as a file', async () => {
+	reset(['/a.md']);
+	storedSnapshot = snapshotOf(['HOME', '/a.md']);
+
+	await makeSession().restore();
+
+	// A sentinel is not a file that might come back later, so it is dropped
+	// rather than kept as an unreadable tab.
+	assert.equal(readsOf().includes('HOME'), false);
+	assert.deepEqual(
+		tabManager.tabs.map((tab) => tab.path),
+		['/a.md'],
+	);
+	assert.deepEqual(persistedPaths(), ['/a.md']);
+});
+
+test('a snapshot of nothing but HOME does not cost the window its session', async () => {
+	reset([]);
+	storedSnapshot = snapshotOf(['HOME']);
+
+	await makeSession().restore();
+
+	assert.deepEqual(tabManager.tabs, []);
+	assert.equal(
+		invokeCalls.some((call) => call.cmd === 'read_file_content_checked'),
+		false,
+	);
+});
+
+test('a deferred document is released once Markpad has read it', async () => {
+	reset(['/a.md', '/big.md']);
+	localStore.set(
+		RESTORE_IN_PROGRESS_KEY,
+		JSON.stringify({ running: true, pending: '/big.md', deferred: [], interruptions: 0 }),
+	);
+	const session = makeSession();
+	await session.restore();
+	assert.deepEqual(breadcrumb().deferred, ['/big.md']);
+
+	// The user opens it by hand and nothing goes wrong.
+	const deferredTab = tabManager.tabs.find((tab) => tab.path === '/big.md')!;
+	tabManager.setTabRawContent(deferredTab.id, '# big');
+
+	await session.persistState();
+
+	assert.equal(breadcrumb(), null, 'the deferral is not permanent');
+});

--- a/scripts/windowStateRestore.test.ts
+++ b/scripts/windowStateRestore.test.ts
@@ -23,8 +23,10 @@ function slice(source: string, from: string, to: string): string {
 test('serializeState writes window state only', () => {
 	const fn = slice(tabs, 'serializeState()', 'restoreState(');
 	assert.match(fn, /version: 2/);
-	// untitled tabs have no disk backing; they are resolved at close, never persisted
-	assert.match(fn, /filter\(\(t\) => t\.path !== ''\)/);
+	// untitled tabs have no disk backing; they are resolved at close, never
+	// persisted — and neither is the home tab, whose path is the sentinel
+	// string 'HOME' rather than a file (homeSentinelSnapshot.test.ts)
+	assert.match(fn, /filter\(\(t\) => hasRealFilePath\(t\.path\)\)/);
 	// no full-object spread and no content fields in the snapshot
 	assert.doesNotMatch(fn, /\.\.\.t/);
 	assert.doesNotMatch(fn, /rawContent/);
@@ -35,8 +37,9 @@ test('serializeState writes window state only', () => {
 
 test('restoreState rebuilds clean tabs and drops legacy untitled entries', () => {
 	const fn = slice(tabs, 'restoreState(', 'addTab(');
-	// path is the identity of a restored tab; entries without one are skipped
-	assert.match(fn, /saved\.path === ''\) continue;/);
+	// path is the identity of a restored tab; entries without a real file path
+	// are skipped, including 'HOME' entries left by older builds
+	assert.match(fn, /!hasRealFilePath\(saved\.path\)\) continue;/);
 	// restored tabs start clean; content is read from disk afterwards
 	assert.match(fn, /isDirty: false/);
 	assert.match(fn, /rawContent: ''/);
@@ -47,8 +50,13 @@ test('restoreState rebuilds clean tabs and drops legacy untitled entries', () =>
 test('startup restore reads content from disk, not from the snapshot', () => {
 	const restore = slice(session, 'async function restore', 'async function claimTransferredTab');
 	assert.match(restore, /read_file_content/);
-	// a missing file drops its tab instead of restoring a ghost
-	assert.match(restore, /options\.dropRestoredTab\(tab\.id\);/);
+	// a file that cannot be read keeps its tab and its place in the snapshot —
+	// dropping it here also dropped it from the snapshot written moments later
+	// (sessionRestoreResilience.test.ts)
+	assert.match(restore, /tabManager\.markTabContentUnavailable\(tab\.id\);/);
+	// dropping is reserved for an entry that is not a file at all — a legacy
+	// 'HOME' sentinel (homeSentinelSnapshot.test.ts)
+	assert.match(restore, /if \(!hasRealFilePath\(tab\.path\)\) \{\s*\n\s*options\.dropRestoredTab\(tab\.id\);/);
 	assert.match(viewer, /await windowSession\.restore\(\);/);
 });
 
@@ -93,17 +101,14 @@ test('v2 snapshots are invisible to legacy builds (Rust file, localStorage keys 
 		session,
 		/localStorage\.getItem\(options\.windowStateKey\) \?\?\n?\s*localStorage\.getItem\(options\.legacyStateKey\)/,
 	);
-	// The shared helper clears the Rust snapshot and both localStorage keys;
-	// explicit exit and interrupted restore both use this same cleanup path.
+	// The shared helper clears the Rust snapshot and both localStorage keys.
+	// Only explicit exit uses it: a restore that goes wrong must never delete
+	// the record of which documents were open (interruptedSessionRestore.test.ts).
 	const discardStart = session.indexOf('async function discardPersistedState');
-	const discardScope = session.slice(discardStart, session.indexOf('\n\t}\n\n\tasync function persistState', discardStart));
+	const discardScope = session.slice(discardStart, session.indexOf('\n\t}\n\n\tfunction readProgress', discardStart));
 	assert.match(discardScope, /clear_window_state/);
 	assert.match(discardScope, /removeItem\(options\.windowStateKey\)/);
 	assert.match(discardScope, /removeItem\(options\.legacyStateKey\)/);
-	assert.match(
-		session,
-		/if \(localStorage\.getItem\(options\.restoreInProgressKey\)\)[\s\S]*?await discardPersistedState\(\)/,
-	);
 	// Explicit exit delegates to the same cleanup path.
 	const exitFn = viewer.slice(viewer.indexOf('async function appExit'));
 	const exitScope = exitFn.slice(0, exitFn.indexOf('\n\t}'));

--- a/src/lib/sessions/windowSession.svelte.ts
+++ b/src/lib/sessions/windowSession.svelte.ts
@@ -1,12 +1,46 @@
 import { invoke } from '@tauri-apps/api/core';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { tabManager } from '../stores/tabs.svelte.js';
+import { hasRealFilePath } from '../utils/tabFileActions.js';
 import { validateTransferPayload, type TransferableTab } from '../utils/tabTransfer.js';
 
 type RestoredTab = {
 	id: string;
 	path: string;
 };
+
+/**
+ * The breadcrumb a restore pass leaves behind so the next launch knows what
+ * happened to the last one. It exists because a restore that never returns —
+ * the renderer dies on one pathological document — otherwise repeats forever.
+ *
+ * It names the document being restored, not just the fact that a restore was
+ * running: blaming the whole session for one file is what made an interrupted
+ * restore delete every tab the user had open.
+ */
+type RestoreProgress = {
+	/** Set while a pass is running. Still set at startup means it never finished. */
+	running: boolean;
+	/** The document the pass was on. The suspect if the pass never finished. */
+	pending: string | null;
+	/** Documents blamed for an earlier interruption; not read at startup. */
+	deferred: string[];
+	/** Consecutive interrupted launches; reset by a pass that finishes. */
+	interruptions: number;
+};
+
+/** Enough to keep the suspects, few enough to stay a breadcrumb. */
+const MAX_DEFERRED = 8;
+
+/**
+ * After this many launches interrupted in a row, startup stops reading
+ * documents altogether and restores the tabs alone. Skipping one more document
+ * per launch does terminate, but it spends one crash per document to get there;
+ * three is enough to tell "this file is poison" from "the user quit during
+ * startup", and a session that opens without reading anything still hands back
+ * every tab, each one re-readable on demand.
+ */
+const MAX_INTERRUPTIONS = 3;
 
 type WindowSessionOptions = {
 	isMainWindow: boolean;
@@ -43,8 +77,60 @@ export function createWindowSession(options: WindowSessionOptions) {
 		}
 	}
 
+	function readProgress(): RestoreProgress | null {
+		const raw = localStorage.getItem(options.restoreInProgressKey);
+		if (!raw) return null;
+		try {
+			const data = JSON.parse(raw) as Partial<RestoreProgress> | null;
+			if (!data || typeof data !== 'object') throw new Error('not a progress record');
+			const deferred = Array.isArray(data.deferred)
+				? data.deferred.filter((path): path is string => typeof path === 'string' && path !== '')
+				: [];
+			return {
+				running: data.running === true,
+				pending: typeof data.pending === 'string' && data.pending !== '' ? data.pending : null,
+				deferred: deferred.slice(-MAX_DEFERRED),
+				interruptions: typeof data.interruptions === 'number' && data.interruptions > 0 ? Math.floor(data.interruptions) : 0,
+			};
+		} catch {
+			// Older builds wrote the string `'true'`. It still means the previous
+			// pass never finished, it just names no suspect — so it counts as one
+			// interruption and defers nothing.
+			return { running: true, pending: null, deferred: [], interruptions: 0 };
+		}
+	}
+
+	function writeProgress(progress: RestoreProgress) {
+		// A finished pass with nothing deferred leaves no breadcrumb at all,
+		// which is what keeps the key absent in the ordinary case.
+		if (!progress.running && progress.deferred.length === 0) {
+			localStorage.removeItem(options.restoreInProgressKey);
+			return;
+		}
+		localStorage.setItem(options.restoreInProgressKey, JSON.stringify(progress));
+	}
+
+	/**
+	 * A deferred document is released as soon as Markpad has read it once — the
+	 * user opened it by hand and nothing went wrong, so the file is not the
+	 * problem (or is not any more). Without this the deferral is permanent and
+	 * one bad startup would cost the user automatic restore of that document
+	 * forever.
+	 */
+	function releaseReadableDeferrals() {
+		const progress = readProgress();
+		if (!progress || progress.deferred.length === 0) return;
+		const readable = new Set(
+			tabManager.tabs.filter((tab) => tab.isTruncated !== true && tab.rawContent !== '').map((tab) => tab.path),
+		);
+		const deferred = progress.deferred.filter((path) => !readable.has(path));
+		if (deferred.length === progress.deferred.length) return;
+		writeProgress({ ...progress, deferred });
+	}
+
 	async function persistState() {
 		if (!options.isMainWindow) return;
+		releaseReadableDeferrals();
 		try {
 			await invoke('save_window_state', { json: options.serializeState() });
 			localStorage.removeItem(options.windowStateKey);
@@ -59,23 +145,56 @@ export function createWindowSession(options: WindowSessionOptions) {
 		if (!options.shouldRestoreState()) {
 			localStorage.removeItem(options.windowStateKey);
 			localStorage.removeItem(options.legacyStateKey);
+			// Nothing will be restored, so there is nothing for a breadcrumb to
+			// say about the next launch.
+			localStorage.removeItem(options.restoreInProgressKey);
 			return;
 		}
 		const savedData =
 			localStorage.getItem(options.windowStateKey) ??
 			localStorage.getItem(options.legacyStateKey) ??
 			((await invoke('load_window_state').catch(() => null)) as string | null);
-		if (localStorage.getItem(options.restoreInProgressKey)) {
-			options.onWarning('Skipping interrupted Markpad session restore');
-			await discardPersistedState();
-			localStorage.removeItem(options.restoreInProgressKey);
-			return;
+		const previous = readProgress();
+		const deferred = previous ? [...previous.deferred] : [];
+		let interruptions = previous?.interruptions ?? 0;
+		if (previous?.running) {
+			// The last pass never finished. Defer the one document it was on
+			// rather than the session it was part of.
+			interruptions += 1;
+			if (previous.pending && !deferred.includes(previous.pending)) {
+				deferred.push(previous.pending);
+				while (deferred.length > MAX_DEFERRED) deferred.shift();
+			}
+			options.onWarning(
+				previous.pending
+					? `Markpad session restore was interrupted; deferring ${previous.pending}`
+					: 'Markpad session restore was interrupted with no document to blame',
+			);
 		}
+		// Nothing here is allowed to delete the snapshot: a restore that goes
+		// wrong must cost the user at most the automatic reopening of a
+		// document, never the record of which documents were open.
+		const deferAll = interruptions >= MAX_INTERRUPTIONS;
 		if (savedData) {
-			localStorage.setItem(options.restoreInProgressKey, 'true');
+			const progress: RestoreProgress = { running: true, pending: null, deferred, interruptions };
+			writeProgress(progress);
 			try {
 				options.restoreState(savedData);
 				for (const tab of options.restoredTabs()) {
+					// The home screen is not a document. Snapshots from builds that
+					// wrote its `'HOME'` sentinel must not turn into a read of a
+					// file by that name — and unlike a file that merely failed to
+					// read, there is nothing here to come back to later.
+					if (!hasRealFilePath(tab.path)) {
+						options.dropRestoredTab(tab.id);
+						continue;
+					}
+					if (deferAll || deferred.includes(tab.path)) {
+						tabManager.markTabContentUnavailable(tab.id);
+						continue;
+					}
+					progress.pending = tab.path;
+					writeProgress(progress);
 					try {
 						// `_checked`, because restore fills an editable buffer: reads
 						// decode leniently, so a file in a legacy encoding comes back
@@ -89,16 +208,29 @@ export function createWindowSession(options: WindowSessionOptions) {
 						if (options.isDisposed()) return;
 					} catch (error) {
 						if (options.isDisposed()) return;
-						options.onWarning('Restore: dropping tab for unreadable file', error);
-						options.dropRestoredTab(tab.id);
+						// One failed read is not a decision to close the document.
+						// The file may be on a share that is down or a drive that is
+						// not plugged in; dropping the tab here also dropped it from
+						// the snapshot written moments later, so it never came back.
+						options.onWarning('Restore: keeping tab whose file could not be read', error);
+						tabManager.markTabContentUnavailable(tab.id);
 					}
+					progress.pending = null;
+					writeProgress(progress);
 				}
+				// The pass got to the end, so whatever interrupted the previous
+				// launches is behind us; only the deferrals stay.
+				interruptions = 0;
 			} catch (error) {
 				options.onError('Failed to restore Markpad session', error);
-				await discardPersistedState();
 			} finally {
-				localStorage.removeItem(options.restoreInProgressKey);
+				writeProgress({ running: false, pending: null, deferred, interruptions });
 			}
+		} else {
+			// No snapshot to read: a breadcrumb left by an earlier launch has
+			// nothing left to describe, and leaving it would count as another
+			// interruption next time.
+			writeProgress({ running: false, pending: null, deferred, interruptions: 0 });
 		}
 		if (options.isDisposed()) return;
 		if (options.restoredTabs().length > 0) await persistState();

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -1,6 +1,7 @@
 import { t } from '../utils/i18n.js';
 import { nextUntitledTitle } from '../utils/untitledTitle.js';
 import { settings } from './settings.svelte.js';
+import { hasRealFilePath } from '../utils/tabFileActions.js';
 import { buildTransferredTab, type TransferableTab } from '../utils/tabTransfer.js';
 import {
 	canGoBackInHistory,
@@ -88,6 +89,13 @@ class TabManager {
 	 * handled exclusively by the close dialogs, never smuggled through here.
 	 * Untitled tabs have no disk backing and are resolved at close, so they
 	 * are not persisted.
+	 *
+	 * The filter is `hasRealFilePath`, not `path !== ''`: the home screen sits
+	 * in a tab whose path is the sentinel string `'HOME'`, which passes the
+	 * non-empty test and used to be written into the snapshot. Restoring it
+	 * then asked the backend to read a file called `HOME`, and the failure left
+	 * a permanently unreadable phantom tab — or, when HOME was the only tab, a
+	 * window that came back empty.
 	 */
 	serializeState(): string {
 		const stateData = {
@@ -95,7 +103,7 @@ class TabManager {
 			windowTag: this.windowTag,
 			activeTabId: this.activeTabId,
 			tabs: this.tabs
-				.filter((t) => t.path !== '')
+				.filter((t) => hasRealFilePath(t.path))
 				.map((t) => ({
 					id: t.id,
 					path: t.path,
@@ -117,6 +125,11 @@ class TabManager {
 	 * the caller reads each file from disk afterwards. Also accepts the legacy
 	 * full-tab format, from which only the window-state fields are taken
 	 * (legacy untitled entries are dropped).
+	 *
+	 * Entries are accepted only for real file paths. Snapshots written by
+	 * earlier builds can still contain the `'HOME'` sentinel, so the read side
+	 * has to reject it too — otherwise those users keep restoring a tab that
+	 * can never be read.
 	 */
 	restoreState(jsonBuffer: string) {
 		try {
@@ -137,7 +150,7 @@ class TabManager {
 
 			const restored: Tab[] = [];
 			for (const saved of data.tabs) {
-				if (!saved || typeof saved.path !== 'string' || saved.path === '') continue;
+				if (!saved || typeof saved.path !== 'string' || !hasRealFilePath(saved.path)) continue;
 				const filename = saved.path.split('\\').pop()?.split('/').pop() || saved.path;
 				const fileHistory = createFileHistory(saved.path, '');
 				restored.push({
@@ -349,6 +362,30 @@ class TabManager {
 			tab.isDirty = false;
 			tab.isTruncated = isTruncated;
 		}
+	}
+
+	/**
+	 * The tab's file could not be read. The tab stays open with its path — the
+	 * file may be on a share that is temporarily down, a drive that is not
+	 * plugged in, or a file another program has locked, and none of those are
+	 * the user's decision to close a document — but its empty buffer is flagged
+	 * incomplete so nothing can mistake it for the document and write it back.
+	 *
+	 * This is the same flag the large-file preview read uses, deliberately: it
+	 * already means "this buffer is not the whole file", every writer already
+	 * refuses it, and `documentSession.ensureFullContent` already re-reads the
+	 * file and clears the flag the next time the user opens the tab for
+	 * editing — which is how a tab recovers once the drive is plugged back in.
+	 *
+	 * A dirty buffer is never touched: unsaved text the user typed outranks a
+	 * failed read of the file it came from.
+	 */
+	markTabContentUnavailable(id: string) {
+		const tab = this.tabs.find((t) => t.id === id);
+		if (!tab || tab.isDirty) return;
+		tab.rawContent = '';
+		tab.originalContent = '';
+		tab.isTruncated = true;
 	}
 
 	/**


### PR DESCRIPTION
Three ways a restore lost documents. All three were permanent, because the trimmed result was written straight back to the snapshot — the failure of one launch became the state of every launch after it.

## 1. One failed read evicted the tab

The per-tab `catch` called `dropRestoredTab` (wired to `closeTab`), and the loop then re-serialised. A network share not yet mounted, an external drive not plugged in, a file briefly locked by another program — **the tab was gone, and plugging the drive back in did not bring it back**.

The tab now stays, with its path, and its empty buffer is marked through the **existing `isTruncated` flag** rather than a new state. That choice is the point:

- `isTruncated` already means "this buffer is not the whole document", and **every writer already refuses it** — `saveContent`/`saveContentAs` bail out, `canTransfer`/`canDetach` refuse. A new flag would need each of those to learn about it, which is one chance per call site to forget, and the cost of forgetting is an empty buffer written over the user's file.
- `ensureFullContent` already re-reads the file and clears the flag when the tab is opened for editing, so **the tab heals itself** once the drive is back. No new recovery machinery.
- It matches the precedent set by #293 in `documentSession.loadMarkdown`: a read failure keeps the buffer rather than closing the tab.

A dirty buffer is never marked — unsaved text outranks a failed read of its file.

## 2. An interrupted restore deleted the whole snapshot

Any truthy `restoreInProgressKey` triggered `discardPersistedState()`, which clears both localStorage keys **and** invokes `clear_window_state`. The whole session record, gone.

The #260 breadcrumb was right in intent and too coarse in shape: it recorded **that** a restore was running, not **what** it was running, so the only response available was collective punishment. It now records:

```ts
{ running: boolean; pending: string | null; deferred: string[]; interruptions: number }
```

`pending` is written before each document's read and cleared after it, so a crash leaves the breadcrumb sitting on the culprit. The next launch defers that one path and restores everything else.

- **Termination:** after three interruptions, startup restores the tab list and reads no file at all. That end state is stable, crash-free, and loses nothing. Three strikes distinguishes a poison file from a user force-quitting during startup.
- **Release:** `persistState()` drops any deferred path whose tab now holds real content — Markpad read it successfully at some point, so it is not the problem any more. Without this, one bad startup would cost that file automatic restore forever; **a quarantine with no exit is a permanent loss on a longer timescale.**
- **Migration:** the legacy `'true'` value fails JSON parsing and reads as "interrupted, no suspect" — it costs one retry instead of the session.

`restore()` no longer deletes the snapshot anywhere, including its outer catch, which now only reports. `discardPersistedState` survives for explicit exit — the user's own choice.

## 3. The `'HOME'` sentinel was written into the snapshot

`serializeState` filtered `t.path !== ''`, while `addHomeTab` sets `path: 'HOME'`. `tabFileActions.hasRealFilePath()` tests for both, and is used **everywhere except here** — two spellings of "is this a real file", one of them wrong.

Reading it back invoked `read_file_content('HOME')`, which threw, which took path 1 above. A window whose only tab was HOME restored empty.

Both sides now use `hasRealFilePath`. The read side is not optional: snapshots already on users' disks contain the sentinel. A third guard in the restore loop means `'HOME'` cannot reach the backend by any route.

**These three ship together deliberately.** Fix 1 without fix 3 would turn a legacy HOME entry from something silently dropped into a permanently unreadable phantom tab that re-persists every launch — a regression. They are the same failure: startup losing tabs it should have kept.

## Tests

16 new tests across two files, executing the **real** code — both `tabs.svelte.ts` and `windowSession.svelte.ts` import cleanly under `node --test --import tsx` with the rune stubs the repo already uses in `truncatedBufferGuard.test.ts`, plus a stubbed `__TAURI_INTERNALS__` and `localStorage`. `sessionRestoreResilience.test.ts` drives `createWindowSession().restore()` against a fake disk and a fake snapshot store, then asserts on the tab list, the persisted snapshot, and the breadcrumb.

Counter-proof, source files stashed and tests kept:

| | tests | pass | fail |
|---|---|---|---|
| `master` + these tests | 419 | 398 | **21** |
| Final | 419 | 419 | 0 |

Named failures include: *a file that cannot be read keeps its tab* · *the failed read is not written back into the snapshot* · *an interrupted restore keeps the snapshot instead of deleting it* · *an interrupted restore names the document it was on* · *a deferred document is released once Markpad has read it* · *a breadcrumb from an older build no longer wipes the session* · *a session snapshot never carries the home tab* · *a HOME entry in an older snapshot is never read as a file*.

Two existing test files asserted the old behaviour verbatim (`filter((t) => t.path !== '')`, `dropRestoredTab(tab.id)`, `restoreInProgressKey … discardPersistedState()`). They could not both stay and the bugs be fixed; only the assertions naming the old behaviour were rewritten, every unrelated assertion kept, each pointed at the behavioural test that now covers it.

```
npm run check   432 files, 0 errors, 0 warnings
npm test        419 / 419
cargo test       98 / 98   (Rust untouched)
```

## Not covered

- **An unreadable tab renders blank with no explanation.** Nothing is destroyed — edit mode is blocked by `ensureFullContent` and saving is refused — but the tab looks like an empty document. A "couldn't read this — retry" affordance needs `MarkdownViewer.svelte` and a new i18n key; deliberately out of scope here.
- **No retry on tab click.** The re-read happens on entering edit or split view, not on activation.
- **`MAX_INTERRUPTIONS = 3` and `MAX_DEFERRED = 8` are judgement calls, not measurements.** Chrome and Firefox handle the same situation by *asking* the user after a crashed session, which is the better answer and needs UI.
- **Case-insensitive filesystems**: paths are compared exactly, so `/notes/A.md` and `/notes/a.md` are distinct. Same limitation `refuseIfLossilyDecoded` already documents; closing it needs backend canonicalisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)