### PR TITLE
fix(preview): restore the scroll position to the block it was taken from

### DIFF
--- a/scripts/previewAnchorRestore.test.ts
+++ b/scripts/previewAnchorRestore.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Preview scroll restore: does an anchor line actually resolve to an element?
+ *
+ * The restore path in `MarkdownViewer.svelte` takes the saved `tab.anchorLine`
+ * and looks for the rendered element whose `data-sourcepos` range contains that
+ * line. Before this fix it only walked `body.children`, but `processMarkdownHtml`
+ * moves everything after a heading into a JS-created `.foldable-content-wrapper`
+ * that carries no `data-sourcepos` — so the only top-level elements left with a
+ * source range are the *shallowest* headings. An anchor resolved only when it
+ * happened to land exactly on one of those heading lines.
+ *
+ * This file measures that as a rate rather than asserting "it runs":
+ *
+ *   - `legacyTopLevelMatch` is the pre-fix algorithm, restated verbatim over
+ *     the same DOM. It is kept here as the control; if the fix ever regresses
+ *     into a top-level-only scan the two rates collapse into each other.
+ *   - `findAnchorElement` is the shipped implementation.
+ *
+ * Both run over real `processMarkdownHtml` output (via the `renderProtocolDom`
+ * shim, same as `renderProtocol.test.ts`). The input HTML is generated in the
+ * shape comrak emits — the tag/attribute shape is taken from the recorded
+ * `convert_markdown` output in `renderProtocolFixtures.ts`.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { installShimDom, parseHtml, NODE_ELEMENT, type ShimElement } from './renderProtocolDom.ts';
+
+installShimDom();
+
+const { processMarkdownHtml } = await import('../src/lib/utils/markdown.ts');
+const { findAnchorElement, getAnchorScrollTop, parseSourceposLineRange } = await import(
+	'../src/lib/utils/previewAnchor.ts'
+);
+
+const FILE_PATH = '/documents/notes.md';
+
+/* ------------------------------------------------------------------ */
+/* comrak-shaped document generator                                    */
+/* ------------------------------------------------------------------ */
+
+type Block = { startLine: number; endLine: number };
+
+class DocumentBuilder {
+	private line = 1;
+	private readonly parts: string[] = [];
+	readonly blocks: Block[] = [];
+
+	blank() {
+		this.line += 1;
+	}
+
+	heading(level: number, text: string, slug: string) {
+		const line = this.line;
+		this.line += 1;
+		this.blocks.push({ startLine: line, endLine: line });
+		this.parts.push(
+			`<h${level} data-sourcepos="${line}:1-${line}:${level + 1 + text.length}">` +
+				`<a href="#${slug}" aria-hidden="true" class="anchor" id="${slug}"></a>${text}</h${level}>`,
+		);
+	}
+
+	paragraph(text: string) {
+		const line = this.line;
+		this.line += 1;
+		this.blocks.push({ startLine: line, endLine: line });
+		this.parts.push(`<p data-sourcepos="${line}:1-${line}:${text.length}">${text}</p>`);
+	}
+
+	list(items: string[]) {
+		const start = this.line;
+		const end = start + items.length - 1;
+		const itemHtml = items.map((item, index) => {
+			const itemLine = start + index;
+			return `<li data-sourcepos="${itemLine}:1-${itemLine}:${item.length + 2}">${item}</li>`;
+		});
+		this.blocks.push({ startLine: start, endLine: end });
+		this.parts.push(`<ul data-sourcepos="${start}:1-${end}:${items[items.length - 1].length + 2}">\n${itemHtml.join('\n')}\n</ul>`);
+		this.line = end + 1;
+	}
+
+	code(lines: string[]) {
+		const start = this.line;
+		const end = start + lines.length + 1;
+		this.blocks.push({ startLine: start, endLine: end });
+		this.parts.push(
+			`<pre data-sourcepos="${start}:1-${end}:3"><code class="language-sh">${lines.join('\n')}\n</code></pre>`,
+		);
+		this.line = end + 1;
+	}
+
+	get lineCount() {
+		return this.line - 1;
+	}
+
+	html() {
+		return this.parts.join('\n') + '\n';
+	}
+}
+
+/**
+ * One section body: the block mix a real document repeats between headings.
+ * Sized at 20 source lines so a 477-heading document lands near the 10k lines
+ * the audit measured.
+ */
+function sectionBody(doc: DocumentBuilder, seed: number) {
+	doc.blank();
+	doc.paragraph(`Prose paragraph ${seed} explaining the section in a sentence.`);
+	doc.blank();
+	doc.list([`item ${seed} alpha`, `item ${seed} beta`, `item ${seed} gamma`]);
+	doc.blank();
+	doc.paragraph(`Second prose paragraph ${seed} with a little more detail.`);
+	doc.blank();
+	doc.code([`echo section-${seed}`, `run --flag ${seed}`]);
+	doc.blank();
+	doc.paragraph(`Third prose paragraph ${seed}, the one after the code block.`);
+	doc.blank();
+	doc.list([`follow-up ${seed} one`, `follow-up ${seed} two`, `follow-up ${seed} three`]);
+	doc.blank();
+}
+
+/** A flat document: every heading is an `h2`, so all of them stay top level. */
+function buildFlatDocument(sections: number) {
+	const doc = new DocumentBuilder();
+	doc.paragraph('Intro paragraph before the first heading.');
+	doc.blank();
+	for (let i = 1; i <= sections; i += 1) {
+		doc.heading(2, `Section ${i}`, `section-${i}`);
+		sectionBody(doc, i);
+	}
+	return doc;
+}
+
+/** A nested document: `h1 > h2 > h3`, so only the `h1`s stay top level. */
+function buildNestedDocument(chapters: number) {
+	const doc = new DocumentBuilder();
+	doc.paragraph('Intro paragraph before the first heading.');
+	doc.blank();
+	for (let c = 1; c <= chapters; c += 1) {
+		doc.heading(1, `Chapter ${c}`, `chapter-${c}`);
+		sectionBody(doc, c * 100);
+		doc.heading(2, `Chapter ${c} Section`, `chapter-${c}-section`);
+		sectionBody(doc, c * 100 + 1);
+		doc.heading(3, `Chapter ${c} Unit`, `chapter-${c}-unit`);
+		sectionBody(doc, c * 100 + 2);
+	}
+	return doc;
+}
+
+/* ------------------------------------------------------------------ */
+/* measurement                                                         */
+/* ------------------------------------------------------------------ */
+
+function elementChildren(node: ShimElement): ShimElement[] {
+	return node.childNodes.filter((child): child is ShimElement => child.nodeType === NODE_ELEMENT);
+}
+
+/**
+ * The pre-fix restore loop, restated: scan `body.children` only, take the first
+ * child whose own `data-sourcepos` range contains the line.
+ */
+function legacyTopLevelMatch(body: ShimElement, line: number) {
+	for (const el of elementChildren(body)) {
+		const sourcepos = el.getAttribute('data-sourcepos');
+		if (!sourcepos) continue;
+		const [start, end] = sourcepos.split('-');
+		const startLine = parseInt(start.split(':')[0], 10);
+		const endLine = parseInt(end.split(':')[0], 10);
+		if (Number.isNaN(startLine) || Number.isNaN(endLine)) continue;
+		if (line >= startLine && line <= endLine) return { startLine, endLine };
+	}
+	return null;
+}
+
+/** Every source line the renderer attributed to some block, sampled evenly. */
+function sampleAnchorLines(blocks: Block[], count: number): number[] {
+	const lines = new Set<number>();
+	for (const block of blocks) {
+		for (let line = block.startLine; line <= block.endLine; line += 1) lines.add(line);
+	}
+	const all = [...lines].sort((a, b) => a - b);
+	const step = all.length / count;
+	const sampled: number[] = [];
+	for (let i = 0; i < count; i += 1) sampled.push(all[Math.floor(i * step)]);
+	return sampled;
+}
+
+type Rate = { hits: number; total: number; percent: number };
+
+function rate(hits: number, total: number): Rate {
+	return { hits, total, percent: Math.round((hits / total) * 1000) / 10 };
+}
+
+function measure(doc: DocumentBuilder, sampleSize: number) {
+	const body = parseHtml(processMarkdownHtml(doc.html(), FILE_PATH, new Set())).body;
+	const anchors = sampleAnchorLines(doc.blocks, sampleSize);
+
+	let legacyHits = 0;
+	let fixedHits = 0;
+	for (const line of anchors) {
+		const legacy = legacyTopLevelMatch(body, line);
+		if (legacy && line >= legacy.startLine && line <= legacy.endLine) legacyHits += 1;
+
+		const fixed = findAnchorElement(body, line);
+		if (fixed && line >= fixed.startLine && line <= fixed.endLine) fixedHits += 1;
+	}
+
+	const topLevel = elementChildren(body);
+	return {
+		body,
+		anchors,
+		annotatedElements: body.querySelectorAll('[data-sourcepos]').length,
+		topLevelChildren: topLevel.length,
+		topLevelWithSourcepos: topLevel.filter((el) => el.getAttribute('data-sourcepos') !== null).length,
+		legacy: rate(legacyHits, anchors.length),
+		fixed: rate(fixedHits, anchors.length),
+	};
+}
+
+/* ------------------------------------------------------------------ */
+/* tests                                                               */
+/* ------------------------------------------------------------------ */
+
+test('flat h2 document: anchor lines resolve to an element', (t) => {
+	const doc = buildFlatDocument(477);
+	const result = measure(doc, 300);
+
+	t.diagnostic(`flat: ${doc.lineCount} source lines, ${result.annotatedElements} elements with data-sourcepos`);
+	t.diagnostic(`flat: ${result.topLevelChildren} top-level children, ` +
+		`${result.topLevelWithSourcepos} of them with data-sourcepos`);
+	t.diagnostic(`flat: legacy top-level scan ${result.legacy.hits}/${result.legacy.total} (${result.legacy.percent}%)`);
+	t.diagnostic(`flat: findAnchorElement ${result.fixed.hits}/${result.fixed.total} (${result.fixed.percent}%)`);
+
+	// The control: the pre-fix scan only ever matched a top-level heading line.
+	assert.ok(
+		result.legacy.percent < 15,
+		`the pre-fix top-level scan is expected to miss almost everything, got ${result.legacy.percent}%`,
+	);
+	// The fix: every sampled anchor line resolves.
+	assert.equal(result.fixed.hits, result.fixed.total);
+});
+
+test('nested h1/h2/h3 document: anchor lines resolve to an element', (t) => {
+	const doc = buildNestedDocument(159);
+	const result = measure(doc, 300);
+
+	t.diagnostic(`nested: ${doc.lineCount} source lines, ${result.annotatedElements} elements with data-sourcepos`);
+	t.diagnostic(`nested: ${result.topLevelChildren} top-level children, ` +
+		`${result.topLevelWithSourcepos} of them with data-sourcepos`);
+	t.diagnostic(`nested: legacy top-level scan ${result.legacy.hits}/${result.legacy.total} (${result.legacy.percent}%)`);
+	t.diagnostic(`nested: findAnchorElement ${result.fixed.hits}/${result.fixed.total} (${result.fixed.percent}%)`);
+
+	assert.ok(
+		result.legacy.percent < 15,
+		`the pre-fix top-level scan is expected to miss almost everything, got ${result.legacy.percent}%`,
+	);
+	assert.equal(result.fixed.hits, result.fixed.total);
+});
+
+test('the resolved element is the narrowest block containing the line', () => {
+	const doc = new DocumentBuilder();
+	doc.heading(2, 'Heading', 'heading');
+	doc.blank();
+	doc.list(['first', 'second', 'third']);
+	const body = parseHtml(processMarkdownHtml(doc.html(), FILE_PATH, new Set())).body;
+
+	// The list occupies lines 3-5; the anchor for line 4 must be that `li`,
+	// not the enclosing `ul` and not the heading's fold wrapper.
+	const match = findAnchorElement(body, 4);
+	assert.ok(match);
+	assert.equal((match.element as ShimElement).tagName, 'LI');
+	assert.deepEqual({ startLine: match.startLine, endLine: match.endLine }, { startLine: 4, endLine: 4 });
+});
+
+test('a collapsed fold resolves to the collapsed wrapper, not to its hidden contents', () => {
+	const doc = new DocumentBuilder();
+	doc.heading(2, 'Heading', 'heading');
+	doc.blank();
+	doc.paragraph('Hidden body text.');
+	const body = parseHtml(processMarkdownHtml(doc.html(), FILE_PATH, new Set(['heading']))).body;
+
+	// Line 3 is the paragraph inside the collapsed section. Its geometry is
+	// meaningless while the wrapper is `height: 0; overflow: hidden`, so the
+	// wrapper itself — which sits at the right scroll offset — is the answer.
+	const match = findAnchorElement(body, 3);
+	assert.ok(match);
+	const element = match.element as ShimElement;
+	assert.ok(element.classList.contains('foldable-content-wrapper'));
+	assert.ok(element.classList.contains('is-collapsed'));
+});
+
+test('an anchor line past the end of the document does not resolve', () => {
+	const doc = buildFlatDocument(3);
+	const body = parseHtml(processMarkdownHtml(doc.html(), FILE_PATH, new Set())).body;
+	assert.equal(findAnchorElement(body, doc.lineCount + 500), null);
+});
+
+test('scroll target interpolates inside the resolved element', () => {
+	const range = { startLine: 10, endLine: 20 };
+	assert.equal(getAnchorScrollTop(1000, 200, range, 10, 60), 940);
+	assert.equal(getAnchorScrollTop(1000, 200, range, 15, 60), 1040);
+	assert.equal(getAnchorScrollTop(1000, 200, range, 20, 60), 1140);
+	// Single-line blocks have no interior to interpolate over.
+	assert.equal(getAnchorScrollTop(1000, 200, { startLine: 7, endLine: 7 }, 7, 60), 940);
+	// Never scrolls above the top of the document.
+	assert.equal(getAnchorScrollTop(10, 20, { startLine: 1, endLine: 1 }, 1, 60), 0);
+});
+
+test('source position ranges parse the way comrak writes them', () => {
+	assert.deepEqual(parseSourceposLineRange('12:1-14:9'), { startLine: 12, endLine: 14 });
+	assert.equal(parseSourceposLineRange(''), null);
+	assert.equal(parseSourceposLineRange(null), null);
+	assert.equal(parseSourceposLineRange('nonsense'), null);
+});
+
+/**
+ * The two assertions below are source assertions, not behavior assertions: the
+ * restore effect lives inside a Svelte component and cannot be imported. They
+ * pin the wiring — that the component calls the measured resolver, and that the
+ * top-level-only scan the rates above were measured against does not come back.
+ */
+test('the viewer restores through the measured resolver', async () => {
+	const { readFileSync } = await import('node:fs');
+	const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+
+	assert.match(viewer, /import \{[\s\S]*findAnchorElement[\s\S]*\} from '\.\/utils\/previewAnchor\.js'/);
+	assert.match(
+		viewer,
+		/const match = findAnchorElement\(body, tab\.anchorLine\);[\s\S]*body\.scrollTop = getAnchorScrollTop\(/,
+	);
+	assert.doesNotMatch(viewer, /Array\.from\(body\.children\)/);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -37,6 +37,12 @@ import {
 } from './utils/richContent.js';
 import { observeFoldLayout } from './utils/foldLayout.js';
 import {
+	findAnchorElement,
+	getAnchorScrollTop,
+	parseSourceposLineRange,
+	PREVIEW_ANCHOR_OFFSET,
+} from './utils/previewAnchor.js';
+import {
 	addFrontMatterListItems,
 	getMarkdownBodyWithoutFrontMatter,
 	getFrontMatterListItems,
@@ -1108,34 +1114,24 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 					let scrolled = false;
 
 					if (tab.anchorLine > 0) {
-						// Interpolated Restore
-						// Find element containing the anchor line
-						const children = Array.from(body.children) as HTMLElement[];
-						for (const el of children) {
-							const sourcepos = el.dataset.sourcepos;
-							if (sourcepos) {
-								const [start, end] = sourcepos.split('-');
-								const startLine = parseInt(start.split(':')[0]);
-								const endLine = parseInt(end.split(':')[0]);
-
-								if (!isNaN(startLine) && !isNaN(endLine)) {
-									if (tab.anchorLine >= startLine && tab.anchorLine <= endLine) {
-										// Found the container
-										const totalLines = endLine - startLine; // Can be 0 for single line
-										let ratio = 0;
-										if (totalLines > 0) {
-											ratio = (tab.anchorLine - startLine) / totalLines;
-										}
-
-										// Calculate target pixel position
-										// We want the anchor line to be roughly at offset 60
-										const targetOffset = el.offsetTop + el.offsetHeight * ratio - 60;
-										body.scrollTop = Math.max(0, targetOffset);
-										scrolled = true;
-										break;
-									}
-								}
-							}
+						// Interpolated restore: find the rendered element that owns the
+						// saved source line and put that line back under the anchor
+						// offset. This has to descend — `processMarkdownHtml` re-parents
+						// every block after a heading into a `.foldable-content-wrapper`
+						// with no `data-sourcepos`, so a scan of `body.children` only
+						// ever matched an anchor sitting exactly on a top-level heading
+						// line (see scripts/previewAnchorRestore.test.ts for the rate).
+						const match = findAnchorElement(body, tab.anchorLine);
+						if (match) {
+							const el = match.element as HTMLElement;
+							body.scrollTop = getAnchorScrollTop(
+								el.offsetTop,
+								el.offsetHeight,
+								match,
+								tab.anchorLine,
+								PREVIEW_ANCHOR_OFFSET,
+							);
+							scrolled = true;
 						}
 					}
 
@@ -1242,19 +1238,10 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		ratio: number;
 	};
 
-	function parseSourceposLineRange(sourcepos: string | undefined) {
-		if (!sourcepos) return null;
-		const [start, end] = sourcepos.split('-');
-		const startLine = parseInt(start?.split(':')[0] ?? '', 10);
-		const endLine = parseInt(end?.split(':')[0] ?? '', 10);
-
-		if (Number.isNaN(startLine) || Number.isNaN(endLine)) return null;
-		return { startLine, endLine };
-	}
-
 	function getPreviewScrollAnchor(target: HTMLElement): PreviewScrollAnchor | null {
-		const anchorOffset = target.scrollTop + 60;
-		const viewportRatio = target.clientHeight > 0 ? Math.min(1, 60 / target.clientHeight) : 0;
+		const anchorOffset = target.scrollTop + PREVIEW_ANCHOR_OFFSET;
+		const viewportRatio =
+			target.clientHeight > 0 ? Math.min(1, PREVIEW_ANCHOR_OFFSET / target.clientHeight) : 0;
 		const candidates = Array.from(target.querySelectorAll<HTMLElement>('[data-sourcepos]'));
 
 		let best: { el: HTMLElement; startLine: number; endLine: number; distance: number } | null = null;

--- a/src/lib/utils/previewAnchor.ts
+++ b/src/lib/utils/previewAnchor.ts
@@ -1,0 +1,169 @@
+/**
+ * Resolving a saved source line back to a rendered preview element.
+ *
+ * Scrolling the preview saves a source line (`tab.anchorLine`, produced by
+ * `getPreviewScrollAnchor`) and re-activating the tab has to turn that line
+ * back into a scroll offset. Both directions key off the `data-sourcepos`
+ * attributes comrak writes onto the rendered blocks.
+ *
+ * The one thing that makes this non-trivial: `processMarkdownHtml` re-parents
+ * everything that follows a heading into a `.foldable-content-wrapper` it
+ * creates itself, and that wrapper has no `data-sourcepos` of its own. After
+ * that pass the only top-level elements still carrying a source range are the
+ * shallowest headings in the document, so a scan of `body.children` can only
+ * ever match an anchor that landed exactly on one of those heading lines.
+ *
+ * `findAnchorElement` therefore descends. It treats an element without a source
+ * range as a transparent container whose span is derived from its first and
+ * last annotated descendants, which lets it skip a whole section in one
+ * comparison instead of visiting every annotated element in the document. The
+ * work is proportional to the number of siblings along the path to the match
+ * (plus the fold depth), not to the document size — the restore runs once per
+ * tab activation, but this keeps it off the same O(all elements) footing as the
+ * per-scroll-event capture path.
+ */
+
+/** Inclusive source line range, as written in `data-sourcepos`. */
+export type LineRange = {
+	startLine: number;
+	endLine: number;
+};
+
+/**
+ * The subset of `Element` this module reads. Declaring it structurally keeps
+ * the resolution testable against the render-protocol DOM shim, which is what
+ * lets the hit rate be measured over real `processMarkdownHtml` output.
+ */
+export type AnchorNode = {
+	readonly nodeType: number;
+	readonly childNodes: Iterable<AnchorNode>;
+	getAttribute?(name: string): string | null;
+	readonly classList?: { contains(token: string): boolean };
+};
+
+export type AnchorMatch = LineRange & {
+	element: AnchorNode;
+};
+
+const ELEMENT_NODE = 1;
+
+/**
+ * Distance from the top of the viewport at which the anchor line is pinned.
+ * Capture and restore have to agree on it or every round trip drifts by the
+ * difference.
+ */
+export const PREVIEW_ANCHOR_OFFSET = 60;
+
+export function parseSourceposLineRange(sourcepos: string | null | undefined): LineRange | null {
+	if (!sourcepos) return null;
+
+	const [start, end] = sourcepos.split('-');
+	const startLine = parseInt(start?.split(':')[0] ?? '', 10);
+	const endLine = parseInt(end?.split(':')[0] ?? '', 10);
+
+	if (Number.isNaN(startLine) || Number.isNaN(endLine)) return null;
+	return { startLine, endLine };
+}
+
+function elementChildren(node: AnchorNode): AnchorNode[] {
+	const out: AnchorNode[] = [];
+	for (const child of node.childNodes) {
+		if (child.nodeType === ELEMENT_NODE) out.push(child);
+	}
+	return out;
+}
+
+function ownRange(node: AnchorNode): LineRange | null {
+	return parseSourceposLineRange(node.getAttribute?.('data-sourcepos'));
+}
+
+/**
+ * A collapsed fold (or callout) keeps its children in the layout tree — the
+ * wrapper is `height: 0; overflow: hidden`, not `display: none` — so those
+ * children still report offsets, and those offsets point at where the content
+ * *would* be rather than where it is. Descent stops at such a container and
+ * uses the container itself, which sits at the right place on screen.
+ */
+function isCollapsedContainer(node: AnchorNode): boolean {
+	return node.classList?.contains('is-collapsed') === true;
+}
+
+/**
+ * The span an element covers: its own range, or — for a container the render
+ * pipeline created — the range from its first to its last annotated descendant.
+ */
+function resolveSpan(node: AnchorNode): LineRange | null {
+	const own = ownRange(node);
+	if (own) return own;
+
+	const children = elementChildren(node);
+
+	let first: LineRange | null = null;
+	for (const child of children) {
+		first = resolveSpan(child);
+		if (first) break;
+	}
+	if (!first) return null;
+
+	let last: LineRange | null = null;
+	for (let index = children.length - 1; index >= 0; index -= 1) {
+		last = resolveSpan(children[index]);
+		if (last) break;
+	}
+
+	return { startLine: first.startLine, endLine: Math.max(first.endLine, last?.endLine ?? first.endLine) };
+}
+
+function contains(range: LineRange, line: number): boolean {
+	return line >= range.startLine && line <= range.endLine;
+}
+
+function search(node: AnchorNode, line: number, inherited: AnchorMatch | null): AnchorMatch | null {
+	for (const child of elementChildren(node)) {
+		const own = ownRange(child);
+		const span = own ?? resolveSpan(child);
+		if (!span || !contains(span, line)) continue;
+
+		const carried: AnchorMatch | null = own ? { element: child, ...own } : inherited;
+		const fallback: AnchorMatch = carried ?? { element: child, ...span };
+
+		if (!own && isCollapsedContainer(child)) return { element: child, ...span };
+
+		return search(child, line, carried) ?? fallback;
+	}
+
+	return null;
+}
+
+/**
+ * The narrowest visible element whose source range contains `line`, or `null`
+ * when the line falls outside every rendered block (a stale anchor, or a blank
+ * line between blocks) and the caller should fall back to a proportional
+ * restore.
+ */
+export function findAnchorElement(root: AnchorNode, line: number): AnchorMatch | null {
+	if (!Number.isFinite(line) || line <= 0) return null;
+	return search(root, line, null);
+}
+
+/**
+ * Where to scroll so `line` sits `offset` pixels below the top of the viewport,
+ * interpolating linearly across the resolved element for multi-line blocks.
+ *
+ * `elementTop` is `offsetTop`, matching what `getPreviewScrollAnchor` measures
+ * on the way in. Both sides read the same property on the same element, so a
+ * positioned ancestor above the scroll container shifts both by the same amount
+ * and cancels out of the round trip.
+ */
+export function getAnchorScrollTop(
+	elementTop: number,
+	elementHeight: number,
+	range: LineRange,
+	line: number,
+	offset: number = PREVIEW_ANCHOR_OFFSET,
+): number {
+	const totalLines = range.endLine - range.startLine;
+	const ratio = totalLines > 0 ? Math.max(0, Math.min(1, (line - range.startLine) / totalLines)) : 0;
+
+	return Math.max(0, elementTop + elementHeight * ratio - offset);
+}


### PR DESCRIPTION
Switch tabs and come back, and the preview lands on a rough percentage of the document rather than where you left off.

## Why

The line-based restore walks only `markdownBody.children`, but `processMarkdownHtml` moves everything after a heading into a `.foldable-content-wrapper` — a JS-created element with **no `data-sourcepos`**.

What is actually left at the top level, measured on real output rather than assumed: **the shallowest-level headings, plus whatever precedes the first one.**

```
flat h2 document      955 top-level children, 478 with data-sourcepos
nested h1>h2>h3       319 top-level children, 160 with data-sourcepos
```

So a saved anchor resolved **only when it happened to fall on one of those heading lines**. Everything else fell through to the percentage fallback.

(The audit note that started this said the top level retains roughly four elements. That is wrong, and the correct mechanism matters for the fix — the surviving elements *are* the headings, which is exactly what the old loop was hitting.)

## Hit rate, before and after

Same fixture, same 300 evenly-sampled anchor lines, both algorithms run over the same post-`processMarkdownHtml` DOM. The pre-fix loop is restated verbatim in the test as a permanent control:

| 10 000-line document, 6 202 annotated elements | before | after |
|---|---|---|
| flat, 477 `h2` | **23 / 300 — 7.7 %** | **300 / 300** |
| nested `h1>h2>h3`, 159 `h1` | **7 / 300 — 2.3 %** | **300 / 300** |

## The fix descends rather than widening the query

An element without a source position is treated as a **transparent container** whose span comes from its first and last annotated descendants. Two obvious alternatives were tried first and rejected on concrete grounds:

**Giving the wrapper its first child's range** does not fix it — that range covers only the first block, so every line deeper in the section still misses. The union-span variant *does* work at the top level, but it **poisons the capture side**: the wrapper precedes its own contents in document order, so it would win the `distance === 0` early break and coarsen every anchor that gets written down.

**A flat `querySelectorAll('[data-sourcepos]')` deep scan** is what makes `getPreviewScrollAnchor` cost 18–41 ms per scroll event — a layout read per element — and it has two correctness holes: it returns the *outermost* container rather than the narrowest, and it reads offsets inside `height: 0; overflow: hidden` collapsed folds, where children still report their un-collapsed positions and would scroll to the wrong place.

The descent gets the **narrowest** block, **stops at a collapsed fold** (returning the zero-height wrapper, which sits at the correct offset just below its heading), and reads layout **exactly once**.

## Effect on the per-scroll cost

**Not fixed, and deliberately not widened.** `getPreviewScrollAnchor` still does its flat scan on every scroll event. Two things did improve:

- The restore path does **1 layout read instead of ~9 000**. Traversal alone, measured in the DOM shim over the 10k fixture: descent 0.31 ms/lookup vs flat scan 1.26 ms/lookup — and that excludes layout, which is where the browser's 18–41 ms actually goes.
- A future fix for the scroll-event cost can reuse the same descent shape keyed on pixels instead of lines.

`parseSourceposLineRange` was duplicated between the component and the new module; it is now imported. The magic `60` on both the capture and restore sides is now one `PREVIEW_ANCHOR_OFFSET`.

## Tests

| | |
|---|---|
| `findAnchorElement` regressed to the pre-fix top-level scan, tests unchanged | **4 of 8 fail**, and the measured rate collapses to exactly the control — `23/300 (7.7%)` and `7/300 (2.3%)`, `actual: 23, expected: 300` |
| Module and wiring stashed | suite fails to load |
| Final | 8 / 8 |

```
npm run check   437 files, 0 errors
npm test        517 / 517
cargo test      131 / 131
```

## Not covered

- **An anchor on a blank line, or stale after an edit** → returns `null` and falls through to the existing percentage restore. Unchanged; the capture side only ever emits lines inside a block range.
- **`offsetTop` is not measured against the scroll container.** `.markdown-body` has no `position`, so offsets are relative to a positioned ancestor above it. Kept on purpose — capture compares `offsetTop` to `scrollTop + 60` and restore sets `scrollTop = offsetTop − 60`, so the constant cancels in the round trip, and switching only the restore side to `getBoundingClientRect` would have introduced a real error. **But** `.markdown-body pre` and `.markdown-body .footnotes li` *are* `position: relative`, so a match resolved inside a code block or a footnote measures against that ancestor. Pre-existing on the capture side; not addressed here.
- **No browser round-trip test.** Resolution is measured over real `processMarkdownHtml` output via the existing DOM shim and the pixel maths is tested as a pure function, but capture→restore end to end is reasoned, not measured.
- The fixture is comrak-*shaped*, not comrak-produced (the JS side has no renderer; the shape comes from the recorded `convert_markdown` output in `renderProtocolFixtures.ts`). Tables, footnotes, blockquote callouts and front-matter panels are not in it.
- The sibling scan is linear in the sections preceding the match (~720 `childNodes` expansions per lookup on the 10k fixture). No binary search: sibling range monotonicity is not structurally guaranteed, and restore is low-frequency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)