### PR TITLE
perf(preview): stop redrawing unchanged mermaid diagrams on every keystroke

### DIFF
--- a/scripts/diagramCache.test.ts
+++ b/scripts/diagramCache.test.ts
@@ -1,0 +1,327 @@
+/**
+ * The preview re-renders the whole article on a 16ms debounce — in split mode,
+ * and in edit mode with the TOC open, that is about once per keystroke — and
+ * `{@html sanitizedHtml}` swaps the entire block, which puts every
+ * `<pre><code class="language-mermaid">` back. So every diagram was redrawn from
+ * scratch on every keystroke. Measured in a headless browser on a document with
+ * 44 diagrams and 132 code blocks, one pass cost 2.2–2.5s, of which
+ * `mermaid.render` was all but ~30ms.
+ *
+ * These tests pin the two halves of the fix that can go wrong quietly:
+ *
+ *   - The *cache*: what must miss (a changed character, a changed theme) and
+ *     what the bounds are. A memo that never misses is a correctness bug and a
+ *     memo that never evicts is a leak; neither shows up as a failure on screen.
+ *   - The *re-identification*: Mermaid bakes the id it is handed into the
+ *     diagram's `<style>` selectors, its markers and the `url(#…)` that point at
+ *     them, so a reused SVG has to be stamped with a fresh id. Two copies of one
+ *     diagram sharing an id is the failure mode that looks fine on screen right
+ *     up until a marker or a style rule resolves against the wrong diagram.
+ *
+ * Mermaid itself is stood in for at the library boundary — the same seam the
+ * export tests use — because the real one needs layout to size a node. What the
+ * fake reproduces is the id scheme, which is the part this code depends on, and
+ * which was read off real Mermaid 11 output: every id and every `url(#…)`
+ * carries the svg id, *except* sequence diagrams, whose actor groups are
+ * numbered from a module counter (`actor44`, `root-44`) and are referenced by
+ * nothing.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { installShimDom } from './renderProtocolDom.ts';
+
+installShimDom();
+(globalThis as any).window = globalThis;
+
+const DOMPurify = (await import('dompurify')).default as any;
+DOMPurify.sanitize = (html: string) => html;
+
+const { renderRichContent } = await import('../src/lib/utils/richContent.ts');
+const { resetDiagramCache, templateDiagramSvg, fillDiagramTemplate } = await import(
+	'../src/lib/utils/diagramCache.ts'
+);
+
+// ---------------------------------------------------------------- fixtures
+
+interface Recorder {
+	renders: Array<{ id: string; source: string; theme: string }>;
+	themes: string[];
+}
+
+/**
+ * The id scheme of real Mermaid output: the svg id prefixes the style block's
+ * selectors, the arrow marker and the reference to it.
+ */
+function svgFor(id: string, source: string, theme: string, extra = ''): string {
+	return (
+		`<svg id="${id}" role="graphics-document">` +
+		`<style>#${id} .node rect{fill:${theme === 'dark' ? '#333' : '#eee'};}</style>` +
+		`<defs><marker id="${id}_flowchart-pointEnd"></marker></defs>` +
+		`<path marker-end="url(#${id}_flowchart-pointEnd)"></path>` +
+		extra +
+		`<foreignObject><div>${source.trim()}</div></foreignObject>` +
+		`</svg>`
+	);
+}
+
+function libraries(record: Recorder, extraFor: (source: string, id: string) => string = () => '') {
+	let theme = 'neutral';
+	return {
+		hljs: { highlightElement() {} },
+		// The renderer refuses to run without these; the diagrams are what is
+		// under test, so they do nothing.
+		katex: { render() {} },
+		renderMathInElement() {},
+		mermaid: {
+			initialize(config: { theme: string }) {
+				theme = config.theme;
+				record.themes.push(config.theme);
+			},
+			async render(id: string, source: string) {
+				record.renders.push({ id, source, theme });
+				return { svg: svgFor(id, source, theme, extraFor(source, id)) };
+			},
+		},
+	};
+}
+
+function articleWith(...sources: string[]): string {
+	return sources
+		.map((source) => `<pre><code class="language-mermaid">${source}</code></pre>`)
+		.join('\n');
+}
+
+function newRecorder(): Recorder {
+	return { renders: [], themes: [] };
+}
+
+let idCounter = 0;
+/** Unique per call, like the real one, and readable in a failure message. */
+function ids(): (index: number) => string {
+	const run = idCounter++;
+	return (index: number) => `mermaid-${run}-${index}`;
+}
+
+async function render(
+	html: string,
+	options: { record: Recorder; theme?: string; extraFor?: (source: string, id: string) => string },
+): Promise<any> {
+	const root = (globalThis as any).document.createElement('div');
+	root.innerHTML = html;
+	await renderRichContent({
+		root,
+		libraries: libraries(options.record, options.extraFor) as any,
+		mermaidTheme: options.theme ?? 'neutral',
+		idFactory: ids(),
+	});
+	return root;
+}
+
+function idsIn(html: string): string[] {
+	return [...html.matchAll(/\sid="([^"]*)"/g)].map((match) => match[1]);
+}
+
+// ------------------------------------------------------------------- tests
+
+test('a second pass over the same document draws nothing again', async () => {
+	resetDiagramCache();
+	const article = articleWith('graph TD; A-->B;', 'graph LR; C-->D;');
+
+	const first = newRecorder();
+	const before = await render(article, { record: first });
+	assert.equal(first.renders.length, 2);
+
+	const second = newRecorder();
+	const after = await render(article, { record: second });
+	assert.deepEqual(second.renders, [], 'the second pass must not call mermaid.render at all');
+
+	// Same drawing, not just the same count: identifiers aside, the reused SVG
+	// is what Mermaid produced.
+	const normalise = (html: string) =>
+		html
+			.replace(/\sid="[^"]*"/g, ' id="X"')
+			.replace(/url\(#[^)]*\)/g, 'url(#X)')
+			.replace(/#mermaid-[\w-]*/g, '#X');
+	assert.equal(normalise(after.innerHTML), normalise(before.innerHTML));
+});
+
+test('changing one character of a diagram redraws it', async () => {
+	resetDiagramCache();
+	const warm = newRecorder();
+	await render(articleWith('graph TD; A-->B;'), { record: warm });
+
+	const typed = newRecorder();
+	await render(articleWith('graph TD; A-->Bc;'), { record: typed });
+	assert.deepEqual(
+		typed.renders.map((call) => call.source),
+		['graph TD; A-->Bc;'],
+	);
+});
+
+test('changing the theme redraws every diagram, and the old theme is still warm', async () => {
+	resetDiagramCache();
+	const source = 'graph TD; Theme-->Switch;';
+
+	const light = newRecorder();
+	const lightRoot = await render(articleWith(source), { record: light, theme: 'neutral' });
+	assert.equal(light.renders.length, 1);
+	assert.match(lightRoot.innerHTML, /fill:#eee/);
+
+	const dark = newRecorder();
+	const darkRoot = await render(articleWith(source), { record: dark, theme: 'dark' });
+	assert.equal(dark.renders.length, 1, 'a theme switch must not reuse the other theme’s colours');
+	assert.match(darkRoot.innerHTML, /fill:#333/);
+
+	// Switching back is a hit: both themes live in the cache at once, so a user
+	// toggling appearance does not pay twice.
+	const back = newRecorder();
+	const backRoot = await render(articleWith(source), { record: back, theme: 'neutral' });
+	assert.deepEqual(back.renders, []);
+	assert.match(backRoot.innerHTML, /fill:#eee/);
+});
+
+test('two copies of one diagram never share an id', async () => {
+	resetDiagramCache();
+	const source = 'graph TD; Same-->Twice;';
+	const record = newRecorder();
+
+	// Even on the very first pass the second copy is a cache hit, so this is the
+	// case the cache creates and the case it has to get right.
+	const root = await render(articleWith(source, source), { record });
+	assert.equal(record.renders.length, 1);
+
+	const all = idsIn(root.innerHTML);
+	assert.equal(all.length, 4, 'two diagrams, each with an svg id and a marker id');
+	assert.equal(new Set(all).size, 4, `duplicate ids in the document: ${all.join(', ')}`);
+
+	// The re-identification has to be complete, not just applied to the `<svg>`:
+	// each copy's style block and marker reference must point at its own id.
+	const [firstSvg, secondSvg] = root.innerHTML.split('<svg ').slice(1);
+	for (const [svgId, svg] of [
+		[all[0], firstSvg],
+		[all[2], secondSvg],
+	] as const) {
+		assert.ok(svg.includes(`<style>#${svgId} .node rect`), `style block not re-pointed for ${svgId}`);
+		assert.ok(svg.includes(`url(#${svgId}_flowchart-pointEnd)`), `marker not re-pointed for ${svgId}`);
+	}
+});
+
+test('a reused diagram still carries its source for the PDF re-render', async () => {
+	resetDiagramCache();
+	const source = 'graph TD; Print-->Me;';
+	await render(articleWith(source), { record: newRecorder() });
+
+	const reused = newRecorder();
+	const root = await render(articleWith(source), { record: reused });
+	assert.deepEqual(reused.renders, []);
+	// `mermaidPrint` finds diagrams by this attribute; a cached container without
+	// it would silently print dark diagrams on paper.
+	assert.match(root.innerHTML, /class="mermaid-diagram" data-mermaid-source="graph TD; Print-->Me;"/);
+});
+
+test('ids Mermaid does not namespace are namespaced by the cache', async () => {
+	resetDiagramCache();
+	// A sequence diagram's actor ids come from a module counter, not from the
+	// svg id — two copies of one diagram would otherwise both say `actor7`.
+	const source = 'sequenceDiagram; A->>B: hi';
+	const record = newRecorder();
+	const root = await render(articleWith(source, source), {
+		record,
+		extraFor: () => '<g id="actor7"><g id="root-7"></g></g>',
+	});
+
+	assert.equal(record.renders.length, 1);
+	const all = idsIn(root.innerHTML);
+	assert.equal(new Set(all).size, all.length, `duplicate ids in the document: ${all.join(', ')}`);
+	// The drawn copy keeps exactly what Mermaid emitted — the cache changes
+	// nothing about a miss. The reused copy is the one that has to be moved out
+	// of the way, and it lands under its own svg id.
+	assert.equal(all.filter((id) => id === 'actor7').length, 1);
+	assert.equal(all.filter((id) => id !== 'actor7' && id.endsWith('-actor7')).length, 1);
+});
+
+test('a diagram whose stray id is referenced is not cached at all', async () => {
+	resetDiagramCache();
+	// The cache renames stray declarations but does not rewrite references to
+	// them. If a future Mermaid points at one, the honest answer is to redraw.
+	const source = 'graph TD; Referenced-->Stray;';
+	const record = newRecorder();
+	await render(articleWith(source), {
+		record,
+		extraFor: () => '<clipPath id="halo"></clipPath><rect clip-path="url(#halo)"></rect>',
+	});
+
+	const again = newRecorder();
+	await render(articleWith(source), {
+		record: again,
+		extraFor: () => '<clipPath id="halo"></clipPath><rect clip-path="url(#halo)"></rect>',
+	});
+	assert.equal(again.renders.length, 1, 'an un-templatable diagram must be redrawn, not reused');
+});
+
+test('the cache is bounded by entry count', async () => {
+	resetDiagramCache();
+	// 128 entries is the cap. Fill past it and the first one must be gone.
+	const first = 'graph TD; N0-->X;';
+	await render(articleWith(first), { record: newRecorder() });
+	for (let i = 1; i <= 128; i++) {
+		await render(articleWith(`graph TD; N${i}-->X;`), { record: newRecorder() });
+	}
+
+	const evicted = newRecorder();
+	await render(articleWith(first), { record: evicted });
+	assert.equal(evicted.renders.length, 1, 'the oldest entry must have been evicted');
+
+	// …and the most recent one is still there.
+	const kept = newRecorder();
+	await render(articleWith('graph TD; N128-->X;'), { record: kept });
+	assert.deepEqual(kept.renders, []);
+});
+
+test('the cache is bounded by size, not only by count', async () => {
+	resetDiagramCache();
+	// Eight ~400k-character diagrams are only eight entries but 3.2M characters,
+	// which is over the budget: a handful of enormous diagrams must not sit in
+	// memory forever just because they are few.
+	const bulk = (n: number) => `graph TD; Big${n}["${'x'.repeat(400_000)}"];`;
+	const first = bulk(0);
+	await render(articleWith(first), { record: newRecorder() });
+	for (let i = 1; i < 8; i++) await render(articleWith(bulk(i)), { record: newRecorder() });
+
+	const evicted = newRecorder();
+	await render(articleWith(first), { record: evicted });
+	assert.equal(evicted.renders.length, 1);
+});
+
+test('a diagram is redrawn rather than reused when its own text spells out the slot', async () => {
+	resetDiagramCache();
+	// The template marks where the id goes with a literal token. A diagram whose
+	// text contains that token cannot be templated without rewriting the user's
+	// own text, so it is left uncached.
+	const source = 'graph TD; A["{{markpad-diagram-id}}"];';
+	await render(articleWith(source), { record: newRecorder() });
+	const again = newRecorder();
+	await render(articleWith(source), { record: again });
+	assert.equal(again.renders.length, 1);
+});
+
+// ------------------------------------------------- the templating, on its own
+
+test('templating refuses anything it cannot re-identify', () => {
+	// The id it was told about is not the one in the markup: nothing to lift out.
+	assert.equal(templateDiagramSvg('<svg id="other"></svg>', 'mine'), null);
+	// A referenced stray id.
+	assert.equal(
+		templateDiagramSvg('<svg id="mine"><clipPath id="halo"/><g clip-path="url(#halo)"/></svg>', 'mine'),
+		null,
+	);
+
+	const template = templateDiagramSvg('<svg id="mine"><style>#mine{fill:red}</style></svg>', 'mine');
+	assert.ok(template);
+	assert.equal(
+		fillDiagramTemplate(template as string, 'fresh'),
+		'<svg id="fresh"><style>#fresh{fill:red}</style></svg>',
+	);
+});

--- a/src/lib/utils/diagramCache.ts
+++ b/src/lib/utils/diagramCache.ts
@@ -1,0 +1,167 @@
+/**
+ * A memo for rendered Mermaid diagrams, keyed by the only two inputs that
+ * decide what Mermaid draws: the diagram source and the theme.
+ *
+ * Why this exists: the preview re-renders the whole article on a 16ms debounce
+ * — in split mode, and in edit mode with the TOC open, that is roughly once per
+ * keystroke — and `{@html sanitizedHtml}` swaps the entire block, which puts
+ * every `<pre><code class="language-mermaid">` back. So every diagram was drawn
+ * from scratch on every keystroke. Measured on a 44-diagram document, one pass
+ * spent ~2.3s in `mermaid.render` and ~30ms in everything else.
+ *
+ * ## The one hard part: the svg id is baked into the output
+ *
+ * Mermaid's renderer, given an id and a source, does not return an
+ * id-independent string. (This module never calls it — `richContent.ts` is the
+ * one render site, and `singleImplementationConvention.test.ts` keeps it that
+ * way.) The id it is given prefixes the diagram's `<style>` selectors (`#id
+ * .node rect{…}`),
+ * every arrow marker's `id`, and every `url(#id_flowchart-v2-pointEnd)` that
+ * points at one. Handing the same bytes back for a second diagram would put a
+ * duplicate id in the document; handing back a *stale* id would be fine on its
+ * own but is indistinguishable, from the DOM's point of view, from the first
+ * case once the same document holds two copies of one diagram.
+ *
+ * So the cache does not store a rendered diagram. It stores a *template*: the
+ * rendered string with the render id lifted out into a slot. Each use fills the
+ * slot with the fresh id the caller's `idFactory` produced, so the reused SVG is
+ * as uniquely identified as a freshly rendered one, and — for every diagram type
+ * whose ids Mermaid already prefixes with the svg id — byte-identical to one.
+ *
+ * ## Ids Mermaid does *not* prefix
+ *
+ * Sequence diagrams are the exception: their actor groups get ids from a module
+ * counter (`actor44`, `root-44`), not from the svg id. Those are declarations
+ * that nothing in the SVG points at, so the template renames them into the slot
+ * too (`<slot>-actor44`) and they stay unique per copy. If a future Mermaid
+ * starts *referencing* one of them, `templateDiagramSvg` sees the reference and
+ * refuses to build a template at all: that diagram then renders fresh every
+ * time, which is exactly the behaviour this module replaced. Slower, never
+ * wrong.
+ */
+
+/**
+ * The placeholder the render id is lifted into. The only way this could collide
+ * with real content is a diagram whose own text spells it out, and
+ * `templateDiagramSvg` refuses to build a template in exactly that case — so a
+ * filled slot can never be mistaken for content.
+ */
+const ID_SLOT = '{{markpad-diagram-id}}';
+
+const DECLARED_ID = /\sid="([^"]*)"/g;
+
+function escapeForRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Turns one rendered SVG into a reusable template, or returns `null` if it
+ * cannot be proven safe to reuse.
+ *
+ * `renderId` is the id the SVG was rendered with. Everything derived from it is
+ * replaced by the slot; every other declared id is moved under the slot so two
+ * copies of the same diagram cannot collide.
+ */
+export function templateDiagramSvg(svg: string, renderId: string): string | null {
+	if (!renderId || svg.includes(ID_SLOT)) return null;
+	// Not the shape this module knows how to re-id. Better to render again than
+	// to guess.
+	if (!svg.includes(`id="${renderId}"`)) return null;
+
+	let template = svg.split(renderId).join(ID_SLOT);
+
+	const declared = new Set<string>();
+	for (const match of svg.matchAll(DECLARED_ID)) declared.add(match[1]);
+
+	for (const id of declared) {
+		if (!id || id.includes(renderId)) continue;
+		// This one is not namespaced by the render id. Renaming a declaration is
+		// safe; rewriting references is not something this module tries to do, so
+		// a referenced stray id means "do not cache".
+		if (new RegExp(`#${escapeForRegExp(id)}(?![\\w-])`).test(svg)) return null;
+		template = template.split(` id="${id}"`).join(` id="${ID_SLOT}-${id}"`);
+	}
+
+	return template;
+}
+
+/** Fills a template's slots with `svgId`. */
+export function fillDiagramTemplate(template: string, svgId: string): string {
+	return template.split(ID_SLOT).join(svgId);
+}
+
+/**
+ * Upper bounds. The cache outlives a document and a tab — the preview keeps
+ * rendering into the same window as the user switches files — so it needs a
+ * ceiling that does not depend on anyone remembering to clear it.
+ *
+ * 2M characters is roughly 4MB of UTF-16. Measured against the document that
+ * motivated this — 44 diagrams of assorted types — the whole document's
+ * templates come to 1.02M characters, so the budget holds about two such
+ * documents at once: the open tab, and the one before it. Toggling the theme on
+ * a document that large can evict the other theme, which costs one slow render
+ * and is what happened on every keystroke before this existed.
+ *
+ * The entry count is the second bound, for documents full of tiny diagrams.
+ */
+const MAX_ENTRIES = 128;
+const MAX_CHARS = 2_000_000;
+
+/**
+ * Insertion order is the eviction order, and a hit re-inserts, which makes this
+ * an LRU without a second data structure.
+ */
+const templates = new Map<string, string>();
+let cachedChars = 0;
+
+/**
+ * Injective in both parts, so a theme name that happens to be a prefix of a
+ * diagram source cannot collide with one that is not.
+ *
+ * Nothing else belongs in the key. `renderRichContent` configures Mermaid with
+ * `{ startOnLoad: false, theme }` and nothing more, and the Mermaid module
+ * itself is loaded once per window — a version change means a new build means a
+ * new window, and this Map is per module instance.
+ */
+function cacheKey(source: string, theme: string): string {
+	return `${theme.length}:${theme}${source}`;
+}
+
+export function lookupDiagramTemplate(source: string, theme: string): string | null {
+	const key = cacheKey(source, theme);
+	const template = templates.get(key);
+	if (template === undefined) return null;
+	templates.delete(key);
+	templates.set(key, template);
+	return template;
+}
+
+export function storeDiagramTemplate(source: string, theme: string, template: string): void {
+	// A single diagram that would evict everything else is not worth caching.
+	if (template.length > MAX_CHARS / 4) return;
+
+	const key = cacheKey(source, theme);
+	const existing = templates.get(key);
+	if (existing !== undefined) {
+		templates.delete(key);
+		cachedChars -= existing.length;
+	}
+	templates.set(key, template);
+	cachedChars += template.length;
+
+	for (const [oldest, value] of templates) {
+		if (templates.size <= MAX_ENTRIES && cachedChars <= MAX_CHARS) break;
+		if (oldest === key) break; // never evict what was just asked for
+		templates.delete(oldest);
+		cachedChars -= value.length;
+	}
+}
+
+/**
+ * Test seam, in the spirit of `idFactory`: the cache is module-level and
+ * therefore process-wide, while a test wants to start from empty.
+ */
+export function resetDiagramCache(): void {
+	templates.clear();
+	cachedChars = 0;
+}

--- a/src/lib/utils/richContent.ts
+++ b/src/lib/utils/richContent.ts
@@ -1,4 +1,10 @@
 import DOMPurify from 'dompurify';
+import {
+	fillDiagramTemplate,
+	lookupDiagramTemplate,
+	storeDiagramTemplate,
+	templateDiagramSvg,
+} from './diagramCache.js';
 import { rememberDiagramSource } from './mermaidPrint.js';
 
 /**
@@ -146,7 +152,26 @@ export async function renderRichContent(options: RenderRichContentOptions): Prom
 		if (codeEl.classList.contains('language-mermaid')) {
 			const mermaidCode = codeEl.textContent || '';
 			try {
-				const { svg } = await mermaid.render(idFactory(diagramIndex++), mermaidCode);
+				// The preview re-renders the whole article roughly once per keystroke
+				// and `{@html}` puts every diagram's source back, so drawing is the
+				// one step worth remembering between passes. The cache holds a
+				// *template* rather than the SVG: the id below is stamped into it, so
+				// a reused diagram is as uniquely identified as a fresh one. See
+				// `diagramCache.ts` for why that is the whole difficulty.
+				const svgId = idFactory(diagramIndex++);
+				const cached = lookupDiagramTemplate(mermaidCode, options.mermaidTheme);
+				let svg: string;
+				if (cached !== null) {
+					svg = fillDiagramTemplate(cached, svgId);
+				} else {
+					svg = (await mermaid.render(svgId, mermaidCode)).svg;
+					// A source that contains the render id would have its own text
+					// rewritten by the substitution, so that one is left uncached.
+					if (!mermaidCode.includes(svgId)) {
+						const template = templateDiagramSvg(svg, svgId);
+						if (template !== null) storeDiagramTemplate(mermaidCode, options.mermaidTheme, template);
+					}
+				}
 
 				const container = doc.createElement('div');
 				container.className = 'mermaid-diagram';


### PR DESCRIPTION
## The cost

`{@html sanitizedHtml}` replaces the preview subtree wholesale, which restores every `<pre><code class="language-mermaid">`, so `renderRichContent` redraws **every diagram from scratch**. In split view — or in the editor with the outline open — that runs behind a 16 ms debounce, i.e. roughly **once per keystroke**.

Measured against the repo's real `richContent.ts`, real mermaid/hljs/katex/DOMPurify, in a headless browser, on a `convert_markdown`-shaped fixture with 44 diagrams, 132 code blocks and math. Each pass resets `root.innerHTML` first — exactly what `{@html}` does:

| | pass 1 | pass 2 | pass 3 | `mermaid.render` calls |
|---|---|---|---|---|
| **before** | 2508 ms | 2185 ms | 2334 ms | 44 every pass |
| **after** | 2622 ms (cold) | **189 ms** | **196 ms** | 41 cold, then **0** |

≈**12×** on the repeat pass. A four-diagram document costs about a second per keystroke today.

Interleaved A/B in one page load (arms alternated so machine state cannot be the difference; the "before" arm salts each source so no reuse is possible — i.e. the old work *plus* the new templating overhead):

| round | before | after |
|---|---|---|
| 1 | 9574 / 6796 ms | 367 / 421 ms |
| 2 | 3883 / 5621 ms | 276 / 482 ms |
| 3 | 4054 / 3771 ms | 256 / 179 ms |

## The render id is the whole difficulty

`(source, theme)` is the complete input — `renderRichContent` configures Mermaid with `{ startOnLoad: false, theme }` and nothing else — but the **id cannot be part of the key and cannot be reused verbatim**.

Read from real output rather than assumed: in a flowchart the render id appears **99 times in 13.7 KB** — the `<svg id>`, every `<style>#id …` selector, all 12 marker ids, the node and edge ids, and the `url(#id_flowchart-v2-pointEnd)` references pointing at them.

- Put it in the key → every lookup misses, the cache is useless.
- Reuse the bytes → duplicate ids in the document, and marker `url(#…)` references resolving to the wrong diagram.

So an entry stores a **template** with the id lifted into a slot, refilled with the fresh id `idFactory` produced on each use. For flowchart / class / state the result is byte-identical to a fresh render.

**Sequence diagrams are the exception, and they are why this is checked rather than assumed.** Their actor groups are numbered from a *module counter* (`actor44`, `root-44`), not from the svg id, so the template renames those too. And the mechanism is self-checking: if any stray id is *referenced* anywhere — `url(#X)`, `href="#X"`, a CSS selector — `templateDiagramSvg` returns `null` and that diagram renders fresh every pass. **Slower, never wrong.** Same refusal if the id is absent from the markup, or if a document's own text spells out the slot token.

Verified on the rendered document: **968 element ids, 0 duplicates**, and a fidelity comparison of fresh vs cache-served renders with identifiers normalised away — **44/44 identical**.

## Bounds and invalidation

- **LRU via `Map` insertion order plus delete-on-hit** — no second data structure.
- **128 entries and 2,000,000 characters (~4 MB UTF-16).** The whole 44-diagram document is 1.02 M characters of templates, so the budget holds roughly two such documents. A diagram larger than a quarter of the budget is never stored, so one monster cannot evict everything.
- **Invalidation is by key, never by clearing.** A one-character edit misses; a theme change misses. Both themes coexist, so toggling appearance back is a **hit** — measured: neutral 120 ms → dark 1954 ms / 41 renders → neutral 124 ms / **0** renders.
- Concurrent passes (preview and export) can both miss and both store. Idempotent.

## The export gets faster too

`MarkdownViewer.svelte` passes the export the same `currentMermaidTheme()` it passes the preview, so **exporting the document on screen is an all-hit pass**. For a cold export the added cost is only the templating, measured directly over 44 diagrams: `mermaid.render` 3732 ms, `templateDiagramSvg` **4 ms total** (0.09 ms/diagram), `fillDiagramTemplate` **0.7 ms**. **+0.1 % on an all-miss pass.**

## The render chain is unchanged

`sanitizeDiagramSvg` still runs on every string reaching `innerHTML` — hit and miss alike — and `rememberDiagramSource` still runs on every container, so the PDF path's light-theme re-render is unaffected. `MarkdownViewer.svelte` is not touched; the cache sits entirely under `renderRichContent`. No new dependencies.

## Tests

11 tests: source changed → miss · theme changed → miss · theme changed back → hit with the right colours · two identical diagrams in one document get distinct svgIds **and** distinct style-block and marker targets · a reused container still carries `data-mermaid-source` · non-namespaced ids get namespaced · a referenced stray id is not cached at all · bounded by entry count · bounded by size · slot token in user text → not cached · templating units.

Four mutations, each producing a distinct red set:

| mutation | pass / fail | went red |
|---|---|---|
| *(clean)* | **11 / 0** | — |
| cache hits forced off | 5 / **6** | draws-nothing-again, theme-warm, distinct-ids, source-attr, stray-namespacing, entry-bound |
| theme dropped from the key | 10 / **1** | theme-change-redraws |
| stray-reference refusal removed | 9 / **2** | referenced-stray-not-cached, templating-refuses |
| id reused verbatim | 8 / **3** | distinct-ids, stray-namespacing, templating-refuses |

Browser-side too: with hits forced off, pass 2 went from 189 ms back to 6676 ms with 44 render calls.

```
npm run check   436 files, 0 errors
npm test        511 / 511
cargo test      131 / 131
```

`singleImplementationConvention`'s `mermaid.render(` marker initially matched a **doc comment** in the new module. The test was not touched — the comment was reworded, since the module genuinely never calls Mermaid.

## Not covered

- **The PDF path still redraws everything.** `renderDiagramsForPrint` is a separate loop with its own theme (`neutral`); the same cache would serve it keyed on `('neutral', source)`. Clean follow-up.
- **Diagram types verified for id-portability**: flowchart, sequence, class, state. Not exercised: gantt, pie, ER, gitGraph, mindmap, timeline, C4, sankey, xychart, block, architecture. The refusal mechanism is the safety net — anything whose stray ids are referenced is not cached — but that is a net, not a measurement.
- **Only mermaid 11.16 was inspected.** A future id scheme change degrades to *refusing to cache*, not wrong output — but no test would tell you the speedup had silently gone away.
- The fixture is 141 KB with smaller diagrams (~50 ms each) than the 730 KB / 256 ms-median document the original measurement used. The ratio is what transfers; on the larger document the absolute win should be bigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)