### PR TITLE
test: pin what the compiler cannot see, not how it is spelled

### DIFF
--- a/scripts/editorOptionWiring.test.ts
+++ b/scripts/editorOptionWiring.test.ts
@@ -86,12 +86,14 @@ test('tab cycling avoids Cmd+Tab, which macOS never delivers to the app', () => 
 		'no unconditional CtrlCmd+Shift+Tab binding',
 	);
 
+	// Back-reference rather than the literal `tabCycleModifier`: what has to hold
+	// is that the binding uses the same value the platform check produced, and
+	// the local holding it is free to be renamed.
 	assert.match(
 		editor,
-		/const tabCycleModifier = isMacPlatform\(\)\s*\?\s*monaco\.KeyMod\.WinCtrl\s*:\s*monaco\.KeyMod\.CtrlCmd/,
-		'modifier is chosen per platform: real Ctrl on macOS, CtrlCmd elsewhere',
+		/const (\w+) = isMacPlatform\(\)\s*\?\s*monaco\.KeyMod\.WinCtrl\s*:\s*monaco\.KeyMod\.CtrlCmd[\s\S]*?keybindings: \[\1 \| monaco\.KeyCode\.Tab\]/,
+		'modifier is chosen per platform (real Ctrl on macOS, CtrlCmd elsewhere) and tab-next uses it',
 	);
-	assert.match(editor, /keybindings: \[tabCycleModifier \| monaco\.KeyCode\.Tab\]/, 'tab-next uses the platform modifier');
 	assert.match(
 		editor,
 		/tabCycleModifier \| monaco\.KeyMod\.Shift \| monaco\.KeyCode\.Tab/,

--- a/scripts/foldKeys.test.ts
+++ b/scripts/foldKeys.test.ts
@@ -19,7 +19,7 @@ test('processMarkdownHtml promotes the anchor id onto the heading element', () =
 
 test('fold restore keys by heading id before falling back to text', () => {
 	const source = readFileSync('src/lib/utils/markdown.ts', 'utf8');
-	assert.match(source, /const key = h\.id \|\| h\.textContent/, 'restore key prefers the (now populated) heading id');
+	assert.match(source, /const \w+ = \w+\.id \|\| \w+\.textContent/, 'restore key prefers the (now populated) heading id');
 });
 
 test('viewer fold handlers key by heading id before falling back to text', () => {

--- a/scripts/mermaidPrintTheme.test.ts
+++ b/scripts/mermaidPrintTheme.test.ts
@@ -150,17 +150,38 @@ test('the helper is inert when there is nothing to re-render', async () => {
 });
 
 test('the PDF export wraps the print render and always restores', () => {
-	assert.match(viewer, /const restoreDiagrams = await renderDiagramsForPrint\(\{/);
-	assert.match(viewer, /\} finally \{\n\t\t\trestoreDiagrams\(\);\n\t\t\}/);
+	// Whatever the restore handle is called, a `finally` has to call it — an
+	// export that throws between the print render and the restore would otherwise
+	// leave every diagram on screen stuck in the print theme.
+	const handle = viewer.match(/(?:const|let)\s+([A-Za-z_$][\w$]*)\s*=\s*await renderDiagramsForPrint\(/);
+	assert.ok(handle, 'the PDF export must take a restore handle from renderDiagramsForPrint');
+	assert.match(
+		viewer,
+		new RegExp(`\\}\\s*finally\\s*\\{[^}]*\\b${handle![1]}\\(\\)`),
+		'the restore must run from a finally block',
+	);
+
 	// The screen render must record the source, or there is nothing to rebuild.
 	// It moved into the shared renderer in #4xx, when the HTML export started
 	// calling the same function; the assertion follows it rather than being
 	// relaxed, because "some path renders diagrams without remembering the
 	// source" is exactly the drift that deleted the markdown.ts copy.
-	assert.match(richContent, /rememberDiagramSource\(container, mermaidCode\);/);
-	// One theme decision, shared by the screen render and the restore: the
-	// viewer resolves it once and hands it to both.
-	assert.match(richContent, /mermaid\.initialize\(\{ startOnLoad: false, theme: options\.mermaidTheme \}\)/);
-	assert.match(viewer, /mermaidTheme: currentMermaidTheme\(\),/);
-	assert.match(viewer, /screenTheme: currentMermaidTheme\(\),/);
+	assert.match(richContent, /rememberDiagramSource\(\s*\w+\s*,\s*\w+\s*\)/);
+
+	// One theme decision, shared by the screen render and the restore. Asserted
+	// as "both options are fed the same expression" rather than as the literal
+	// `currentMermaidTheme()`: what must not drift is that the two agree, and the
+	// private helper producing the value is free to be renamed or inlined.
+	assert.match(
+		richContent,
+		/mermaid\.initialize\(\{[^}]*\btheme:\s*\w+\.mermaidTheme\b/,
+		'the shared renderer must use the theme it was handed, not resolve its own',
+	);
+	const screenTheme = viewer.match(/\bscreenTheme:\s*([^,\n]+),/);
+	assert.ok(screenTheme, 'the print render must be told the screen theme so it can restore it');
+	assert.match(
+		viewer,
+		new RegExp(`\\bmermaidTheme:\\s*${screenTheme![1].replace(/[.*+?^${}()|[\]\\]/g, '\\$&')},`),
+		'the on-screen render and the print restore must resolve the theme the same way',
+	);
 });

--- a/scripts/previewSanitize.test.ts
+++ b/scripts/previewSanitize.test.ts
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict';
-import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import { MARKDOWN_SANITIZE_CONFIG, ALLOWED_MARKDOWN_URI_REGEXP } from '../src/lib/utils/sanitize.js';
+import { SANITIZER_FILES, callSiteOffsets, enclosingFunctionName, filesMatching, readSourceFiles } from './sourceTree.js';
 
 // The preview is the path the `<style>` clause in the shared policy was written
 // for, and it was the one path not using it. `tab.content` (the rendered,
@@ -32,27 +32,48 @@ import { MARKDOWN_SANITIZE_CONFIG, ALLOWED_MARKDOWN_URI_REGEXP } from '../src/li
 // gets, and that is what these tests pin.
 const POC_STYLE = '<style>.titlebar{display:none} body{background-image:url("https://attacker.example/beacon")}</style>';
 
+const SOURCES = readSourceFiles('src');
 const viewerSource = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
 const sanitizeSource = readFileSync('src/lib/utils/sanitize.ts', 'utf8');
 const richContentSource = readFileSync('src/lib/utils/richContent.ts', 'utf8');
 
+/**
+ * The identifier the preview injects with `{@html}`, proved to be the shared
+ * sanitizer's output.
+ *
+ * The chain is what matters — something is declared from
+ * `sanitizeMarkdownHtml(...)` and *that* something is what reaches `{@html}` —
+ * so this reads the name out of the source instead of pinning it. The previous
+ * form spelled the whole declaration out (`let sanitizedHtml = $derived(...)`),
+ * which made the private binding name, the `let`, and the `$derived` wrapper
+ * into contract; renaming the variable or switching how it is computed would
+ * have failed the suite while the security property held.
+ */
+function sanitizedSinkName(): string {
+	const declaration = viewerSource.match(/(?:let|const)\s+([A-Za-z_$][\w$]*)\s*=\s*[^;\n]*\bsanitizeMarkdownHtml\(/);
+	assert.ok(declaration, 'the preview must derive what it injects from sanitizeMarkdownHtml');
+	return declaration![1];
+}
+
 test('the preview sanitizes through the shared policy, not a local config', () => {
 	assert.match(
 		viewerSource,
-		/import \{ sanitizeMarkdownHtml \} from '\.\/utils\/sanitize\.js'/,
+		/import\s*\{[^}]*\bsanitizeMarkdownHtml\b[^}]*\}\s*from\s*'[^']*\/sanitize\.js'/,
 		'the viewer must import the shared sanitizer',
 	);
-	assert.match(
-		viewerSource,
-		/let sanitizedHtml = \$derived\(sanitizeMarkdownHtml\(htmlContent\)\)/,
-		'the preview sink must run the shared sanitizer over tab.content',
-	);
 
-	// The regression itself: a DOMPurify call on the document HTML with a
-	// config assembled at the call site. Whatever that config contains, it is
-	// by construction not the shared one, and the `<style>` clause is exactly
-	// the kind of rule that gets left out of a copy.
-	assert.doesNotMatch(viewerSource, /DOMPurify\.sanitize\(\s*htmlContent/);
+	// The sink itself: every bare `{@html ident}` in the viewer injects the
+	// sanitizer's output and nothing else. Stated over *all* of them rather than
+	// over one known-good spelling, so adding a second injection point of the raw
+	// document is a failure instead of an unnoticed addition.
+	const injected = [...new Set([...viewerSource.matchAll(/\{@html\s+([A-Za-z_$][\w$]*)\s*\}/g)].map((m) => m[1]))];
+	assert.deepEqual(injected, [sanitizedSinkName()], 'the preview sink must inject the shared sanitizer output');
+
+	// The regression itself — a DOMPurify call with a config assembled at the
+	// call site — is caught for the whole tree by the call-site allowlist below;
+	// the viewer is not on it. What stays here is the other half of that
+	// regression, which the allowlist cannot see: the viewer hand-copied the URI
+	// pattern out of the shared policy.
 	assert.doesNotMatch(
 		viewerSource,
 		/ALLOWED_URI_REGEXP/,
@@ -76,40 +97,26 @@ test('the shared policy the preview now gets is the one that forbids author styl
 // silently reintroduces a private policy — this file exists because that is
 // precisely what happened. Pin the set of call sites: a document that reaches
 // the DOM must go through `sanitizeMarkdownHtml`, and anything else has to
-// justify itself here.
-const SANITIZE_CALL_SITES: Record<string, number> = {
-	// The shared policy itself.
-	'src/lib/utils/sanitize.ts': 1,
-	// Mermaid's own SVG output, not a user's markdown: it needs `foreignObject`
-	// (which the document policy does not allow) and it depends on the inline
-	// `<style>` the document policy forbids, so it is deliberately a different
-	// configuration on a different input. Verified in a browser: the pinned
-	// DOMPurify keeps mermaid's `<style>` under the diagram config and strips it
-	// under MARKDOWN_SANITIZE_CONFIG, which would flatten every diagram.
-	// It sits next to the only thing that produces diagrams, which is now the
-	// renderer the preview and the HTML export share.
-	'src/lib/utils/richContent.ts': 1,
-};
-
-function walk(dir: string): string[] {
-	const out: string[] = [];
-	for (const name of readdirSync(dir)) {
-		const path = join(dir, name);
-		if (statSync(path).isDirectory()) out.push(...walk(path));
-		else if (/\.(ts|svelte|js)$/.test(name)) out.push(path);
-	}
-	return out;
-}
-
+// justify itself.
+//
+// The allowlist itself (`sanitize.ts`, which owns the document policy, and
+// `richContent.ts`, which sanitizes Mermaid's own SVG under a deliberately
+// different config — it needs `foreignObject` and the inline `<style>` the
+// document policy forbids, verified in a browser against the pinned DOMPurify)
+// lives in scripts/sourceTree.ts, because singleImplementationConvention.test.ts
+// pins the *import* sites against the same two files. It used to be written out
+// in both places, so widening one and forgetting the other was a silent way to
+// end up with one scan guarding a set the other had already given up on.
 test('DOMPurify call sites in src are the allowlisted ones', () => {
-	const found: Record<string, number> = {};
-	for (const path of walk('src')) {
-		const count = readFileSync(path, 'utf8').split('DOMPurify.sanitize(').length - 1;
-		if (count > 0) found[path.replace(/\\/g, '/')] = count;
-	}
+	// A per-file occurrence count used to be asserted here as well. It is dropped
+	// on purpose: what a reviewer has to approve is *which files* may configure a
+	// sanitizer, and "richContent.ts calls it once, not twice" made every
+	// refactor inside an already-approved file a test failure. A second config in
+	// an allowlisted file is still visible — the two tests below pin what each of
+	// the two configs must contain.
 	assert.deepEqual(
-		found,
-		SANITIZE_CALL_SITES,
+		filesMatching(SOURCES, /DOMPurify\.sanitize\(/),
+		SANITIZER_FILES,
 		'unexpected DOMPurify.sanitize call site — rendered markdown goes through sanitizeMarkdownHtml',
 	);
 });
@@ -128,16 +135,24 @@ test('the two paths keep their opposite orders on purpose', () => {
 	// (scripts/exportSanitize.test.ts pins that). The preview processes first
 	// and sanitizes at the sink, so the string that reaches `{@html}` is exactly
 	// the sanitizer's output — there is no parse/serialize round trip after the
-	// filter has run. Pin the shape so the difference cannot be "tidied up"
+	// filter has run. Pin the order so the difference cannot be "tidied up"
 	// into a weaker one without reading why.
-	const renderCall = viewerSource.indexOf('return processMarkdownHtml(html, filePath, collapsedHeaders);');
-	const sinkCall = viewerSource.indexOf('let sanitizedHtml = $derived(sanitizeMarkdownHtml(htmlContent))');
-	assert.ok(renderCall !== -1, 'renderMarkdownPreview must process the renderer output');
-	assert.ok(sinkCall !== -1, 'the sink must sanitize');
+	//
+	// The order is what is asserted, by naming the function each half runs in.
+	// The previous form searched for the two statements verbatim — down to the
+	// argument list `(html, filePath, collapsedHeaders)` and the trailing
+	// semicolon — which pinned three private parameter names and a formatting
+	// choice as the price of checking which call happens where.
+	assert.deepEqual(
+		callSiteOffsets(viewerSource, 'processMarkdownHtml').map((offset) => enclosingFunctionName(viewerSource, offset)),
+		['renderMarkdownPreview'],
+		'renderMarkdownPreview must be the one place that processes the renderer output',
+	);
 	assert.doesNotMatch(
 		viewerSource,
 		/processMarkdownHtml\(\s*sanitizeMarkdownHtml/,
 		'the preview must not move the filter ahead of processing without revisiting the note above',
 	);
-	assert.match(viewerSource, /\{@html sanitizedHtml\}/, 'the sink injects the sanitized string');
+	// The sink half — that what `{@html}` injects is the sanitizer's output — is
+	// asserted over every injection point in the first test above.
 });

--- a/scripts/recentFilesMultiWindow.test.ts
+++ b/scripts/recentFilesMultiWindow.test.ts
@@ -202,9 +202,9 @@ test('only this key, and a wholesale clear, count as a remote change', () => {
 const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
 
 test('every mutation goes through the read-modify-write helper', () => {
-	assert.match(viewer, /recentFiles = updateStoredRecentFiles\(\(current\) => promoteRecentFile\(current, path\)\)/);
-	assert.match(viewer, /recentFiles = updateStoredRecentFiles\(\(current\) => dropRecentFile\(current, path\)\)/);
-	assert.match(viewer, /recentFiles = updateStoredRecentFiles\(\(current\) => renameRecentFile\(current, oldPath, newPath\)\)/);
+	assert.match(viewer, /recentFiles = updateStoredRecentFiles\(\((\w+)\) => promoteRecentFile\(\1, path\)\)/);
+	assert.match(viewer, /recentFiles = updateStoredRecentFiles\(\((\w+)\) => dropRecentFile\(\1, path\)\)/);
+	assert.match(viewer, /recentFiles = updateStoredRecentFiles\(\((\w+)\) => renameRecentFile\(\1, oldPath, newPath\)\)/);
 	assert.equal(viewer.match(/updateStoredRecentFiles\(/g)?.length, 3, 'exactly three call sites, all of them shown above');
 });
 

--- a/scripts/renderPipelineConvention.test.ts
+++ b/scripts/renderPipelineConvention.test.ts
@@ -1,55 +1,42 @@
 import assert from 'node:assert/strict';
-import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
+
+import { callSiteOffsets, enclosingFunctionName } from './sourceTree.js';
 
 // Every preview render must go through renderMarkdownPreview, which strips
 // YAML front matter before invoking the Rust renderer. Calling the raw
 // `invoke('render_markdown')` command anywhere else silently bypasses that
 // step — the compiler cannot catch it because the command name is a string.
-// This test pins the exact set of files allowed to touch the raw command.
+//
+// Which *files* may name the raw command is a single-implementation question and
+// is pinned by the RULES table in singleImplementationConvention.test.ts. What is
+// left here is the half that table cannot express: inside the viewer, the raw
+// command must sit in renderMarkdownPreview and nowhere else.
 //
 // If you add a new render call site, use renderMarkdownPreview (or
 // renderTabPreviewFromRaw for the full render-and-apply sequence) instead
 // of widening the allowlist.
 
-const RAW_COMMAND = "invoke('render_markdown'";
+const VIEWER = 'src/lib/MarkdownViewer.svelte';
+const WRAPPER = 'renderMarkdownPreview';
 
-const ALLOWED: Record<string, number> = {
-	// The pipeline helper itself — the one legitimate caller.
-	'src/lib/MarkdownViewer.svelte': 1,
-	// Export strips front matter on its own before rendering.
-	'src/lib/utils/export.ts': 1,
-};
-
-function walk(dir: string): string[] {
-	const out: string[] = [];
-	for (const name of readdirSync(dir)) {
-		const path = join(dir, name);
-		if (statSync(path).isDirectory()) out.push(...walk(path));
-		else if (/\.(ts|svelte|js)$/.test(name)) out.push(path);
-	}
-	return out;
-}
-
-test('raw render_markdown invocations appear only at allowlisted sites', () => {
-	const found: Record<string, number> = {};
-	for (const path of walk('src')) {
-		const count = readFileSync(path, 'utf8').split(RAW_COMMAND).length - 1;
-		if (count > 0) found[path.replace(/\\/g, '/')] = count;
-	}
-	assert.deepEqual(
-		found,
-		ALLOWED,
-		'unexpected raw render_markdown call site — render through renderMarkdownPreview instead',
+test('every raw render_markdown call in the viewer sits inside renderMarkdownPreview', () => {
+	const viewer = readFileSync(VIEWER, 'utf8');
+	const offsets = callSiteOffsets(viewer, 'invoke').filter((offset) =>
+		/^invoke\(\s*'render_markdown'/.test(viewer.slice(offset)),
 	);
-});
 
-test('the viewer occurrence lives inside renderMarkdownPreview', () => {
-	const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
-	assert.match(
-		viewer,
-		/async function renderMarkdownPreview[\s\S]{0,400}?invoke\('render_markdown'/,
-		'renderMarkdownPreview must be the function wrapping the raw command',
+	// Not "there is exactly one occurrence, and something matching the wrapper
+	// name appears within 400 characters of it". That form passed as soon as a
+	// single call was wrapped and stopped guarding the moment the function grew
+	// past the window; this one names the enclosing function of *each* call, so a
+	// second bypassing call site inside the same file is a failure rather than an
+	// off-by-one in a character budget.
+	assert.ok(offsets.length > 0, `${VIEWER} no longer invokes render_markdown — has the render path moved?`);
+	assert.deepEqual(
+		offsets.map((offset) => enclosingFunctionName(viewer, offset)),
+		offsets.map(() => WRAPPER),
+		`the raw render_markdown command must be invoked from ${WRAPPER}, which strips front matter first`,
 	);
 });

--- a/scripts/singleImplementationConvention.test.ts
+++ b/scripts/singleImplementationConvention.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { join } from 'node:path';
 import test from 'node:test';
+
+import { SANITIZER_FILES, filesMatching, readSourceFiles } from './sourceTree.js';
 
 // A fixed behavior must have exactly one implementation.
 //
@@ -15,6 +15,16 @@ import test from 'node:test';
 // each read one hard-coded file, so a second copy living anywhere else is
 // invisible to them. Every rule below therefore scans the whole `src` tree and
 // pins *which files* are allowed to contain the marker.
+//
+// A marker is only allowed to be something the compiler cannot see for itself:
+// an exported symbol or type name, a magic string handed to another language or
+// library (a Tauri command, a Monaco language id, a CSS custom property), or the
+// literal shape of a defect that must never come back. A marker must never be a
+// private identifier — a parameter name, a local variable, a helper that nothing
+// outside its own file can reach. `every rule keeps at least one live
+// implementation` below turns every marker into something a rename can break, so
+// pinning a private name would promote it to a public contract and make ordinary
+// local refactoring fail this suite for no behavioural reason.
 //
 // To add a behavior: append a row. `allowed` is the complete set of src-relative
 // paths permitted to match `marker`; anything else is a duplicate implementation.
@@ -34,7 +44,7 @@ const RULES: Rule[] = [
 		name: 'mermaid rendering remembers the diagram source',
 		why: 'PDF/HTML export re-renders Mermaid in the light theme from data-mermaid-source; a render path without rememberDiagramSource exports blank or dark-themed diagrams (#359).',
 		marker: /mermaid\.render\(/g,
-		allowed: ['src/lib/utils/richContent.ts', 'src/lib/utils/mermaidPrint.ts'],
+		allowed: ['src/lib/utils/mermaidPrint.ts', 'src/lib/utils/richContent.ts'],
 		requires: {
 			pattern: /rememberDiagramSource/,
 			message: 'a Mermaid render site must record the source via rememberDiagramSource',
@@ -42,9 +52,15 @@ const RULES: Rule[] = [
 	},
 	{
 		name: 'Mermaid theme resolution has one implementation',
-		why: 'resolveMermaidTheme in mermaidPrint.ts is shared by the on-screen render and the print restore so the two cannot drift; a hand-rolled dark/neutral ternary is that drift.',
-		marker: /["']dark["']\s*:\s*["']neutral["']/g,
-		allowed: ['src/lib/utils/mermaidPrint.ts'],
+		why: 'resolveMermaidTheme in mermaidPrint.ts is shared by the on-screen render and the print restore so the two cannot drift; a second site deciding the theme is that drift.',
+		// Pins the exported helper, not the `'dark' : 'neutral'` ternary inside it:
+		// the ternary is one of many spellings of the same decision (an if/else or
+		// double quotes slipped straight past), while what actually has to stay
+		// single is the function both paths call. What the function *returns* for
+		// each appearance setting is checked for real — by calling it — in
+		// mermaidPrintTheme.test.ts.
+		marker: /resolveMermaidTheme\s*\(/g,
+		allowed: ['src/lib/MarkdownViewer.svelte', 'src/lib/utils/mermaidPrint.ts'],
 	},
 	{
 		name: 'editor scroll-sync max is measured from content height',
@@ -66,52 +82,60 @@ const RULES: Rule[] = [
 	{
 		name: 'DOMPurify is configured in one place',
 		why: 'The sanitize contract lives in utils/sanitize.ts; an inline DOMPurify config elsewhere is a second, unreviewed sanitizer.',
+		// Import sites, so an aliased `import purify from "dompurify"` cannot slip
+		// past the `DOMPurify.sanitize(` call-site scan in previewSanitize.test.ts.
+		// Both scans read the same allowlist so a new sanitizer is one decision.
 		marker: /from\s+["']dompurify["']/g,
-		allowed: ['src/lib/utils/sanitize.ts', 'src/lib/utils/richContent.ts'],
+		allowed: SANITIZER_FILES,
+	},
+	{
+		name: 'the raw render_markdown command has one set of call sites',
+		why: 'Every preview render must go through renderMarkdownPreview, which strips YAML front matter before invoking the Rust renderer; a raw invoke elsewhere renders the front matter as body text. The command name is a string, so the compiler cannot see the call at all.',
+		// The viewer half — that its one occurrence sits inside
+		// renderMarkdownPreview rather than merely in the same file — is pinned by
+		// renderPipelineConvention.test.ts.
+		marker: /invoke\(\s*'render_markdown'/g,
+		allowed: ['src/lib/MarkdownViewer.svelte', 'src/lib/utils/export.ts'],
 	},
 	{
 		name: 'rich-content rendering has one implementation',
 		why: 'utils/richContent.ts owns the render pipeline (highlight.js + KaTeX + Mermaid) for both the preview and the HTML export; a second renderRichContent is a fork that drifts from it — which is exactly how the export ended up shipping raw LaTeX and unhighlighted code.',
 		// The viewer keeps a same-named wrapper that supplies the live element and
-		// the copy-button behaviour, so the marker pins the implementation (the
-		// one that takes an options object) rather than the name.
-		marker: /function\s+renderRichContent\s*\(\s*options/g,
+		// the copy-button behaviour, so the marker has to separate the two. It does
+		// that on the exported options *type* — a real contract the export imports
+		// — rather than on the parameter being spelled `options`, which is private
+		// to the implementation and free to be renamed.
+		marker: /function\s+renderRichContent\s*\([^)]*\bRenderRichContentOptions\b/g,
 		allowed: ['src/lib/utils/richContent.ts'],
 	},
 	{
 		name: 'editor language mapping has one implementation',
-		why: 'A second extension-to-language table drifts from the one the editor actually uses.',
-		marker: /function\s+getLanguage\s*\(/g,
+		why: 'A second extension-to-language table drifts from the one the editor actually uses, and the editor then opens a file under the wrong Monaco grammar.',
+		// Pins the Monaco language id the table falls back to, not the private
+		// `getLanguage` helper that happens to hold it today: 'plaintext' is a
+		// magic string Monaco defines and TypeScript cannot check, and any second
+		// extension table has to name it too.
+		marker: /return '(?:plaintext)'/g,
 		allowed: ['src/lib/MarkdownViewer.svelte'],
 	},
 	{
 		name: 'highlight color palette has one definition',
-		why: 'A second palette drifts from the one bound to the --highlight-color custom property.',
-		marker: /(?:const|let)\s+highlightColorMap\b/g,
+		why: 'A second palette drifts from the one bound to the --highlight-color custom property, so find highlights and the settings preview disagree.',
+		// Pins the custom property the palette feeds — the actual contract with
+		// styles.css and FindBar.svelte, and a string no type system reads —
+		// instead of the private `highlightColorMap` binding that produces it.
+		marker: /--highlight-color:/g,
 		allowed: ['src/lib/MarkdownViewer.svelte'],
 	},
 ];
 
-function walk(dir: string): string[] {
-	const out: string[] = [];
-	for (const name of readdirSync(dir)) {
-		const path = join(dir, name);
-		if (statSync(path).isDirectory()) out.push(...walk(path));
-		else if (/\.(ts|svelte|js)$/.test(name)) out.push(path);
-	}
-	return out;
-}
-
-const SOURCES = walk('src').map((path) => ({
-	path: path.replace(/\\/g, '/'),
-	text: readFileSync(path, 'utf8'),
-}));
+const SOURCES = readSourceFiles('src');
 
 for (const rule of RULES) {
 	test(`single implementation: ${rule.name}`, () => {
-		const matched = SOURCES.filter(({ text }) => new RegExp(rule.marker.source, rule.marker.flags).test(text));
+		const matched = filesMatching(SOURCES, rule.marker);
 
-		const unexpected = matched.map(({ path }) => path).filter((path) => !rule.allowed.includes(path));
+		const unexpected = matched.filter((path) => !rule.allowed.includes(path));
 		assert.deepEqual(
 			unexpected,
 			[],
@@ -119,7 +143,8 @@ for (const rule of RULES) {
 		);
 
 		if (rule.requires) {
-			for (const { path, text } of matched) {
+			for (const path of matched) {
+				const text = SOURCES.find((source) => source.path === path)!.text;
 				assert.match(text, rule.requires.pattern, `${path}: ${rule.requires.message}`);
 			}
 		}
@@ -131,7 +156,9 @@ test('every rule keeps at least one live implementation', () => {
 	// (renamed symbol, deleted feature) and is silently no longer guarding.
 	for (const rule of RULES) {
 		if (rule.allowed.length === 0) continue;
-		const matched = SOURCES.some(({ text }) => new RegExp(rule.marker.source, rule.marker.flags).test(text));
-		assert.ok(matched, `rule "${rule.name}" matches nothing in src — update its marker or drop the rule`);
+		assert.ok(
+			filesMatching(SOURCES, rule.marker).length > 0,
+			`rule "${rule.name}" matches nothing in src — update its marker or drop the rule`,
+		);
 	}
 });

--- a/scripts/sourceTree.ts
+++ b/scripts/sourceTree.ts
@@ -1,0 +1,83 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Shared plumbing for the few tests that have to read `src/` as text.
+//
+// They exist because some contracts are invisible to the compiler: a Tauri
+// command name is a string, `.svelte` files cannot be imported by the Node test
+// runner, and "this behaviour has exactly one implementation" is not a type.
+// Everything else belongs in a test that imports the real function and runs it.
+//
+// Three copies of `walk()` used to live in singleImplementationConvention,
+// renderPipelineConvention and previewSanitize; the DOMPurify allowlist was
+// maintained twice. One copy each, here.
+
+export type SourceFile = { path: string; text: string };
+
+/** Every compilable source file under `dir`, with forward-slash paths. */
+export function walkSourceFiles(dir: string): string[] {
+	const out: string[] = [];
+	for (const name of readdirSync(dir)) {
+		const path = join(dir, name);
+		if (statSync(path).isDirectory()) out.push(...walkSourceFiles(path));
+		else if (/\.(ts|svelte|js)$/.test(name)) out.push(path.replace(/\\/g, '/'));
+	}
+	return out;
+}
+
+export function readSourceFiles(dir: string): SourceFile[] {
+	return walkSourceFiles(dir).map((path) => ({ path, text: readFileSync(path, 'utf8') }));
+}
+
+/** src-relative paths of the files that contain `marker`, sorted. */
+export function filesMatching(sources: SourceFile[], marker: RegExp): string[] {
+	return sources
+		.filter(({ text }) => new RegExp(marker.source, marker.flags.replace('g', '')).test(text))
+		.map(({ path }) => path)
+		.sort();
+}
+
+/**
+ * The only files allowed to hand DOMPurify a configuration.
+ *
+ * `sanitize.ts` owns the document policy; `richContent.ts` sanitizes Mermaid's
+ * own SVG output, which needs `foreignObject` and the inline `<style>` the
+ * document policy forbids — a different input under a deliberately different
+ * config. Both `previewSanitize.test.ts` (call sites) and
+ * `singleImplementationConvention.test.ts` (imports) key off this one list, so
+ * adding a sanitizer is one edit and one decision instead of two.
+ */
+export const SANITIZER_FILES = ['src/lib/utils/richContent.ts', 'src/lib/utils/sanitize.ts'];
+
+/**
+ * The name of the top-level `<script>`/module function whose body contains
+ * `index`, or null if the offset sits outside every function.
+ *
+ * Used instead of "the two strings appear within N characters of each other":
+ * a proximity window silently stops guarding when the function grows, and it
+ * cannot see a *second* call site that escaped the wrapper entirely. Both files
+ * this serves declare their functions at one level of indentation, which is
+ * what makes the enclosing function findable without parsing braces (and
+ * without being fooled by braces inside strings, regexes or Svelte templates).
+ */
+export function enclosingFunctionName(text: string, index: number): string | null {
+	const declarations = [...text.matchAll(/\n\t(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(/g)];
+	let enclosing: string | null = null;
+	for (const declaration of declarations) {
+		if (declaration.index! > index) break;
+		enclosing = declaration[1];
+	}
+	return enclosing;
+}
+
+/** Byte offsets of every `name(` call in `text`, skipping import statements. */
+export function callSiteOffsets(text: string, name: string): number[] {
+	const offsets: number[] = [];
+	const pattern = new RegExp(`\\b${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\(`, 'g');
+	for (const match of text.matchAll(pattern)) {
+		const lineStart = text.lastIndexOf('\n', match.index!) + 1;
+		if (/^\s*import\b/.test(text.slice(lineStart, match.index!))) continue;
+		offsets.push(match.index!);
+	}
+	return offsets;
+}

--- a/scripts/tocEditorJump.test.ts
+++ b/scripts/tocEditorJump.test.ts
@@ -8,8 +8,8 @@ const toc = readFileSync('src/lib/components/Toc.svelte', 'utf8');
 
 test('ToC editor jumps use the clicked heading source line, not duplicate heading text', () => {
 	assert.match(toc, /onjump\?: \(id: string, text: string, sourceLine: number \| null\) => void;/);
-	assert.match(toc, /const sourceLine = Number\(el\.dataset\.sourcepos\?\.match\(\/\^\(\\d\+\):\/\)\?\.\[1\]\);/);
+	assert.match(toc, /const \w+ = Number\(\w+\.dataset\.sourcepos\?\.match\(\/\^\(\\d\+\):\/\)\?\.\[1\]\)/);
 	assert.match(viewer, /onjump=\{\(id: string, text: string, sourceLine: number \| null\) => \{[\s\S]*?editorPane\.revealHeader\(sourceLine, text\);/);
 	assert.match(editor, /export function revealHeader\(sourceLine: number \| null, text: string\)/);
-	assert.match(editor, /const lineNumber = sourceLine \?\? 0;[\s\S]*?revealLineInCenterIfOutsideViewport\(lineNumber,/);
+	assert.match(editor, /const (\w+) = sourceLine \?\? 0;[\s\S]*?revealLineInCenterIfOutsideViewport\(\1,/);
 });

--- a/scripts/wikilinkFileTargets.test.ts
+++ b/scripts/wikilinkFileTargets.test.ts
@@ -81,9 +81,23 @@ test('the extension list the rewriter mirrors still matches markdownLinks.ts', (
 	}
 });
 
-test('Copy Reference still emits the wikilink form the rewriter parses', () => {
-	// Both call sites (document context menu and the TOC context menu) build
-	// `[[<basename without extension>#<heading>]]`.
-	const emitted = [...viewerSource.matchAll(/`\[\[\$\{(?:fn|filename)\}#\$\{[^}]+\}\]\]`/g)];
-	assert.equal(emitted.length, 3, `Copy Reference reference format changed: ${emitted.length} call sites matched`);
+test('every wikilink Copy Reference builds carries the heading the rewriter needs', () => {
+	// The rewriter only rewrites heading-bearing forms; a bare `[[Notes]]` stays
+	// literal text (see the scope note above). So the contract is that *every*
+	// `[[...]]` the viewer writes to the clipboard contains a `#`.
+	//
+	// Asserted that way round rather than as "three call sites match
+	// `[[${fn}#${...}]]`". That form hard-coded the local variable names holding
+	// the basename — renaming `fn` broke it — and the count, so adding a fourth
+	// correct Copy Reference entry failed while replacing one of the three with a
+	// broken bare form still left three matches and passed.
+	const emitted = [...viewerSource.matchAll(/`\[\[[^`]*\]\]`/g)].map((match) => match[0]);
+	assert.ok(emitted.length > 0, 'Copy Reference no longer builds a wikilink — has the format moved?');
+	for (const wikilink of emitted) {
+		assert.match(
+			wikilink,
+			/#/,
+			`${wikilink}: a wikilink without a heading is left as literal text by process_wikilinks()`,
+		);
+	}
 });


### PR DESCRIPTION
No production code changes. `git status src src-tauri` is empty.

## The problem, measured

The suite grew quickly, and **674 of its assertions read source text rather than run code**. Some of those have no alternative: `invoke` passes a command name as a plain string that no compiler checks, *"this behaviour has one implementation"* is not expressible in types, and Svelte components cannot be imported under node (`.svelte.ts` stores throw `$state is not defined` under `tsx` — verified).

But a large share had drifted a layer too low — pinning private identifiers, parameter names, a statement's literal punctuation, and in one case a `finally` block matched down to **three tabs of indentation**. A local rename then fails a test, which is friction rather than safety.

**The count barely moved: 674 → 668.** This is a composition change, not a trim.

## Result, measured two ways

| Probe | Before | After |
|---|---|---|
| **Nine pure private renames** (no behaviour change) | **5 tests red** | **0 red** |
| **Sixteen injected regressions** | 15 / 16 caught | **16 / 16** |
| Copies of `function walk(dir)` in `scripts/` | 3, md5-identical | 0 |
| DOMPurify allowlists maintained by hand | 2 | 1 |
| Tests / duration | 501 / 3.51s | 501 / 3.46s |

### The one the old suite missed

`invoke('render_markdown')` moving **out of** `renderMarkdownPreview` — bypassing front-matter stripping — while the file still contained exactly one occurrence, ~120 characters after the wrapper's declaration. The old assertion was `count === 1` plus a `[\s\S]{0,400}` proximity window, and it stayed green. Naming the **enclosing function** of every raw call catches it, with no count and no window.

## Where the markers moved to

| Was | Now | Why |
|---|---|---|
| `/["']dark["']:["']neutral["']/` — the ternary's literal spelling | `resolveMermaidTheme\(` | An exported symbol. The old form was evadable by writing `if/else` |
| `function renderRichContent\(\s*options` — the **parameter name** | `RenderRichContentOptions` | The exported **type** is the contract the export imports |
| `function getLanguage\(` — a private 25-line helper | `return 'plaintext'` | The Monaco magic string TypeScript cannot check, which any second extension table must also name |
| `const highlightColorMap` — a private binding | `--highlight-color:` | The CSS custom property — the actual contract with `styles.css` and `FindBar.svelte` |
| `indexOf('return processMarkdownHtml(html, filePath, collapsedHeaders);')` | enclosing-function check | Three parameter names and a semicolon were load-bearing |
| `(?:fn\|filename)` local names + `emitted.length === 3` | every `[[…]]` template must contain `#` | The old form let you replace one of the three sites with a broken bare form and stay green at 3 |
| `let sanitizedHtml = $derived(sanitizeMarkdownHtml(htmlContent))` | read the sink identifier, then assert **every** bare `{@html ident}` is that one | Adding a *second* raw injection point now fails; before it did not |

Three assertions got **stronger**, not merely looser. New `scripts/sourceTree.ts` holds the ex-duplicate walker, the ex-duplicate allowlist, and `enclosingFunctionName` / `callSiteOffsets` — the replacements for proximity windows and verbatim-statement matching. It carries the rule in a comment: *a marker may be an exported symbol, a cross-language or library magic string, or the literal shape of a fixed defect — never a private identifier.*

## Kept deliberately

- **The three classes that reproduce defects that really happened**: `asset.localhost.evil.test` prefix forgery, CRLF handling, path case / NFC-NFD. Untouched.
- **Two rules pinning a defect's literal shape** — `getScrollHeight() - …height` (#316) and `createElement('iframe')` (#388), both `allowed: []`. The criterion protects exactly this.
- **`previewRenderRevision.test.ts` and `viewerDisposal.test.ts`** pin private locals and are brittle by the criterion — but they are the **only** coverage of a stale async render overwriting a newer one, and of listeners leaking past component destroy. The logic lives inside `.svelte`, and no name-free formulation still pins the check. Per "nothing else catches it → do not delete": kept, and flagged here as known-brittle.
- **Exhaustive-count assertions** (`updateStoredRecentFiles(` ×3, `discardUnsavedBuffer: true` ×2). These close over an enumerated list — *"these three, shown above, and no others"* — which is the legitimate single-implementation shape, unlike `emitted.length === 3`, which enumerated nothing.

## Verification of the verification

Each of the 18 changes lists which mutation proves the replacement still fires; every mutation was reverted with `git checkout`. Independently re-run here: a legal rename (`npm run check` 0 errors, proving it compiles) leaves **501/501 green**, and breaking `mermaid.render` plus planting a duplicate theme ternary in `export.ts` turns **2 tests red**.

```
npm run check   435 files, 0 errors
npm test        501 / 501
cargo test      131 / 131
```

## Not covered

- The behavioural half of the sanitizer story still cannot run under node (DOMPurify needs a real DOM); `previewSanitize.test.ts` still records a browser-measured result in a comment.
- Two markers remain heuristics a determined rewrite can evade (`return 'plaintext'`, `--highlight-color:`). Strictly better than the private names they replace, but grep-based single-implementation rules are heuristics, not proofs.
- `lossyDecodeSaveGuard.test.ts` has the same smells but is being rewritten in #416; left alone to avoid a conflict.
- Making `.svelte` logic importable — extracting `getLanguage` and friends into `src/lib/utils/` — would be the real fix for a whole tier of these tests. That is production surgery and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)