### PR TITLE
fix(documents): never reload a file over its own unsaved edits

### DIFF
--- a/scripts/reopenDirtyDocument.test.ts
+++ b/scripts/reopenDirtyDocument.test.ts
@@ -1,0 +1,259 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+// Opening a file that is ALREADY open in a tab with unsaved edits must not
+// re-read it from disk. `setTabRawContent` replaces rawContent AND
+// originalContent, so the edits would not merely be overwritten — the tab
+// would look clean afterwards and the user could not tell what was lost.
+//
+// This is the same loss `resolveExternalChange` already refuses for a watcher
+// event (#374), reached through the ordinary open path instead: recent files,
+// drag-and-drop, the OS handing us a path, or a link opened in a new tab.
+// Discarding a buffer stays what it is everywhere else — an explicit command
+// ("Reload from disk", the external-change "Reload"), never a side effect of
+// asking to see a file.
+
+const g = globalThis as any;
+const runeEffect = (fn: () => void) => {
+	void fn;
+};
+runeEffect.root = (fn: () => unknown) => fn();
+g.$state = (value: unknown) => value;
+g.$state.raw = (value: unknown) => value;
+g.$state.snapshot = (value: unknown) => value;
+g.$derived = (value: unknown) => value;
+g.$derived.by = (fn: () => unknown) => fn();
+g.$effect = runeEffect;
+g.window = g.window ?? {};
+
+const localStore = new Map<string, string>();
+g.localStorage = {
+	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
+	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
+	removeItem: (key: string) => void localStore.delete(key),
+	clear: () => localStore.clear(),
+};
+
+// What the file says right now, and every read the session performed.
+const disk = new Map<string, string>();
+const reads: string[] = [];
+
+g.window.__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string, args: any) => {
+		if (cmd === 'read_file_content_checked') {
+			reads.push(args.path);
+			return Promise.resolve([disk.get(args.path) ?? '', false]);
+		}
+		if (cmd === 'open_markdown_preview') {
+			reads.push(args.path);
+			return Promise.resolve(['', disk.get(args.path) ?? '', true, false]);
+		}
+		if (cmd === 'get_os_type') return Promise.resolve('macos');
+		return Promise.resolve(null);
+	},
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
+
+const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
+
+function makeSession() {
+	return createDocumentSession({
+		setShowHome: () => {},
+		currentFile: () => tabManager.activeTab?.path ?? '',
+		resetScrollHistory: () => {},
+		renderMarkdown: async (raw: string) => raw,
+		afterLoad: async () => {},
+		saveRecentFile: () => {},
+		deleteRecentFile: () => {},
+		setLoadingTabs: () => {},
+		measureInitialViewport: () => {},
+		isScrolling: () => false,
+		renderRichContent: () => {},
+		onError: () => {},
+		selfWriteGraceMs: 400,
+		cancelPendingAutoSave: () => {},
+		askClose: async () => 'discard' as const,
+		onCloseSaveNewerEdits: () => {},
+		onCloseAutoSaveFailed: () => {},
+	});
+}
+
+function reset() {
+	tabManager.closeAll();
+	tabManager.recentlyClosed.length = 0;
+	localStore.clear();
+	disk.clear();
+	reads.length = 0;
+}
+
+/** A tab holding `path`, edited but not saved. */
+function openEdited(path: string, onDisk: string, edits: string) {
+	disk.set(path, onDisk);
+	tabManager.addTab(path, onDisk);
+	const id = tabManager.activeTabId!;
+	tabManager.updateTabRawContent(id, edits);
+	return tabManager.tabs.find((tab) => tab.id === id)!;
+}
+
+// --- opening a file must never cost a buffer ---
+
+// `openMarkdownTargetInNewTab` calls `addTab` and then loads with
+// `skipTabManagement`, so whatever tab `addTab` leaves active is the one the
+// disk content lands in. Today that is always a fresh tab, so this passes
+// without the guard — it is pinned here because it is the invariant, and any
+// future change to how an already-open path is resolved has to keep it.
+//
+// It asserts ONLY that the edits survive: no tab counts, no active-tab
+// identity, nothing about how the request was routed. A failure here means
+// work was destroyed, and nothing else.
+test('following a link into a new tab never costs the target tab its unsaved edits', async () => {
+	reset();
+	const session = makeSession();
+	const edited = openEdited('/notes/target.md', 'on disk', 'my unsaved paragraph');
+	tabManager.addTab('/notes/from.md', 'from text');
+
+	// Exactly what openMarkdownTargetInNewTab does.
+	tabManager.addTab('/notes/target.md');
+	await session.loadMarkdown('/notes/target.md', { skipTabManagement: true, resetScrollHistory: true });
+
+	assert.equal(edited.rawContent, 'my unsaved paragraph');
+	assert.equal(edited.originalContent, 'on disk', 'the saved baseline is intact, so the tab can still tell you what changed');
+	assert.equal(edited.isDirty, true, 'the tab still knows it has something to save');
+});
+
+test('the call shape this guards is still the one MarkdownViewer uses', () => {
+	const body = viewer.slice(viewer.indexOf('async function openMarkdownTargetInNewTab'));
+	const fn = body.slice(0, body.indexOf('\n\tasync function', 1));
+	assert.match(fn, /tabManager\.addTab\(/);
+	assert.match(fn, /loadMarkdown\([^)]*\{[^}]*skipTabManagement: true/);
+});
+
+// --- the pre-existing loss, independent of one-tab-per-path ---
+
+test('re-opening an edited file from recents activates its tab instead of reloading it', async () => {
+	reset();
+	const session = makeSession();
+	const edited = openEdited('/notes/a.md', 'on disk', 'my unsaved paragraph');
+	tabManager.addTab('/notes/b.md', 'b');
+
+	await session.loadMarkdown('/notes/a.md');
+
+	assert.equal(edited.rawContent, 'my unsaved paragraph');
+	assert.equal(edited.originalContent, 'on disk');
+	assert.equal(edited.isDirty, true);
+	assert.equal(tabManager.activeTabId, edited.id);
+	assert.deepEqual(reads, []);
+});
+
+test('re-opening the edited file already in front does not reload it either', async () => {
+	reset();
+	const session = makeSession();
+	const edited = openEdited('/notes/a.md', 'on disk', 'my unsaved paragraph');
+
+	// The Home screen is an overlay, not a tab switch: opening the file you are
+	// already editing leaves activeTabId alone, so "did we switch tabs?" is not
+	// a safe test for this.
+	await session.loadMarkdown('/notes/a.md');
+
+	assert.equal(edited.rawContent, 'my unsaved paragraph');
+	assert.equal(edited.isDirty, true);
+	assert.deepEqual(reads, []);
+});
+
+// --- the guard must not block the ordinary paths ---
+
+test('a clean tab is reloaded from disk as before', async () => {
+	reset();
+	const session = makeSession();
+	disk.set('/notes/a.md', 'first');
+	tabManager.addTab('/notes/a.md', 'first');
+	const id = tabManager.activeTabId!;
+
+	disk.set('/notes/a.md', 'second');
+	await session.loadMarkdown('/notes/a.md');
+
+	const tab = tabManager.tabs.find((item) => item.id === id)!;
+	assert.equal(tab.rawContent, 'second');
+	assert.equal(tab.isDirty, false);
+	assert.deepEqual(reads, ['/notes/a.md']);
+});
+
+test('an edited tab following a link to a DIFFERENT file still loads it', async () => {
+	reset();
+	const session = makeSession();
+	disk.set('/notes/b.md', 'b on disk');
+	const edited = openEdited('/notes/a.md', 'a on disk', 'edits');
+
+	// `navigate` rewrites this tab's path; the caller has already dealt with the
+	// buffer (canCloseTab) before getting here.
+	await session.loadMarkdown('/notes/b.md', { navigate: true });
+
+	assert.equal(edited.path, '/notes/b.md');
+	assert.equal(edited.rawContent, 'b on disk');
+	assert.deepEqual(reads, ['/notes/b.md']);
+});
+
+// --- reverting is still possible, and only by saying so ---
+//
+// Authorization is declared by the caller, never inferred by the session from
+// nearby state. An earlier draft let an unanswered external-change conflict
+// stand in for the user's "Reload" click; that is guessing intent from an
+// adjacent flag, and two callers can be in that state for different reasons.
+
+// The two revert commands, and only those two. Anything else that starts
+// passing this flag is a caller claiming the user chose to lose work.
+for (const name of ['resolveExternalChangeByReloading', 'reloadFromDisk']) {
+	test(`${name} declares that it is discarding the buffer`, () => {
+		const body = viewer.slice(viewer.indexOf(`async function ${name}`));
+		const fn = body.slice(0, body.indexOf('\n\t}') + 3);
+		assert.match(fn, /loadMarkdown\(/);
+		assert.match(fn, /discardUnsavedBuffer: true/);
+	});
+}
+
+test('nothing else in the viewer asks to discard a buffer', () => {
+	assert.equal(viewer.match(/discardUnsavedBuffer: true/g)?.length, 2);
+});
+
+test('a Reload of a file changed under unsaved edits replaces the buffer', async () => {
+	reset();
+	const session = makeSession();
+	const edited = openEdited('/notes/a.md', 'on disk', 'my unsaved paragraph');
+
+	disk.set('/notes/a.md', 'someone else wrote this');
+	const outcome = session.resolveExternalChange('/notes/a.md');
+	assert.equal(outcome.action, 'conflict', 'the watcher never reloads it on its own');
+
+	// The options resolveExternalChangeByReloading passes, verbatim.
+	await session.loadMarkdown('/notes/a.md', {
+		preserveEditState: true,
+		skipTabManagement: true,
+		resetScrollHistory: true,
+		discardUnsavedBuffer: true,
+	});
+
+	assert.equal(edited.rawContent, 'someone else wrote this');
+	assert.equal(edited.isDirty, false);
+	assert.deepEqual(reads, ['/notes/a.md']);
+});
+
+test('a conflict alone does not authorize the next open to discard the buffer', async () => {
+	reset();
+	const session = makeSession();
+	const edited = openEdited('/notes/a.md', 'on disk', 'my unsaved paragraph');
+
+	disk.set('/notes/a.md', 'someone else wrote this');
+	session.resolveExternalChange('/notes/a.md');
+
+	// Same tab, same path, conflict outstanding — but this is an open, and it
+	// did not ask to discard anything.
+	await session.loadMarkdown('/notes/a.md');
+
+	assert.equal(edited.rawContent, 'my unsaved paragraph');
+	assert.equal(edited.isDirty, true);
+	assert.deepEqual(reads, []);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -1718,6 +1718,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			preserveEditState: true,
 			skipTabManagement: true,
 			resetScrollHistory: true,
+			// The user answered "the file changed under your edits" with the
+			// disk version. Every other caller of loadMarkdown is an OPEN and
+			// must leave an edited buffer alone; this one is the revert, and
+			// says so rather than leaving the session to infer it.
+			discardUnsavedBuffer: true,
 		});
 	}
 
@@ -2002,6 +2007,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			preserveEditState: true,
 			skipTabManagement: true,
 			resetScrollHistory: true,
+			// canCloseTab has already resolved the buffer, so normally there is
+			// nothing left to discard — but the user can type during that await,
+			// and a reload that silently did nothing would be worse than one
+			// that does what its menu item says.
+			discardUnsavedBuffer: true,
 		});
 		addToast('Reloaded from disk', 'info');
 	}

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -11,6 +11,19 @@ export type LoadMarkdownOptions = {
 	skipTabManagement?: boolean;
 	preserveEditState?: boolean;
 	resetScrollHistory?: boolean;
+	/**
+	 * Read the file even though the tab that will receive it holds unsaved
+	 * edits, discarding them. This is a REVERT, not an open, and only a caller
+	 * acting on an explicit user decision may ask for it — the "Reload" answer
+	 * to the external-change conflict, or "Reload from disk" after the close
+	 * dialog has already resolved the buffer.
+	 *
+	 * Defaults to false, which is what makes `loadMarkdown` safe to call from
+	 * every "open this file" entry point (recent files, drag-and-drop, a link
+	 * opened in a new tab, the OS handing us a path) without each of them
+	 * having to know whether that file is already open and edited.
+	 */
+	discardUnsavedBuffer?: boolean;
 };
 
 /**
@@ -212,6 +225,34 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 			}
 			const activeId = tabManager.activeTabId;
 			if (!activeId) return;
+
+			// Opening a file that is already open, in a tab that has unsaved
+			// edits, must not re-read it: the load below replaces rawContent AND
+			// originalContent, so the edits would be gone and the tab would not
+			// even look dirty afterwards — the same silent loss
+			// `resolveExternalChange` refuses for a watcher event, reached
+			// through the ordinary open path instead.
+			//
+			// The whole request is answered by activating that tab, which every
+			// mainstream editor does: VS Code reveals the existing editor over
+			// its dirty `ITextModel`, Sublime Text focuses the view that already
+			// holds the buffer, and Vim's `:e` refuses outright without `!`.
+			// Discarding a buffer is a separate, explicit command everywhere —
+			// here, "Reload from disk" and the external-change "Reload", and both
+			// declare it by passing `discardUnsavedBuffer`. Authorization is
+			// something a caller states, never something this function infers
+			// from surrounding state.
+			//
+			// Note the tab is found by `activeTabId`: whether the caller reached
+			// it by `setActive` on an already-open file, by `addTab` resolving to
+			// it, or by never having left it, the buffer at risk is the same one.
+			const receiving = tabManager.tabs.find((item) => item.id === activeId);
+			if (receiving && receiving.isDirty && receiving.path === filePath && !loadOptions.discardUnsavedBuffer) {
+				if (filePath) options.saveRecentFile(filePath);
+				await options.afterLoad();
+				return;
+			}
+
 			const fullLoadRevision = (loadRevisionByTab.get(activeId) ?? 0) + 1;
 			loadRevisionByTab.set(activeId, fullLoadRevision);
 			const isMarkdown = hasMarkdownLinkExtension(filePath);


### PR DESCRIPTION
> **1 / 2.** #2 (`fix/one-tab-per-path`) builds on this and needs it — but this one stands alone.

## The defect, on `master` today

A file is open with unsaved edits. You then open it again — from the recents list, by dropping it on the window, or by double-clicking it in Finder. `loadMarkdown` takes its `existing` branch, reads the file from disk, and writes it into that tab.

**The edits are gone.** And because `setTabRawContent` replaces `originalContent` along with `rawContent`, **the tab shows as clean afterwards** — so there is no dirty dot, no prompt, and no way for the user to know that anything was lost, let alone what.

This has nothing to do with the follow-up PR; it is reachable today through three ordinary actions.

## The fix

Re-opening a file whose tab holds unsaved edits skips the disk read and shows the tab, buffer intact.

Four editors already agree, and they agree on the *shape* rather than the detail — **an open never discards a buffer; reverting is always a separate explicit command**:

| | |
|---|---|
| **VS Code** | one `ITextModel` per URI; opening an already-open dirty file reveals the existing editor, no read, no prompt. `File: Revert File` is separate |
| **Sublime Text** | focuses the view that already holds the buffer; `File ▸ Revert File` is separate |
| **JetBrains** | the in-memory document wins; `File ▸ Reload from Disk` is explicit |
| **Vim** | strongest case — `:e` on a modified buffer **refuses**: `E37: No write since last change`. You need `:e!` |

**No prompt**, for a second reason as well: this path is walked by batch opens (`for (const path of paths) await loadMarkdown(path)`), session restore, and pinned-tag restore. A dialog per file would be unusable. Markpad already has both explicit revert affordances, so **no new UI and no new i18n keys** — `i18n.ts` is untouched.

## Authorization is declared, not inferred

The revert commands now pass `discardUnsavedBuffer`. An earlier draft inferred the authority instead — "there is an unanswered external-change conflict, so this reload must be the answer to it" — which is the same *guess intent from adjacent state* pattern that has caused trouble elsewhere in this codebase. It carried a map, four `delete` calls scattered across `resolveExternalChange`/`saveContent`/`saveContentAs`, and unbounded growth. All of it is gone; `resolveExternalChange` is byte-identical with `master`, and the guard is one line:

```ts
if (receiving && receiving.isDirty && receiving.path === filePath && !loadOptions.discardUnsavedBuffer) {
```

`documentSession.svelte.ts` is purely additive: **+41 lines, no new state, nothing to reap.**

**`reloadFromDisk` gets the flag too**, not just the external-change reload. It calls `canCloseTab` first, so the tab is normally clean by the time it loads — but the user can type during that await, and then the guard would have made the menu item **silently do nothing**. A reload that quietly no-ops is worse than one that does what it says.

Three tests pin that:

- `resolveExternalChangeByReloading declares that it is discarding the buffer`
- `reloadFromDisk declares that it is discarding the buffer`
- **`nothing else in the viewer asks to discard a buffer`** — asserts the flag appears exactly **twice** in `MarkdownViewer.svelte`. Any future caller claiming the user chose to lose work has to change that number, which is the review prompt.

Plus the behavioural pair: *a Reload of a file changed under unsaved edits replaces the buffer* (verbatim options from the real caller), and its inverse — *a conflict alone does not authorize the next open to discard the buffer*: same tab, same path, conflict outstanding, but it is an open, so nothing is lost. **That last one is the old inference bug written down as a permanent test.**

## Tests

`scripts/reopenDirtyDocument.test.ts`, 11 tests, driving the real session.

| vs `master` | **6 red / 5 green** |
|---|---|

The five greens are the don't-over-block boundaries: a clean tab still reloads, a link to a *different* file still loads, the call-shape check, and the gate test — which correctly passes on `master` because `master`'s `addTab` builds a *second* tab, so nothing is overwritten there. (That gate goes red only in the one state where the follow-up PR lands without this one.)

```
npm run check   435 files, 0 errors
npm test        489 / 489
cargo test      131 / 131
```

## Not covered

- **Case-insensitive filesystems**: `receiving.path === filePath` is exact equality, so `/notes/A.md` and `/notes/a.md` read as two files on macOS and Windows. `refuseIfLossilyDecoded` documents the same gap; both need the backend to canonicalise.
- **Dirty + truncated tabs**: skipping the read leaves a large file holding its 50KB preview slice. `ensureFullContent` already refuses a dirty truncated buffer, so this is pre-existing and unchanged.
- Two of the tests read `MarkdownViewer.svelte` as source text. That is deliberate — it is what keeps the session's assumptions and the viewer's calls from drifting apart silently — but they are string matches and will need a look if that file moves again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)