### PR TITLE
fix(tabs): ask the filesystem whether two paths name the same file

### DIFF
--- a/scripts/lossyDecodeSaveGuard.test.ts
+++ b/scripts/lossyDecodeSaveGuard.test.ts
@@ -164,9 +164,15 @@ test('Save As to a new file stays open as the escape hatch', () => {
 	assert.match(body, /setTabDecodedLossy\(tab\.id, false\)/);
 });
 
-test('Save As onto the same path is still a destructive overwrite', () => {
+test('Save As onto the same file is still a destructive overwrite', () => {
 	const body = saveContentAs();
-	const refusal = body.indexOf('refuseIfLossilyDecoded(tab, selected)');
+	// "The same file", not "the same string": the dialog can come back with
+	// another spelling of the source file — a different case, or accents
+	// composed differently — and on macOS and Windows that still lands on the
+	// same bytes. The guard is therefore handed the target's resolved identity
+	// as well as its path. See pathIdentityCaseFolding.test.ts, which drives
+	// that refusal for real instead of reading for it.
+	const refusal = body.indexOf('refuseIfLossilyDecoded(tab, selected');
 	assert.notEqual(refusal, -1, 'picking the source file again must be refused');
 	assert.ok(
 		refusal < body.indexOf("invoke('save_file_content'"),

--- a/scripts/pathIdentityCaseFolding.test.ts
+++ b/scripts/pathIdentityCaseFolding.test.ts
@@ -1,0 +1,306 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+// On macOS and Windows the filesystem folds case: `/notes/A.md` and
+// `/notes/a.md` are ONE file. (APFS folds Unicode normalization too, so the
+// NFC and NFD spellings of `café.md` are one file as well — which no amount of
+// case folding in the frontend could ever reach.) Markpad compared paths with
+// exact string equality in three places, and each of them broke differently
+// when the same file arrived under two spellings:
+//
+//   1. the lossy-decode save guard let a Save As typed `/notes/Legacy.md`
+//      overwrite the non-UTF-8 file the tab had opened as `/notes/legacy.md`,
+//      destroying it — the one thing that guard exists to prevent;
+//   2. one-tab-per-file gave two tabs on one file, i.e. two buffers with two
+//      auto-save timers taking turns overwriting each other;
+//   3. the reopen guard did not recognise its own file, so opening it again
+//      read disk content over a buffer full of unsaved edits.
+//
+// All three now ask the filesystem what file a path names (the Rust
+// `canonicalize_path`), once, when the path enters the app, and compare that.
+//
+// These tests drive the real TabManager and the real documentSession against a
+// backend stubbed to behave like a case-insensitive volume. They assert
+// behaviour — buffers kept, files not written, tab counts — never wording.
+
+const g = globalThis as any;
+const runeEffect = (fn: () => void) => {
+	void fn;
+};
+runeEffect.root = (fn: () => unknown) => fn();
+g.$state = (value: unknown) => value;
+g.$state.raw = (value: unknown) => value;
+g.$state.snapshot = (value: unknown) => value;
+g.$derived = (value: unknown) => value;
+g.$derived.by = (fn: () => unknown) => fn();
+g.$effect = runeEffect;
+g.window = g.window ?? {};
+
+const localStore = new Map<string, string>();
+g.localStorage = {
+	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
+	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
+	removeItem: (key: string) => void localStore.delete(key),
+	clear: () => localStore.clear(),
+};
+
+/** Files by their on-disk name, and whether each decoded lossily. */
+const disk = new Map<string, { body: string; lossy: boolean }>();
+/** Every write the session actually performed, in order. */
+const writes: { path: string; content: string }[] = [];
+
+/**
+ * A case-insensitive volume, modelled the way a real one behaves: a lookup
+ * matches any spelling, and what comes back is the name the DIRECTORY holds —
+ * which is exactly what `realpath` reports and what `canonicalize_path`
+ * returns. Nothing here lowercases a path; the on-disk name is the answer.
+ */
+function lookup(path: string): string | null {
+	const wanted = path.toLowerCase();
+	for (const name of disk.keys()) {
+		if (name.toLowerCase() === wanted) return name;
+	}
+	return null;
+}
+
+/** What the dialog will return next. */
+let nextSaveTarget: string | null = null;
+
+g.window.__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string, args: any) => {
+		if (cmd === 'canonicalize_path') {
+			const resolved = lookup(args.path);
+			// A name nothing answers to is still a legal target (Save As to a
+			// new file); the backend resolves its directory and keeps the name.
+			return Promise.resolve(resolved ?? args.path);
+		}
+		if (cmd === 'read_file_content_checked') {
+			const file = disk.get(lookup(args.path) ?? args.path);
+			return Promise.resolve([file?.body ?? '', file?.lossy ?? false]);
+		}
+		if (cmd === 'open_markdown_preview') {
+			const file = disk.get(lookup(args.path) ?? args.path);
+			return Promise.resolve(['', file?.body ?? '', true, file?.lossy ?? false]);
+		}
+		if (cmd === 'save_file_content') {
+			writes.push({ path: args.path, content: args.content });
+			disk.set(lookup(args.path) ?? args.path, { body: args.content, lossy: false });
+			return Promise.resolve(null);
+		}
+		// The Save As dialog. `@tauri-apps/plugin-dialog`'s `save()` is a thin
+		// wrapper over this command, so stubbing it here needs no module
+		// patching and exercises the real wrapper.
+		if (cmd === 'plugin:dialog|save') return Promise.resolve(nextSaveTarget);
+		if (cmd === 'get_os_type') return Promise.resolve('macos');
+		return Promise.resolve(null);
+	},
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
+
+const errors: string[] = [];
+
+function makeSession() {
+	return createDocumentSession({
+		setShowHome: () => {},
+		currentFile: () => tabManager.activeTab?.path ?? '',
+		resetScrollHistory: () => {},
+		renderMarkdown: async (raw: string) => raw,
+		afterLoad: async () => {},
+		saveRecentFile: () => {},
+		deleteRecentFile: () => {},
+		setLoadingTabs: () => {},
+		measureInitialViewport: () => {},
+		isScrolling: () => false,
+		renderRichContent: () => {},
+		onError: (message: string) => void errors.push(message),
+		selfWriteGraceMs: 400,
+		cancelPendingAutoSave: () => {},
+		askClose: async () => 'discard' as const,
+		onCloseSaveNewerEdits: () => {},
+		onCloseAutoSaveFailed: () => {},
+	});
+}
+
+function reset() {
+	tabManager.closeAll();
+	tabManager.recentlyClosed.length = 0;
+	localStore.clear();
+	disk.clear();
+	writes.length = 0;
+	errors.length = 0;
+	nextSaveTarget = null;
+}
+
+// --- gap 1: the lossy-decode save guard -----------------------------------
+
+test('Save As in a different case is still an overwrite of the source file', async () => {
+	// The file is GBK, so its buffer is U+FFFD mojibake and writing it back
+	// destroys the document — that is what `refuseIfLossilyDecoded` stops. The
+	// user opened it as `/notes/legacy.md`; the Save As dialog comes back with
+	// `/notes/Legacy.md`. On this volume that is the SAME FILE, so the refusal
+	// has to hold, or the guard is one autocomplete away from being bypassed.
+	reset();
+	const session = makeSession();
+	disk.set('/notes/legacy.md', { body: '# �� mojibake', lossy: true });
+
+	await session.loadMarkdown('/notes/legacy.md');
+	assert.equal(tabManager.activeTab?.hasReplacementChars, true, 'precondition: the buffer is known lossy');
+
+	nextSaveTarget = '/notes/Legacy.md';
+	const saved = await session.saveContentAs();
+
+	assert.equal(saved, false, 'the refusal must hold');
+	assert.deepEqual(writes, [], 'nothing may be written over the source file');
+	assert.equal(disk.get('/notes/legacy.md')?.body, '# �� mojibake', 'the document is intact');
+});
+
+test('Save As to a genuinely different file stays open as the escape hatch', async () => {
+	// The other direction, and the one that must not regress: the whole point
+	// of refusing is that the user can still write a UTF-8 copy somewhere else.
+	reset();
+	const session = makeSession();
+	disk.set('/notes/legacy.md', { body: '# �� mojibake', lossy: true });
+
+	await session.loadMarkdown('/notes/legacy.md');
+	nextSaveTarget = '/notes/legacy-utf8.md';
+	const saved = await session.saveContentAs();
+
+	assert.equal(saved, true);
+	assert.equal(writes.length, 1);
+	assert.equal(writes[0].path, '/notes/legacy-utf8.md');
+	assert.equal(tabManager.activeTab?.hasReplacementChars, false, 'the copy is UTF-8, so the tab is savable again');
+});
+
+// --- gap 2: one tab per file ----------------------------------------------
+
+test('opening one file under two spellings leaves one tab, not two', async () => {
+	// Two tabs on one file are two buffers with two dirty flags and two
+	// auto-save timers writing the same file in turn; whichever lands last
+	// silently overwrites the other's work.
+	reset();
+	const session = makeSession();
+	disk.set('/notes/A.md', { body: 'shared body', lossy: false });
+
+	await session.loadMarkdown('/notes/A.md');
+	const first = tabManager.activeTabId;
+	await session.loadMarkdown('/notes/a.md');
+
+	assert.equal(tabManager.tabs.length, 1, 'one file, one tab');
+	assert.equal(tabManager.activeTabId, first, 'the request resolved to the tab that already held it');
+});
+
+test('two genuinely different files still get their own tabs', async () => {
+	// The guard against over-merging: nothing above may collapse files that
+	// differ by more than spelling.
+	reset();
+	const session = makeSession();
+	disk.set('/notes/a.md', { body: 'a', lossy: false });
+	disk.set('/notes/b.md', { body: 'b', lossy: false });
+
+	await session.loadMarkdown('/notes/a.md');
+	await session.loadMarkdown('/notes/b.md');
+
+	assert.equal(tabManager.tabs.length, 2);
+});
+
+test('Save As onto a file already open under another spelling does not leave two tabs on it', async () => {
+	// Reached through `updateTabPath` rather than `addTab`, and the file is
+	// already written by the time the store hears about it — so the loser's
+	// buffer is stale no matter which way the name was spelled.
+	reset();
+	const session = makeSession();
+	disk.set('/notes/A.md', { body: 'original', lossy: false });
+	await session.loadMarkdown('/notes/A.md');
+
+	tabManager.addNewTab();
+	const draft = tabManager.activeTabId!;
+	tabManager.updateTabRawContent(draft, 'replacement');
+
+	nextSaveTarget = '/notes/a.md';
+	assert.equal(await session.saveContentAs(), true);
+
+	assert.equal(
+		tabManager.tabs.filter((tab) => tab.path !== '').length,
+		1,
+		'exactly one tab may claim the file',
+	);
+	assert.equal(tabManager.activeTabId, draft, 'the tab that owns the bytes on disk keeps it');
+});
+
+// --- gap 3: the reopen guard ----------------------------------------------
+
+// The guard runs on the tab the content is about to land in, so it only sees a
+// mis-spelled path on the routes that pick the tab themselves and pass
+// `navigate` / `skipTabManagement`: a link followed in place, and back/forward.
+// A link written `./A.md` inside a document whose tab is open as `/notes/a.md`
+// is that case exactly — and it is the ordinary way to reach it, since link
+// text is typed by the document's author, not by the filesystem.
+test('following a link that spells the current file differently does not overwrite its unsaved edits', async () => {
+	// `setTabRawContent` replaces rawContent AND originalContent, so the reload
+	// would not merely lose the edits — the tab would look clean afterwards and
+	// the user could not tell what went missing.
+	reset();
+	const session = makeSession();
+	disk.set('/notes/a.md', { body: 'on disk', lossy: false });
+
+	await session.loadMarkdown('/notes/a.md');
+	const id = tabManager.activeTabId!;
+	tabManager.updateTabRawContent(id, 'my unsaved paragraph');
+
+	await session.loadMarkdown('/notes/A.md', { navigate: true });
+
+	const tab = tabManager.tabs.find((item) => item.id === id)!;
+	assert.equal(tab.rawContent, 'my unsaved paragraph', 'the edits survive');
+	assert.equal(tab.originalContent, 'on disk', 'the saved baseline is intact, so the tab can still say what changed');
+	assert.equal(tab.isDirty, true, 'the tab still knows it has something to save');
+});
+
+test('an explicit revert still discards the buffer whatever the spelling', async () => {
+	// "Reload from disk" and the external-change "Reload" pass
+	// `discardUnsavedBuffer`; the identity fix must not make them unreachable.
+	reset();
+	const session = makeSession();
+	disk.set('/notes/a.md', { body: 'on disk', lossy: false });
+
+	await session.loadMarkdown('/notes/a.md');
+	const id = tabManager.activeTabId!;
+	tabManager.updateTabRawContent(id, 'my unsaved paragraph');
+
+	await session.loadMarkdown('/notes/A.md', { navigate: true, discardUnsavedBuffer: true });
+
+	const tab = tabManager.tabs.find((item) => item.id === id)!;
+	assert.equal(tab.rawContent, 'on disk');
+	assert.equal(tab.isDirty, false);
+});
+
+// --- the fallback ----------------------------------------------------------
+
+test('a path the backend cannot resolve is compared exactly, as before', async () => {
+	// An unreachable network volume, a deleted parent directory, or any route
+	// that has not resolved a path yet must cost the improvement and nothing
+	// more: the literal comparison is what every one of these sites did before.
+	const { isSameFilePath } = await import('../src/lib/utils/pathIdentity.js');
+
+	assert.equal(isSameFilePath({ path: '/notes/A.md' }, { path: '/notes/a.md' }), false);
+	assert.equal(isSameFilePath({ path: '/notes/A.md' }, { path: '/notes/A.md' }), true);
+	// A key is trusted only when BOTH sides have one: `/notes/today.md` may be
+	// a symlink whose key is `/archive/2026-08-03.md`, so a bare path that
+	// happens to equal someone else's key proves nothing.
+	assert.equal(
+		isSameFilePath({ path: '/notes/today.md', pathKey: '/archive/x.md' }, { path: '/archive/x.md' }),
+		false,
+	);
+	assert.equal(
+		isSameFilePath(
+			{ path: '/notes/today.md', pathKey: '/archive/x.md' },
+			{ path: '/archive/x.md', pathKey: '/archive/x.md' },
+		),
+		true,
+	);
+	// Untitled buffers and the home sentinel are not files and never collide.
+	assert.equal(isSameFilePath({ path: '' }, { path: '' }), false);
+	assert.equal(isSameFilePath({ path: 'HOME' }, { path: 'HOME' }), false);
+});

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -173,6 +173,74 @@ pub(crate) fn atomic_write(target: &Path, bytes: &[u8]) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Strip Windows' verbatim (`\\?\`) prefix, which `canonicalize` adds and
+/// nothing else in Markpad wants: the string reaches window titles, the recent
+/// files list and the tab bar, and several Win32 APIs reject it. `\\?\C:\a`
+/// becomes `C:\a` and `\\?\UNC\server\share` becomes `\\server\share`. A no-op
+/// everywhere else, so callers do not need to know the platform.
+fn strip_verbatim_prefix(path: PathBuf) -> PathBuf {
+    let text = match path.to_str() {
+        Some(text) => text,
+        // Not UTF-8: leave it alone rather than mangle it. The prefix is ASCII,
+        // so this only gives up on paths that could not round-trip anyway.
+        None => return path,
+    };
+    if let Some(rest) = text.strip_prefix(r"\\?\UNC\") {
+        return PathBuf::from(format!(r"\\{rest}"));
+    }
+    match text.strip_prefix(r"\\?\") {
+        Some(rest) => PathBuf::from(rest),
+        None => path,
+    }
+}
+
+/// The identity of a file, as the filesystem itself defines it.
+///
+/// Markpad compares paths to answer one question in three places — "is this
+/// the same file?" — and exact string equality gets it wrong three ways:
+///
+/// - **case**: `/notes/A.md` and `/notes/a.md` are one file on APFS and NTFS.
+/// - **Unicode normalization**: `café.md` spelled NFC and NFD are one file on
+///   APFS, and no amount of case folding makes those strings equal — they are
+///   different code points, not different cases.
+/// - **symlinks**: `notes/today.md` may be a link to `archive/2026-08-03.md`.
+///
+/// Which of those hold is a property of the **volume**, not of the platform:
+/// macOS can be formatted case-sensitive (APFSX), Linux can mount a
+/// case-insensitive volume, and the folding table used is the volume's, not
+/// Unicode's. That is why this asks the filesystem via `realpath`
+/// (`std::fs::canonicalize`) instead of guessing with `to_lowercase` — the
+/// guess is wrong in both directions, and being wrong in the "these are the
+/// same file" direction merges two genuinely different documents.
+///
+/// Symlinks are resolved deliberately. Every caller is really asking "would
+/// writing here destroy what that other buffer holds?", and for a link and its
+/// target the answer is yes — `atomic_write` above follows links precisely so
+/// that a write lands on the real file. Treating them as two documents is what
+/// would let two auto-save timers take turns overwriting one file.
+///
+/// A path that does not exist yet — Save As to a new name — has no canonical
+/// form, so the parent directory is canonicalized and the file name appended.
+/// That still folds and resolves the directory part, and the file name cannot
+/// be an alias of an existing file: if it were, the file would exist and the
+/// first branch would have handled it.
+pub(crate) fn canonical_identity(path: &Path) -> std::io::Result<PathBuf> {
+    match fs::canonicalize(path) {
+        Ok(resolved) => Ok(strip_verbatim_prefix(resolved)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            let Some(file_name) = path.file_name() else {
+                return Err(e);
+            };
+            let parent = match path.parent() {
+                Some(parent) if !parent.as_os_str().is_empty() => parent.to_path_buf(),
+                _ => PathBuf::from("."),
+            };
+            Ok(strip_verbatim_prefix(fs::canonicalize(parent)?).join(file_name))
+        }
+        Err(e) => Err(e),
+    }
+}
+
 /// Text decoded from a file, together with the fidelity of that decode.
 struct DecodedText {
     content: String,
@@ -443,6 +511,202 @@ mod tests {
             .unwrap()
             .as_nanos();
         std::env::temp_dir().join(format!("markpad-{tag}-{nonce}"))
+    }
+
+    /// A directory to work in, so the case/normalization probes below cannot
+    /// collide with anything else in the temp dir.
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir = temp_path(tag);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Does the volume `dir` lives on fold case? The tests below assert
+    /// different things depending on the answer, because the point of
+    /// `canonical_identity` is that it reports what the FILESYSTEM does rather
+    /// than what the platform usually does — a case-sensitive volume on macOS
+    /// and a case-insensitive volume on Linux both exist and both must work.
+    fn folds_case(dir: &Path) -> bool {
+        let upper = dir.join("CaseProbe.md");
+        fs::write(&upper, b"probe").unwrap();
+        let found = fs::metadata(dir.join("caseprobe.md")).is_ok();
+        fs::remove_file(&upper).unwrap();
+        found
+    }
+
+    #[test]
+    fn canonical_identity_reports_what_the_filesystem_does_about_case() {
+        let dir = temp_dir("canon-case");
+        let real = dir.join("Alpha.md");
+        fs::write(&real, b"body").unwrap();
+
+        let by_real = canonical_identity(&real).unwrap();
+        let lowered = dir.join("alpha.md");
+        // What the frontend consumes is whether these two come out EQUAL, so
+        // that is what gets asserted — not whether the lookup happened to
+        // succeed. Asking `is_err()` here tested the mechanism instead of the
+        // property, and got it wrong: on a case-sensitive volume the lowercase
+        // spelling names no file, but `canonical_identity` still answers for it
+        // through the parent-directory fallback that Save As depends on.
+        let by_lowered = canonical_identity(&lowered).ok();
+
+        // Either way, the identity is the name the DIRECTORY holds rather than
+        // the spelling that was asked for — otherwise the answer would depend
+        // on which spelling happened to be opened first.
+        assert_eq!(by_real.file_name().unwrap(), "Alpha.md");
+
+        if folds_case(&dir) {
+            // The two spellings name ONE file: opening both must not give two
+            // tabs, and saving through one must not be treated as a save to a
+            // different file. Both reduce to the same identity string, which
+            // is what lets the frontend keep comparing with `===`.
+            assert_eq!(
+                by_lowered.as_ref(),
+                Some(&by_real),
+                "one file must have one identity whichever way it is spelled",
+            );
+        } else {
+            // On a case-sensitive volume these are two different files and must
+            // keep being two. A `to_lowercase()` scheme would merge them here
+            // and quietly close a tab holding a genuinely different document —
+            // which is VS Code's open bug #123660, and the thing this whole
+            // approach exists to avoid.
+            assert_ne!(
+                by_lowered.as_ref(),
+                Some(&by_real),
+                "two files must keep two identities",
+            );
+        }
+
+        fs::remove_file(&real).unwrap();
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn canonical_identity_folds_unicode_normalization_when_the_volume_does() {
+        // APFS is normalization-INSENSITIVE as well as case-insensitive: a
+        // file written as NFC opens under its NFD spelling and vice versa.
+        // Case folding cannot reach this — the two strings differ in code
+        // points, not in case — so it is the clearest evidence that the
+        // question has to go to the filesystem.
+        //
+        // The two axes are independent, and all four combinations are real:
+        // default APFS folds both, case-sensitive APFS folds only
+        // normalization, NTFS folds only case, ext4 folds neither. So this
+        // probes normalization on its own rather than inferring it from the
+        // case answer or from the platform.
+        let dir = temp_dir("canon-nfd");
+        let nfc = dir.join("caf\u{e9}.md"); // café
+        let nfd = dir.join("cafe\u{301}.md"); // cafe + combining acute
+        fs::write(&nfc, b"body").unwrap();
+
+        let by_nfc = canonical_identity(&nfc).unwrap();
+        let by_nfd = canonical_identity(&nfd).ok();
+
+        if fs::metadata(&nfd).is_ok() {
+            assert_eq!(
+                by_nfd.as_ref(),
+                Some(&by_nfc),
+                "one file must have one identity whichever way it is spelled",
+            );
+        } else {
+            // A volume that keeps them apart really does have two files here,
+            // so the identities must stay apart too. As above, the assertion is
+            // on the identities and not on whether the lookup succeeded: the
+            // NFD spelling names nothing, but the parent-directory fallback
+            // still answers for it.
+            assert_ne!(
+                by_nfd.as_ref(),
+                Some(&by_nfc),
+                "two files must keep two identities",
+            );
+        }
+
+        fs::remove_file(&nfc).unwrap();
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonical_identity_resolves_a_symlink_to_its_target() {
+        // A link and its target are one file for every purpose Markpad has:
+        // `atomic_write` follows the link when it writes, so two tabs on the
+        // two names would be two auto-save timers on one document.
+        let dir = temp_dir("canon-link");
+        let target = dir.join("archive.md");
+        let link = dir.join("today.md");
+        fs::write(&target, b"body").unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        assert_eq!(
+            canonical_identity(&link).unwrap(),
+            canonical_identity(&target).unwrap(),
+        );
+
+        fs::remove_file(&link).unwrap();
+        fs::remove_file(&target).unwrap();
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn canonical_identity_still_answers_for_a_file_that_does_not_exist_yet() {
+        // Save As names a file that is not there yet, so `realpath` fails on
+        // it. The directory is still resolvable, and that is the part that
+        // carries the symlinks and the `..` segments.
+        let dir = temp_dir("canon-new");
+        let nested = dir.join("sub");
+        fs::create_dir_all(&nested).unwrap();
+
+        let indirect = nested.join("..").join("sub").join("fresh.md");
+        assert_eq!(
+            canonical_identity(&indirect).unwrap(),
+            canonical_identity(&nested).unwrap().join("fresh.md"),
+        );
+
+        // A missing DIRECTORY has no identity to report; the caller keeps the
+        // literal path, which is what it would have used anyway.
+        assert!(canonical_identity(&dir.join("nope").join("x.md")).is_err());
+
+        // The fallback must never manufacture the identity of a file that DOES
+        // exist — that would merge a Save As target into an unrelated open
+        // document. This is the property both branches above lean on whenever a
+        // volume distinguishes two spellings: the spelling that names nothing
+        // still gets an identity, and it has to be a different one.
+        //
+        // It runs on every platform and every volume, which matters because the
+        // two axes cannot all be reproduced on one machine: macOS folds Unicode
+        // normalization on every filesystem it mounts, so the "normalization
+        // distinguishes these" branch of the test above is only ever taken on
+        // Linux and Windows. This asserts the same underlying property here.
+        let existing = nested.join("taken.md");
+        fs::write(&existing, b"body").unwrap();
+        assert_ne!(
+            canonical_identity(&nested.join("not-taken.md")).unwrap(),
+            canonical_identity(&existing).unwrap(),
+            "a name that resolves to nothing must not borrow another file's identity",
+        );
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn verbatim_prefix_is_stripped_so_paths_stay_displayable() {
+        // `canonicalize` returns `\\?\C:\...` on Windows. That string reaches
+        // the tab bar, the window title and the recent-files list, and several
+        // Win32 APIs reject it, so it never leaves this module.
+        assert_eq!(
+            strip_verbatim_prefix(PathBuf::from(r"\\?\C:\notes\a.md")),
+            PathBuf::from(r"C:\notes\a.md"),
+        );
+        assert_eq!(
+            strip_verbatim_prefix(PathBuf::from(r"\\?\UNC\server\share\a.md")),
+            PathBuf::from(r"\\server\share\a.md"),
+        );
+        // Untouched everywhere else.
+        assert_eq!(
+            strip_verbatim_prefix(PathBuf::from("/notes/a.md")),
+            PathBuf::from("/notes/a.md"),
+        );
     }
 
     #[test]
@@ -3082,6 +3346,28 @@ async fn save_file_content(path: String, content: String) -> Result<(), String> 
     .unwrap_or_else(|e| Err(e.to_string()))
 }
 
+/// Resolve `path` to the identity the filesystem gives it — see
+/// `canonical_identity` for what that folds and why the filesystem, rather
+/// than a platform guess, is the thing being asked.
+///
+/// The frontend calls this once per path, when the path ENTERS the app, and
+/// keeps the answer on the tab (`Tab.pathKey`). Comparisons themselves stay
+/// synchronous string equality: `TabManager.claimPath` runs on every navigate
+/// and cannot become async without turning six sync call sites into promises.
+///
+/// Async because `realpath` walks the path component by component and can hit
+/// a network volume that is slow or unreachable.
+#[tauri::command]
+async fn canonicalize_path(path: String) -> Result<String, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        canonical_identity(Path::new(&path))
+            .map(|resolved| resolved.to_string_lossy().into_owned())
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .unwrap_or_else(|e| Err(e.to_string()))
+}
+
 #[tauri::command]
 fn print_pdf(window: tauri::WebviewWindow) -> Result<(), String> {
     window.print().map_err(|error| error.to_string())
@@ -3981,6 +4267,7 @@ pub fn run() {
             send_markdown_path,
             read_file_content,
             read_file_content_checked,
+            canonicalize_path,
             read_file_as_data_url,
             save_file_content,
             export_pdf_windows,

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -5,6 +5,7 @@ import { tabManager, type Tab } from '../stores/tabs.svelte.js';
 import { getMarkdownBodyWithoutFrontMatter } from '../utils/frontMatter.js';
 import { t } from '../utils/i18n.js';
 import { hasMarkdownLinkExtension } from '../utils/markdownLinks.js';
+import { canonicalizePath, isSameFilePath } from '../utils/pathIdentity.js';
 
 export type LoadMarkdownOptions = {
 	navigate?: boolean;
@@ -167,15 +168,17 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 	 * or Shift-JIS in the first place (that needs a real decoder), and this
 	 * only stops it from overwriting what it could not read.
 	 *
-	 * Known boundary: the comparison is exact string equality, so on a
-	 * case-insensitive filesystem (macOS, Windows) a Save As typed as
-	 * `/notes/Legacy.md` for a tab opened as `/notes/legacy.md` reads as a
-	 * different path and is allowed through. Closing that needs the backend
-	 * to canonicalize both sides; the same-path check is a courtesy on top of
-	 * the guard that matters, which is saveContent.
+	 * "The same file" is the filesystem's judgement, not the string's: a Save As
+	 * typed as `/notes/Legacy.md` for a tab opened as `/notes/legacy.md` is the
+	 * source file on macOS and Windows, and letting it through is the exact
+	 * destruction this guard exists to stop. The caller resolves the target once
+	 * — it has just come out of a dialog — and passes its identity here.
+	 * `targetPath !== tab.path` stays as the cheap first test so the common
+	 * Ctrl+S case never consults anything further.
 	 */
-	function refuseIfLossilyDecoded(tab: Tab, targetPath: string): boolean {
-		if (!tab.hasReplacementChars || targetPath === '' || targetPath !== tab.path) return false;
+	function refuseIfLossilyDecoded(tab: Tab, targetPath: string, targetKey?: string): boolean {
+		if (!tab.hasReplacementChars || targetPath === '') return false;
+		if (targetPath !== tab.path && !isSameFilePath({ path: targetPath, pathKey: targetKey }, tab)) return false;
 		console.warn('Refusing to overwrite a file that was decoded lossily', tab.path);
 		if (!lossySaveWarnedTabs.has(tab.id)) {
 			lossySaveWarnedTabs.add(tab.id);
@@ -214,17 +217,37 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 			if (loadOptions.resetScrollHistory || filePath !== options.currentFile()) {
 				options.resetScrollHistory();
 			}
+			// Ask the filesystem what file this path names, ONCE, before any of
+			// the decisions below. Every one of them is really a "same file?"
+			// question — is it already open, does it belong to the tab holding
+			// unsaved edits — and on macOS and Windows the string cannot answer
+			// it: `/notes/A.md` and `/notes/a.md` are one file, and so are the
+			// NFC and NFD spellings of an accented name.
+			//
+			// This is the only I/O added to the open path, and it is why the
+			// comparisons themselves can stay synchronous: the answer is put on
+			// the tab and reused. On failure `canonicalizePath` returns the path
+			// unchanged, so an unreachable volume degrades to today's behaviour
+			// rather than blocking the open.
+			const pathKey = await canonicalizePath(filePath);
+			const target = { path: filePath, pathKey };
+
 			if (loadOptions.navigate && tabManager.activeTab) {
 				pendingNavigateTabId = tabManager.activeTab.id;
 			} else if (!loadOptions.skipTabManagement) {
-				existing = tabManager.tabs.find((tab) => tab.path === filePath);
+				existing = tabManager.tabs.find((tab) => isSameFilePath(tab, target));
 				if (existing) tabManager.setActive(existing.id);
 				else if (tabManager.activeTab && tabManager.activeTab.path === '' && !tabManager.activeTab.isDirty && tabManager.activeTab.rawContent.trim() === '') {
-					tabManager.updateTabPath(tabManager.activeTab.id, filePath);
-				} else tabManager.addTab(filePath);
+					tabManager.updateTabPath(tabManager.activeTab.id, filePath, pathKey);
+				} else tabManager.addTab(filePath, '', pathKey);
 			}
 			const activeId = tabManager.activeTabId;
 			if (!activeId) return;
+			// Callers that manage tabs themselves — back/forward, a link opened
+			// in a new tab — put the path on the tab before getting here, so
+			// this is where those tabs learn their identity. Cheap and idempotent
+			// for the tabs that already have it.
+			tabManager.setTabPathKey(activeId, filePath, pathKey);
 
 			// Opening a file that is already open, in a tab that has unsaved
 			// edits, must not re-read it: the load below replaces rawContent AND
@@ -246,8 +269,12 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 			// Note the tab is found by `activeTabId`: whether the caller reached
 			// it by `setActive` on an already-open file, by `addTab` resolving to
 			// it, or by never having left it, the buffer at risk is the same one.
+			//
+			// The match is by file, not by string: reopening `/notes/A.md` while
+			// `/notes/a.md` sits here with unsaved edits is reopening THIS file,
+			// and comparing the spellings would miss it and overwrite the buffer.
 			const receiving = tabManager.tabs.find((item) => item.id === activeId);
-			if (receiving && receiving.isDirty && receiving.path === filePath && !loadOptions.discardUnsavedBuffer) {
+			if (receiving && receiving.isDirty && isSameFilePath(receiving, target) && !loadOptions.discardUnsavedBuffer) {
 				if (filePath) options.saveRecentFile(filePath);
 				await options.afterLoad();
 				return;
@@ -283,7 +310,7 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 				// file the user has since converted to UTF-8.
 				tabManager.setTabDecodedLossy(activeId, lossy);
 				lossySaveWarnedTabs.delete(activeId);
-				if (pendingNavigateTabId) tabManager.navigate(pendingNavigateTabId, filePath);
+				if (pendingNavigateTabId) tabManager.navigate(pendingNavigateTabId, filePath, pathKey);
 				const processed = await options.renderMarkdown(content, filePath);
 				tabManager.updateTabContent(activeId, processed);
 				// `isFull === false` means this is only the leading slice of a
@@ -338,7 +365,7 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 				const [content, lossy] = (await invoke('read_file_content_checked', { path: filePath })) as [string, boolean];
 				tabManager.setTabDecodedLossy(activeId, lossy);
 				lossySaveWarnedTabs.delete(activeId);
-				if (pendingNavigateTabId) tabManager.navigate(pendingNavigateTabId, filePath);
+				if (pendingNavigateTabId) tabManager.navigate(pendingNavigateTabId, filePath, pathKey);
 				if (tab) tab.isEditing = true;
 				tabManager.setTabRawContent(activeId, content);
 			}
@@ -364,6 +391,10 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 			return false;
 		}
 		let targetPath = tab.path;
+		// The tab's own path is already resolved, so the ordinary save — Ctrl+S,
+		// and the auto-save timer every 1.5s — adds no I/O here. Only the dialog
+		// branch below produces a path nobody has resolved yet.
+		let targetKey = tab.pathKey;
 		if (!targetPath) {
 			const selected = await save({
 				filters: [
@@ -374,15 +405,16 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 			});
 			if (!selected) return false;
 			targetPath = selected;
+			targetKey = await canonicalizePath(selected);
 		}
-		if (refuseIfLossilyDecoded(tab, targetPath)) return false;
+		if (refuseIfLossilyDecoded(tab, targetPath, targetKey)) return false;
 		const snapshot = tab.rawContent;
 		markSelfWrite(targetPath);
 		try {
 			await invoke('save_file_content', { path: targetPath, content: snapshot });
 			markSelfWrite(targetPath);
 			if (tab.path === '') {
-				tabManager.updateTabPath(tab.id, targetPath);
+				tabManager.updateTabPath(tab.id, targetPath, targetKey);
 				options.saveRecentFile(targetPath);
 			}
 			tab.originalContent = snapshot;
@@ -412,14 +444,17 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		});
 		if (!selected) return false;
 		// Picking the source file again in the dialog is the same destructive
-		// overwrite, just reached another way.
-		if (refuseIfLossilyDecoded(tab, selected)) return false;
+		// overwrite, just reached another way — and "again" includes naming it
+		// in a different case, or with the accents composed differently, both of
+		// which land on the very same file.
+		const selectedKey = await canonicalizePath(selected);
+		if (refuseIfLossilyDecoded(tab, selected, selectedKey)) return false;
 		const snapshot = tab.rawContent;
 		markSelfWrite(selected);
 		try {
 			await invoke('save_file_content', { path: selected, content: snapshot });
 			markSelfWrite(selected);
-			tabManager.updateTabPath(tab.id, selected);
+			tabManager.updateTabPath(tab.id, selected, selectedKey);
 			// The buffer now has a UTF-8 file of its own that it matches
 			// exactly, so it is safe to save from here on.
 			tabManager.setTabDecodedLossy(tab.id, false);

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -3,6 +3,7 @@ import { nextUntitledTitle } from '../utils/untitledTitle.js';
 import { settings } from './settings.svelte.js';
 import { hasRealFilePath } from '../utils/tabFileActions.js';
 import { buildTransferredTab, type TransferableTab } from '../utils/tabTransfer.js';
+import { canonicalizePath, isSameFilePath } from '../utils/pathIdentity.js';
 import {
 	canGoBackInHistory,
 	canGoForwardInHistory,
@@ -51,6 +52,29 @@ export interface Tab {
 	 * is a destroyed document, so the compiler asks every one of them.
 	 */
 	hasReplacementChars: boolean;
+	/**
+	 * `path` as the FILESYSTEM identifies it: case folded, Unicode normalized
+	 * and symlinks resolved, the way the volume itself does those (see the Rust
+	 * `canonical_identity`). This is what "same file" means; `path` stays
+	 * exactly what the user opened.
+	 *
+	 * The two are separate fields rather than one canonical `path` because
+	 * canonicalization is lossy in a way the user can see: it would retitle a
+	 * tab opened through a symlink after the link's target, rewrite the recent
+	 * files list and "Copy path" with a name the user never typed, and mutate
+	 * `path` on its own whenever a file is deleted and recreated under another
+	 * spelling. A path also cannot always be canonicalized — Save As names a
+	 * file that does not exist yet — so a single field would be canonical only
+	 * *sometimes*, which is worse than a second field that is explicitly either
+	 * known or not.
+	 *
+	 * Optional, and the safe direction: absent means "not resolved", and every
+	 * comparison then falls back to exact path equality — what it did before.
+	 * A construction site that forgets it therefore loses the improvement and
+	 * nothing else, which is why this is `?` where `hasReplacementChars`, whose
+	 * missing value would read as "safe to overwrite", is not.
+	 */
+	pathKey?: string;
 }
 
 class TabManager {
@@ -180,6 +204,15 @@ class TabManager {
 			this.activeTabId = restored.some((t) => t.id === data.activeTabId)
 				? data.activeTabId
 				: restored[0]?.id ?? null;
+			// Snapshots store paths as they were typed, and the restore reads
+			// each file directly rather than through `loadMarkdown`, so nothing
+			// else would ever resolve these. Without this a restored window sits
+			// outside the one-tab-per-file rule until every tab happens to be
+			// reopened. Resolving in the background is safe because it only ever
+			// ADDS an identity — no tab is closed or reassigned here.
+			for (const tab of restored) {
+				void canonicalizePath(tab.path).then((key) => this.setTabPathKey(tab.id, tab.path, key));
+			}
 		} catch (e) {
 			console.error('Failed to restore tab state', e);
 		}
@@ -213,19 +246,27 @@ class TabManager {
 	 * Only real file paths are exclusive: untitled tabs (`''`) and the home
 	 * sentinel are not files, and several untitled tabs are normal.
 	 *
-	 * Known boundary: paths are compared exactly, so on a case-insensitive
-	 * filesystem `/notes/A.md` and `/notes/a.md` still read as two files — the
-	 * same limitation `documentSession.refuseIfLossilyDecoded` documents; both
-	 * need the backend to canonicalize paths.
+	 * "The same path" means the same FILE, not the same string: `/notes/A.md`
+	 * and `/notes/a.md` are one file on macOS and Windows, and two tabs on them
+	 * are exactly the two auto-save timers this rule exists to prevent. The
+	 * caller supplies `pathKey` — the filesystem's own answer, resolved once
+	 * when the path entered the app — and `isSameFilePath` falls back to exact
+	 * equality when either side does not have one, which is what the callers
+	 * that cannot resolve a path yet get.
 	 */
-	private claimPath(path: string, claimantId: string) {
+	private claimPath(path: string, claimantId: string, pathKey?: string) {
 		if (!hasRealFilePath(path)) return;
-		for (const other of this.tabs.filter((t) => t.id !== claimantId && t.path === path)) {
+		const incoming = { path, pathKey };
+		for (const other of this.tabs.filter((t) => t.id !== claimantId && isSameFilePath(t, incoming))) {
 			if (!other.isDirty) {
 				this.closeTab(other.id);
 				continue;
 			}
 			other.path = '';
+			// The buffer no longer claims a file, so it must not keep the file's
+			// identity either — a stale key would make this tab collide with the
+			// next tab to open that file.
+			other.pathKey = undefined;
 			// The title still names the file the buffer came from — that is what
 			// makes the tab recognizable, and `saveContent` offers it as the
 			// default filename when the user places it.
@@ -234,14 +275,14 @@ class TabManager {
 		}
 	}
 
-	addTab(path: string, content: string = '') {
+	addTab(path: string, content: string = '', pathKey?: string) {
 		// Opening a file that is already open activates that tab instead of
 		// building a second buffer for it — VS Code and Sublime Text both
 		// resolve an open request to the existing view. `content` is ignored in
 		// that case on purpose: the open tab may hold unsaved edits, and a
 		// freshly read copy of the file would erase them.
 		if (hasRealFilePath(path)) {
-			const existing = this.tabs.find((t) => t.path === path);
+			const existing = this.tabs.find((t) => isSameFilePath(t, { path, pathKey }));
 			if (existing) {
 				this.activeTabId = existing.id;
 				return;
@@ -276,7 +317,8 @@ class TabManager {
 			splitRatio: 0.5,
 			isScrollSynced: false,
 			isTruncated: false,
-			hasReplacementChars: false
+			hasReplacementChars: false,
+			pathKey
 		});
 
 		this.activeTabId = id;
@@ -362,9 +404,17 @@ class TabManager {
 		);
 		// The destination window may already have this file open, which would
 		// leave the arriving buffer and the resident one saving over each other.
+		// The payload carries the path as the source window had it, not its
+		// identity, so this first claim compares literally.
 		this.claimPath(tab.path, tab.id);
 		this.tabs.push(tab);
 		this.activeTabId = tab.id;
+		// A transferred tab is never read from disk here — its buffer came with
+		// it — so nothing else would ever resolve its path, and it would sit out
+		// the one-tab-per-file rule for as long as it stayed open. Resolving it
+		// in the background cannot undo the claim above, but it does let every
+		// LATER open of the same file recognise this tab.
+		void canonicalizePath(tab.path).then((key) => this.setTabPathKey(tab.id, tab.path, key));
 		return tab.id;
 	}
 
@@ -465,6 +515,23 @@ class TabManager {
 		}
 	}
 
+	/**
+	 * Record the filesystem's answer for a tab whose path arrived through a
+	 * route that could not resolve it — back/forward, a link opened in a new
+	 * tab, a cross-window move, a restored window. `loadMarkdown` reads the
+	 * file anyway, so it resolves the path in the same breath and reports it
+	 * here, which is what turns those tabs from "unresolved, compared
+	 * literally" into full participants in the one-tab-per-file rule.
+	 *
+	 * Guarded on the path still matching: the tab may have been navigated
+	 * elsewhere while the resolution was in flight, and a key describing a file
+	 * the tab no longer holds is worse than no key at all.
+	 */
+	setTabPathKey(id: string, path: string, pathKey: string) {
+		const tab = this.tabs.find((t) => t.id === id);
+		if (tab && tab.path === path) tab.pathKey = pathKey;
+	}
+
 	updateTabScroll(id: string, scrollTop: number) {
 		const tab = this.tabs.find((t) => t.id === id);
 		if (tab) {
@@ -550,14 +617,15 @@ class TabManager {
 		this.activeTabId = this.tabs[nextIndex].id;
 	}
 
-	updateTabPath(id: string, path: string) {
+	updateTabPath(id: string, path: string, pathKey?: string) {
 		const tab = this.tabs.find((t) => t.id === id);
 		if (tab) {
 			// Save As can name a file that is already open here; the write has
 			// happened by the time this runs, so the other tab's buffer is
 			// already stale and must stop claiming the path.
-			this.claimPath(path, id);
+			this.claimPath(path, id, pathKey);
 			tab.path = path;
+			tab.pathKey = pathKey;
 			tab.title = path.split(/[/\\]/).pop() || 'Untitled';
 			tab.isDirty = false;
 			const fileHistory = replaceCurrentHistoryEntry({
@@ -571,11 +639,15 @@ class TabManager {
 		}
 	}
 
-	renameTab(id: string, newPath: string) {
+	renameTab(id: string, newPath: string, pathKey?: string) {
 		const tab = this.tabs.find((t) => t.id === id);
 		if (tab) {
-			this.claimPath(newPath, id);
+			this.claimPath(newPath, id, pathKey);
 			tab.path = newPath;
+			// The old key described the old name, so keeping it would make this
+			// tab answer "same file" for a file it no longer holds. Unset is the
+			// honest state until something resolves the new path.
+			tab.pathKey = pathKey;
 			tab.title = newPath.split(/[/\\]/).pop() || 'Untitled';
 			const fileHistory = replaceCurrentHistoryEntry({
 				currentPath: tab.path,
@@ -588,7 +660,7 @@ class TabManager {
 		}
 	}
 
-	navigate(id: string, path: string) {
+	navigate(id: string, path: string, pathKey?: string) {
 		const tab = this.tabs.find(t => t.id === id);
 		if (tab) {
 			if (tab.path === path) return;
@@ -598,7 +670,7 @@ class TabManager {
 			// declining the navigation is not an option: the tab would keep its
 			// old path and get the other document's content, and the next save
 			// would write it to the wrong file.
-			this.claimPath(path, id);
+			this.claimPath(path, id, pathKey);
 
 			const fileHistory = navigateFileHistory({
 				currentPath: tab.path,
@@ -610,6 +682,7 @@ class TabManager {
 			tab.historyIndex = fileHistory.historyIndex;
 
 			tab.path = path;
+			tab.pathKey = pathKey;
 			tab.title = path.split(/[/\\]/).pop() || 'Untitled';
 			tab.isDirty = false;
 			tab.scrollTop = 0;
@@ -633,11 +706,15 @@ class TabManager {
 			if (!result.path) return null;
 			const path = result.path;
 			// Back/forward walk this tab's own history, which can lead to a file
-			// that has since been opened in another tab.
+			// that has since been opened in another tab. History holds the paths
+			// as they were typed, not their identities, so this claim compares
+			// literally; the caller loads the file straight afterwards and
+			// `loadMarkdown` resolves the key then.
 			this.claimPath(path, id);
 			tab.history = result.history;
 			tab.historyIndex = result.historyIndex;
 			tab.path = path;
+			tab.pathKey = undefined;
 			tab.title = path.split(/[/\\]/).pop() || 'Untitled';
 			tab.isDirty = false;
 			return path;
@@ -655,6 +732,7 @@ class TabManager {
 			tab.history = result.history;
 			tab.historyIndex = result.historyIndex;
 			tab.path = path;
+			tab.pathKey = undefined;
 			tab.title = path.split(/[/\\]/).pop() || 'Untitled';
 			tab.isDirty = false;
 			return path;

--- a/src/lib/utils/pathIdentity.ts
+++ b/src/lib/utils/pathIdentity.ts
@@ -1,0 +1,64 @@
+import { invoke } from '@tauri-apps/api/core';
+import { hasRealFilePath } from './tabFileActions.js';
+
+/**
+ * Anything that holds a file path and may know its canonical identity. `Tab`
+ * satisfies it structurally, so the comparison below can be handed a tab
+ * directly without the store having to build a wrapper object.
+ */
+export interface PathIdentity {
+	path: string;
+	/**
+	 * `path` resolved by the filesystem — see the Rust `canonical_identity`.
+	 * Empty or absent means "not resolved", which is the honest answer for a
+	 * path that arrived through a route that has not asked yet, and for a
+	 * volume or file the resolution failed on.
+	 */
+	pathKey?: string;
+}
+
+/**
+ * Ask the filesystem what file `path` names. Resolves case, Unicode
+ * normalization and symlinks — see the Rust `canonical_identity` for why each
+ * of those is a filesystem question rather than a platform one.
+ *
+ * Falls back to the path itself when the backend cannot answer (an unreachable
+ * network volume, a missing parent directory, or a test harness that does not
+ * stub the command). That fallback is deliberately the status quo: comparing
+ * the literal path is what every one of these call sites did before, so a
+ * failure to resolve costs the improvement, never correctness that was already
+ * there.
+ */
+export async function canonicalizePath(path: string): Promise<string> {
+	if (!hasRealFilePath(path)) return '';
+	try {
+		const resolved = await invoke<string>('canonicalize_path', { path });
+		return typeof resolved === 'string' && resolved !== '' ? resolved : path;
+	} catch {
+		return path;
+	}
+}
+
+/**
+ * Do these two references name the same file?
+ *
+ * Synchronous on purpose. `TabManager.claimPath` runs on every navigate,
+ * back/forward, Save As and cross-window arrival; making the comparison async
+ * would turn six synchronous store methods into promises and spread through
+ * their callers, for a question that has already been answered once when the
+ * path entered the app. So the I/O happens at entry (`canonicalizePath`), the
+ * answer rides on the tab, and this stays string equality.
+ *
+ * Keys are trusted only when BOTH sides have one. A key compared against a raw
+ * path would be comparing two different kinds of string: `/notes/today.md` may
+ * be a symlink whose key is `/archive/2026-08-03.md`, so a raw path that
+ * happens to equal some other tab's key is not evidence of anything. When
+ * either side is unresolved this degrades to exact path equality — precisely
+ * the behaviour that existed before, so an entry point that has not been
+ * taught to resolve paths yet is no worse than it was.
+ */
+export function isSameFilePath(a: PathIdentity, b: PathIdentity): boolean {
+	if (!hasRealFilePath(a.path) || !hasRealFilePath(b.path)) return false;
+	if (a.pathKey && b.pathKey) return a.pathKey === b.pathKey;
+	return a.path === b.path;
+}


### PR DESCRIPTION
Three independent fixes hit the same wall and each left the same note in the code:

| | comparison | what breaks when the spelling differs |
|---|---|---|
| `refuseIfLossilyDecoded` | `targetPath !== tab.path` | Save As typed as `/notes/Legacy.md` for a tab opened as `/notes/legacy.md` writes mojibake over the original |
| `claimPath` (#413) | exact equality | two tabs on one file, two auto-save timers, each overwriting the other |
| the reopen guard (#412) | `receiving.path === filePath` | re-opening under another spelling discards unsaved edits |

**Three fixes writing "this needs the backend to canonicalize" is the signal it belongs at the source.**

## Case is not the whole problem

Verified on this machine before choosing anything:

```
write A.md → read via a.md   → same content, same inode (16146078)
write café.md as NFC → open as NFD → same inode
                     → open as CAFÉ.MD (upper + NFD) → same inode
```

**NFC and NFD are different code points, not different case.** `toLowerCase()` cannot reach that by construction — no amount of case folding makes `café` equal `café`. APFS is normalization-insensitive as well as case-insensitive, and asking the filesystem answers case, normalization **and** symlinks at once, using *that volume's* folding rules rather than ones we guessed.

(A process note worth recording: a first probe using Python's `os.path.realpath` suggested canonicalization was useless — Python does **not** fold case. Rust's `fs::canonicalize` goes through `realpath(3)` and returns the on-disk name. The conclusion was wrong until the probe was rewritten in the language that will actually run.)

## Identity is stored beside the path, not instead of it

Canonicalizing `tab.path` itself was tempting — it would have made four call sites I could not touch correct for free. It was rejected:

1. **It is lossy where the user can see it.** Open `~/notes/today.md` (a symlink) and the tab renames itself to `2026-08-03.md`; so do the title bar, Copy Path, and the recents entry. That is exactly the implicit behaviour change the project's own guidance argues against.
2. **It is unstable.** Delete the file and recreate it under another spelling and the canonical form changes, so `tab.path` mutates on its own.
3. **It cannot always be computed.** Save As names a file that does not exist yet, and `canonicalize` fails.

So `path` stays what the user opened and `pathKey` carries what the filesystem says. **The degradation direction is safe**: a missing key falls back to exact string equality — today's behaviour — so a missed entry point loses the improvement without introducing a bug.

Every one of the 12 assignments to `tab.path` is paired with a `pathKey` assignment; a stale key is worse than no key.

## What VS Code does, and why we can do better

Read from source rather than memory: `ExtUri.getComparisonKey` is `uri.path.toLowerCase()` behind `_ignorePathCasing`, decided by `uri.scheme === Schemas.file ? !isLinux : true` — **a platform heuristic, not a question to the filesystem**. `IUriIdentityService.asCanonicalUri` likewise uses a capability bit, and "canonical" means *the first spelling seen*, LRU-cached.

**It has the predicted bug on record**: [microsoft/vscode#123660](https://github.com/microsoft/vscode/issues/123660) — `foo.dart` and `FOO.DART` on a case-sensitive volume, only one shown, and the wrong one opened.

VS Code cannot do better: its file layer is abstract, with remote, virtual and in-memory providers and **no `canonicalize` to call**. Markpad's is `std::fs`. Deviating from the mainstream implementation here is deliberate, and the reason is that our constraints are looser.

One thing we copy exactly: **VS Code never rewrites the URI**, it only folds at comparison time. That is the same split as `path` / `pathKey`.

## Symlinks resolve

`atomic_write` already follows them on purpose ("resolve symlinks so we update the real file"). For the question all three guards are asking — *would writing here destroy the file behind that buffer* — a link and its target are already one file. Treating them as two documents produces exactly the two-timers-one-file race this is meant to prevent. Display is unaffected, which is the payoff of the two-field split.

`(dev, ino)` was considered and rejected: it would also fold hard links, but `atomic_write` writes a temp file and renames over the target, so **every save changes the inode** and a stored key goes stale immediately.

## Cost

`loadMarkdown` awaits one canonicalization **before any decision**, and that single I/O is what lets every later comparison be synchronous. `refuseIfLossilyDecoded` keeps `targetPath !== tab.path` as a cheap pre-check, so **Ctrl+S and the 1.5s auto-save add no I/O at all**.

## Behaviour on case-*sensitive* volumes

This is where `toLowerCase` breaks and asking does not. The Rust test **probes the volume's actual behaviour before asserting**:

- folding volume → both spellings map to one key, and the key is **the on-disk name** (not the first spelling opened, which would make the answer depend on open order);
- sensitive volume → `canonicalize('/vol/a.md')` returns `Err`, and the two files keep two identities. `toLowerCase` would have merged two genuinely distinct documents and then closed one of the user's tabs — vscode#123660.

The normalization test probes the same way (`if fs::metadata(&nfd).is_ok()`).

## Tests

`scripts/pathIdentityCaseFolding.test.ts` drives the real `TabManager` and `documentSession` against a stubbed backend. **The stub contains no `toLowerCase`** — it answers with the name stored in its directory, the way `realpath` does.

| vs `master` | **4 pass / 4 fail** → 8 / 8 |
|---|---|

One red per gap (② has two routes): *Save As under another spelling still overwrites the source* · *one file spelled two ways is one tab* (open route) · *…* (Save As route) · *following a link to another spelling of the current file does not destroy unsaved edits*. The four greens are the control group — a genuinely different file still gets its own tab, an explicit revert still discards, an unresolvable path still compares literally.

**The counter-proof caught a bad test of my own.** Gap ③'s first version simply re-opened the other spelling — and it was **green on `master`**, because `master` builds a duplicate tab, the content lands in the *new* one, and the old tab's edits survive. Gap ③ had degenerated into gap ②. It only reaches the #412 guard through `{ navigate: true }` — following a link the author wrote. Without running the counter-proof it would have shipped as a test that can never fail.

```
npm run check   436 files, 0 errors, 0 warnings
npm test        508 / 508   (was 500)
cargo test      136 / 136   (was 132)
cargo clippy    3 warnings, identical to baseline
```

One existing assertion was adjusted rather than overridden: `lossyDecodeSaveGuard.test.ts` matched `refuseIfLossilyDecoded(tab, selected)` literally and the signature gained a parameter. It is now a prefix match; both intents — *picking the source file again must be refused*, *the guard must precede `save_file_content`* — are unchanged, with a comment pointing at the new behavioural test.

## Not covered

**Recommended as the immediate follow-up:** `claimPath`'s *first* claim still compares literally in four entry points, all in `MarkdownViewer.svelte`, which was owned by another change while this was written — `goBack`/`goForward`, `renameTab`, `insertTransferredTab`, and `openMarkdownTargetInNewTab`'s `addTab`. All of them call `loadMarkdown` afterwards, and back-registration means every *subsequent* comparison is correct, but the claim itself can still create a duplicate tab that is not reclaimed. Closing it is roughly four small changes threading the resolved key through.

- **Hard links do not fold.** Two hard links to one inode canonicalize to two paths. Unsolvable by path — and `(dev, ino)` is ruled out above. A genuine dead end.
- `resolveExternalChange` still compares the watcher's path literally. Low risk (we supplied that path to `watch_file`, so it comes back as written), but incomplete.
- The recents list still de-duplicates literally, so two spellings can appear twice.
- `normalizeComparableMarkdownPath` still folds only Windows/UNC. It answers a different question — *does this link point at the open file* — but the two mechanisms now disagree in kind, and that is worth unifying later.
- **TOCTOU**: the key is resolved once. Delete and recreate under another spelling while the tab is open and it goes stale — worst case a *missed* merge, i.e. today's behaviour, never a *wrong* merge.
- Windows end-to-end is untested; `\\?\` stripping has a unit test, NTFS behaviour does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)