### PR TITLE
fix(tabs): one tab per file path

### DIFF
--- a/scripts/reopenDirtyDocument.test.ts
+++ b/scripts/reopenDirtyDocument.test.ts
@@ -125,6 +125,24 @@ test('following a link into a new tab never costs the target tab its unsaved edi
 	assert.equal(edited.isDirty, true, 'the tab still knows it has something to save');
 });
 
+// One tab per path makes `addTab` resolve the click to the tab that already
+// holds the file instead of building a second one — which is what hands that
+// edited buffer to the loader in the first place. The test above is what makes
+// that safe; this one is what makes it useful.
+test('following a link into a new tab shows the tab that already holds the file', async () => {
+	reset();
+	const session = makeSession();
+	const edited = openEdited('/notes/target.md', 'on disk', 'my unsaved paragraph');
+	tabManager.addTab('/notes/from.md', 'from text');
+
+	tabManager.addTab('/notes/target.md');
+	await session.loadMarkdown('/notes/target.md', { skipTabManagement: true, resetScrollHistory: true });
+
+	assert.equal(tabManager.tabs.filter((tab) => tab.path === '/notes/target.md').length, 1);
+	assert.equal(tabManager.activeTabId, edited.id);
+	assert.deepEqual(reads, [], 'the file is not even read');
+});
+
 test('the call shape this guards is still the one MarkdownViewer uses', () => {
 	const body = viewer.slice(viewer.indexOf('async function openMarkdownTargetInNewTab'));
 	const fn = body.slice(0, body.indexOf('\n\tasync function', 1));

--- a/scripts/tabPathIdentity.test.ts
+++ b/scripts/tabPathIdentity.test.ts
@@ -1,0 +1,202 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+// A file path identifies a tab. Two tabs on one file are two buffers with two
+// dirty flags and two auto-save timers writing the same file in turn, so
+// whichever lands last silently overwrites the other's work. Every way to
+// reach that state goes through a different caller — a link opened in a new
+// tab, Save As onto an open file, back/forward, a tab moved in from another
+// window — so the constraint belongs to the store.
+//
+// These tests drive the real TabManager: they assert behaviour, not wording.
+
+const g = globalThis as any;
+const runeEffect = (fn: () => void) => {
+	void fn;
+};
+runeEffect.root = (fn: () => unknown) => fn();
+g.$state = (value: unknown) => value;
+g.$state.raw = (value: unknown) => value;
+g.$state.snapshot = (value: unknown) => value;
+g.$derived = (value: unknown) => value;
+g.$derived.by = (fn: () => unknown) => fn();
+g.$effect = runeEffect;
+g.window = g.window ?? {};
+
+const localStore = new Map<string, string>();
+g.localStorage = {
+	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
+	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
+	removeItem: (key: string) => void localStore.delete(key),
+	clear: () => localStore.clear(),
+};
+g.window.__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+
+function reset() {
+	tabManager.closeAll();
+	tabManager.recentlyClosed.length = 0;
+	localStore.clear();
+}
+
+function tabsFor(path: string) {
+	return tabManager.tabs.filter((tab) => tab.path === path);
+}
+
+// --- one tab per file ---
+
+test('opening a file that is already open activates that tab instead of duplicating it', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', 'first');
+	const first = tabManager.activeTabId;
+	tabManager.addTab('/notes/b.md');
+
+	tabManager.addTab('/notes/a.md');
+
+	assert.equal(tabsFor('/notes/a.md').length, 1);
+	assert.equal(tabManager.activeTabId, first, 'the request resolves to the existing tab');
+	assert.equal(tabManager.tabs.length, 2);
+});
+
+// Scope: this proves the STORE does not clobber the buffer when an open file
+// is opened again. It does not prove the whole open flow is safe —
+// `documentSession.loadMarkdown` re-reads the file into the tab it activates,
+// which is a pre-existing behaviour of the ordinary open path and lives
+// outside this file.
+test('re-opening a file does not overwrite the unsaved edits in its tab', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', 'saved text');
+	const id = tabManager.activeTabId!;
+	tabManager.updateTabRawContent(id, 'unsaved edits');
+
+	tabManager.addTab('/notes/a.md', 'saved text');
+
+	const tab = tabManager.tabs.find((item) => item.id === id)!;
+	assert.equal(tab.rawContent, 'unsaved edits');
+	assert.equal(tab.isDirty, true);
+});
+
+test('following a link to an open file leaves exactly one tab holding it', () => {
+	reset();
+	tabManager.addTab('/notes/target.md', 'target text');
+	tabManager.addTab('/notes/from.md', 'from text');
+	const walker = tabManager.activeTabId!;
+
+	tabManager.navigate(walker, '/notes/target.md');
+
+	assert.equal(tabsFor('/notes/target.md').length, 1);
+	assert.equal(tabsFor('/notes/target.md')[0].id, walker);
+	// The clean loser is a copy of the file the winner now holds, so closing it
+	// costs nothing — and it lands on the reopen stack like any other close.
+	assert.ok(tabManager.recentlyClosed.includes('/notes/target.md'));
+});
+
+test('a tab with unsaved edits is never closed to resolve a path conflict', () => {
+	reset();
+	tabManager.addTab('/notes/target.md', 'target text');
+	const resident = tabManager.activeTabId!;
+	tabManager.updateTabRawContent(resident, 'work in progress');
+	tabManager.addTab('/notes/from.md', 'from text');
+	const walker = tabManager.activeTabId!;
+
+	tabManager.navigate(walker, '/notes/target.md');
+
+	const kept = tabManager.tabs.find((tab) => tab.id === resident);
+	assert.ok(kept, 'the dirty buffer survives');
+	assert.equal(kept!.rawContent, 'work in progress');
+	assert.equal(kept!.isDirty, true);
+	// It keeps the text and gives up the path: nothing is discarded, and
+	// nothing can auto-save over the file behind the user's back.
+	assert.equal(kept!.path, '');
+	assert.equal(tabsFor('/notes/target.md').length, 1);
+	assert.equal(tabsFor('/notes/target.md')[0].id, walker);
+});
+
+test('Save As onto a file that is already open does not leave two tabs on it', () => {
+	reset();
+	tabManager.addTab('/notes/target.md', 'target text');
+	tabManager.addNewTab();
+	const untitled = tabManager.activeTabId!;
+
+	// saveContentAs writes the file first and then re-points the tab.
+	tabManager.updateTabPath(untitled, '/notes/target.md');
+
+	assert.equal(tabsFor('/notes/target.md').length, 1);
+	assert.equal(tabsFor('/notes/target.md')[0].id, untitled);
+});
+
+test('an external rename onto an open file does not leave two tabs on it', () => {
+	reset();
+	tabManager.addTab('/notes/target.md', 'target text');
+	tabManager.addTab('/notes/other.md', 'other text');
+	const renamed = tabManager.activeTabId!;
+
+	tabManager.renameTab(renamed, '/notes/target.md');
+
+	assert.equal(tabsFor('/notes/target.md').length, 1);
+	assert.equal(tabsFor('/notes/target.md')[0].id, renamed);
+});
+
+test('going back to a file another tab has since opened does not duplicate it', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', 'a');
+	const walker = tabManager.activeTabId!;
+	tabManager.navigate(walker, '/notes/b.md');
+	tabManager.addTab('/notes/a.md');
+
+	assert.equal(tabManager.goBack(walker), '/notes/a.md');
+
+	assert.equal(tabsFor('/notes/a.md').length, 1);
+	assert.equal(tabsFor('/notes/a.md')[0].id, walker);
+});
+
+test('a tab arriving from another window does not duplicate a file open here', () => {
+	reset();
+	tabManager.addTab('/notes/shared.md', 'resident copy');
+
+	tabManager.insertTransferredTab({
+		path: '/notes/shared.md',
+		title: 'shared.md',
+		rawContent: 'edited elsewhere',
+		originalContent: 'resident copy',
+		isDirty: true,
+		isEditing: true,
+		scrollTop: 0,
+		scrollPercentage: 0,
+		anchorLine: 0,
+		isSplit: false,
+		splitRatio: 0.5,
+		isScrollSynced: false,
+		hasReplacementChars: false,
+		history: ['/notes/shared.md'],
+		historyIndex: 0,
+	});
+
+	assert.equal(tabsFor('/notes/shared.md').length, 1);
+	assert.equal(tabsFor('/notes/shared.md')[0].rawContent, 'edited elsewhere');
+});
+
+test('untitled tabs are not files and do not collide', () => {
+	reset();
+	tabManager.addNewTab();
+	tabManager.addNewTab();
+	tabManager.addNewTab();
+
+	assert.equal(tabManager.tabs.length, 3);
+	assert.equal(tabsFor('').length, 3);
+});
+
+test('the home tab is a singleton on its own terms, not through the path rule', () => {
+	reset();
+	tabManager.addHomeTab();
+	const home = tabManager.activeTabId;
+	tabManager.addTab('/notes/a.md');
+	tabManager.addHomeTab();
+
+	assert.equal(tabsFor('HOME').length, 1);
+	assert.equal(tabManager.activeTabId, home);
+});

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -185,7 +185,69 @@ class TabManager {
 		}
 	}
 
+	/**
+	 * A file path identifies a tab: at most one tab per window may hold a given
+	 * path. Two tabs on the same file are two independent buffers with two
+	 * independent dirty flags and two auto-save timers writing the same file in
+	 * turn, so whichever lands last silently overwrites the other's work — and
+	 * the store is the only place that can rule it out, because every duplicate
+	 * arrives through a different caller (a link opened in a new tab, Save As
+	 * onto an open file, a tab moved in from another window).
+	 *
+	 * Mainstream editors make this state unrepresentable rather than merely
+	 * unlikely: VS Code keys one `ITextModel` per file URI and points every
+	 * editor at it, and Sublime Text's Open File links to the view that already
+	 * holds the buffer (`clone_file` makes a second VIEW of the SAME buffer,
+	 * never a second buffer). Markpad has no buffer/view split — a tab is the
+	 * buffer — so the equivalent invariant is one tab per path.
+	 *
+	 * Resolving a conflict must not cost the user anything, so the loser is
+	 * handled by what it has to lose:
+	 * - clean: closed, since its buffer is a copy of the file the winner now
+	 *   holds. It lands on the reopen-closed-tab stack like any other close.
+	 * - dirty: kept, with its buffer intact, but its claim on the path is
+	 *   released (it becomes untitled). Nothing is discarded and nothing can
+	 *   auto-save over the file behind the user's back; saving it asks where to
+	 *   put it, which is the one decision only the user can make.
+	 *
+	 * Only real file paths are exclusive: untitled tabs (`''`) and the home
+	 * sentinel are not files, and several untitled tabs are normal.
+	 *
+	 * Known boundary: paths are compared exactly, so on a case-insensitive
+	 * filesystem `/notes/A.md` and `/notes/a.md` still read as two files — the
+	 * same limitation `documentSession.refuseIfLossilyDecoded` documents; both
+	 * need the backend to canonicalize paths.
+	 */
+	private claimPath(path: string, claimantId: string) {
+		if (!hasRealFilePath(path)) return;
+		for (const other of this.tabs.filter((t) => t.id !== claimantId && t.path === path)) {
+			if (!other.isDirty) {
+				this.closeTab(other.id);
+				continue;
+			}
+			other.path = '';
+			// The title still names the file the buffer came from — that is what
+			// makes the tab recognizable, and `saveContent` offers it as the
+			// default filename when the user places it.
+			other.history = [''];
+			other.historyIndex = 0;
+		}
+	}
+
 	addTab(path: string, content: string = '') {
+		// Opening a file that is already open activates that tab instead of
+		// building a second buffer for it — VS Code and Sublime Text both
+		// resolve an open request to the existing view. `content` is ignored in
+		// that case on purpose: the open tab may hold unsaved edits, and a
+		// freshly read copy of the file would erase them.
+		if (hasRealFilePath(path)) {
+			const existing = this.tabs.find((t) => t.path === path);
+			if (existing) {
+				this.activeTabId = existing.id;
+				return;
+			}
+		}
+
 		const id = crypto.randomUUID();
 		const filename =
 			path.split('\\').pop()?.split('/').pop() ||
@@ -298,6 +360,9 @@ class TabManager {
 			this.tabs.map((tab) => tab.title),
 			t('tabs.untitled', settings.language),
 		);
+		// The destination window may already have this file open, which would
+		// leave the arriving buffer and the resident one saving over each other.
+		this.claimPath(tab.path, tab.id);
 		this.tabs.push(tab);
 		this.activeTabId = tab.id;
 		return tab.id;
@@ -488,6 +553,10 @@ class TabManager {
 	updateTabPath(id: string, path: string) {
 		const tab = this.tabs.find((t) => t.id === id);
 		if (tab) {
+			// Save As can name a file that is already open here; the write has
+			// happened by the time this runs, so the other tab's buffer is
+			// already stale and must stop claiming the path.
+			this.claimPath(path, id);
 			tab.path = path;
 			tab.title = path.split(/[/\\]/).pop() || 'Untitled';
 			tab.isDirty = false;
@@ -505,6 +574,7 @@ class TabManager {
 	renameTab(id: string, newPath: string) {
 		const tab = this.tabs.find((t) => t.id === id);
 		if (tab) {
+			this.claimPath(newPath, id);
 			tab.path = newPath;
 			tab.title = newPath.split(/[/\\]/).pop() || 'Untitled';
 			const fileHistory = replaceCurrentHistoryEntry({
@@ -522,6 +592,13 @@ class TabManager {
 		const tab = this.tabs.find(t => t.id === id);
 		if (tab) {
 			if (tab.path === path) return;
+
+			// Following a link to a file another tab already holds. The caller
+			// has read that file and is about to put its text in THIS tab, so
+			// declining the navigation is not an option: the tab would keep its
+			// old path and get the other document's content, and the next save
+			// would write it to the wrong file.
+			this.claimPath(path, id);
 
 			const fileHistory = navigateFileHistory({
 				currentPath: tab.path,
@@ -555,6 +632,9 @@ class TabManager {
 			const result = goBackInHistory(tab);
 			if (!result.path) return null;
 			const path = result.path;
+			// Back/forward walk this tab's own history, which can lead to a file
+			// that has since been opened in another tab.
+			this.claimPath(path, id);
 			tab.history = result.history;
 			tab.historyIndex = result.historyIndex;
 			tab.path = path;
@@ -571,6 +651,7 @@ class TabManager {
 			const result = goForwardInHistory(tab);
 			if (!result.path) return null;
 			const path = result.path;
+			this.claimPath(path, id);
 			tab.history = result.history;
 			tab.historyIndex = result.historyIndex;
 			tab.path = path;


### PR DESCRIPTION
> **2 / 2.** Base: #412 — and it must land first. See "Why this is safe now" below.

## The defect

`navigate`, `updateTabPath`, `renameTab`, `goBack`, `goForward` and `insertTransferredTab` all assigned `tab.path` **without checking whether another tab already held it**, and `openMarkdownTargetInNewTab` called `addTab` unconditionally. So:

- right-click a link to a file that is already open → **Open in new tab**, or
- **Save As** from an untitled tab onto a file that is already open

…gave you two tabs on one path. Each then carried its own `isDirty` and its own auto-save timer, and they wrote over each other.

`loadMarkdown` already de-duplicated, but only on the ordinary open path.

## What the invariant should be

**Neither VS Code nor Sublime forbids two *tabs*. Both forbid two *buffers*.**

- **VS Code** keys one `ITextModel` per URI; editors are views onto it, so edits appear in all of them and there is exactly one save path. Two divergent buffers for one URI is not a representable state.
- **Sublime Text**: opening an already-open file links you to the existing view. Getting a second tab requires `clone_file`, which explicitly creates a second **view of the same buffer** — never a second buffer.

Markpad has no buffer/view split — **a tab *is* the buffer** — so the faithful translation of that invariant is one tab per path. Only real file paths are exclusive; several untitled tabs remain normal.

## Conflict resolution, by what the loser stands to lose

| loser | outcome |
|---|---|
| **clean** | closed — its buffer is a copy of the file the winner now holds, so nothing is lost, and it lands on the reopen-closed-tab stack like any other close |
| **dirty** | kept, and releases the path — becomes untitled, buffer and title intact. Nothing is discarded, nothing can auto-save over the file behind the user's back, and saving it asks where to put it, which is the one decision only the user can make |

### Why not "refuse the claim and activate the existing tab"

That is the naive reading of what VS Code does, and here it would be **worse than the bug**. `loadMarkdown` captures `activeId` *before* calling `navigate`, then writes the newly read content into that captured tab. Declining the path change leaves the tab pointing at file A while receiving file B's text — and the next save writes B over A.

## Why this is safe now, and was not before

De-duplicating means "open link in new tab" resolves to an **already-open tab** and hands it to a loader that previously would have written disk content into a brand-new one. If that tab has unsaved edits, the de-duplication is what makes them reachable.

**#412 closes that.** The receipt is a single test, deliberately narrowed to one assertion so its verdict is unambiguous:

| state | `following a link into a new tab never costs the target tab its unsaved edits` |
|---|---|
| `master` | **green** — `addTab` makes a second tab, so nothing is overwritten |
| this PR **without** #412 | **red** ← the trade |
| #412 alone | green |
| both | **green** |

I ran that third state explicitly rather than reasoning about it.

## Tests

`scripts/tabPathIdentity.test.ts` (10) plus one assertion added to `reopenDirtyDocument.test.ts`.

| vs #412 | **8 red / 14 green** |
|---|---|

By file: `tabPathIdentity` 7 red / 3 green — the three greens are the don't-over-fire boundaries (untitled tabs do not collide, the HOME sentinel is a singleton on its own terms, and "re-opening doesn't overwrite edits", which passes on #412 precisely *because* #412 landed). `reopenDirtyDocument` 1 red / 11 green, the red being the new tab-identity assertion.

```
npm run check   435 files, 0 errors
npm test        500 / 500
cargo test      131 / 131
```

## Not covered

- **Case-insensitive filesystems**: path uniqueness is exact string equality, so `/notes/A.md` and `/notes/a.md` are two files on macOS and Windows. `refuseIfLossilyDecoded` and #412 document the same gap; all three need the backend to canonicalise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)