### PR TITLE
fix(export): render math, highlighting and diagrams into the exported HTML

### DIFF
--- a/scripts/exportRichContent.test.ts
+++ b/scripts/exportRichContent.test.ts
@@ -1,0 +1,372 @@
+/**
+ * The HTML export has to contain rendered rich content, not the source of it.
+ *
+ * Before this, `exportAsHtml` ran `render_markdown → sanitize →
+ * processMarkdownHtml` and stopped. `renderRichContent` — highlight.js, KaTeX,
+ * Mermaid — was a function inside `MarkdownViewer.svelte` that only the preview
+ * could reach. So an exported file, the artefact whose entire purpose is being
+ * read by someone without Markpad, arrived with
+ * `<p data-math="display" data-math-source="E = mc^2">E = mc^2</p>`,
+ * `<pre><code class="language-mermaid">` and code blocks with no highlight
+ * classes at all.
+ *
+ * These tests run the real `exportAsHtml` and assert on the bytes it hands to
+ * `save_file_content`. Two things are stood in for, both at a library boundary
+ * rather than at one of ours:
+ *
+ *   - highlight.js, KaTeX and Mermaid. All three need a real browser DOM
+ *     (measured against the shim: `hljs.highlightElement` and `katex.render`
+ *     both throw on it, and Mermaid needs layout to size a node). They are
+ *     injected through the same `libraries` field the app fills from the
+ *     preview's own instances, so what is exercised here is Markpad's pipeline
+ *     — which elements get handed to which library, and where the results end
+ *     up — and not the libraries' own output.
+ *   - `DOMPurify.sanitize`, which is a no-op object without a real DOM. It is
+ *     replaced by the identity function. What the filter does and where it sits
+ *     in the pipeline is pinned by `exportSanitize.test.ts`; the relevant fact
+ *     here is only that the diagram filter and the document filter are separate
+ *     calls, which the diagram test below covers from the other side.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { installShimDom } from './renderProtocolDom.ts';
+
+installShimDom();
+(globalThis as any).window = globalThis;
+// The app resolves the bundled font assets against its own origin.
+(globalThis as any).location = { href: 'http://tauri.localhost/' };
+
+const DOMPurify = (await import('dompurify')).default as any;
+DOMPurify.sanitize = (html: string) => html;
+
+const {
+	absolutizeKatexFontUrls,
+	collectUsedKatexFamilies,
+	findKatexFontFaces,
+	inlineKatexFontFaces,
+	katexFontUrlsToEmbed,
+} = await import('../src/lib/utils/exportFonts.ts');
+const { exportAsHtml } = await import('../src/lib/utils/export.ts');
+const { renderRichContent } = await import('../src/lib/utils/richContent.ts');
+
+// ---------------------------------------------------------------- fixtures
+
+/** The shape comrak emits for the document below, after `processMarkdownHtml`. */
+const RENDERED = [
+	'<h1>Notes</h1>',
+	'<p data-math="display" data-math-source="E = mc^2">E = mc^2</p>',
+	'<p>and inline \\(a_i\\) too</p>',
+	'<pre><code class="language-js">const answer = 42;</code></pre>',
+	'<pre><code class="language-mermaid">graph TD; A--&gt;B;</code></pre>',
+].join('\n');
+
+/**
+ * A slice of `katex.min.css` in the shape `CSSRule.cssText` produces, with the
+ * hashed, *stylesheet-relative* asset URLs the real build emits (verified
+ * against `build/_app/immutable/assets/*.css`: `url(./KaTeX_Main-Regular.
+ * B22Nviop.woff2)`). Three families are declared; only the ones the article
+ * references should survive into the export.
+ */
+const SHEET_HREF = 'http://tauri.localhost/_app/immutable/assets/2.C6eSkZFI.css';
+const KATEX_CSS = `
+.katex { font: normal 1.21em KaTeX_Main,Times New Roman,serif; }
+.katex .mathnormal { font-family: KaTeX_Math; font-style: italic; }
+.katex .mathcal { font-family: KaTeX_Caligraphic; }
+@font-face { font-family: KaTeX_Main; src: url("./KaTeX_Main-Regular.B22Nviop.woff2") format("woff2"), url("./KaTeX_Main-Regular.Dr94JaBh.woff") format("woff"); font-weight: normal; font-style: normal; }
+@font-face { font-family: KaTeX_Math; src: url("./KaTeX_Math-Italic.woff2") format("woff2"); font-weight: normal; font-style: italic; }
+@font-face { font-family: KaTeX_Caligraphic; src: url("./KaTeX_Caligraphic-Regular.woff2") format("woff2"); font-weight: normal; font-style: normal; }
+`;
+
+function fakeLibraries(record: { mermaidThemes: string[]; mathCalls: string[] }) {
+	return {
+		hljs: {
+			highlightElement(element: any) {
+				element.classList.add('hljs');
+				element.innerHTML = `<span class="hljs-keyword">${element.textContent}</span>`;
+			},
+		},
+		katex: {
+			render(source: string, element: any, options: any) {
+				record.mathCalls.push(`${options.displayMode ? 'display' : 'inline'}:${source}`);
+				element.innerHTML = `<span class="katex"><span class="mord mathnormal">${source}</span></span>`;
+			},
+		},
+		renderMathInElement(root: any) {
+			// Stands in for KaTeX's auto-render over `\(…\)`, which the renderer
+			// runs after the `[data-math]` pass.
+			for (const paragraph of root.querySelectorAll('p')) {
+				const html = paragraph.innerHTML;
+				if (!html.includes('\\(')) continue;
+				record.mathCalls.push(`inline:${html.replace(/^[\s\S]*\\\((.*?)\\\)[\s\S]*$/, '$1')}`);
+				paragraph.innerHTML = html.replace(
+					/\\\((.*?)\\\)/g,
+					'<span class="katex"><span class="mord mathnormal">$1</span></span>',
+				);
+			}
+		},
+		mermaid: {
+			initialize(config: { theme: string }) {
+				record.mermaidThemes.push(config.theme);
+			},
+			async render(id: string, source: string) {
+				return {
+					svg:
+						`<svg id="${id}" role="graphics-document">` +
+						`<style>#${id} .node rect{fill:#eee;}</style>` +
+						`<foreignObject><div>${source.trim()}</div></foreignObject>` +
+						`</svg>`,
+				};
+			},
+		},
+	};
+}
+
+interface ExportRun {
+	document: string;
+	savedTo: string | null;
+	mermaidThemes: string[];
+	mathCalls: string[];
+	fetched: string[];
+}
+
+async function runExport(
+	options: { css?: string; theme?: string; mermaidTheme?: string } = {},
+): Promise<ExportRun> {
+	const record = { mermaidThemes: [] as string[], mathCalls: [] as string[] };
+	const fetched: string[] = [];
+	let saved: { path: string; content: string } | null = null;
+
+	(globalThis as any).window.__TAURI_INTERNALS__ = {
+		convertFileSrc: (path: string) => `asset://localhost/${path}`,
+		invoke: async (command: string, args: any) => {
+			switch (command) {
+				case 'plugin:dialog|save':
+					return '/tmp/notes.html';
+				case 'render_markdown':
+					return RENDERED;
+				case 'save_file_content':
+					saved = { path: args.path, content: args.content };
+					return null;
+				default:
+					throw new Error(`unexpected command ${command}`);
+			}
+		},
+	};
+
+	(globalThis as any).fetch = async (url: string) => {
+		fetched.push(url);
+		return {
+			ok: true,
+			// Deterministic bytes so the base64 in the assertions is stable.
+			arrayBuffer: async () => new Uint8Array([119, 79, 70, 50]).buffer,
+		};
+	};
+
+	// CSSOM hands out one rule at a time, each with the sheet that owns it —
+	// which is the only place the base for a relative font URL exists.
+	(globalThis as any).document.styleSheets = [
+		{
+			href: SHEET_HREF,
+			cssRules: (options.css ?? KATEX_CSS)
+				.trim()
+				.split('\n')
+				.map((cssText) => ({ cssText })),
+		},
+	];
+	if (options.theme) (globalThis as any).document.documentElement.setAttribute('data-theme', options.theme);
+	else (globalThis as any).document.documentElement.removeAttribute('data-theme');
+
+	await exportAsHtml({
+		rawContent: '# Notes\n',
+		tabTitle: 'Notes',
+		tabPath: '/documents/notes.md',
+		mermaidTheme: options.mermaidTheme ?? 'neutral',
+		libraries: fakeLibraries(record) as any,
+	});
+
+	return {
+		document: saved ? (saved as any).content : '',
+		savedTo: saved ? (saved as any).path : null,
+		mermaidThemes: record.mermaidThemes,
+		mathCalls: record.mathCalls,
+		fetched,
+	};
+}
+
+// ------------------------------------------------------------------- tests
+
+test('an exported file contains typeset math, not its LaTeX source', async () => {
+	const run = await runExport();
+
+	assert.equal(run.savedTo, '/tmp/notes.html');
+	// The regression, stated as the reader sees it: where the formula belongs,
+	// the exported page must hold the formula and not its source. (KaTeX renders
+	// into the element and leaves `data-math-source` on it, which is why the
+	// assertion is about what the element *contains*.)
+	assert.match(
+		run.document,
+		/<p data-math="display" data-math-source="E = mc\^2"><span class="katex">/,
+	);
+	assert.doesNotMatch(run.document, /<p data-math="display"[^>]*>E = mc\^2<\/p>/);
+
+	// Display and inline math both reach KaTeX, with the source the renderer
+	// preserved rather than the text comrak happened to leave behind.
+	assert.deepEqual(run.mathCalls, ['display:E = mc^2', 'inline:a_i']);
+	assert.doesNotMatch(run.document, /\\\(/);
+});
+
+test('an exported file contains highlighted code', async () => {
+	const run = await runExport();
+
+	assert.match(run.document, /class="hljs-keyword"/);
+	assert.match(run.document, /<code class="language-js hljs">/);
+	// The shell the preview builds around a code block travels too, so the
+	// exported page uses the same stylesheet rules the app does.
+	assert.match(run.document, /class="code-block-shell"/);
+	// The label is created for both paths but hidden in the export; it must not
+	// arrive as a button that looks clickable and is not.
+	assert.match(run.document, /\.lang-label \{\s*display: none !important;/);
+});
+
+test('an exported file contains drawn diagrams, not mermaid source', async () => {
+	const run = await runExport({ mermaidTheme: 'dark' });
+
+	assert.doesNotMatch(run.document, /language-mermaid/);
+	// The diagram source travels on the container, which is what lets a later
+	// PDF export re-render it in a light theme (#359).
+	assert.match(run.document, /class="mermaid-diagram" data-mermaid-source="graph TD; A-->B;"/);
+	assert.match(run.document, /<svg id="mermaid-/);
+	// Mermaid's `<style>` is what carries a diagram's fills and strokes. It has
+	// to survive into the export — the document-level policy forbids `<style>`
+	// and would flatten every diagram, so the export must not re-run that filter
+	// over the rendered output.
+	assert.match(run.document, /<style>#mermaid-[^{]*\.node rect\{fill:#eee;\}<\/style>/);
+	// Case-insensitive: the shim lower-cases tag names on serialisation, a real
+	// browser keeps `foreignObject`. Either way the element has to survive the
+	// diagram filter, or the diagram's labels do not.
+	assert.match(run.document, /<foreignobject>/i);
+
+	// The exported page carries the theme it was made in, so the diagrams are
+	// baked for that theme rather than for paper.
+	assert.deepEqual(run.mermaidThemes, ['dark']);
+});
+
+test('the export still assembles the same document around the rendered article', async () => {
+	const run = await runExport({ theme: 'dark' });
+
+	assert.match(run.document, /^<!DOCTYPE html>\n<html lang="en" data-theme="dark">/);
+	assert.match(run.document, /<meta http-equiv="Content-Security-Policy" content="default-src 'none';/);
+	assert.match(run.document, /<article class="markdown-body">/);
+	// The heading still goes through `processMarkdownHtml`'s fold wrapping —
+	// rich rendering is added to that pipeline, not substituted for it.
+	assert.match(run.document, /<h1 class="foldable-header"[^>]*>.*Notes<\/h1>/);
+});
+
+test('a document with math carries only the KaTeX fonts it uses', async () => {
+	const run = await runExport();
+
+	// `.katex` implies KaTeX_Main; the `mathnormal` span implies KaTeX_Math.
+	// KaTeX_Caligraphic is declared in the stylesheet and referenced by nothing,
+	// so it must not be paid for.
+	//
+	// The URLs are fetched absolute, resolved against the *stylesheet* rather
+	// than the page. Resolving against `location.href` — the obvious thing, and
+	// what the first draft did — silently produces
+	// `http://tauri.localhost/KaTeX_Main-Regular…woff2`, which 404s, drops the
+	// face and leaves the formula in Times without anything looking broken.
+	assert.deepEqual(run.fetched, [
+		'http://tauri.localhost/_app/immutable/assets/KaTeX_Main-Regular.B22Nviop.woff2',
+		'http://tauri.localhost/_app/immutable/assets/KaTeX_Math-Italic.woff2',
+	]);
+
+	assert.match(run.document, /font-family: KaTeX_Main; src: url\(data:font\/woff2;base64,d09GMg==\) format\("woff2"\)/);
+	assert.match(run.document, /font-family: KaTeX_Math; src: url\(data:font\/woff2;base64,d09GMg==\) format\("woff2"\)/);
+	assert.doesNotMatch(run.document, /KaTeX_Caligraphic-Regular\.woff2/);
+	// No app-internal URL survives into the file, absolute or relative.
+	assert.doesNotMatch(run.document, /tauri\.localhost/);
+	assert.doesNotMatch(run.document, /url\("\.\//);
+});
+
+test('a document with no math carries no KaTeX fonts at all', async () => {
+	// The state #382 measured and decided was fine: nothing references the
+	// families, so the rules were dead weight whose relative URLs 404 next to
+	// the file. They now go, rather than travelling as a lie about what the
+	// document needs.
+	const cssOnly = KATEX_CSS;
+	const document = inlineKatexFontFaces(cssOnly, new Set(), new Map());
+	assert.doesNotMatch(document, /@font-face/);
+	assert.match(document, /\.katex \{/);
+});
+
+// ------------------------------------------------- the pieces, on their own
+
+test('the renderer works on a detached element', async () => {
+	// The property that makes one implementation possible for both paths: the
+	// export renders into a `<div>` that is in no document, so nothing in the
+	// renderer may reach for a global element.
+	const record = { mermaidThemes: [] as string[], mathCalls: [] as string[] };
+	const root = (globalThis as any).document.createElement('div');
+	root.innerHTML = RENDERED;
+	assert.equal(root.parentNode, null);
+
+	await renderRichContent({
+		root,
+		libraries: fakeLibraries(record) as any,
+		mermaidTheme: 'neutral',
+		idFactory: (index: number) => `diagram-${index}`,
+	});
+
+	assert.match(root.innerHTML, /<svg id="diagram-0"/);
+	assert.match(root.innerHTML, /class="katex"/);
+	assert.match(root.innerHTML, /class="hljs-keyword"/);
+});
+
+test('the font pass reads the stylesheet rather than a hard-coded family list', () => {
+	const faces = findKatexFontFaces(KATEX_CSS);
+	assert.deepEqual(
+		faces.map((face) => [face.family, face.woff2Url]),
+		[
+			['KaTeX_Main', './KaTeX_Main-Regular.B22Nviop.woff2'],
+			['KaTeX_Math', './KaTeX_Math-Italic.woff2'],
+			['KaTeX_Caligraphic', './KaTeX_Caligraphic-Regular.woff2'],
+		],
+	);
+
+	// Only KaTeX's own faces are made absolute, and only while the sheet that
+	// owns them is still known.
+	assert.equal(
+		absolutizeKatexFontUrls(
+			'@font-face { font-family: KaTeX_Main; src: url("./KaTeX_Main-Regular.B22Nviop.woff2") format("woff2"); }',
+			SHEET_HREF,
+		),
+		'@font-face { font-family: KaTeX_Main; src: url("http://tauri.localhost/_app/immutable/assets/KaTeX_Main-Regular.B22Nviop.woff2") format("woff2"); }',
+	);
+	assert.equal(
+		absolutizeKatexFontUrls('@font-face{font-family:codicon;src:url(./codicon.ttf)}', SHEET_HREF),
+		'@font-face{font-family:codicon;src:url(./codicon.ttf)}',
+	);
+
+	const root = (globalThis as any).document.createElement('div');
+	root.innerHTML = '<span class="katex"><span class="mord mathcal">L</span></span>';
+	const families = collectUsedKatexFamilies(root, KATEX_CSS);
+	// `.katex` alone pulls in KaTeX_Main; `mathcal` adds Caligraphic; nothing
+	// asks for KaTeX_Math.
+	assert.deepEqual([...families].sort(), ['KaTeX_Caligraphic', 'KaTeX_Main']);
+	assert.deepEqual(katexFontUrlsToEmbed(KATEX_CSS, families), [
+		'./KaTeX_Main-Regular.B22Nviop.woff2',
+		'./KaTeX_Caligraphic-Regular.woff2',
+	]);
+
+	// A face whose bytes could not be read is deleted, not left pointing at a
+	// URL that does not exist next to the exported file.
+	const withoutBytes = inlineKatexFontFaces(KATEX_CSS, families, new Map());
+	assert.doesNotMatch(withoutBytes, /@font-face/);
+});
+
+test('an element with no math needs no fonts', () => {
+	const root = (globalThis as any).document.createElement('div');
+	root.innerHTML = '<p>plain text</p>';
+	assert.equal(collectUsedKatexFamilies(root, KATEX_CSS).size, 0);
+});

--- a/scripts/mermaidPrintTheme.test.ts
+++ b/scripts/mermaidPrintTheme.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../src/lib/utils/mermaidPrint.js';
 
 const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
+const richContent = readFileSync(new URL('../src/lib/utils/richContent.ts', import.meta.url), 'utf8');
 
 /**
  * Minimal stand-ins for the DOM pieces the helper touches. Enough to drive
@@ -152,7 +153,14 @@ test('the PDF export wraps the print render and always restores', () => {
 	assert.match(viewer, /const restoreDiagrams = await renderDiagramsForPrint\(\{/);
 	assert.match(viewer, /\} finally \{\n\t\t\trestoreDiagrams\(\);\n\t\t\}/);
 	// The screen render must record the source, or there is nothing to rebuild.
-	assert.match(viewer, /rememberDiagramSource\(container, mermaidCode\);/);
-	// One theme decision, shared by the screen render and the restore.
-	assert.match(viewer, /mermaid\.initialize\(\{ startOnLoad: false, theme: currentMermaidTheme\(\) \}\)/);
+	// It moved into the shared renderer in #4xx, when the HTML export started
+	// calling the same function; the assertion follows it rather than being
+	// relaxed, because "some path renders diagrams without remembering the
+	// source" is exactly the drift that deleted the markdown.ts copy.
+	assert.match(richContent, /rememberDiagramSource\(container, mermaidCode\);/);
+	// One theme decision, shared by the screen render and the restore: the
+	// viewer resolves it once and hands it to both.
+	assert.match(richContent, /mermaid\.initialize\(\{ startOnLoad: false, theme: options\.mermaidTheme \}\)/);
+	assert.match(viewer, /mermaidTheme: currentMermaidTheme\(\),/);
+	assert.match(viewer, /screenTheme: currentMermaidTheme\(\),/);
 });

--- a/scripts/previewSanitize.test.ts
+++ b/scripts/previewSanitize.test.ts
@@ -34,6 +34,7 @@ const POC_STYLE = '<style>.titlebar{display:none} body{background-image:url("htt
 
 const viewerSource = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
 const sanitizeSource = readFileSync('src/lib/utils/sanitize.ts', 'utf8');
+const richContentSource = readFileSync('src/lib/utils/richContent.ts', 'utf8');
 
 test('the preview sanitizes through the shared policy, not a local config', () => {
 	assert.match(
@@ -85,7 +86,9 @@ const SANITIZE_CALL_SITES: Record<string, number> = {
 	// configuration on a different input. Verified in a browser: the pinned
 	// DOMPurify keeps mermaid's `<style>` under the diagram config and strips it
 	// under MARKDOWN_SANITIZE_CONFIG, which would flatten every diagram.
-	'src/lib/MarkdownViewer.svelte': 1,
+	// It sits next to the only thing that produces diagrams, which is now the
+	// renderer the preview and the HTML export share.
+	'src/lib/utils/richContent.ts': 1,
 };
 
 function walk(dir: string): string[] {
@@ -115,7 +118,7 @@ test('the diagram sanitizer stays separate from the document policy', () => {
 	// Both halves of the split are asserted so a later "let us unify these"
 	// change has to confront the reason: the diagram config must keep the tag
 	// the document config forbids.
-	assert.match(viewerSource, /ADD_TAGS: \['foreignObject'\]/);
+	assert.match(richContentSource, /ADD_TAGS: \['foreignObject'\]/);
 	assert.ok(!MARKDOWN_SANITIZE_CONFIG.FORBID_TAGS.includes('foreignObject'));
 	assert.ok(MARKDOWN_SANITIZE_CONFIG.FORBID_TAGS.includes('style'));
 });

--- a/scripts/renderProtocolDom.ts
+++ b/scripts/renderProtocolDom.ts
@@ -252,6 +252,20 @@ class ShimClassList {
 		return this.tokens().includes(name);
 	}
 
+	/**
+	 * A real `DOMTokenList` is iterable, and the render pipeline reads class
+	 * lists that way (`Array.from(el.classList).some(c => c.startsWith(…))`).
+	 * Without this the copy silently yields `[]` and every such test passes for
+	 * the wrong reason.
+	 */
+	[Symbol.iterator](): IterableIterator<string> {
+		return this.tokens()[Symbol.iterator]();
+	}
+
+	get length(): number {
+		return this.tokens().length;
+	}
+
 	toggle(name: string, force?: boolean) {
 		const present = this.contains(name);
 		const next = force ?? !present;

--- a/scripts/singleImplementationConvention.test.ts
+++ b/scripts/singleImplementationConvention.test.ts
@@ -34,7 +34,7 @@ const RULES: Rule[] = [
 		name: 'mermaid rendering remembers the diagram source',
 		why: 'PDF/HTML export re-renders Mermaid in the light theme from data-mermaid-source; a render path without rememberDiagramSource exports blank or dark-themed diagrams (#359).',
 		marker: /mermaid\.render\(/g,
-		allowed: ['src/lib/MarkdownViewer.svelte', 'src/lib/utils/mermaidPrint.ts'],
+		allowed: ['src/lib/utils/richContent.ts', 'src/lib/utils/mermaidPrint.ts'],
 		requires: {
 			pattern: /rememberDiagramSource/,
 			message: 'a Mermaid render site must record the source via rememberDiagramSource',
@@ -67,13 +67,16 @@ const RULES: Rule[] = [
 		name: 'DOMPurify is configured in one place',
 		why: 'The sanitize contract lives in utils/sanitize.ts; an inline DOMPurify config elsewhere is a second, unreviewed sanitizer.',
 		marker: /from\s+["']dompurify["']/g,
-		allowed: ['src/lib/utils/sanitize.ts', 'src/lib/MarkdownViewer.svelte'],
+		allowed: ['src/lib/utils/sanitize.ts', 'src/lib/utils/richContent.ts'],
 	},
 	{
 		name: 'rich-content rendering has one implementation',
-		why: 'The viewer owns the render pipeline (highlight.js + KaTeX + Mermaid); a second renderRichContent is a fork that drifts from it.',
-		marker: /function\s+renderRichContent\s*\(/g,
-		allowed: ['src/lib/MarkdownViewer.svelte'],
+		why: 'utils/richContent.ts owns the render pipeline (highlight.js + KaTeX + Mermaid) for both the preview and the HTML export; a second renderRichContent is a fork that drifts from it — which is exactly how the export ended up shipping raw LaTeX and unhighlighted code.',
+		// The viewer keeps a same-named wrapper that supplies the live element and
+		// the copy-button behaviour, so the marker pins the implementation (the
+		// one that takes an options object) rather than the name.
+		marker: /function\s+renderRichContent\s*\(\s*options/g,
+		allowed: ['src/lib/utils/richContent.ts'],
 	},
 	{
 		name: 'editor language mapping has one implementation',

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -26,10 +26,15 @@
 import { processMarkdownHtml } from './utils/markdown';
 import { sanitizeMarkdownHtml } from './utils/sanitize.js';
 import {
-	rememberDiagramSource,
 	renderDiagramsForPrint,
 	resolveMermaidTheme,
 } from './utils/mermaidPrint.js';
+import {
+	loadRichContentLibraries,
+	renderRichContent as renderRichContentInto,
+	sanitizeDiagramSvg,
+	type RichContentLibraries,
+} from './utils/richContent.js';
 import { observeFoldLayout } from './utils/foldLayout.js';
 import {
 	addFrontMatterListItems,
@@ -63,7 +68,6 @@ import {
 
 	const appWindow = getCurrentWindow();
 
-	import DOMPurify from 'dompurify';
 	import HomePage from './components/HomePage.svelte';
 import { tabManager } from './stores/tabs.svelte.js';
 import { snapshotTab } from './utils/tabTransfer.js';
@@ -73,11 +77,12 @@ import { t } from './utils/i18n.js';
 import { createWindowSession } from './sessions/windowSession.svelte.js';
 import { createDocumentSession, type LoadMarkdownOptions } from './sessions/documentSession.svelte.js';
 
-	// syntax highlighting & latex
-	let hljs: any = $state(null);
-	let katex: any = $state(null);
-	let renderMathInElement: any = $state(null);
-	let mermaid: any = $state(null);
+	// syntax highlighting & latex — loaded through the shared module so the
+	// preview and the HTML export cannot end up with different libraries.
+	let richLibraries = $state<RichContentLibraries | null>(null);
+	let hljs = $derived(richLibraries ? richLibraries.hljs : null);
+	let renderMathInElement = $derived(richLibraries ? richLibraries.renderMathInElement : null);
+	let mermaid = $derived(richLibraries ? richLibraries.mermaid : null);
 
 	import 'highlight.js/styles/github-dark.css';
 	import 'katex/dist/katex.min.css';
@@ -1028,85 +1033,21 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		});
 	}
 
-	// Mermaid puts text inside foreignObject, so the diagram sanitizer is more
-	// permissive than the document one; keep the two in one place.
-	function sanitizeDiagramSvg(svg: string) {
-		return DOMPurify.sanitize(svg, {
-			ADD_TAGS: ['foreignObject'],
-			ADD_ATTR: ['dominant-baseline', 'text-anchor'],
-		});
-	}
-
+	/**
+	 * The preview half of the shared renderer: same function the HTML export
+	 * calls, pointed at the live preview element and given the copy-to-clipboard
+	 * behaviour an exported file cannot have.
+	 */
 	async function renderRichContent() {
-		if (!markdownBody) return;
+		if (!markdownBody || !richLibraries) return;
 
-		if (!hljs || !renderMathInElement || !mermaid) return;
-
-		mermaid.initialize({ startOnLoad: false, theme: currentMermaidTheme() });
-
-		// Process code blocks
-		const codeBlocks = Array.from(markdownBody.querySelectorAll('pre code'));
-		for (const block of codeBlocks) {
-			const codeEl = block as HTMLElement;
-			const preEl = codeEl.parentElement as HTMLPreElement;
-
-			// Check for Mermaid blocks
-			if (codeEl.classList.contains('language-mermaid')) {
-				try {
-					const mermaidCode = codeEl.textContent || '';
-					const id = `mermaid-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
-
-					// Render the diagram
-					const { svg } = await mermaid.render(id, mermaidCode);
-
-					// Create container and replace the <pre> block
-					const container = document.createElement('div');
-					container.className = 'mermaid-diagram';
-					// Kept so the export can rebuild the diagram with a light
-					// theme instead of recolouring Mermaid's output.
-					rememberDiagramSource(container, mermaidCode);
-					container.innerHTML = sanitizeDiagramSvg(svg);
-					preEl.replaceWith(container);
-				} catch (error) {
-					console.error('Failed to render Mermaid diagram:', error);
-					// Display error in place of diagram
-					const errorDiv = document.createElement('div');
-					errorDiv.className = 'mermaid-error';
-					errorDiv.style.color = 'red';
-					errorDiv.style.padding = '1em';
-					errorDiv.textContent = `Error rendering Mermaid diagram: ${error}`;
-					preEl.replaceWith(errorDiv);
-				}
-				continue; // Skip highlight.js for this block
-			}
-
-			// Existing highlight.js logic
-			// Check if language was explicitly specified BEFORE highlight.js runs
-			const hasExplicitLang = Array.from(codeEl.classList).some((c) => c.startsWith('language-'));
-			
-			// Only highlight if explicit language is specified
-			if (hasExplicitLang) {
-				hljs.highlightElement(codeEl);
-			}
-
-			const langClass = Array.from(codeEl.classList).find((c) => c.startsWith('language-'));
-
-			if (preEl && preEl.tagName === 'PRE') {
-				preEl.querySelectorAll('.lang-label').forEach((l) => l.remove());
-				const codeContent = codeEl.textContent || '';
-				const existingWrapper = preEl.parentElement?.classList.contains('code-block-shell') ? preEl.parentElement as HTMLDivElement : null;
-				existingWrapper?.querySelectorAll(':scope > .lang-label').forEach((l) => l.remove());
-
-				const wrapper = existingWrapper ?? document.createElement('div');
-				if (!existingWrapper) {
-					wrapper.className = 'code-block-shell';
-					preEl.replaceWith(wrapper);
-					wrapper.appendChild(preEl);
-				}
-
-				const copyCode = () => {
-					const codeToCopy = codeContent.replace(/\n$/, '');
-					invoke('clipboard_write_text', { text: codeToCopy }).then(() => {
+		await renderRichContentInto({
+			root: markdownBody,
+			libraries: richLibraries,
+			mermaidTheme: currentMermaidTheme(),
+			onCopyCode: (code, label) => {
+				invoke('clipboard_write_text', { text: code.replace(/\n$/, '') })
+					.then(() => {
 						const originalContent = label.innerHTML;
 						label.innerHTML = 'Copied!';
 						label.classList.add('copied');
@@ -1114,53 +1055,12 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 							label.innerHTML = originalContent;
 							label.classList.remove('copied');
 						}, 1500);
-					}).catch((err) => {
+					})
+					.catch((err) => {
 						console.error('Failed to copy code:', err);
 					});
-				};
-
-				const label = document.createElement('button');
-				label.className = 'lang-label';
-				label.title = 'Click to copy code';
-				label.onclick = copyCode;
-
-				if (hasExplicitLang && langClass) {
-					label.textContent = langClass.replace('language-', '');
-					wrapper.appendChild(label);
-				} else {
-					label.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>`;
-					wrapper.appendChild(label);
-				}
-			}
-		}
-
-		// KaTeX math rendering
-		if (katex) {
-			const mathElements = markdownBody.querySelectorAll('[data-math]');
-			for (const el of Array.from(mathElements)) {
-				const isDisplay = el.getAttribute('data-math') === 'display';
-				const mathSource = el.getAttribute('data-math-source') || el.textContent || '';
-				try {
-					katex.render(mathSource, el as HTMLElement, {
-						displayMode: isDisplay,
-						throwOnError: false,
-					});
-				} catch (e) {
-					console.error('KaTeX rendering error:', e);
-				}
-			}
-		}
-
-		if (renderMathInElement) {
-			renderMathInElement(markdownBody, {
-				delimiters: [
-					{ left: '$$', right: '$$', display: true },
-					{ left: '\\(', right: '\\)', display: false },
-					{ left: '\\[', right: '\\]', display: true },
-				],
-				throwOnError: false,
-			});
-		}
+			},
+		});
 	}
 
 	$effect(() => {
@@ -1974,6 +1874,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			rawContent,
 			tabTitle: tab?.title || '',
 			tabPath: tab?.path || '',
+			// The exported page carries the appearance it was made in (see
+			// `exportThemeAttribute`), and Mermaid bakes its theme into the SVG,
+			// so the diagrams have to be rendered for the same appearance.
+			mermaidTheme: currentMermaidTheme(),
+			libraries: richLibraries,
 		});
 		if (result?.missingImages) {
 			addToast(`Exported HTML, but ${result.missingImages} local image(s) could not be embedded.`, 'warning');
@@ -2876,29 +2781,12 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		loadRecentFiles();
 		isDisposed = false;
 
-		// @ts-ignore
-		Promise.all([import('highlight.js'), import('highlightjs-svelte'), import('katex'), import('mermaid')]).then(async ([hljsModule, svelteModule, katexMainModule, mermaidModule]) => {
-			if (isDisposed) return;
-			hljs = hljsModule.default;
-			try {
-				svelteModule.default(hljs);
-			} catch(e) { console.error('svelte hljs error', e); }
-			
-			katex = katexMainModule.default;
-			// some extensions bind to window.katex
-			(window as any).katex = katex;
-			
-			// @ts-ignore
-			const [autoRenderModule] = await Promise.all([
-				import('katex/dist/contrib/auto-render.js'),
-				import('katex/dist/contrib/mhchem.js'),
-				import('katex/dist/contrib/copy-tex.js')
-			]);
-			if (isDisposed) return;
-			
-			renderMathInElement = autoRenderModule.default;
-			mermaid = mermaidModule.default;
-		});
+		loadRichContentLibraries()
+			.then((libraries) => {
+				if (isDisposed) return;
+				richLibraries = libraries;
+			})
+			.catch((error) => console.error('Failed to load rich content libraries', error));
 
 		let unlisteners: (() => void)[] = [];
 

--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -9,11 +9,39 @@ import {
 	rewriteMarkdownHrefForExport,
 } from './exportHtml.js';
 import { sanitizeMarkdownHtml } from './sanitize.js';
+import {
+	loadRichContentLibraries,
+	renderRichContent,
+	type RichContentLibraries,
+} from './richContent.js';
+import {
+	absolutizeKatexFontUrls,
+	collectUsedKatexFamilies,
+	fetchFontDataUrls,
+	inlineKatexFontFaces,
+	katexFontUrlsToEmbed,
+} from './exportFonts.js';
 
 interface ExportContext {
 	rawContent: string;
 	tabTitle: string;
 	tabPath: string;
+	/**
+	 * Mermaid's theme name for the appearance this export is being made in.
+	 * Unlike the PDF route — paper is always white, so that one forces a light
+	 * theme — an HTML export deliberately carries the author's theme (see
+	 * `exportThemeAttribute` below), so the diagrams have to be baked to match.
+	 */
+	mermaidTheme: string;
+	/**
+	 * The libraries the preview is already using, handed in the same way
+	 * `renderDiagramsForPrint` takes `mermaid` and `sanitizeSvg`. Passing the
+	 * viewer's own instances is what guarantees the exported document was
+	 * produced by the same highlight.js language registry and the same KaTeX
+	 * the user was looking at. `null` (an export triggered before the lazy load
+	 * finished) falls back to the shared loader.
+	 */
+	libraries: RichContentLibraries | null;
 }
 
 export type ExportHtmlResult = {
@@ -193,7 +221,66 @@ ${input.articleHtml}
 </html>`;
 }
 
-async function buildExportArticle(ctx: ExportContext): Promise<{ html: string; embeddedImages: number; missingImages: number }> {
+/**
+ * Runs the preview's renderer over the detached export DOM.
+ *
+ * Placed *after* `sanitizeMarkdownHtml` on purpose, and the document-level
+ * filter is deliberately not run again afterwards. Two reasons, and they point
+ * the same way:
+ *
+ *   - The filter's job is to see the untrusted document, which it already did:
+ *     everything added from here on is markup Markpad's own libraries generate.
+ *     highlight.js re-emits the code block as escaped text; KaTeX builds nodes
+ *     itself and runs with its default `trust: false`, so `\href`, `\url` and
+ *     `\includegraphics` are inert; Mermaid's SVG goes through
+ *     `sanitizeDiagramSvg`, the same filter the preview uses.
+ *   - Running the document policy over Mermaid's SVG would destroy it.
+ *     `MARKDOWN_SANITIZE_CONFIG` sets `FORBID_TAGS: ['style']`, and Mermaid
+ *     ships every diagram's fills, strokes and label colours as a `<style>`
+ *     inside the SVG. Strip it and the diagram arrives as an unstyled skeleton.
+ *
+ * That `<style>` is the one genuinely new thing an export now carries, so it is
+ * worth being explicit about why it is acceptable here:
+ *
+ *   - It is namespaced. Mermaid compiles the block through stylis with a
+ *     middleware that prefixes every rule with `#<svg-id>` and drops any at-rule
+ *     outside a small allowlist (`@import` and `@font-face` are removed). The
+ *     id is one Markpad generates, not one the document chose. So the block
+ *     cannot restyle anything outside its own diagram, and cannot pull in a
+ *     remote stylesheet or font.
+ *   - It is not a new capability. A diagram's `classDef` declarations do reach
+ *     the block, so a hostile document could in principle land a
+ *     `url(https://…)` in it and have the exported file phone home when opened.
+ *     But the export already leaves remote `<img src="https://…">` exactly as
+ *     the author wrote it, and the export CSP allows `img-src https: http:`
+ *     precisely so those keep working. A document that wants to beacon on open
+ *     can already do it in one line of Markdown, with no diagram involved.
+ *   - The exported file is a *less* privileged place for it than the preview,
+ *     which has been injecting this same `<style>` into the app's live document
+ *     since diagrams were added. There, `<style>` is worth forbidding at the
+ *     document level (it can hide the title bar); in a standalone file whose
+ *     entire content is the user's own document, there is nothing to hide.
+ */
+async function renderExportRichContent(root: HTMLElement, ctx: ExportContext): Promise<void> {
+	try {
+		const libraries = ctx.libraries ?? (await loadRichContentLibraries());
+		await renderRichContent({
+			root,
+			libraries,
+			mermaidTheme: ctx.mermaidTheme,
+			onError: (error) => console.error('Rich content failed to render for HTML export', error),
+			// `onCopyCode` is deliberately not passed: an exported file cannot
+			// run script, so the language label there is a static label rather
+			// than a copy button that silently does nothing.
+		});
+	} catch (error) {
+		// An export that ships the raw block is worse than one that does not,
+		// but it is much better than an export that never happens.
+		console.error('Failed to render rich content for HTML export', error);
+	}
+}
+
+async function buildExportArticle(ctx: ExportContext): Promise<{ root: HTMLElement; embeddedImages: number; missingImages: number }> {
 	const body = getMarkdownBodyWithoutFrontMatter(ctx.rawContent);
 	const rendered = (await invoke('render_markdown', { content: body })) as string;
 	// The export used to write `rendered` to disk untouched. comrak runs with
@@ -222,6 +309,13 @@ async function buildExportArticle(ctx: ExportContext): Promise<{ html: string; e
 	const wrapper = document.createElement('div');
 	wrapper.innerHTML = renderStaticFrontMatterPanel(parseFrontMatter(ctx.rawContent)) + processed;
 
+	// Highlight, typeset and draw before the link and image passes, so those see
+	// the markup that actually ships. The renderer works on this detached
+	// element exactly as it works on the live preview: nothing an exported file
+	// contains can be produced by the file itself, because the policy above
+	// grants it no script privilege, so all of it has to be baked in here.
+	await renderExportRichContent(wrapper, ctx);
+
 	for (const link of Array.from(wrapper.querySelectorAll('a[href]'))) {
 		const href = link.getAttribute('href');
 		if (!href) continue;
@@ -249,10 +343,33 @@ async function buildExportArticle(ctx: ExportContext): Promise<{ html: string; e
 	}
 
 	return {
-		html: wrapper.innerHTML,
+		root: wrapper,
 		embeddedImages,
 		missingImages,
 	};
+}
+
+/**
+ * Replaces KaTeX's `@font-face` rules in the copied stylesheet with the fonts
+ * the finished article actually references, inline as data URIs, and deletes
+ * the rest. See `exportFonts.ts` for why this is now worth doing and why it is
+ * done per family. A document with no math loses ~5 KB of dead rules and gains
+ * nothing else.
+ */
+async function embedExportFonts(styles: string, root: HTMLElement): Promise<string> {
+	try {
+		const usedFamilies = collectUsedKatexFamilies(root, styles);
+		const dataUrls = usedFamilies.size
+			? await fetchFontDataUrls(katexFontUrlsToEmbed(styles, usedFamilies))
+			: new Map<string, string>();
+		return inlineKatexFontFaces(styles, usedFamilies, dataUrls);
+	} catch (error) {
+		// Worst case the export keeps the rules it has always had, which resolve
+		// to nothing next to the file. That is the pre-existing behaviour, not a
+		// regression, and it must not cost the user the export.
+		console.error('Failed to embed export fonts', error);
+		return styles;
+	}
 }
 
 export async function exportAsHtml(ctx: ExportContext): Promise<ExportHtmlResult | null> {
@@ -270,7 +387,9 @@ export async function exportAsHtml(ctx: ExportContext): Promise<ExportHtmlResult
 	for (const sheet of document.styleSheets) {
 		try {
 			for (const rule of sheet.cssRules) {
-				styles += rule.cssText + '\n';
+				// The stylesheet's own URL is the base KaTeX's relative font
+				// sources resolve against, and it is only available here.
+				styles += absolutizeKatexFontUrls(rule.cssText, sheet.href) + '\n';
 			}
 		} catch {
 			// cross-origin sheets
@@ -278,12 +397,13 @@ export async function exportAsHtml(ctx: ExportContext): Promise<ExportHtmlResult
 	}
 
 	const article = await buildExportArticle(ctx);
+	styles = await embedExportFonts(styles, article.root);
 
 	const fullHtml = buildExportDocument({
 		theme: document.documentElement.dataset.theme,
 		title: ctx.tabTitle,
 		styles,
-		articleHtml: article.html,
+		articleHtml: article.root.innerHTML,
 	});
 
 	try {

--- a/src/lib/utils/exportFonts.ts
+++ b/src/lib/utils/exportFonts.ts
@@ -1,0 +1,254 @@
+/**
+ * KaTeX web fonts for an exported HTML file.
+ *
+ * #382 decided not to inline any fonts into an export, and it was right at the
+ * time: the export had no KaTeX output in it at all, so KaTeX's `@font-face`
+ * rules travelled in the copied stylesheet as pure dead weight — rules whose
+ * relative `url()`s 404 next to the exported file, and which the export CSP
+ * (`font-src data:`) blocks anyway. Nothing referenced them, so nothing looked
+ * wrong.
+ *
+ * Now that the export renders math, that reasoning inverts. Every `.katex`
+ * subtree asks for `KaTeX_Main` first and falls back to
+ * `Times New Roman, serif`, and KaTeX lays the formula out using *its own*
+ * font metrics — glyph widths, the height of a fraction bar, where an accent
+ * sits. Fall back and the layout stays but the glyphs no longer fit it, and
+ * anything KaTeX draws from its dedicated fonts is simply not in Times:
+ * stretchy delimiters (KaTeX_Size1–4), most AMS symbols, `\mathcal`,
+ * `\mathfrak`, `\mathscr`. Those come out as tofu or as the wrong letter.
+ *
+ * So the fonts have to be embedded, and the only question is how many. All 20
+ * faces are 296 KB raw / ~395 KB as base64 — paid by every export, including
+ * the ones with no math. Instead this module works out which families the
+ * rendered article actually references, embeds only those, and deletes the rest
+ * of KaTeX's `@font-face` rules from the copied stylesheet. A document with no
+ * math therefore gets *smaller* than before (the dead rules go too); a document
+ * with ordinary algebra pays for KaTeX_Main and KaTeX_Math only.
+ *
+ * Granularity is the family, not the individual face. Picking the exact
+ * weight/style would need the export to resolve the cascade (`\mathbf` sets
+ * `font-weight` on top of a family, `<strong>` around math changes it again),
+ * and getting that subtly wrong shows up as one italic variable silently
+ * rendering in Times. "If a family is referenced at all, ship its faces" cannot
+ * fail that way.
+ */
+
+/** `@font-face` families KaTeX declares; nothing else in the app ships fonts. */
+const KATEX_FAMILY_PREFIX = 'KaTeX_';
+
+function unquote(value: string): string {
+	return value.trim().replace(/^["']|["']$/g, '');
+}
+
+/**
+ * The class tokens of a selector, minus `katex` itself.
+ *
+ * Combinators are deliberately ignored: this is a "could this rule apply"
+ * question, and over-including a family costs a few kilobytes while
+ * under-including it costs a broken formula.
+ */
+function selectorClasses(selector: string): string[] {
+	return [...selector.matchAll(/\.([A-Za-z0-9_-]+)/g)]
+		.map((match) => match[1])
+		.filter((name) => name !== 'katex');
+}
+
+export interface KatexFamilyRule {
+	/** Class tokens that must all be present for the rule to apply. */
+	classes: string[];
+	families: string[];
+}
+
+/**
+ * Every rule in the copied stylesheet that points some element at a KaTeX
+ * family, read out of the stylesheet rather than hard-coded, so a KaTeX upgrade
+ * that renames a class or adds a family is picked up without edits here.
+ */
+export function parseKatexFamilyRules(css: string): KatexFamilyRule[] {
+	const rules: KatexFamilyRule[] = [];
+	for (const match of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+		const selector = match[1].trim();
+		const body = match[2];
+		if (!selector || selector.startsWith('@')) continue;
+		const families = [...body.matchAll(/KaTeX_[A-Za-z0-9_]+/g)].map((m) => m[0]);
+		if (families.length === 0) continue;
+		for (const part of selector.split(',')) {
+			if (!/\.katex\b/.test(part)) continue;
+			rules.push({ classes: selectorClasses(part), families });
+		}
+	}
+	return rules;
+}
+
+/** Every class token used anywhere under `root`, including `root` itself. */
+export function collectClassNames(root: Element): Set<string> {
+	const names = new Set<string>();
+	// Walked rather than selected: `querySelectorAll('*')` is the one call that
+	// would tie this to a full selector engine, and the walk is no slower.
+	const visit = (element: Element) => {
+		for (const name of (element.getAttribute('class') || '').split(/\s+/)) {
+			if (name) names.add(name);
+		}
+		for (const child of Array.from(element.childNodes)) {
+			if (child.nodeType === Node.ELEMENT_NODE) visit(child as Element);
+		}
+	};
+	visit(root);
+	return names;
+}
+
+/**
+ * The KaTeX families the rendered article can actually ask for. Empty when the
+ * document contains no math at all, which is the common case.
+ */
+export function collectUsedKatexFamilies(root: Element, css: string): Set<string> {
+	const used = new Set<string>();
+	const classNames = collectClassNames(root);
+	if (!classNames.has('katex')) return used;
+
+	for (const rule of parseKatexFamilyRules(css)) {
+		if (!rule.classes.every((name) => classNames.has(name))) continue;
+		for (const family of rule.families) used.add(family);
+	}
+	return used;
+}
+
+export interface KatexFontFace {
+	family: string;
+	/** The `url()` of the woff2 source, as written in the stylesheet. */
+	woff2Url: string | null;
+	/** Offsets of the whole `@font-face { … }` block in the stylesheet. */
+	start: number;
+	end: number;
+}
+
+/** Locates the `@font-face` blocks that belong to KaTeX. */
+export function findKatexFontFaces(css: string): KatexFontFace[] {
+	const faces: KatexFontFace[] = [];
+	const pattern = /@font-face\s*\{/g;
+	let match: RegExpExecArray | null;
+	while ((match = pattern.exec(css))) {
+		const bodyStart = match.index + match[0].length;
+		const bodyEnd = css.indexOf('}', bodyStart);
+		if (bodyEnd === -1) break;
+		const body = css.slice(bodyStart, bodyEnd);
+		const family = unquote(/font-family\s*:\s*([^;]+)/.exec(body)?.[1] ?? '');
+		if (!family.startsWith(KATEX_FAMILY_PREFIX)) continue;
+
+		let woff2Url: string | null = null;
+		for (const url of body.matchAll(/url\(\s*(["']?)([^"')]+)\1\s*\)/g)) {
+			if (/\.woff2(\?|$)/i.test(url[2])) {
+				woff2Url = url[2];
+				break;
+			}
+		}
+		faces.push({ family, woff2Url, start: match.index, end: bodyEnd + 1 });
+	}
+	return faces;
+}
+
+/**
+ * Rewrites the copied stylesheet so that every KaTeX `@font-face` either
+ * carries its font inline or is gone.
+ *
+ * A face whose bytes could not be read is deleted rather than left pointing at
+ * a URL that does not exist next to the exported file: the rendering is
+ * identical either way (the browser falls back), and a dead rule in a file that
+ * is meant to be self-contained is just a lie about what it needs.
+ */
+export function inlineKatexFontFaces(
+	css: string,
+	usedFamilies: Set<string>,
+	dataUrlByUrl: Map<string, string>,
+): string {
+	const faces = findKatexFontFaces(css);
+	if (faces.length === 0) return css;
+
+	let out = '';
+	let cursor = 0;
+	for (const face of faces) {
+		out += css.slice(cursor, face.start);
+		cursor = face.end;
+
+		if (!usedFamilies.has(face.family)) continue;
+		const dataUrl = face.woff2Url ? dataUrlByUrl.get(face.woff2Url) : undefined;
+		if (!dataUrl) continue;
+
+		const block = css.slice(face.start, face.end);
+		out += block.replace(
+			/src\s*:[^;}]*/,
+			`src: url(${dataUrl}) format("woff2")`,
+		);
+	}
+	out += css.slice(cursor);
+	return out;
+}
+
+/**
+ * Rewrites KaTeX's `@font-face` sources to absolute URLs while the stylesheet
+ * they came from is still in hand.
+ *
+ * The build emits them relative to the stylesheet — `url(./KaTeX_Main-Regular.
+ * <hash>.woff2)`, next to `_app/immutable/assets/…css` — and the stylesheet does
+ * not sit next to the page. Resolving later, against `location.href`, silently
+ * produces a URL that 404s and a formula that quietly falls back to a serif.
+ * By the time the rules are one concatenated string the base is gone, so it has
+ * to happen here.
+ *
+ * Only KaTeX's own faces are touched, and every one of those is either replaced
+ * by a data URI or deleted before the file is written, so no internal app URL
+ * can survive into the export.
+ */
+export function absolutizeKatexFontUrls(cssText: string, base: string | null): string {
+	if (!/^@font-face/.test(cssText.trim()) || !cssText.includes(KATEX_FAMILY_PREFIX)) return cssText;
+	return cssText.replace(/url\(\s*(["']?)([^"')]+)\1\s*\)/g, (whole, quote: string, url: string) => {
+		try {
+			return `url(${quote}${new URL(url, base || location.href).href}${quote})`;
+		} catch {
+			return whole;
+		}
+	});
+}
+
+/** The woff2 sources that have to be fetched for the families in use. */
+export function katexFontUrlsToEmbed(css: string, usedFamilies: Set<string>): string[] {
+	const urls = new Set<string>();
+	for (const face of findKatexFontFaces(css)) {
+		if (!usedFamilies.has(face.family) || !face.woff2Url) continue;
+		urls.add(face.woff2Url);
+	}
+	return [...urls];
+}
+
+/** `btoa` in chunks: a 30 KB font blows the argument limit of `apply`. */
+export function bytesToBase64(bytes: Uint8Array): string {
+	let binary = '';
+	const chunk = 0x8000;
+	for (let index = 0; index < bytes.length; index += chunk) {
+		binary += String.fromCharCode(...bytes.subarray(index, index + chunk));
+	}
+	return btoa(binary);
+}
+
+/**
+ * Reads the app's own bundled font assets, by the absolute URLs
+ * `absolutizeKatexFontUrls` produced. Same-origin, so it is allowed by the
+ * app's `connect-src 'self'`; a failure is not fatal — the face is dropped and
+ * that formula falls back to a serif.
+ */
+export async function fetchFontDataUrls(urls: string[]): Promise<Map<string, string>> {
+	const out = new Map<string, string>();
+	await Promise.all(
+		urls.map(async (url) => {
+			try {
+				const response = await fetch(url);
+				if (!response.ok) throw new Error(`HTTP ${response.status}`);
+				const bytes = new Uint8Array(await response.arrayBuffer());
+				out.set(url, `data:font/woff2;base64,${bytesToBase64(bytes)}`);
+			} catch (error) {
+				console.warn('Failed to embed export font', url, error);
+			}
+		}),
+	);
+	return out;
+}

--- a/src/lib/utils/richContent.ts
+++ b/src/lib/utils/richContent.ts
@@ -1,0 +1,244 @@
+import DOMPurify from 'dompurify';
+import { rememberDiagramSource } from './mermaidPrint.js';
+
+/**
+ * The one implementation of "turn rendered Markdown into the thing the user
+ * actually wants to look at": syntax highlighting, KaTeX, Mermaid diagrams.
+ *
+ * It used to live inside `MarkdownViewer.svelte`, closed over the component's
+ * lazily imported libraries and the live preview element, and could therefore
+ * only ever run on screen. The HTML export ran the same
+ * `render_markdown → sanitize → processMarkdownHtml` pipeline and then stopped,
+ * so an exported document arrived with `E = mc^2` as literal LaTeX, code blocks
+ * with no highlighting, and diagrams as `<pre><code class="language-mermaid">`
+ * source. The thing the export exists for — handing the document to somebody
+ * who does not have Markpad — was exactly the case that got the raw text.
+ *
+ * There was a second copy of this in `markdown.ts` once. It drifted (it had
+ * lost `rememberDiagramSource`, which the PDF path needs) and was deleted in
+ * #397. So the fix is not another copy: it is this module, which the preview and
+ * the export both call, on a live element and on a detached one respectively.
+ * Nothing here reaches for a global element or a global document — everything
+ * comes from `root` — because a detached `<div>` is a first-class caller.
+ */
+
+export interface RichContentLibraries {
+	hljs: any;
+	katex: any;
+	renderMathInElement: any;
+	mermaid: any;
+}
+
+let librariesPromise: Promise<RichContentLibraries> | null = null;
+
+/**
+ * Loads highlight.js, KaTeX and Mermaid once per window.
+ *
+ * The preview kicks this off on mount; the export awaits the same promise, so
+ * an export never pays for a second copy and — more to the point — cannot end
+ * up with a differently configured KaTeX or a different highlight.js language
+ * registry than the preview the user was just looking at.
+ */
+export function loadRichContentLibraries(): Promise<RichContentLibraries> {
+	if (librariesPromise) return librariesPromise;
+	librariesPromise = (async () => {
+		const [hljsModule, svelteModule, katexMainModule, mermaidModule] = await Promise.all([
+			import('highlight.js'),
+			import('highlightjs-svelte'),
+			import('katex'),
+			import('mermaid'),
+		]);
+
+		const hljs = (hljsModule as any).default;
+		try {
+			(svelteModule as any).default(hljs);
+		} catch (e) {
+			console.error('svelte hljs error', e);
+		}
+
+		const katex = (katexMainModule as any).default;
+		// mhchem and copy-tex are KaTeX extensions that bind to the global.
+		(window as any).katex = katex;
+
+		const [autoRenderModule] = await Promise.all([
+			import('katex/dist/contrib/auto-render.js'),
+			import('katex/dist/contrib/mhchem.js'),
+			import('katex/dist/contrib/copy-tex.js'),
+		]);
+
+		return {
+			hljs,
+			katex,
+			renderMathInElement: (autoRenderModule as any).default,
+			mermaid: (mermaidModule as any).default,
+		};
+	})().catch((error) => {
+		// A failed load must not be cached as a permanent failure: the preview
+		// retries on the next render, and the export falls back to shipping the
+		// unrendered block rather than nothing at all.
+		librariesPromise = null;
+		throw error;
+	});
+	return librariesPromise;
+}
+
+/**
+ * Mermaid puts diagram text inside `foreignObject` and ships the diagram's
+ * colours as a `<style>` element inside the SVG, so diagrams need a more
+ * permissive filter than the document-level `MARKDOWN_SANITIZE_CONFIG` (which
+ * forbids `<style>` outright). Keeping the two policies distinct — and this one
+ * in one place — is what stops a document author's `<style>` from being let
+ * through by the back door: this filter is only ever applied to a string
+ * Mermaid produced, never to the document.
+ *
+ * On why that `<style>` is acceptable inside an exported file, see
+ * `renderExportRichContent` in `export.ts`.
+ */
+export function sanitizeDiagramSvg(svg: string): string {
+	return DOMPurify.sanitize(svg, {
+		ADD_TAGS: ['foreignObject'],
+		ADD_ATTR: ['dominant-baseline', 'text-anchor'],
+	});
+}
+
+export interface RenderRichContentOptions {
+	/** The element holding processed Markdown. Live or detached, both work. */
+	root: HTMLElement;
+	libraries: RichContentLibraries;
+	/** Mermaid's own theme name, from `resolveMermaidTheme`. */
+	mermaidTheme: string;
+	/**
+	 * Wires the language label up as a copy button. Omitted by the export: an
+	 * exported file cannot run script at all (its policy grants no script
+	 * privilege), so a handler there would be a button that does nothing.
+	 */
+	onCopyCode?: (code: string, label: HTMLElement) => void;
+	/** Injected so diagram ids are deterministic under test. */
+	idFactory?: (index: number) => string;
+	onError?: (error: unknown) => void;
+}
+
+function defaultIdFactory(index: number): string {
+	return `mermaid-${Date.now()}-${index}-${Math.floor(Math.random() * 10000)}`;
+}
+
+const COPY_ICON_SVG =
+	'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>';
+
+export async function renderRichContent(options: RenderRichContentOptions): Promise<void> {
+	const { root, libraries } = options;
+	if (!root) return;
+
+	const { hljs, katex, renderMathInElement, mermaid } = libraries;
+	if (!hljs || !renderMathInElement || !mermaid) return;
+
+	const doc = root.ownerDocument ?? document;
+	const idFactory = options.idFactory ?? defaultIdFactory;
+
+	mermaid.initialize({ startOnLoad: false, theme: options.mermaidTheme });
+
+	const codeBlocks = Array.from(root.querySelectorAll('pre code'));
+	let diagramIndex = 0;
+	for (const block of codeBlocks) {
+		const codeEl = block as HTMLElement;
+		const preEl = codeEl.parentElement as HTMLPreElement;
+
+		if (codeEl.classList.contains('language-mermaid')) {
+			const mermaidCode = codeEl.textContent || '';
+			try {
+				const { svg } = await mermaid.render(idFactory(diagramIndex++), mermaidCode);
+
+				const container = doc.createElement('div');
+				container.className = 'mermaid-diagram';
+				// Kept so the PDF path can rebuild the diagram with a light theme
+				// instead of recolouring Mermaid's output.
+				rememberDiagramSource(container, mermaidCode);
+				container.innerHTML = sanitizeDiagramSvg(svg);
+				preEl.replaceWith(container);
+			} catch (error) {
+				options.onError?.(error);
+				console.error('Failed to render Mermaid diagram:', error);
+				const errorDiv = doc.createElement('div');
+				errorDiv.className = 'mermaid-error';
+				errorDiv.style.color = 'red';
+				errorDiv.style.padding = '1em';
+				errorDiv.textContent = `Error rendering Mermaid diagram: ${error}`;
+				preEl.replaceWith(errorDiv);
+			}
+			continue; // Skip highlight.js for this block
+		}
+
+		// Check if language was explicitly specified BEFORE highlight.js runs
+		const hasExplicitLang = Array.from(codeEl.classList).some((c) => c.startsWith('language-'));
+
+		// Only highlight if explicit language is specified
+		if (hasExplicitLang) {
+			try {
+				hljs.highlightElement(codeEl);
+			} catch (error) {
+				options.onError?.(error);
+				console.error('Failed to highlight code block:', error);
+			}
+		}
+
+		const langClass = Array.from(codeEl.classList).find((c) => c.startsWith('language-'));
+
+		if (preEl && preEl.tagName === 'PRE') {
+			preEl.querySelectorAll('.lang-label').forEach((l) => l.remove());
+			const codeContent = codeEl.textContent || '';
+			const existingWrapper = preEl.parentElement?.classList.contains('code-block-shell')
+				? (preEl.parentElement as HTMLDivElement)
+				: null;
+			existingWrapper?.querySelectorAll(':scope > .lang-label').forEach((l) => l.remove());
+
+			const wrapper = existingWrapper ?? doc.createElement('div');
+			if (!existingWrapper) {
+				wrapper.className = 'code-block-shell';
+				preEl.replaceWith(wrapper);
+				wrapper.appendChild(preEl);
+			}
+
+			const label = doc.createElement('button');
+			label.className = 'lang-label';
+			label.title = 'Click to copy code';
+			const onCopyCode = options.onCopyCode;
+			if (onCopyCode) label.onclick = () => onCopyCode(codeContent, label);
+
+			if (hasExplicitLang && langClass) {
+				label.textContent = langClass.replace('language-', '');
+			} else {
+				label.innerHTML = COPY_ICON_SVG;
+			}
+			wrapper.appendChild(label);
+		}
+	}
+
+	// KaTeX math rendering
+	if (katex) {
+		const mathElements = root.querySelectorAll('[data-math]');
+		for (const el of Array.from(mathElements)) {
+			const isDisplay = el.getAttribute('data-math') === 'display';
+			const mathSource = el.getAttribute('data-math-source') || el.textContent || '';
+			try {
+				katex.render(mathSource, el as HTMLElement, {
+					displayMode: isDisplay,
+					throwOnError: false,
+				});
+			} catch (e) {
+				options.onError?.(e);
+				console.error('KaTeX rendering error:', e);
+			}
+		}
+	}
+
+	if (renderMathInElement) {
+		renderMathInElement(root, {
+			delimiters: [
+				{ left: '$$', right: '$$', display: true },
+				{ left: '\\(', right: '\\)', display: false },
+				{ left: '\\[', right: '\\]', display: true },
+			],
+			throwOnError: false,
+		});
+	}
+}


### PR DESCRIPTION
> **6 / 6** of the stack. Base: #409.

## The defect

`exportAsHtml` re-renders from raw Markdown and **never calls `renderRichContent`**, which only ever ran in the viewer. An exported file therefore carried:

```html
<p data-math="display" data-math-source="E = mc^2">E = mc^2</p>
<pre><code class="language-mermaid">graph TD; …</code></pre>
```

— LaTeX source, colourless code, and diagrams as source blocks. **The person you exported the document for saw none of it rendered.**

This is the last instance of the audit's *"two paths do the same thing and only one is maintained"*.

## The fix: one function, two callers

`renderRichContent` moves out of `MarkdownViewer.svelte` into `src/lib/utils/richContent.ts`, taking `{ root, libraries, mermaidTheme, … }` instead of closing over component state, and reading `root.ownerDocument` rather than the global — so **a detached element is a first-class caller**. The export renders into the wrapper it already built. No offscreen container, no second document, no iframe.

The viewer keeps an 8-line wrapper supplying the live element and the clipboard behaviour. `sanitizeDiagramSvg` moves alongside — it is the diagram policy, and it belongs next to the only thing that makes diagrams. `sanitize.ts` is untouched.

Library loading moves in too, as `loadRichContentLibraries()` behind a module-cached promise, so the export can never get a differently configured KaTeX or a different highlight.js language registry than the preview.

## Sanitization: the document filter is **not** re-run

Pipeline: `render_markdown → sanitizeMarkdownHtml → processMarkdownHtml → renderRichContent → href/image passes`.

The document policy still sees the untrusted document, and only that. Everything after is produced by our own libraries from already-filtered text: highlight.js re-emits the block as escaped text, KaTeX builds nodes itself and runs with its default `trust: false` (so `\href`, `\url`, `\includegraphics` are inert), and mermaid's SVG goes through `sanitizeDiagramSvg` — the same filter the preview uses.

Re-running `MARKDOWN_SANITIZE_CONFIG` afterwards would also **destroy every diagram** (`FORBID_TAGS: ['style']`). Both reasons point the same way. `exportSanitize.test.ts`'s ordering assertions hold unchanged.

### Mermaid's `<style>` in an exported file

Read from mermaid 11.16.0's source rather than assumed:

1. **It is namespaced.** `createUserStyles` → `compileCSS(svgId, …)` runs stylis with an `addNamespace` middleware prefixing every rule with `#<svgId>`, and **deletes any at-rule outside a small allowlist** — `@import` and `@font-face` are removed with a warning. The id is one Markpad generates. The block cannot restyle anything outside its diagram, and cannot pull in a remote stylesheet or font.
2. **It is not a new capability.** `sanitizeCss` only checks brace balance, so a hostile `classDef` could land a `url(https://…)` in it — but the export already leaves remote `<img src="https://…">` exactly as the author wrote it, which is what that CSP clause is for. A document that wants to beacon on open can do it in one line of Markdown with no diagram involved.
3. **The export is the *less* privileged place for it.** The identical `<style>` has been entering the app's **live** document since diagrams were added. There it is worth forbidding at the document level — it can hide the title bar. In a standalone file whose entire content is the author's own document, there is nothing to hide.

The reasoning is written into the doc comment where the next person will hit it.

## KaTeX fonts: #382's conclusion reverses, because its premise did

#382 declined to embed them on the measured grounds that **there was no KaTeX output in an export**. That is exactly what this PR changes, so the question was re-measured rather than inherited.

**The failure is not missing glyphs — it is wrong ones that look right:**

| input | KaTeX emits | without the font, the reader sees |
|---|---|---|
| `\mathbb{R}` | ASCII `R` + class `mathbb` → KaTeX_AMS | **`R`**, not `ℝ` |
| `\mathcal{L}` | ASCII `L` + `mathcal` → KaTeX_Caligraphic | plain **`L`** |
| `\mathfrak{g}` | ASCII `g` + `mathfrak` → KaTeX_Fraktur | plain **`g`** |
| `\left(…\right)` | `(` + `delimsizing size3` | normal-height paren around a two-line fraction |
| `\sum` | U+2211 + `op-symbol large-op` | undersized serif operator |

Measured end to end through the real `exportAsHtml`:

| document | before | after |
|---|---|---|
| no math | 72,977 B | **68,213 B** (−6.5%) |
| simple algebra | 73,010 B | 230,471 B |
| calculus (∑ ∫ big delims) | 72,983 B | 242,431 B |
| analysis (ℝ ℋ 𝔤) | 72,985 B | 315,312 B |

**Only referenced families are embedded** — all 20 faces would be 338 KB on every export. Granularity is the *family*, not the face, deliberately: face-level would cut simple algebra to ~57 KB but requires resolving the cascade (`\mathbf` adds weight to a family; `**$x$**` inherits it), and getting that subtly wrong renders one variable in Times with nothing looking broken. "If a family is referenced, ship its faces" cannot fail that way.

No CSP change needed — `font-src data:` was already in `EXPORT_CSP`.

### A bug that would have made this a silent no-op

The build emits KaTeX's font URLs **relative to the stylesheet** (`url(./KaTeX_Main-Regular.B22Nviop.woff2)` inside `_app/immutable/assets/*.css`, verified against a real `npm run build`), not relative to the page. Resolving them against `location.href` 404s the face, the face is dropped, and the formula quietly falls back to a serif — nothing looks broken. They are absolutised during the `document.styleSheets` walk, while the owning sheet is still in hand.

## Preview-side changes, all narrowing

- **Library loading is now atomic.** Previously `hljs` was assigned after the first `Promise.all` and `mermaid`/`renderMathInElement` after a second `await`, leaving a window where `hljs` was truthy and the render guard was not.
- `hljs.highlightElement` is wrapped in try/catch — one bad block no longer aborts the rest of the render, or the rest of an export.
- Mermaid ids gained the loop index. They were `mermaid-${Date.now()}-${rand}`; two diagrams in the same millisecond could collide, and that id namespaces the diagram's own `<style>` and its marker URLs.

Otherwise the extracted function is byte-for-byte the old logic.

## Tests

`scripts/exportRichContent.test.ts` drives the **real `exportAsHtml`** and asserts on the bytes handed to `save_file_content` — the full path including the dialog, the renderer round trip, the sanitize/process pipeline, the font pass and `buildExportDocument`.

| | |
|---|---|
| Baseline | 469 / 0 |
| Final | **478 / 0** |
| Counter-proof — modules present, the two calls deleted from `export.ts` | **5 pass / 4 fail** |

The four that go red are exactly the four artefact assertions: typeset math, highlighted code, drawn diagrams, embedded fonts.

Two things are stood in for, both at a *library* boundary rather than one of ours: highlight.js / KaTeX / mermaid (measured to throw on the #378 shim — `hljs.highlightElement` and `katex.render` both fail, mermaid needs layout), injected through the same `libraries` field the app fills from the preview's own instances; and `DOMPurify.sanitize`, a no-op without a real DOM, replaced by identity — what the filter does and where it sits stays pinned by `exportSanitize.test.ts`.

Two shim additions, documented in place: `ShimClassList` is now iterable (a real `DOMTokenList` is, and `Array.from(el.classList)` was silently yielding `[]` — **without this the highlighting test would have passed for the wrong reason**), and CSSOM is modelled as one rule per `cssText` with the owning sheet's `href`.

Existing structural guards were **followed to the new location rather than relaxed**: `singleImplementationConvention` now pins `richContent.ts` as the sole `mermaid.render(` / `dompurify` / `renderRichContent(options` site.

```
npm run check   435 files, 0 errors
npm test        478 / 478
cargo test      131 / 131
npm run build   clean
```

## Not covered

- **`theme: 'system'` with diagrams.** The page follows the reader's OS, but the SVG is baked with the *exporter's* preference — a system-dark author's export read on a light machine gets a light page with dark diagrams. A script-free fix needs two SVGs behind `prefers-color-scheme`.
- Real library **output** is not asserted — only that the pipeline hands them the right elements and places the results correctly.
- **Dev-mode font base**: Vite injects CSS as `<style>` with no `href`, so the base falls back to `location.href`. It works there because dev paths are absolute; untested.
- Monaco's `codicon` `@font-face` is left untouched and still dead in exports — unchanged, and it never applies inside `.markdown-body`.
- Diagram renders are serial awaits, so a document with many diagrams takes proportionally longer with no progress indication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)