### PR TITLE
fix(markdown): hide math delimiters from comrak instead of patching characters

### DIFF
--- a/scripts/mathDelimiterContract.test.ts
+++ b/scripts/mathDelimiterContract.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The cross-language math-delimiter contract — frontend half.
+ *
+ * Correctness of the math pipeline rests on one invariant that lives in two
+ * languages at once:
+ *
+ *     the spans `src-tauri/src/lib.rs` hides from comrak
+ *   ≡ the spans `src/lib/utils/markdown.ts` renders with KaTeX
+ *
+ *   backend ⊂ frontend → comrak rewrites the formula before KaTeX ever sees
+ *                        it. That is issues #174, #177 and #197.
+ *   backend ⊃ frontend → the text is withheld from Markdown and then rendered
+ *                        by nobody; the reader gets dead text that is neither
+ *                        prose nor a formula.
+ *
+ * Neither side is the reference. Both are asserted against one hand-authored
+ * table, `mathDelimiterCorpus.json`; the Rust half is
+ * `the_backend_recognises_exactly_the_math_the_contract_lists`. Loosen a
+ * condition in `findInlineMathEnd` — say, drop "a closer may not be followed
+ * by a digit" — and this file goes red on its own, without anyone remembering
+ * that a second implementation exists.
+ *
+ * Nothing here re-implements the delimiter rule. The frontend's decision is
+ * read back only from artefacts the frontend itself produces: `\(…\)`, which
+ * only `convertInlineMathDelimiters` emits, and `data-math-source`, which only
+ * `processDisplayMathBlocks` sets. An extractor that parsed `$…$` on its own
+ * could agree with a broken implementation, which would defeat the point.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import {
+	installShimDom,
+	parseHtml,
+	NODE_ELEMENT,
+	NODE_TEXT,
+	type ShimElement,
+	type ShimNode,
+	type ShimText,
+} from './renderProtocolDom.ts';
+
+installShimDom();
+
+const { processMarkdownHtml } = await import('../src/lib/utils/markdown.ts');
+
+type ContractSpan = { kind: 'inline' | 'display'; source: string };
+type ContractCase = {
+	name: string;
+	markdown: string;
+	/** Real `convert_markdown` output; kept live by the Rust half. */
+	html: string;
+	math: ContractSpan[];
+};
+
+const corpus: { cases: ContractCase[] } = JSON.parse(
+	readFileSync(fileURLToPath(new URL('./mathDelimiterCorpus.json', import.meta.url)), 'utf8'),
+);
+
+const FILE_PATH = '/documents/notes.md';
+
+/** Only `convertInlineMathDelimiters` ever writes `\(`…`\)` into a text node. */
+const INLINE_MATH_RE = /\\\(([\s\S]*?)\\\)/g;
+
+/** What the frontend decided, in document order, in the corpus's vocabulary. */
+function recognisedMath(body: ShimElement): ContractSpan[] {
+	const found: ContractSpan[] = [];
+
+	const visit = (node: ShimNode): void => {
+		if (node.nodeType === NODE_ELEMENT) {
+			const element = node as ShimElement;
+			if (element.getAttribute('data-math') === 'display') {
+				found.push({ kind: 'display', source: element.getAttribute('data-math-source') ?? '' });
+				return;
+			}
+			for (const child of [...element.childNodes]) visit(child);
+			return;
+		}
+		if (node.nodeType === NODE_TEXT) {
+			const text = (node as ShimText).nodeValue ?? '';
+			INLINE_MATH_RE.lastIndex = 0;
+			let match: RegExpExecArray | null;
+			while ((match = INLINE_MATH_RE.exec(text)) !== null) {
+				found.push({ kind: 'inline', source: match[1] });
+			}
+		}
+	};
+
+	for (const child of [...body.childNodes]) visit(child);
+	return found;
+}
+
+test('the frontend renders exactly the math the contract lists', () => {
+	for (const testCase of corpus.cases) {
+		const body = parseHtml(processMarkdownHtml(testCase.html, FILE_PATH, new Set())).body;
+		assert.deepEqual(
+			recognisedMath(body),
+			testCase.math,
+			`${testCase.name}: the frontend and the contract disagree about what is math\n` +
+				`  input: ${JSON.stringify(testCase.markdown)}`,
+		);
+	}
+});
+
+test('the corpus covers both directions of the invariant', () => {
+	// A corpus of nothing but negatives would stay green under an
+	// implementation that recognises no math at all, and a corpus of nothing
+	// but positives would stay green under one that recognises everything.
+	const negatives = corpus.cases.filter((one) => one.math.length === 0);
+	const positives = corpus.cases.filter((one) => one.math.length > 0);
+	assert.ok(negatives.length >= 10, `only ${negatives.length} must-not-be-math cases`);
+	assert.ok(positives.length >= 10, `only ${positives.length} must-be-math cases`);
+	assert.ok(
+		positives.some((one) => one.math.some((span) => span.kind === 'display')),
+		'no display-math case',
+	);
+	assert.ok(
+		positives.some((one) => one.math.some((span) => span.kind === 'inline')),
+		'no inline-math case',
+	);
+});

--- a/scripts/mathDelimiterCorpus.json
+++ b/scripts/mathDelimiterCorpus.json
@@ -1,0 +1,243 @@
+{
+	"$comment": [
+		"Shared math-delimiter corpus. Read by BOTH sides of the render pipeline:",
+		"  src-tauri/src/lib.rs  -> the_backend_recognises_exactly_the_math_the_contract_lists",
+		"  scripts/mathDelimiterContract.test.ts -> the frontend's own decision",
+		"",
+		"The invariant it pins: the set of spans the BACKEND hides from comrak must",
+		"equal the set the FRONTEND renders with KaTeX. Neither side is the",
+		"reference -- both are asserted against the `math` list below.",
+		"  backend narrower  -> comrak mangles the formula before KaTeX sees it (#174/#177/#197)",
+		"  backend wider     -> the text is held back from Markdown and then rendered by nobody",
+		"",
+		"`markdown` and `math` are hand-authored: they state what SHOULD happen.",
+		"`html` is a capture of what convert_markdown really returns, so that the",
+		"frontend test runs on real renderer output; it cannot go stale, because",
+		"the_math_contract_corpus_is_a_live_capture asserts it every `cargo test`.",
+		"To refresh after a comrak upgrade, replace `html` with the value that test",
+		"reports. Never hand-edit `html`, and never edit `math` to match a failure --",
+		"a disagreement here is the bug, not the test.",
+		"",
+		"KNOWN GAP: a same-line `$$x$$` mixed into prose is passed through verbatim",
+		"by convertInlineMathDelimiters, so the frontend's decision about it is not",
+		"observable without re-implementing the rule in the test (which would defeat",
+		"the purpose). Display cases here therefore use the block form, whose",
+		"decision surfaces as data-math-source. Same-line `$$` is covered by the",
+		"Rust-side tests alone."
+	],
+	"cases": [
+		{
+			"name": "two prices in one sentence",
+			"markdown": "It cost $100 and $200 today.\n",
+			"html": "<p data-sourcepos=\"1:1-1:28\">It cost $100 and $200 today.</p>\n",
+			"math": []
+		},
+		{
+			"name": "a single price",
+			"markdown": "The price is $5.\n",
+			"html": "<p data-sourcepos=\"1:1-1:16\">The price is $5.</p>\n",
+			"math": []
+		},
+		{
+			"name": "a price range",
+			"markdown": "Between $5 and $10.\n",
+			"html": "<p data-sourcepos=\"1:1-1:19\">Between $5 and $10.</p>\n",
+			"math": []
+		},
+		{
+			"name": "prices run together",
+			"markdown": "$100$200 back to back.\n",
+			"html": "<p data-sourcepos=\"1:1-1:22\">$100$200 back to back.</p>\n",
+			"math": []
+		},
+		{
+			"name": "a lone dollar sign",
+			"markdown": "A lone $ sign.\n",
+			"html": "<p data-sourcepos=\"1:1-1:14\">A lone $ sign.</p>\n",
+			"math": []
+		},
+		{
+			"name": "a trailing dollar sign",
+			"markdown": "Trailing dollar $\n",
+			"html": "<p data-sourcepos=\"1:1-1:17\">Trailing dollar $</p>\n",
+			"math": []
+		},
+		{
+			"name": "a dollar followed by a space",
+			"markdown": "Costs $ 5 with a space.\n",
+			"html": "<p data-sourcepos=\"1:1-1:23\">Costs $ 5 with a space.</p>\n",
+			"math": []
+		},
+		{
+			"name": "an escaped dollar alone",
+			"markdown": "Costs \\$5 only.\n",
+			"html": "<p data-sourcepos=\"1:1-1:15\">Costs $5 only.</p>\n",
+			"math": []
+		},
+		{
+			"name": "a stray display delimiter in prose",
+			"markdown": "A stray $$ here.\n\nAnd *emphasis* after.\n",
+			"html": "<p data-sourcepos=\"1:1-1:16\">A stray $$ here.</p>\n<p data-sourcepos=\"3:1-3:21\">And <em data-sourcepos=\"3:5-3:14\">emphasis</em> after.</p>\n",
+			"math": []
+		},
+		{
+			"name": "prices on consecutive lines",
+			"markdown": "Costs $5 today\nand $6 tomorrow.\n",
+			"html": "<p data-sourcepos=\"1:1-2:16\">Costs $5 today<br data-sourcepos=\"1:15-1:15\" />\nand $6 tomorrow.</p>\n",
+			"math": []
+		},
+		{
+			"name": "a span may not cross a hard line break",
+			"markdown": "Opens $here\nand closes there$ later.\n",
+			"html": "<p data-sourcepos=\"1:1-2:24\">Opens $here<br data-sourcepos=\"1:12-1:12\" />\nand closes there$ later.</p>\n",
+			"math": []
+		},
+		{
+			"name": "an escaped dollar next to real math",
+			"markdown": "Pay \\$100 for $x$ items.\n",
+			"html": "<p data-sourcepos=\"1:1-1:33\">Pay $100 for $x$ items.</p>\n",
+			"math": [
+				{
+					"kind": "inline",
+					"source": "x"
+				}
+			]
+		},
+		{
+			"name": "a span may not cross an inline code span",
+			"markdown": "$a `x` b$ and $c_1$.\n",
+			"html": "<p data-sourcepos=\"1:1-1:27\">$a <code data-sourcepos=\"1:5-1:5\">x</code> b$ and $c_1$.</p>\n",
+			"math": [
+				{
+					"kind": "inline",
+					"source": "c_1"
+				}
+			]
+		},
+		{
+			"name": "dollars inside inline code are not math",
+			"markdown": "Use `$a$` and $b_1$ here.\n",
+			"html": "<p data-sourcepos=\"1:1-1:32\">Use <code data-sourcepos=\"1:6-1:8\">$a$</code> and $b_1$ here.</p>\n",
+			"math": [
+				{
+					"kind": "inline",
+					"source": "b_1"
+				}
+			]
+		},
+		{
+			"name": "a display delimiter inside a fence does not flip parity",
+			"markdown": "```sh\necho $$\n```\n\n$$\nx_1\n$$\n",
+			"html": "<pre data-sourcepos=\"1:1-3:3\"><code class=\"language-sh\">echo $$\n</code></pre>\n<p data-sourcepos=\"5:1-7:12\">$$<br data-sourcepos=\"5:13-5:13\" />\nx_1<br data-sourcepos=\"6:13-6:13\" />\n$$</p>\n",
+			"math": [
+				{
+					"kind": "display",
+					"source": "x_1"
+				}
+			]
+		},
+		{
+			"name": "currency and math in one CJK sentence",
+			"markdown": "价格是 $5，数学是 $x_1$。\n",
+			"html": "<p data-sourcepos=\"1:1-1:40\">价格是 $5，数学是 $x_1$。</p>\n",
+			"math": [
+				{
+					"kind": "inline",
+					"source": "x_1"
+				}
+			]
+		},
+		{
+			"name": "a price and a formula in one sentence",
+			"markdown": "Costs $5 but $x_1$ is math.\n",
+			"html": "<p data-sourcepos=\"1:1-1:34\">Costs $5 but $x_1$ is math.</p>\n",
+			"math": [
+				{
+					"kind": "inline",
+					"source": "x_1"
+				}
+			]
+		},
+		{
+			"name": "braced subscripts (issue #174)",
+			"markdown": "Let $\\bar{b}_{1} + \\bar{b}_{2}$ be the estimates.\n",
+			"html": "<p data-sourcepos=\"1:1-1:34\">Let $\\bar{b}_{1} + \\bar{b}_{2}$ be the estimates.</p>\n",
+			"math": [
+				{
+					"kind": "inline",
+					"source": "\\bar{b}_{1} + \\bar{b}_{2}"
+				}
+			]
+		},
+		{
+			"name": "adjacent inline spans",
+			"markdown": "$a$$b$\n",
+			"html": "<p data-sourcepos=\"1:1-1:24\">$a$$b$</p>\n",
+			"math": [
+				{
+					"kind": "inline",
+					"source": "a"
+				},
+				{
+					"kind": "inline",
+					"source": "b"
+				}
+			]
+		},
+		{
+			"name": "an inline formula with a caret",
+			"markdown": "Then $E=mc^2$ holds.\n",
+			"html": "<p data-sourcepos=\"1:1-1:24\">Then $E=mc^2$ holds.</p>\n",
+			"math": [
+				{
+					"kind": "inline",
+					"source": "E=mc^2"
+				}
+			]
+		},
+		{
+			"name": "an inline span holding markup characters",
+			"markdown": "$a < b \\& c * d$\n",
+			"html": "<p data-sourcepos=\"1:1-1:12\">$a &lt; b \\&amp; c * d$</p>\n",
+			"math": [
+				{
+					"kind": "inline",
+					"source": "a < b \\& c * d"
+				}
+			]
+		},
+		{
+			"name": "a formula in a task item",
+			"markdown": "- [ ] compute $x_1$\n",
+			"html": "<ul data-sourcepos=\"1:1-1:26\">\n<li data-sourcepos=\"1:1-1:26\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> compute $x_1$</li>\n</ul>\n",
+			"math": [
+				{
+					"kind": "inline",
+					"source": "x_1"
+				}
+			]
+		},
+		{
+			"name": "aligned rows (issue #197)",
+			"markdown": "$$\n\\begin{aligned}\na &= b \\\\\nc &= d\n\\end{aligned}\n$$\n",
+			"html": "<p data-sourcepos=\"1:1-6:12\">$$<br data-sourcepos=\"1:13-1:13\" />\n\\begin{aligned}<br data-sourcepos=\"2:13-2:13\" />\na &amp;= b \\\\<br data-sourcepos=\"3:13-3:13\" />\nc &amp;= d<br data-sourcepos=\"4:13-4:13\" />\n\\end{aligned}<br data-sourcepos=\"5:13-5:13\" />\n$$</p>\n",
+			"math": [
+				{
+					"kind": "display",
+					"source": "\\begin{aligned}\na &= b \\\\\nc &= d\n\\end{aligned}"
+				}
+			]
+		},
+		{
+			"name": "an escaped percent sign (issue #177)",
+			"markdown": "$$\n\\mathbf{Accuracy: 100\\%}\n$$\n",
+			"html": "<p data-sourcepos=\"1:1-3:12\">$$<br data-sourcepos=\"1:13-1:13\" />\n\\mathbf{Accuracy: 100\\%}<br data-sourcepos=\"2:13-2:13\" />\n$$</p>\n",
+			"math": [
+				{
+					"kind": "display",
+					"source": "\\mathbf{Accuracy: 100\\%}"
+				}
+			]
+		}
+	]
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -862,11 +862,359 @@ mod tests {
         assert!(!html.contains("<em"), "unexpected parser output: {html}");
     }
 
+    // -----------------------------------------------------------------
+    // Math delimiters
+    //
+    // comrak runs CommonMark inline rules inside math delimiters, so KaTeX
+    // never sees what the user typed. The three cases below are the
+    // reported symptoms of that one cause; the block after them is the
+    // other half of the bargain, because a rule that mistakes prose for
+    // math breaks far more documents than the bug it fixes.
+    // -----------------------------------------------------------------
+
+    /// The rendered text with the markup taken back out, i.e. roughly what
+    /// `textContent` hands to KaTeX in the frontend.
+    fn rendered_math_source(html: &str) -> String {
+        let mut out = String::new();
+        let mut rest = html;
+        while let Some(at) = rest.find('<') {
+            out.push_str(&rest[..at]);
+            match rest[at..].find('>') {
+                Some(end) => rest = &rest[at + end + 1..],
+                None => {
+                    rest = "";
+                    break;
+                }
+            }
+        }
+        out.push_str(rest);
+        out.replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&quot;", "\"")
+            .replace("&amp;", "&")
+    }
+
     #[test]
-    fn display_math_underscore_protection_preserves_escaped_underscores() {
+    fn issue_174_inline_math_keeps_both_braced_subscripts() {
+        // `$\bar{b}_{1} + \bar{b}_{2}$` — the two `_` are both left- and
+        // right-flanking, so CommonMark pairs them into an `<em>` and KaTeX
+        // receives `$\bar{b}<em>{1} + \bar{b}</em>{2}$`. That is the whole of
+        // "only the first subscript can use braces", and why a space before
+        // the first `_` appeared to fix it.
+        let html = convert_markdown("Let $\\bar{b}_{1} + \\bar{b}_{2}$ be the estimates.\n");
+        assert!(!html.contains("<em"), "math was parsed as emphasis: {html}");
+        assert!(
+            html.contains("$\\bar{b}_{1} + \\bar{b}_{2}$"),
+            "the formula did not survive: {html}",
+        );
+    }
+
+    #[test]
+    fn issue_197_display_math_keeps_the_row_separators_of_an_aligned_block() {
+        // `\\` is a CommonMark escape for a literal `\`, so every row
+        // separator of the block is eaten and KaTeX renders "Only One
+        // Long-Long Line" that overflows horizontally.
+        let markdown =
+            "$$\n\\begin{aligned}\na &= b \\\\\nc &= d \\\\\ne &= f\n\\end{aligned}\n$$\n";
+        let html = convert_markdown(markdown);
+        let source = rendered_math_source(&html);
         assert_eq!(
-            protect_display_math_underscores("outside_a $$x\\_y_z$$ outside_b"),
-            format!("outside_a $$x\\{DISPLAY_MATH_UNDERSCORE_SENTINEL}y{DISPLAY_MATH_UNDERSCORE_SENTINEL}z$$ outside_b"),
+            source.matches("\\\\").count(),
+            2,
+            "the row separators were eaten as CommonMark escapes: {html}",
+        );
+        assert!(
+            source.contains("a &= b \\\\"),
+            "the row separators were eaten as CommonMark escapes: {html}",
+        );
+    }
+
+    #[test]
+    fn issue_177_math_keeps_escaped_percent_signs() {
+        // `\%` loses its backslash to CommonMark, and the bare `%` then
+        // starts a TeX comment: KaTeX reports "Unexpected end of input in a
+        // macro argument".
+        let html = convert_markdown("$$\\mathbf{Accuracy: 100\\%}$$\n");
+        assert!(
+            html.contains("\\mathbf{Accuracy: 100\\%}"),
+            "the escaped percent sign was eaten: {html}",
+        );
+    }
+
+    #[test]
+    fn math_delimiters_survive_every_other_commonmark_inline_rule() {
+        // The point of masking the span rather than one character class:
+        // emphasis, escapes and code marks are all TeX here.
+        let html = convert_markdown("$$a*b*c \\_ \\{ \\& ~y~ [z](w)$$\n");
+        assert!(!html.contains("<em"), "got: {html}");
+        assert!(!html.contains("<del"), "got: {html}");
+        assert!(!html.contains("<a "), "got: {html}");
+        assert!(
+            rendered_math_source(&html).contains("$$a*b*c \\_ \\{ \\& ~y~ [z](w)$$"),
+            "got: {html}",
+        );
+    }
+
+    #[test]
+    fn a_multiline_display_math_block_keeps_one_line_per_source_line() {
+        // The mask is per line, so the block still occupies six lines and
+        // the frontend still sees one `<br />` per row.
+        let markdown = "$$\n\\begin{aligned}\nx &= 1\n\\end{aligned}\n$$\n\n- [ ] task\n";
+        let html = convert_markdown(markdown);
+        assert_eq!(html.matches("<br").count(), 4, "got: {html}");
+        assert!(
+            html.contains("data-sourcepos=\"7:1-7:10\""),
+            "the task moved off line 7: {html}",
+        );
+    }
+
+    #[test]
+    fn a_crlf_display_math_block_keeps_its_line_endings() {
+        let html = convert_markdown("$$\r\na_1 \\\\\r\nb_2\r\n$$\r\n");
+        assert!(!html.contains("<em"), "got: {html}");
+        assert!(
+            rendered_math_source(&html).contains("a_1 \\\\"),
+            "got: {html}",
+        );
+    }
+
+    // --- the other half: prose that must NOT become math ----------------
+
+    #[test]
+    fn two_prices_in_one_sentence_are_not_a_math_span() {
+        // The failure mode that matters most. `$100 and $200` pairs under any
+        // naive "next `$` closes it" rule and would silently swallow the
+        // Markdown of every document that mentions two prices.
+        let html = convert_markdown("It cost $100 and $200 today.\n");
+        assert!(
+            html.contains("It cost $100 and $200 today."),
+            "a price was treated as math: {html}",
+        );
+    }
+
+    #[test]
+    fn ordinary_dollar_amounts_are_not_math_spans() {
+        for markdown in [
+            "The price is $5.\n",
+            "Between $5 and $10.\n",
+            "$100$200 back to back.\n",
+            "A lone $ sign.\n",
+            "Trailing dollar $\n",
+            "Costs $ 5 with a space.\n",
+            "$5\n$6\n",
+        ] {
+            let html = convert_markdown(markdown);
+            assert_eq!(
+                rendered_math_source(&html).trim(),
+                markdown.trim(),
+                "input {markdown:?} was rewritten: {html}",
+            );
+        }
+    }
+
+    #[test]
+    fn an_escaped_dollar_never_opens_a_math_span() {
+        let html = convert_markdown("Pay \\$100 for $x$ items.\n");
+        assert!(
+            html.contains("Pay $100 for $x$ items."),
+            "the escaped dollar opened a span: {html}",
+        );
+    }
+
+    #[test]
+    fn dollars_inside_code_never_open_a_math_span() {
+        // A single `$$` inside a fence used to flip the delimiter parity of
+        // the entire document, because the old protection just split on `$$`.
+        let markdown = "```sh\necho $$\n```\n\nA *word* and $$x_1$$ after.\n\n`$a$` stays code.\n";
+        let html = convert_markdown(markdown);
+        assert!(html.contains("<em"), "the fence ate the emphasis: {html}");
+        assert!(
+            html.contains("$$x_1$$"),
+            "the math after the fence lost its protection: {html}",
+        );
+        assert!(
+            html.contains(">$a$</code>"),
+            "an inline code span was treated as math: {html}",
+        );
+    }
+
+    #[test]
+    fn a_math_span_never_reaches_across_an_inline_code_span() {
+        // The frontend cannot pair delimiters across a `<code>` element —
+        // `processInlineMath` rejects the whole subtree — so neither may the
+        // backend: masking here would silently eat the code span.
+        let html = convert_markdown("$a `x` b$ and *emphasis*.\n");
+        assert!(html.contains(">x</code>"), "got: {html}");
+        assert!(html.contains("<em"), "got: {html}");
+    }
+
+    #[test]
+    fn a_math_span_never_reaches_across_a_line_break() {
+        // `hardbreaks` puts each source line in its own text node, so an
+        // unpaired `$` must not reach the next line and blank out its
+        // Markdown.
+        let html = convert_markdown("Costs $5 today\nand *this* is emphasis $\n");
+        assert!(html.contains("<em"), "got: {html}");
+    }
+
+    #[test]
+    fn an_unpaired_display_delimiter_does_not_swallow_the_document() {
+        let markdown = "$$ unpaired\n\nA *word*.\n\nAnother paragraph with $$ too.\n";
+        let html = convert_markdown(markdown);
+        assert!(html.contains("<em"), "the stray `$$` ran away: {html}");
+    }
+
+    #[test]
+    fn a_document_containing_the_mask_prefix_still_round_trips() {
+        // Uniqueness is by construction, not by luck: the prefix grows until
+        // the document does not contain it.
+        let markdown = format!("{MATH_MASK_PREFIX}0{MATH_MASK_SUFFIX} and $x_1$ here.\n");
+        let html = convert_markdown(&markdown);
+        assert!(
+            html.contains(&format!("{MATH_MASK_PREFIX}0{MATH_MASK_SUFFIX}")),
+            "the document's own text was eaten: {html}",
+        );
+        assert!(html.contains("$x_1$"), "the math was lost: {html}");
+        assert!(!html.contains("<em"), "got: {html}");
+    }
+
+    #[test]
+    fn a_masked_span_is_escaped_the_way_comrak_escapes_text() {
+        let html = convert_markdown("$a < b & c > d \"e\"$\n");
+        assert!(
+            html.contains("$a &lt; b &amp; c &gt; d &quot;e&quot;$"),
+            "the restored span was not escaped: {html}",
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // The cross-language math-delimiter contract
+    //
+    // Everything above proves the backend hides the right spans from
+    // comrak. It cannot prove the thing correctness actually rests on:
+    // that the set the backend hides equals the set the *frontend*
+    // renders. Those are two implementations of one rule in two
+    // languages, and until now only one of them was pinned — loosening
+    // `findInlineMathEnd` in markdown.ts would have left every test in
+    // this file green.
+    //
+    //   backend ⊂ frontend → comrak mangles the formula before KaTeX
+    //                        sees it; that is #174, #177 and #197.
+    //   backend ⊃ frontend → the text is held back from Markdown and
+    //                        then rendered by nobody: the reader gets
+    //                        dead text that is neither prose nor a
+    //                        formula.
+    //
+    // So both sides are asserted against one shared, hand-authored
+    // table: scripts/mathDelimiterCorpus.json. The other half lives in
+    // scripts/mathDelimiterContract.test.ts and runs the real frontend.
+    // Change one side's rule and exactly one of the two goes red.
+    // -----------------------------------------------------------------
+
+    #[derive(serde::Deserialize)]
+    struct MathContractSpan {
+        kind: String,
+        source: String,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct MathContractCase {
+        name: String,
+        markdown: String,
+        html: String,
+        math: Vec<MathContractSpan>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct MathContractCorpus {
+        cases: Vec<MathContractCase>,
+    }
+
+    fn math_contract_corpus() -> MathContractCorpus {
+        serde_json::from_str(include_str!("../../scripts/mathDelimiterCorpus.json"))
+            .expect("scripts/mathDelimiterCorpus.json must stay valid JSON")
+    }
+
+    /// What the backend decided, in the corpus's vocabulary.
+    fn recognised_math(markdown: &str) -> Vec<(String, String)> {
+        let regions = code_region_ranges(markdown);
+        find_math_spans(markdown, &regions)
+            .into_iter()
+            .map(|(start, end)| {
+                let span = &markdown[start..end];
+                match span
+                    .strip_prefix("$$")
+                    .and_then(|inner| inner.strip_suffix("$$"))
+                {
+                    // `extractDisplayMathBlock` trims; mirror it exactly.
+                    Some(inner) => ("display".to_owned(), inner.trim().to_owned()),
+                    None => ("inline".to_owned(), span[1..span.len() - 1].to_owned()),
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn the_backend_recognises_exactly_the_math_the_contract_lists() {
+        for case in math_contract_corpus().cases {
+            let expected: Vec<(String, String)> = case
+                .math
+                .iter()
+                .map(|span| (span.kind.clone(), span.source.clone()))
+                .collect();
+            assert_eq!(
+                recognised_math(&case.markdown),
+                expected,
+                "{}: the backend and the contract disagree about what is math\n  input: {:?}",
+                case.name,
+                case.markdown,
+            );
+        }
+    }
+
+    #[test]
+    fn the_math_contract_corpus_is_a_live_capture() {
+        // Keeps the `html` the frontend test consumes honest: it is what
+        // this renderer produces today, not what it produced once.
+        for case in math_contract_corpus().cases {
+            assert_eq!(
+                convert_markdown(&case.markdown),
+                case.html,
+                "{}: scripts/mathDelimiterCorpus.json no longer matches this \
+                 renderer — replace its `html` with the value on the left, and \
+                 leave `markdown` and `math` alone",
+                case.name,
+            );
+        }
+    }
+
+    #[test]
+    fn math_in_a_heading_keeps_the_anchor_a_wikilink_can_reach() {
+        // comrak derives the heading id from the *rendered* text, so the mask
+        // would otherwise become the anchor and silently break every
+        // `[[#heading]]` pointing at a heading that contains a formula.
+        let heading = "A heading with $x_1$";
+        let html = convert_markdown(&format!("# {heading}\n"));
+        assert!(html.contains("$x_1$"), "the math was lost: {html}");
+        assert_eq!(
+            heading_anchor_id(heading),
+            "a-heading-with-x_1",
+            "the wikilink side changed",
+        );
+        assert!(
+            html.contains("id=\"a-heading-with-x_1\""),
+            "the mask leaked into the anchor: {html}",
+        );
+    }
+
+    #[test]
+    fn math_in_a_link_destination_keeps_the_link_working() {
+        // The token has to survive `escape_href` too, which is why it is
+        // plain ASCII rather than a private-use character.
+        let html = convert_markdown("[t](http://example.com/$a$)\n");
+        assert!(
+            html.contains("href=\"http://example.com/$a$\""),
+            "the link destination was mangled: {html}",
         );
     }
 
@@ -1296,8 +1644,8 @@ mod tests {
                 (|s| process_wikilinks(s).into_owned()) as LineTransform,
             ),
             (
-                "protect_display_math_underscores",
-                protect_display_math_underscores as LineTransform,
+                "mask_math_spans",
+                (|s| mask_math_spans(s).text) as LineTransform,
             ),
         ]
     }
@@ -1397,7 +1745,7 @@ mod tests {
             let autolinks = process_parenthesized_autolinks(content);
             let embeds = process_internal_embeds(&autolinks);
             let links = process_wikilinks(&embeds);
-            protect_display_math_underscores(&links)
+            mask_math_spans(&links).text
         };
         for input in LINE_CONTRACT_CORPUS {
             assert_transform_preserves_line_numbers("the preprocessing pipeline", pipeline, input);
@@ -1430,8 +1778,14 @@ mod tests {
         // Calls in `convert_markdown` that are not preprocessing steps.
         // `annotate_task_checkboxes` runs on the rendered HTML, after
         // sourcepos numbers exist; it is the fail-safe for this contract
-        // rather than a participant in it.
-        let not_a_transform = ["markdown_to_html", "annotate_task_checkboxes"];
+        // rather than a participant in it. `restore_math_spans` also runs on
+        // the rendered HTML — it is the second half of `mask_math_spans`,
+        // which *is* registered, and it never sees the source buffer.
+        let not_a_transform = [
+            "markdown_to_html",
+            "annotate_task_checkboxes",
+            "restore_math_spans",
+        ];
 
         let mut found: Vec<String> = call
             .captures_iter(body)
@@ -2031,21 +2385,441 @@ fn process_parenthesized_autolinks(content: &str) -> Cow<'_, str> {
     }
 }
 
-const DISPLAY_MATH_UNDERSCORE_SENTINEL: &str = "\u{E000}";
+// ---------------------------------------------------------------------------
+// Math spans
+//
+// comrak keeps applying CommonMark inline rules *inside* math delimiters, so
+// the formula KaTeX finally sees has already been rewritten. Three reported
+// bugs are the same bug:
+//
+//   #174  `$\bar{b}_{1} + \bar{b}_{2}$` — the two `_` pair into `<em>`, which
+//         is why only the first subscript ever worked and why putting a space
+//         in front of it "fixed" it (a space makes the `_` non-left-flanking).
+//   #197  `$$ … \\ … $$` — `\\` is a CommonMark escape for a literal `\`, so
+//         every row separator of an `aligned` block is eaten and the whole
+//         block collapses onto one over-wide line.
+//   #177  `\%` loses its backslash, and a bare `%` starts a TeX comment that
+//         swallows the rest of the formula ("Unexpected end of input").
+//
+// Patching one character class at a time (the previous
+// `protect_display_math_underscores` only rewrote `_`, and only between `$$`)
+// cannot win: Markdown has no business parsing TeX at all. So the whole span
+// is replaced by an opaque token before comrak runs and put back afterwards.
+//
+// Deliberately NOT handled here: `\(…\)` and `\[…\]`, which the frontend also
+// renders. They have the same root cause and are not an oversight — CommonMark
+// eats the backslash (`\(` → `(`) before the frontend ever sees a delimiter, so
+// they have never worked in Markpad at all. Fixing them is a separate change
+// with its own regression surface; masking them here would silently start
+// claiming text that no released version ever treated as math.
+//
+// The token is deliberately plain ASCII rather than a private-use character:
+// comrak percent-encodes anything non-ASCII that ends up in a link
+// destination (`http://x/$a$` would come back as `http://x/%EE%80%80…`),
+// while `[A-Z0-9]` survives text nodes, attribute values and hrefs verbatim
+// and carries no CommonMark meaning. Uniqueness is established by
+// construction instead of by luck: the prefix grows until it does not occur
+// in the document.
+// ---------------------------------------------------------------------------
 
-fn protect_display_math_underscores(content: &str) -> String {
-    content
-        .split("$$")
-        .enumerate()
-        .map(|(index, segment)| {
-            if index % 2 == 1 {
-                segment.replace('_', DISPLAY_MATH_UNDERSCORE_SENTINEL)
-            } else {
-                segment.to_owned()
+const MATH_MASK_PREFIX: &str = "MPMATHMASK";
+const MATH_MASK_SUFFIX: char = 'E';
+
+struct MaskedMath {
+    /// The source with every math span replaced by a token.
+    text: String,
+    /// The token prefix actually used — see `mask_math_spans`.
+    prefix: String,
+    /// The masked source, one entry per line of each span, indexed by token.
+    spans: Vec<String>,
+}
+
+/// Byte ranges of `content` that may hold math: one entry per line, with the
+/// code regions cut out.
+///
+/// The split mirrors what the frontend can see. `convert_markdown` renders
+/// with `hardbreaks`, so every source line becomes its own DOM text node, and
+/// `processInlineMath` skips `code`/`pre` subtrees entirely — a `$` on the far
+/// side of a line break or of an inline code span is in a different text node
+/// and can never pair. Scanning the raw buffer the same way is what keeps the
+/// two ends agreeing, and it is also what stops a single `$$` inside a fenced
+/// block from flipping the delimiter parity of the whole document.
+fn math_scan_segments(content: &str, regions: &[(usize, usize)]) -> Vec<(usize, usize)> {
+    let len = content.len();
+    let mut segments = Vec::new();
+    let mut line_start = 0usize;
+    // `regions` is sorted and both loops only move forward, so each region is
+    // visited once across the whole document rather than once per line.
+    let mut first_region = 0usize;
+    loop {
+        let newline = content[line_start..]
+            .find('\n')
+            .map(|offset| line_start + offset)
+            .unwrap_or(len);
+        let mut line_end = newline;
+        if line_end > line_start && content.as_bytes()[line_end - 1] == b'\r' {
+            line_end -= 1;
+        }
+
+        while first_region < regions.len() && regions[first_region].1 <= line_start {
+            first_region += 1;
+        }
+        let mut cursor = line_start;
+        for &(region_start, region_end) in &regions[first_region..] {
+            if region_end <= cursor {
+                continue;
             }
-        })
-        .collect::<Vec<_>>()
-        .join("$$")
+            if region_start >= line_end {
+                break;
+            }
+            if region_start > cursor {
+                segments.push((cursor, region_start.min(line_end)));
+            }
+            cursor = cursor.max(region_end);
+            if cursor >= line_end {
+                break;
+            }
+        }
+        if cursor < line_end {
+            segments.push((cursor, line_end));
+        }
+
+        if newline >= len {
+            break;
+        }
+        line_start = newline + 1;
+    }
+    segments
+}
+
+fn char_before(content: &str, low: usize, at: usize) -> Option<char> {
+    if at <= low {
+        return None;
+    }
+    content[low..at].chars().next_back()
+}
+
+fn char_after(content: &str, high: usize, dollar: usize) -> Option<char> {
+    let next = dollar + 1;
+    if next >= high {
+        return None;
+    }
+    content[next..high].chars().next()
+}
+
+/// The closing `$` of an inline span opened at `open`, or `None`.
+///
+/// A faithful port of `findInlineMathEnd` in `src/lib/utils/markdown.ts`, and
+/// the reason `$100 and $200` is not math: the first candidate closer decides,
+/// and a candidate preceded by whitespace or followed by a digit does not
+/// merely get skipped — it abandons the span. Anything looser turns ordinary
+/// prices into formulas, which is a far worse failure than the bug being
+/// fixed here.
+fn find_inline_close(content: &str, low: usize, high: usize, from: usize) -> Option<usize> {
+    let bytes = content.as_bytes();
+    let mut index = from;
+    while index < high {
+        if bytes[index] != b'$' {
+            index += 1;
+            continue;
+        }
+        let before = char_before(content, low, index);
+        if before == Some('\\') {
+            index += 1;
+            continue;
+        }
+        if before.is_some_and(char::is_whitespace) {
+            return None;
+        }
+        if char_after(content, high, index).is_some_and(|c| c.is_ascii_digit()) {
+            return None;
+        }
+        return Some(index);
+    }
+    None
+}
+
+/// The end offset (exclusive) of a `$$…$$` span opened at `open`.
+///
+/// Within one line this is `findDisplayMathEnd`. Across lines it is the block
+/// form `processDisplayMathBlocks` renders, so both delimiters must sit alone
+/// on their line; that is what stops two unrelated `$$` in prose from pairing
+/// across a hard break. The search stops at a blank line (which ends the
+/// CommonMark block) and at any code region.
+fn find_display_close(
+    content: &str,
+    regions: &[(usize, usize)],
+    open: usize,
+    segment_end: usize,
+) -> Option<usize> {
+    let bytes = content.as_bytes();
+    let len = content.len();
+
+    let mut index = open + 2;
+    while index + 1 < segment_end {
+        if bytes[index] == b'$' && bytes[index + 1] == b'$' && bytes[index - 1] != b'\\' {
+            return Some(index + 2);
+        }
+        index += 1;
+    }
+
+    let (opener_line_end, mut next_line_start) = line_bounds(content, open);
+    if !content[open + 2..opener_line_end].trim().is_empty() {
+        return None;
+    }
+    while next_line_start < len {
+        let (line_end, following) = line_bounds(content, next_line_start);
+        let line = &content[next_line_start..line_end];
+        if line.trim().is_empty() {
+            return None;
+        }
+        if regions
+            .iter()
+            .any(|&(start, end)| start < line_end && end > next_line_start)
+        {
+            return None;
+        }
+        if let Some(offset) = line.find("$$") {
+            let close = next_line_start + offset;
+            if content[next_line_start..close].trim().is_empty()
+                && content[close + 2..line_end].trim().is_empty()
+            {
+                return Some(close + 2);
+            }
+        }
+        next_line_start = following;
+    }
+    None
+}
+
+/// `(end of the line holding `at`, start of the next line)`, with `\r`
+/// excluded from the first and `len` used when there is no next line.
+fn line_bounds(content: &str, at: usize) -> (usize, usize) {
+    let len = content.len();
+    let newline = content[at..]
+        .find('\n')
+        .map(|offset| at + offset)
+        .unwrap_or(len);
+    let mut line_end = newline;
+    if line_end > 0 && content.as_bytes()[line_end - 1] == b'\r' {
+        line_end -= 1;
+    }
+    (line_end, (newline + 1).min(len))
+}
+
+/// The math spans of `content`, as sorted, non-overlapping byte ranges.
+///
+/// A port of `convertInlineMathDelimiters` in `src/lib/utils/markdown.ts`,
+/// which is the only thing that decides what the user actually sees rendered.
+/// Recognising a span here that the frontend will not render would strip the
+/// Markdown out of ordinary prose; recognising less would leave the formula
+/// mangled — so the rules have to be the same rules.
+fn find_math_spans(content: &str, regions: &[(usize, usize)]) -> Vec<(usize, usize)> {
+    let bytes = content.as_bytes();
+    let mut spans: Vec<(usize, usize)> = Vec::new();
+    let mut barrier = 0usize;
+
+    for (segment_start, segment_end) in math_scan_segments(content, regions) {
+        if segment_end <= barrier {
+            continue;
+        }
+        // A multi-line span already consumed the head of this line.
+        let low = segment_start.max(barrier);
+        let mut index = low;
+        // Lets `$a$$b$` open a second span while keeping `$$` itself out of it.
+        let mut previous_dollar_allows_open = false;
+
+        while index < segment_end {
+            if bytes[index] != b'$' {
+                previous_dollar_allows_open = false;
+                index += content[index..].chars().next().map_or(1, char::len_utf8);
+                continue;
+            }
+            let before = char_before(content, low, index);
+            let after = char_after(content, segment_end, index);
+
+            if before != Some('\\') && after == Some('$') {
+                match find_display_close(content, regions, index, segment_end) {
+                    Some(end) => {
+                        spans.push((index, end));
+                        if end > segment_end {
+                            barrier = end;
+                            break;
+                        }
+                        previous_dollar_allows_open = true;
+                        index = end;
+                    }
+                    None => {
+                        previous_dollar_allows_open = false;
+                        index += 2;
+                    }
+                }
+                continue;
+            }
+
+            if before == Some('\\')
+                || (before == Some('$') && !previous_dollar_allows_open)
+                || after.is_some_and(char::is_whitespace)
+            {
+                previous_dollar_allows_open = false;
+                index += 1;
+                continue;
+            }
+
+            match find_inline_close(content, low, segment_end, index + 1) {
+                Some(close) => {
+                    spans.push((index, close + 1));
+                    previous_dollar_allows_open = true;
+                    index = close + 1;
+                }
+                None => {
+                    previous_dollar_allows_open = false;
+                    index += 1;
+                }
+            }
+        }
+    }
+    spans
+}
+
+/// Replaces every math span with a token comrak cannot rewrite.
+///
+/// One token per line of a span, so a six-line `$$…$$` block still occupies
+/// six lines: the line-number contract in `mod tests` is not negotiable, and a
+/// span collapsed into a single token would move every task checkbox below it.
+/// Leading indentation stays outside the token so that a formula inside a list
+/// item keeps belonging to that item.
+fn mask_math_spans(content: &str) -> MaskedMath {
+    // Case-insensitively, because comrak lowercases the token again when it
+    // derives a heading id from it — see `restore_math_spans`.
+    let haystack = content.to_ascii_lowercase();
+    let mut prefix = String::from(MATH_MASK_PREFIX);
+    while haystack.contains(&prefix.to_ascii_lowercase()) {
+        prefix.push('X');
+    }
+
+    let regions = code_region_ranges(content);
+    let found = find_math_spans(content, &regions);
+    if found.is_empty() {
+        return MaskedMath {
+            text: content.to_owned(),
+            prefix,
+            spans: Vec::new(),
+        };
+    }
+
+    let mut text = String::with_capacity(content.len());
+    let mut spans: Vec<String> = Vec::new();
+    let mut copied_to = 0usize;
+    for (start, end) in found {
+        text.push_str(&content[copied_to..start]);
+        for piece in content[start..end].split_inclusive('\n') {
+            let mut body = piece;
+            let mut line_ending = "";
+            if let Some(stripped) = body.strip_suffix('\n') {
+                body = stripped;
+                line_ending = "\n";
+                if let Some(stripped) = body.strip_suffix('\r') {
+                    body = stripped;
+                    line_ending = "\r\n";
+                }
+            }
+            let indent = body.len() - body.trim_start().len();
+            text.push_str(&body[..indent]);
+            let core = &body[indent..];
+            if !core.is_empty() {
+                text.push_str(&format!("{prefix}{}{MATH_MASK_SUFFIX}", spans.len()));
+                spans.push(core.to_owned());
+            }
+            text.push_str(line_ending);
+        }
+        copied_to = end;
+    }
+    text.push_str(&content[copied_to..]);
+
+    MaskedMath {
+        text,
+        prefix,
+        spans,
+    }
+}
+
+/// Puts the masked source back into the rendered HTML.
+///
+/// The span is re-escaped the way comrak escapes a text node, not inserted
+/// raw: the token can legitimately land in a text node, an `alt` value or an
+/// `href`, and `&<>"` are the four characters that would otherwise change the
+/// meaning of the markup in any of the three. The frontend reads the span back
+/// out with `textContent`, which undoes the escaping before KaTeX sees it.
+///
+/// A heading is the one place the token appears twice in two different
+/// spellings: comrak anchorizes the heading's rendered text into `id=` and
+/// `href="#…"`, which lowercases it. There the *anchorized* source goes back
+/// instead, so that `[[#A heading with $x_1$]]` still resolves — the wikilink
+/// side computes the same id from the raw buffer with `heading_anchor_id`.
+fn restore_math_spans(html: &str, masked: &MaskedMath) -> String {
+    if masked.spans.is_empty() {
+        return html.to_owned();
+    }
+    let anchor_prefix = masked.prefix.to_ascii_lowercase();
+    let mut out = String::with_capacity(html.len());
+    let mut rest = html;
+    while let Some((at, anchored)) = [
+        (rest.find(masked.prefix.as_str()), false),
+        (rest.find(anchor_prefix.as_str()), true),
+    ]
+    .into_iter()
+    .filter_map(|(at, anchored)| at.map(|at| (at, anchored)))
+    .min()
+    {
+        out.push_str(&rest[..at]);
+        let after = &rest[at + masked.prefix.len()..];
+        let digits = after
+            .as_bytes()
+            .iter()
+            .take_while(|byte| byte.is_ascii_digit())
+            .count();
+        let suffix = if anchored {
+            MATH_MASK_SUFFIX.to_ascii_lowercase()
+        } else {
+            MATH_MASK_SUFFIX
+        };
+        let index = if digits > 0 && after[digits..].starts_with(suffix) {
+            after[..digits].parse::<usize>().ok()
+        } else {
+            None
+        };
+        match index.and_then(|index| masked.spans.get(index)) {
+            Some(original) if anchored => {
+                out.push_str(&Anchorizer::new().anchorize(original.clone()));
+                rest = &after[digits + suffix.len_utf8()..];
+            }
+            Some(original) => {
+                out.push_str(&escape_html_text(original));
+                rest = &after[digits + suffix.len_utf8()..];
+            }
+            None => {
+                out.push_str(&rest[at..at + masked.prefix.len()]);
+                rest = after;
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+fn escape_html_text(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for ch in text.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            _ => out.push(ch),
+        }
+    }
+    out
 }
 
 /// ⚠️ Every preprocessing step below is bound by a line-number contract:
@@ -2059,7 +2833,7 @@ fn convert_markdown(content: &str) -> String {
     let processed_autolinks = process_parenthesized_autolinks(content);
     let processed_embeds = process_internal_embeds(&processed_autolinks);
     let processed_links = process_wikilinks(&processed_embeds);
-    let protected_math = protect_display_math_underscores(&processed_links);
+    let masked_math = mask_math_spans(&processed_links);
 
     let mut options = ComrakOptions {
         extension: ComrakExtensionOptions {
@@ -2079,9 +2853,8 @@ fn convert_markdown(content: &str) -> String {
     options.render.hardbreaks = true;
     options.render.sourcepos = true;
 
-    let html = markdown_to_html(&protected_math, &options)
-        .replace(DISPLAY_MATH_UNDERSCORE_SENTINEL, "_");
-    annotate_task_checkboxes(html, content)
+    let html = markdown_to_html(&masked_math.text, &options);
+    annotate_task_checkboxes(restore_math_spans(&html, &masked_math), content)
 }
 
 /// Marks the rendered task checkboxes the frontend is allowed to toggle.


### PR DESCRIPTION
Fixes #174, #197, #177 — **one bug reported three times**.

> **Stacked on #389** (`fix/line-count-preserving-transforms`). Merge that first; this branch registers its new step in the line-contract registry #389 introduces.

## The root cause

comrak keeps running CommonMark inline rules *inside* math delimiters, so the formula KaTeX finally receives has already been rewritten. Verified against the current baseline:

| issue | input | what comrak hands KaTeX |
|---|---|---|
| #174 | `$\bar{b}_{1} + \bar{b}_{2}$` | `$\bar{b}<em>{1} + \bar{b}</em>{2}$` |
| #197 | `a &= b \\` in an `aligned` block | `a &amp;= b \` — every row separator eaten, block collapses to one line |
| #177 | `$$\mathbf{100\%}$$` | `$$\mathbf{100%}$$` — bare `%` opens a TeX comment |

#174's reporter noticed *"only the first subscript can use `{}`"* (a lone `_` cannot pair) and *"a space before it fixes it"* (a space makes the `_` non-left-flanking). Both observations are exactly this mechanism.

`protect_display_math_underscores` covered the **intersection** of two narrow cases — only `_`, only `$$` — and settled none of the three. Patching one character class at a time cannot win, because Markdown has no business parsing TeX. The whole span is now masked before comrak runs and restored afterwards, and that function is deleted.

## The inline `$…$` rule is not invented here

**KaTeX's own auto-render refuses to make this call.** `contrib/auto-render.js` ships `$$…$$`, `\(…\)`, `\[…\]` and the AMS environments, with `$…$` **commented out in the source** and a note that LaTeX uses it but it ruins the display of ordinary `$` in text. Upstream's position is that single-`$` needs product-specific disambiguation.

**Markpad already made that decision, in the frontend** — `convertInlineMathDelimiters` / `findInlineMathEnd` in `markdown.ts` decide what a user actually sees rendered. The backend now uses that rule:

- an opening `$` may not be escaped, may not follow an unconsumed `$`, and may not be followed by whitespace;
- the **first** candidate closer decides — a candidate preceded by whitespace or followed by a digit **abandons the span** rather than being skipped. That is the currency guard: in `$100 and $200` the only candidate closer is preceded by a space, so nothing is math;
- `$$` is tried before `$`, with an adjacent-span flag so `$a$$b$` works.

**No frontend change was needed** — the backend moved to the frontend's rule, not the other way round. That direction is deliberate: the frontend's rule is already shipped and existing documents depend on it; the backend's was new and nothing depended on it. Move the side with no installed base.

It is also aligned to what the frontend can **physically see**, not just what it computes:

| Frontend fact | Backend consequence |
|---|---|
| `hardbreaks` puts each source line in its own text node | a span never crosses a line break |
| `processInlineMath` skips `CODE`/`PRE` subtrees | a span never crosses an inline code span |
| `processDisplayMathBlocks` only renders the block form | multi-line `$$` pairs only when both delimiters sit alone on their line |

## The mask

`MPMATHMASK<n>E`, one token per **line** of a span.

- **Plain ASCII, not a private-use character.** The previous `\u{E000}` sentinel is unsafe in a link destination — comrak percent-encodes it, so `[t](http://x/$a$)` came back as `http://x/%EE%80%80…`. `[A-Z0-9]` survives text nodes, `alt` values and `href`s verbatim and carries no CommonMark meaning.
- **Unique by construction:** the prefix grows until it does not occur in the document, checked case-insensitively.
- **Line count preserved** (#389's contract): one token per line, indentation left outside the token so a formula in a list item keeps belonging to it.
- **Heading anchors:** comrak derives heading ids from rendered text, so a masked span also appears *lowercased* inside `id=` and `href="#…"`. Restore puts the **anchorized** source there instead — without this, `[[#A heading with $x_1$]]` broke silently.
- Restore re-escapes exactly the four characters comrak escapes in a text node (`&<>"` — established empirically; comrak does not escape `'`), which the frontend undoes via `textContent`.

**Code regions are excluded from both openers and closers**, and a multi-line `$$` search aborts on any code region. The old parity hazard — a lone `$$` inside a fence flipping the odd/even split for the rest of the document — is gone by construction, because there is no parity any more.

## The invariant is pinned, not remembered

Correctness here depends on **backend and frontend recognising the same spans**, and nothing enforced that. `scripts/mathDelimiterCorpus.json` — 24 cases of `{name, markdown, html, math[]}` — is what both are now asserted against:

- `markdown` and `math` are **hand-authored**: they state what *should* happen, so a corpus that merely records current behaviour cannot occur. **Neither implementation is the reference.**
- `html` is a live capture of real `convert_markdown` output, and a Rust test asserts it still matches — that is what stops the fixture from rotting.
- The TS half runs the **real** `processMarkdownHtml`, and its extractor **re-implements nothing**: it reads the frontend's verdict only from artifacts the frontend alone produces — `\(…\)`, emitted only by `convertInlineMathDelimiters`, and `data-math-source`, set only by `processDisplayMathBlocks`. An extractor that parsed `$…$` itself could agree with a broken implementation.
- A further test requires ≥10 must-be-math and ≥10 must-not-be-math cases, so neither "recognise nothing" nor "recognise everything" can pass.

**Both directions proven red:**

| Mutation | Result |
|---|---|
| frontend: drop the "closer may not be followed by a digit" guard | TS test fails — *prices run together: the frontend and the contract disagree about what is math* |
| backend: drop the same guard | Rust test fails — `left: [("inline", "100")] right: []` |
| any backend change that alters rendering | live-capture test fails, with instructions to replace `html` and leave `markdown`/`math` alone |

## Misjudgement guards

**Treating prose as math is worse than not protecting it**, so that was the primary constraint. Every one of these asserts the input is *not* math and renders normally: `$100 and $200` · `$5` · `$5–$10` · `$100$200` · a lone `$` · a trailing `$` · `$ 5` · `\$100` · `$$` inside a fence · `` `$a$` `` · a span reaching across an inline code span · a span reaching across a line break · prices on consecutive lines · an unpaired `$$` in one paragraph vs another two paragraphs later.

Falsification of the three issues (implementation reverted, tests kept): **117 pass / 5 fail → 123 pass / 0 fail.**

```
npm run check   432 files, 0 errors, 0 warnings
npm test        403 / 403
cargo test      123 / 123
cargo clippy    3 warnings, identical to baseline
```

## Not covered

- **A same-line `$$x$$` mixed into prose** is passed through verbatim by `convertInlineMathDelimiters`, so the frontend's verdict on it is not observable from the test without re-implementing the rule — which would defeat the point. Display cases in the corpus use the block form, whose verdict surfaces as `data-math-source`. That sub-case is guarded on the Rust side only, and the corpus header says so.
- **`\(…\)` / `\[…\]` are deliberately not handled.** Same root cause, but CommonMark eats the backslash before the frontend sees a delimiter, so they have never worked at all; masking them would start claiming text no released version treated as math. Marked in the code as a decision, not an oversight.
- A *paired* pair of backticks inside a span still wins as a code span — the frontend cannot pair delimiters across a `<code>` element either, so both sides decline together.
- A blank line inside a `$$` block ends the CommonMark block and ends the search; the frontend cannot render across paragraphs either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)