### PR TITLE
docs(security): record what confines mermaid's generated stylesheet

### DIFF
--- a/scripts/mermaidStyleScope.test.ts
+++ b/scripts/mermaidStyleScope.test.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+/*
+ * Mermaid emits a `<style>` block built partly from text the document
+ * controls, and `sanitizeDiagramSvg` deliberately lets it through — the
+ * document policy's `FORBID_TAGS: ['style']` would strip it and leave every
+ * diagram an unstyled skeleton. That makes "can a document write CSS that
+ * escapes its own diagram" a real question, and it was audited rather than
+ * assumed: ~110 payloads across every entry point a document controls
+ * (`classDef`, `style`, `linkStyle`, `themeVariables`, `fontFamily`,
+ * `themeCSS` via `%%{init}%%` and via YAML front matter, at-rules, label HTML,
+ * `securityLevel` self-override, textual `</style>` breakout), driven through
+ * the real Mermaid 11.16.0 in headless Chrome, measuring `getComputedStyle`
+ * and `elementFromPoint` on probes placed OUTSIDE the diagram.
+ *
+ * Result: no payload reached a selector matching an ancestor of the diagram's
+ * `<svg>`, so `.titlebar{display:none}` and `body::after{background-image:…}`
+ * are both unreachable. What holds it up is Mermaid-internal, in four
+ * independent places — none of them `sanitizeDiagramSvg`, which was measured
+ * to be a byte-for-byte pass-through for the style block in all 96 cases:
+ *
+ *   1. stylis' `addNamespace` middleware prefixes every emitted selector with
+ *      `#<svg-id>`, and CSS has no ancestor combinator.
+ *   2. `sanitizeCss`'s RUNNING brace-balance check (depth may never go
+ *      negative) is what stops a payload closing the `#<svg-id>{ … }` wrapper
+ *      early. Overall balance would not be enough.
+ *   3. The `CSSStyleSheet.replaceSync()` round-trip re-serialises only rules
+ *      the browser's own parser accepted, so raw text — `</style>`, unbalanced
+ *      constructs — cannot survive into the block.
+ *   4. `config.sanitize()` deletes any string option containing `<`, `>` or
+ *      `url(data:`, and any key on the `secure` list (which includes
+ *      `securityLevel`, so a document cannot lower it).
+ *
+ * `securityLevel` is NOT part of this. It governs HTML inside diagram labels;
+ * it does not gate CSS generation.
+ *
+ * TWO THINGS THIS FILE PINS, because both are currently held by accident
+ * rather than by design:
+ *
+ *   A. The `&` gap is real. stylis substitutes `&` with the namespace, and
+ *      `addNamespace` then skips a selector that already starts with it, so
+ *      `themeCSS: "& ~ *{display:none}"` emits `#<svg-id>~*{display:none}` —
+ *      measured live to hide a `<span>` placed next to the `<svg>`. It reaches
+ *      nothing in Markpad only because the `<svg>` is the sole child of its
+ *      container everywhere it is mounted.
+ *   B. A document can make its own `<svg>` `position:fixed` and cover the
+ *      whole preview pane. It cannot cross into the title bar only because
+ *      `.markdown-body` carries `transform: translate3d(0,0,0)` — added for
+ *      scroll performance — which makes it the containing block for fixed
+ *      descendants.
+ *
+ * These are source assertions: they cannot prove browser behaviour, only that
+ * the two conditions the audit measured are still the ones in the tree. The
+ * audit itself is the evidence; this file is the tripwire.
+ */
+
+const richContent = readFileSync('src/lib/utils/richContent.ts', 'utf8');
+const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+
+/** The block that builds and fills a `.mermaid-diagram` container. */
+function diagramMountBlock(): string {
+	const start = richContent.indexOf("container.className = 'mermaid-diagram'");
+	assert.notEqual(start, -1, 'the diagram container is no longer built here');
+	const end = richContent.indexOf('preEl.replaceWith(container)', start);
+	assert.notEqual(end, -1, 'the diagram container is no longer mounted here');
+	return richContent.slice(start, end);
+}
+
+test('the diagram container is filled by assignment, never appended to', () => {
+	// Invariant A: an `<svg>` with no siblings. Every mount point must replace
+	// the container's contents wholesale; an `appendChild` next to the svg is
+	// what re-arms the `&` gap.
+	const block = diagramMountBlock();
+	assert.match(
+		block,
+		/container\.innerHTML = sanitizeDiagramSvg\(svg\);/,
+		'the container must be filled by assignment, so the svg has no siblings',
+	);
+	assert.doesNotMatch(
+		block,
+		/container\.(appendChild|append|insertBefore|insertAdjacentHTML)\s*\(/,
+		'nothing may be placed next to the svg: the mermaid <style> can select its siblings',
+	);
+	// `.code-block-shell` also uses appendChild, which is fine — that wrapper
+	// holds no mermaid output. Scoping to the diagram block keeps this from
+	// forbidding appendChild across the whole module.
+});
+
+test('the reason the mermaid style block is let through is still written down', () => {
+	// The audit's value is that nobody has to redo it. If `sanitizeDiagramSvg`
+	// ever grows a `FORBID_TAGS`, or the explanation is deleted, the next
+	// reader is back to guessing.
+	assert.match(richContent, /function sanitizeDiagramSvg/);
+	assert.doesNotMatch(
+		richContent.slice(richContent.indexOf('function sanitizeDiagramSvg'), richContent.indexOf('function sanitizeDiagramSvg') + 400),
+		/FORBID_TAGS/,
+		'the diagram policy must not adopt the document policy; it would strip every diagram bare',
+	);
+	assert.match(richContent, /& ~ \*/, 'the measured `&` gap must stay documented at the container');
+});
+
+test('the preview body still creates a containing block for fixed positioning', () => {
+	// Invariant B. A document can set its own svg to `position: fixed`; this
+	// transform is what keeps that inside the preview pane instead of over the
+	// title bar. It is there for scroll performance, which means someone
+	// optimising scrolling could remove it without knowing what else it holds.
+	// It lives in the component's scoped style block, not styles.css.
+	assert.match(
+		viewer,
+		/transform:\s*translate3d\(0,\s*0,\s*0\)/,
+		'removing this transform lets a diagram position itself over the app chrome',
+	);
+});

--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -242,17 +242,21 @@ ${input.articleHtml}
  * That `<style>` is the one genuinely new thing an export now carries, so it is
  * worth being explicit about why it is acceptable here:
  *
- *   - It is namespaced. Mermaid compiles the block through stylis with a
- *     middleware that prefixes every rule with `#<svg-id>` and drops any at-rule
- *     outside a small allowlist (`@import` and `@font-face` are removed). The
- *     id is one Markpad generates, not one the document chose. So the block
- *     cannot restyle anything outside its own diagram, and cannot pull in a
- *     remote stylesheet or font.
- *   - It is not a new capability. A diagram's `classDef` declarations do reach
- *     the block, so a hostile document could in principle land a
- *     `url(https://…)` in it and have the exported file phone home when opened.
- *     But the export already leaves remote `<img src="https://…">` exactly as
- *     the author wrote it, and the export CSP allows `img-src https: http:`
+ *   - It is namespaced, and that was audited rather than assumed — about 110
+ *     payloads across every entry point a document controls, run through the
+ *     real Mermaid in a real browser, measuring computed styles on probes
+ *     outside the diagram. See `scripts/mermaidStyleScope.test.ts` for what
+ *     holds it up; the short version is that stylis prefixes every emitted
+ *     selector with `#<svg-id>`, and CSS has no ancestor combinator, so a rule
+ *     beginning with that id can only ever match the SVG or its descendants.
+ *     The id is one Markpad generates, never one the document chose.
+ *   - It is not a new capability. A hostile document can land a
+ *     `url(https://…)` in the block and have the exported file phone home when
+ *     opened — through `themeCSS`, set from a `%%{init}%%` directive or YAML
+ *     front matter. (Not through `classDef`, as an earlier version of this
+ *     comment said: the flowchart lexer rejects `url()` there outright.) But
+ *     the export already leaves remote `<img src="https://…">` exactly as the
+ *     author wrote it, and the export CSP allows `img-src https: http:`
  *     precisely so those keep working. A document that wants to beacon on open
  *     can already do it in one line of Markdown, with no diagram involved.
  *   - The exported file is a *less* privileged place for it than the preview,

--- a/src/lib/utils/richContent.ts
+++ b/src/lib/utils/richContent.ts
@@ -150,6 +150,19 @@ export async function renderRichContent(options: RenderRichContentOptions): Prom
 
 				const container = doc.createElement('div');
 				container.className = 'mermaid-diagram';
+				// Keep the `<svg>` the only child of this container. Mermaid's
+				// generated `<style>` is confined by an `#<svg-id>` prefix on
+				// every selector, with one measured exception: stylis
+				// substitutes `&` with that prefix, and the namespacing
+				// middleware then skips a selector that already starts with it.
+				// So `themeCSS: "& ~ *{display:none}"` emits
+				// `#<svg-id>~*{display:none}` — a rule that escapes the
+				// diagram and hits its *siblings*. It reaches nothing today
+				// only because there are no siblings. A caption, a copy
+				// button, or an overlay added here would re-arm it; put such
+				// things outside this element, or namespace them out of that
+				// selector's reach. Pinned by
+				// scripts/mermaidStyleScope.test.ts.
 				// Kept so the PDF path can rebuild the diagram with a light theme
 				// instead of recolouring Mermaid's output.
 				rememberDiagramSource(container, mermaidCode);


### PR DESCRIPTION
No behaviour change. Comments and one tripwire test.

## Why this was worth measuring

`sanitizeDiagramSvg` lets mermaid's `<style>` through **on purpose** — the document policy's `FORBID_TAGS: ['style']` would strip it and leave every diagram an unstyled skeleton. That block is built partly from text the document controls, and it is injected into the app's live document. Whether a document can write CSS that escapes its own diagram had never been measured, only assumed.

**Audit:** ~110 payloads across 16 entry points — `classDef` (flowchart and the laxer class/state parsers), `style`, `linkStyle`, `themeVariables`, `fontFamily`, `themeCSS` via `%%{init}%%` **and** via YAML front matter, at-rules (`@import`/`@font-face`/`@media`/`@layer`/`@scope`/`@supports`/`@container`/`@keyframes`), `securityLevel` self-override, `<style>` inside labels and `accTitle`, textual `</style>` breakout — driven through the real Mermaid 11.16.0 / DOMPurify 3.4.12 / stylis 4.3.6 in a real browser, measuring `getComputedStyle` and `elementFromPoint` on probes placed **outside** the diagram. One run went over real HTTP with a logging server.

**Result: no payload reached a selector matching an ancestor of the diagram's `<svg>`.** `.titlebar{display:none}` and an exfiltrating `body::after` are both unreachable.

## What actually holds it up — and what does not

**Not `sanitizeDiagramSvg`.** It was measured to be a **byte-for-byte pass-through** for the style block in all 96 cases. It is the control everyone assumes is doing this job, and it never touches it.

The confinement is mermaid-internal, in four independent places:

1. **stylis' `addNamespace` prefixes every emitted selector with `#<svg-id>`, and CSS has no ancestor combinator** — a rule starting with that id can only ever match the SVG or its descendants, whatever follows. The id is one Markpad generates.
2. **`sanitizeCss`'s *running* brace-balance check** (depth may never go negative) is what stops a payload closing the `#<svg-id>{ … }` wrapper early. Overall balance would not be enough.
3. **The `CSSStyleSheet.replaceSync()` round-trip** re-serialises only rules the browser's parser accepted, so raw text — `</style>`, unbalanced constructs — cannot survive.
4. **`config.sanitize()`** deletes any string option containing `<`, `>` or `url(data:`, and any key on the `secure` list.

`securityLevel` is **not** part of this — it governs HTML inside labels, not CSS generation — and a document cannot lower it anyway (`secure` list).

## Two things held by accident, now pinned

**A. The `&` gap is real.** stylis substitutes `&` with the namespace, and `addNamespace` then *skips* a selector that already starts with it. So:

```
themeCSS: "& ~ *{display:none}"   →   #mermaid-…~*{display:none;}
```

— no prefix, and it was **measured live** to hide a `<span>` placed next to the `<svg>`. It reaches nothing in Markpad **only because the `<svg>` is the sole child of its container** everywhere it is mounted. That is a DOM-shape invariant, not a designed defence: a caption, a copy button, or an overlay added inside `.mermaid-diagram` re-arms it. Now documented at the container and pinned by a test that fails if anything is appended next to the svg.

**B. A document can cover the preview pane.** Making its own SVG `position:fixed` with `!important` produces an opaque full-pane overlay that does not scroll away. It cannot cross into the title bar only because `.markdown-body` carries `transform: translate3d(0,0,0)` — added for **scroll performance** — which makes it the containing block for fixed descendants. Someone optimising scrolling could remove that without knowing what else it holds, so it is pinned too.

## Correction to this file's own comment

`export.ts` claimed `classDef` is the route by which a hostile document lands a `url(https://…)` beacon in the block. **The flowchart lexer rejects `url()` in `classDef`, `style` and `linkStyle` outright.** The working route is `themeCSS`, set from `%%{init}%%` or YAML front matter — confirmed on the wire, 4/4 beacons fetched. The conclusion is unaffected: parity with a plain remote `<img>`, which the export CSP allows precisely so author images keep working; **no new capability**.

## The test

`scripts/mermaidStyleScope.test.ts` — three source assertions plus a header carrying the audit's findings. These cannot prove browser behaviour; they are a tripwire that the two conditions the audit measured are still the ones in the tree. The audit is the evidence; this is what keeps it from silently expiring.

Scoped deliberately: the `appendChild` assertion covers only the block that builds and fills `.mermaid-diagram`, not the module — `.code-block-shell` legitimately appends, and forbidding it everywhere would be a rule about the wrong thing.

```
npm run check   435 files, 0 errors
npm test        503 / 503
```

## Coverage the audit did not achieve

- **Engine mismatch.** Everything ran in Chrome. Markpad ships on WKWebView (macOS), WebKitGTK (Linux) and WebView2 (Windows). Defence 3 depends on constructable stylesheets; `createCssStyles` calls `new CSSStyleSheet()` unconditionally, so an engine lacking it would fail the diagram outright rather than fall back — but that was not verified on WebKit. CSS parser strictness around `@scope`/`@container` also differs.
- **13 diagram types exercised, ~18 not.** `createUserStyles` is shared and per-diagram `getStyles` only receives regex-restricted `themeVariables`, so no difference is expected — **that is an inference, not a measurement**.
- **Not a proof of impossibility.** One gap was found in `addNamespace` and no other across ~110 payloads. "Tried hard, found only the `&` gap" is the claim; "no other gap exists" is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)