### PR TITLE
fix(markdown): keep an escaped dollar escaped, and render display math inside a paragraph

### DIFF
--- a/scripts/mathDelimiterContract.test.ts
+++ b/scripts/mathDelimiterContract.test.ts
@@ -21,10 +21,19 @@
  * that a second implementation exists.
  *
  * Nothing here re-implements the delimiter rule. The frontend's decision is
- * read back only from artefacts the frontend itself produces: `\(…\)`, which
- * only `convertInlineMathDelimiters` emits, and `data-math-source`, which only
- * `processDisplayMathBlocks` sets. An extractor that parsed `$…$` on its own
- * could agree with a broken implementation, which would defeat the point.
+ * read back only from artefacts the frontend itself produces: `\(…\)` and
+ * `\[…\]`, which only `convertInlineMathDelimiters` emits, and
+ * `data-math-source`, which only `processDisplayMathBlocks` sets. An extractor
+ * that parsed `$…$` on its own could agree with a broken implementation, which
+ * would defeat the point.
+ *
+ * Reading artefacts is only equal to reading what the *reader* sees while those
+ * three are the whole of it. They were not: KaTeX's auto-renderer was also
+ * given `$$` and so rendered same-line `$$…$$` straight out of comrak's output,
+ * a fourth channel this extractor could not see and the corpus documented as a
+ * KNOWN GAP. `\$\$x\$\$` — an escape, i.e. the reader saying "not a formula" —
+ * went through it and was typeset. The last test in this file is what keeps
+ * that channel closed.
  */
 
 import assert from 'node:assert/strict';
@@ -43,8 +52,10 @@ import {
 } from './renderProtocolDom.ts';
 
 installShimDom();
+(globalThis as any).window = globalThis;
 
 const { processMarkdownHtml } = await import('../src/lib/utils/markdown.ts');
+const { MATH_DELIMITERS } = await import('../src/lib/utils/richContent.ts');
 
 type ContractSpan = { kind: 'inline' | 'display'; source: string };
 type ContractCase = {
@@ -61,8 +72,11 @@ const corpus: { cases: ContractCase[] } = JSON.parse(
 
 const FILE_PATH = '/documents/notes.md';
 
-/** Only `convertInlineMathDelimiters` ever writes `\(`…`\)` into a text node. */
-const INLINE_MATH_RE = /\\\(([\s\S]*?)\\\)/g;
+/**
+ * Only `convertInlineMathDelimiters` ever writes `\(`…`\)` or `\[`…`\]` into a
+ * text node; CommonMark resolves a user-typed one away long before here.
+ */
+const MATH_ARTEFACT_RE = /\\\(([\s\S]*?)\\\)|\\\[([\s\S]*?)\\\]/g;
 
 /** What the frontend decided, in document order, in the corpus's vocabulary. */
 function recognisedMath(body: ShimElement): ContractSpan[] {
@@ -80,10 +94,14 @@ function recognisedMath(body: ShimElement): ContractSpan[] {
 		}
 		if (node.nodeType === NODE_TEXT) {
 			const text = (node as ShimText).nodeValue ?? '';
-			INLINE_MATH_RE.lastIndex = 0;
+			MATH_ARTEFACT_RE.lastIndex = 0;
 			let match: RegExpExecArray | null;
-			while ((match = INLINE_MATH_RE.exec(text)) !== null) {
-				found.push({ kind: 'inline', source: match[1] });
+			while ((match = MATH_ARTEFACT_RE.exec(text)) !== null) {
+				found.push(
+					match[1] !== undefined
+						? { kind: 'inline', source: match[1] }
+						: { kind: 'display', source: match[2] },
+				);
 			}
 		}
 	};
@@ -120,4 +138,23 @@ test('the corpus covers both directions of the invariant', () => {
 		positives.some((one) => one.math.some((span) => span.kind === 'inline')),
 		'no inline-math case',
 	);
+});
+
+test('KaTeX is given no delimiter that Markdown itself can spell', () => {
+	// The test above reads the frontend's decision off the artefacts
+	// `processMarkdownHtml` mints. That is only the same thing as "what the
+	// reader sees" while KaTeX's auto-renderer looks for nothing else. Give it
+	// `$$` back and same-line `$$…$$` is rendered straight out of comrak's
+	// output — including the `$$` that comrak produced *by resolving the
+	// reader's `\$\$`* — through a channel the extractor cannot see and the
+	// contract therefore cannot police.
+	assert.ok(MATH_DELIMITERS.length > 0, 'no delimiters at all');
+	for (const delimiter of MATH_DELIMITERS) {
+		for (const side of [delimiter.left, delimiter.right]) {
+			assert.ok(
+				side.startsWith('\\'),
+				`KaTeX may only be given delimiters processMarkdownHtml mints, not ${JSON.stringify(side)}`,
+			);
+		}
+	}
 });

--- a/scripts/mathDelimiterCorpus.json
+++ b/scripts/mathDelimiterCorpus.json
@@ -18,12 +18,12 @@
 		"reports. Never hand-edit `html`, and never edit `math` to match a failure --",
 		"a disagreement here is the bug, not the test.",
 		"",
-		"KNOWN GAP: a same-line `$$x$$` mixed into prose is passed through verbatim",
-		"by convertInlineMathDelimiters, so the frontend's decision about it is not",
-		"observable without re-implementing the rule in the test (which would defeat",
-		"the purpose). Display cases here therefore use the block form, whose",
-		"decision surfaces as data-math-source. Same-line `$$` is covered by the",
-		"Rust-side tests alone."
+		"Every span the frontend renders surfaces as one of three artefacts only it",
+		"mints: `\\(…\\)` and `\\[…\\]` from convertInlineMathDelimiters, and",
+		"data-math-source from processDisplayMathBlocks. KaTeX's auto-renderer is",
+		"given no `$`-based delimiter at all (see MATH_DELIMITERS in",
+		"src/lib/utils/richContent.ts), so there is no fourth, unobservable channel:",
+		"what the extractor below sees is what the reader sees."
 	],
 	"cases": [
 		{
@@ -71,7 +71,7 @@
 		{
 			"name": "an escaped dollar alone",
 			"markdown": "Costs \\$5 only.\n",
-			"html": "<p data-sourcepos=\"1:1-1:15\">Costs $5 only.</p>\n",
+			"html": "<p data-sourcepos=\"1:1-1:25\">Costs \\$5 only.</p>\n",
 			"math": []
 		},
 		{
@@ -95,7 +95,7 @@
 		{
 			"name": "an escaped dollar next to real math",
 			"markdown": "Pay \\$100 for $x$ items.\n",
-			"html": "<p data-sourcepos=\"1:1-1:33\">Pay $100 for $x$ items.</p>\n",
+			"html": "<p data-sourcepos=\"1:1-1:43\">Pay \\$100 for $x$ items.</p>\n",
 			"math": [
 				{
 					"kind": "inline",
@@ -225,6 +225,46 @@
 				{
 					"kind": "display",
 					"source": "\\begin{aligned}\na &= b \\\\\nc &= d\n\\end{aligned}"
+				}
+			]
+		},
+		{
+			"name": "an escaped display delimiter in prose",
+			"markdown": "Literal \\$\\$x\\$\\$ here.\n",
+			"html": "<p data-sourcepos=\"1:1-1:63\">Literal \\$\\$x\\$\\$ here.</p>\n",
+			"math": []
+		},
+		{
+			"name": "an escaped display delimiter alone in a paragraph",
+			"markdown": "\\$\\$x\\$\\$\n",
+			"html": "<p data-sourcepos=\"1:1-1:49\">\\$\\$x\\$\\$</p>\n",
+			"math": []
+		},
+		{
+			"name": "an escaped inline delimiter",
+			"markdown": "Literal \\$x\\$ here.\n",
+			"html": "<p data-sourcepos=\"1:1-1:39\">Literal \\$x\\$ here.</p>\n",
+			"math": []
+		},
+		{
+			"name": "same-line display math mixed into prose",
+			"markdown": "Inline prose with $$x_1$$ mixed in.\n",
+			"html": "<p data-sourcepos=\"1:1-1:40\">Inline prose with $$x_1$$ mixed in.</p>\n",
+			"math": [
+				{
+					"kind": "display",
+					"source": "x_1"
+				}
+			]
+		},
+		{
+			"name": "an escaped dollar inside a formula stays TeX",
+			"markdown": "$a \\$ b$\n",
+			"html": "<p data-sourcepos=\"1:1-1:12\">$a \\$ b$</p>\n",
+			"math": [
+				{
+					"kind": "inline",
+					"source": "a \\$ b"
 				}
 			]
 		},

--- a/scripts/renderProtocol.test.ts
+++ b/scripts/renderProtocol.test.ts
@@ -273,13 +273,17 @@ test('display math on its own lines is joined without the hard line breaks', () 
 	assert.equal(math.querySelectorAll('br').length, 0, 'hard breaks leaked into the math source');
 });
 
-test('math mixed with prose stays literal instead of becoming a math block', () => {
+test('math mixed with prose becomes a same-line display span, not a math block', () => {
 	// Two `$$` spans in a paragraph that also carries text: the block form does
-	// not apply, but the underscores still have to survive for the inline pass.
+	// not apply, but the underscores still have to survive, and each span still
+	// has to reach KaTeX. It reaches it as `\[…\]` — a spelling only this
+	// function mints — because the auto-renderer is deliberately given no
+	// `$`-based delimiter; see MATH_DELIMITERS in src/lib/utils/richContent.ts
+	// and scripts/mathDelimiterContract.test.ts.
 	const mixed = render('mathTwoBlocksOneLine');
 	assert.equal(mixed.querySelectorAll('[data-math]').length, 0);
 	assert.equal(mixed.querySelectorAll('em').length, 0);
-	assert.equal(mixed.textContent.trim(), 'before $$a_1$$ middle $$b_2$$ after');
+	assert.equal(mixed.textContent.trim(), 'before \\[a_1\\] middle \\[b_2\\] after');
 
 	const withEmphasis = render('mathEmphasisOutsideStillWorks');
 	assert.deepEqual(
@@ -288,7 +292,7 @@ test('math mixed with prose stays literal instead of becoming a math block', () 
 		'emphasis outside display math must keep working',
 	);
 	assert.ok(
-		withEmphasis.textContent.includes('$$p_1 + q_2$$'),
+		withEmphasis.textContent.includes('\\[p_1 + q_2\\]'),
 		'underscores inside display math were emphasised away',
 	);
 });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1280,8 +1280,64 @@ mod tests {
     fn an_escaped_dollar_never_opens_a_math_span() {
         let html = convert_markdown("Pay \\$100 for $x$ items.\n");
         assert!(
-            html.contains("Pay $100 for $x$ items."),
+            html.contains("Pay \\$100 for $x$ items."),
             "the escaped dollar opened a span: {html}",
+        );
+    }
+
+    #[test]
+    fn an_escaped_dollar_reaches_the_frontend_still_escaped() {
+        // comrak resolves `\$` to `$`, after which nothing downstream can tell
+        // "the reader wants a dollar sign" from "the reader wants a formula" —
+        // and the frontend, which is the side that decides, renders the second.
+        // So the escape is masked like math is and handed over intact; the
+        // frontend resolves it in `convertInlineMathDelimiters`.
+        let html = convert_markdown("Literal \\$\\$x\\$\\$ here.\n");
+        assert!(
+            html.contains("Literal \\$\\$x\\$\\$ here."),
+            "the escape was resolved before the frontend could honour it: {html}",
+        );
+    }
+
+    #[test]
+    fn an_escaped_backslash_keeps_the_dollar_behind_it_live() {
+        // `\\$` is an escaped backslash and then an ordinary `$`. Masking only
+        // the last backslash would hand the frontend `\$` and lose the
+        // distinction the whole mask exists to preserve.
+        let html = convert_markdown("A backslash \\\\$ here.\n");
+        assert!(
+            html.contains("A backslash \\\\$ here."),
+            "the backslash run was split: {html}",
+        );
+    }
+
+    #[test]
+    fn an_escaped_dollar_inside_a_formula_stays_part_of_the_formula() {
+        // Inside math, `\$` is TeX for a dollar sign. The math span already
+        // shields it, and claiming it separately would cut the span in two.
+        let html = convert_markdown("$a \\$ b$\n");
+        assert_eq!(rendered_math_source(&html).trim(), "$a \\$ b$");
+    }
+
+    #[test]
+    fn an_escaped_dollar_in_a_link_destination_is_resolved_not_forwarded() {
+        // Nothing unescapes an `href` on the way to the reader, so the
+        // backslash would simply become part of the URL.
+        let html = convert_markdown("[t](http://example.com/\\$5)\n");
+        assert!(
+            html.contains("href=\"http://example.com/$5\""),
+            "the escape leaked into the link destination: {html}",
+        );
+    }
+
+    #[test]
+    fn an_escaped_dollar_inside_code_is_left_to_commonmark() {
+        // A backslash is not an escape character inside code, so `\$` is two
+        // literal characters there and comrak already gets it right.
+        let html = convert_markdown("Use `\\$x\\$` here.\n");
+        assert!(
+            html.contains(">\\$x\\$</code>"),
+            "the mask reached into a code span: {html}",
         );
     }
 
@@ -2670,12 +2726,21 @@ fn process_parenthesized_autolinks(content: &str) -> Cow<'_, str> {
 // cannot win: Markdown has no business parsing TeX at all. So the whole span
 // is replaced by an opaque token before comrak runs and put back afterwards.
 //
+// Escaped dollars are hidden the same way, for the mirror-image reason. A
+// reader who writes `\$\$x\$\$` is saying "not a formula", and CommonMark
+// resolving that escape destroys the only evidence of it: the frontend, which
+// is the side that actually decides, then sees the same bytes a real `$$x$$`
+// produces and typesets the reader's dollar signs. See
+// `find_escaped_dollar_spans`.
+//
 // Deliberately NOT handled here: `\(…\)` and `\[…\]`, which the frontend also
 // renders. They have the same root cause and are not an oversight — CommonMark
 // eats the backslash (`\(` → `(`) before the frontend ever sees a delimiter, so
 // they have never worked in Markpad at all. Fixing them is a separate change
 // with its own regression surface; masking them here would silently start
-// claiming text that no released version ever treated as math.
+// claiming text that no released version ever treated as math. That the
+// frontend *emits* those two spellings is a different matter: they are its
+// private vocabulary for a decision it has already made.
 //
 // The token is deliberately plain ASCII rather than a private-use character:
 // comrak percent-encodes anything non-ASCII that ends up in a link
@@ -2690,12 +2755,25 @@ const MATH_MASK_PREFIX: &str = "MPMATHMASK";
 const MATH_MASK_SUFFIX: char = 'E';
 
 struct MaskedMath {
-    /// The source with every math span replaced by a token.
+    /// The source with every math span and every escaped dollar replaced by a
+    /// token.
     text: String,
     /// The token prefix actually used — see `mask_math_spans`.
     prefix: String,
     /// The masked source, one entry per line of each span, indexed by token.
-    spans: Vec<String>,
+    spans: Vec<MaskedSpan>,
+}
+
+/// One masked piece of source and the two spellings it can come back as.
+struct MaskedSpan {
+    /// The source, verbatim. This is what a text node gets, because a text
+    /// node is where the frontend's own passes run.
+    text: String,
+    /// What an attribute value gets instead. Nothing unescapes an `href` or an
+    /// `alt` on the way to the reader, so an escaped dollar has to arrive there
+    /// already resolved — the way comrak would have resolved it. For a math
+    /// span the two spellings are the same string.
+    attribute: String,
 }
 
 /// Byte ranges of `content` that may hold math: one entry per line, with the
@@ -2946,7 +3024,70 @@ fn find_math_spans(content: &str, regions: &[(usize, usize)]) -> Vec<(usize, usi
     spans
 }
 
-/// Replaces every math span with a token comrak cannot rewrite.
+/// The escaped dollars of `content`: a `$` carrying a run of backslashes in
+/// front of it, masked together with the whole run.
+///
+/// Declining to treat `\$` as a delimiter — which `find_math_spans` already
+/// does — protects the formula that is not there, and nothing else. comrak
+/// still resolves the escape, so `\$\$x\$\$` reaches the frontend as the same
+/// eight bytes an unescaped `$$x$$` does, and from that point on no rule can
+/// tell the two apart: the frontend renders the reader's literal dollars as a
+/// formula. `convertInlineMathDelimiters` has carried a "a `$` behind a
+/// backslash is not a delimiter" branch since before #402, and it has never
+/// once been able to fire, because the backslash is gone by the time the
+/// frontend looks.
+///
+/// So the escape is hidden from comrak exactly the way math is, and put back
+/// verbatim. The frontend gets its backslash, its dead branch comes alive, and
+/// resolving the escape becomes the job of the side that also decides what is
+/// math — which is the only way the two decisions can agree.
+///
+/// The whole backslash run is taken, not just the last one, so that `\\$`
+/// (an escaped backslash, then a live dollar) is not mistaken for `\$` after
+/// comrak has halved the run. Ranges inside a math span are skipped: there a
+/// `\$` is TeX for a dollar sign, and the math span already shields it.
+fn find_escaped_dollar_spans(
+    content: &str,
+    regions: &[(usize, usize)],
+    math: &[(usize, usize)],
+) -> Vec<(usize, usize)> {
+    let bytes = content.as_bytes();
+    let mut spans = Vec::new();
+    for (segment_start, segment_end) in math_scan_segments(content, regions) {
+        let mut index = segment_start;
+        while index < segment_end {
+            if bytes[index] != b'\\' {
+                index += content[index..].chars().next().map_or(1, char::len_utf8);
+                continue;
+            }
+            let mut run_end = index;
+            while run_end < segment_end && bytes[run_end] == b'\\' {
+                run_end += 1;
+            }
+            if run_end < segment_end && bytes[run_end] == b'$' {
+                if !math.iter().any(|&(start, end)| start < run_end + 1 && end > index) {
+                    spans.push((index, run_end + 1));
+                }
+                index = run_end + 1;
+            } else {
+                index = run_end;
+            }
+        }
+    }
+    spans
+}
+
+/// `\$` as comrak would have rendered it: every pair of backslashes collapses
+/// to one, and the escaping backslash in front of the `$` disappears.
+fn resolve_escaped_dollar(span: &str) -> String {
+    let backslashes = span.len() - 1;
+    let mut out = "\\".repeat(backslashes / 2);
+    out.push('$');
+    out
+}
+
+/// Replaces every math span — and every escaped dollar — with a token comrak
+/// cannot rewrite.
 ///
 /// One token per line of a span, so a six-line `$$…$$` block still occupies
 /// six lines: the line-number contract in `mod tests` is not negotiable, and a
@@ -2963,7 +3104,20 @@ fn mask_math_spans(content: &str) -> MaskedMath {
     }
 
     let regions = code_region_ranges(content);
-    let found = find_math_spans(content, &regions);
+    let math = find_math_spans(content, &regions);
+    // Both halves of one decision: what the frontend must render, and what it
+    // must refuse to render. Hiding only the first half is what let an
+    // explicitly escaped `\$\$x\$\$` come out typeset.
+    let mut found: Vec<(usize, usize, bool)> = math
+        .iter()
+        .map(|&(start, end)| (start, end, false))
+        .chain(
+            find_escaped_dollar_spans(content, &regions, &math)
+                .into_iter()
+                .map(|(start, end)| (start, end, true)),
+        )
+        .collect();
+    found.sort_by_key(|&(start, _, _)| start);
     if found.is_empty() {
         return MaskedMath {
             text: content.to_owned(),
@@ -2973,9 +3127,9 @@ fn mask_math_spans(content: &str) -> MaskedMath {
     }
 
     let mut text = String::with_capacity(content.len());
-    let mut spans: Vec<String> = Vec::new();
+    let mut spans: Vec<MaskedSpan> = Vec::new();
     let mut copied_to = 0usize;
-    for (start, end) in found {
+    for (start, end, escaped) in found {
         text.push_str(&content[copied_to..start]);
         for piece in content[start..end].split_inclusive('\n') {
             let mut body = piece;
@@ -2993,7 +3147,14 @@ fn mask_math_spans(content: &str) -> MaskedMath {
             let core = &body[indent..];
             if !core.is_empty() {
                 text.push_str(&format!("{prefix}{}{MATH_MASK_SUFFIX}", spans.len()));
-                spans.push(core.to_owned());
+                spans.push(MaskedSpan {
+                    attribute: if escaped {
+                        resolve_escaped_dollar(core)
+                    } else {
+                        core.to_owned()
+                    },
+                    text: core.to_owned(),
+                });
             }
             text.push_str(line_ending);
         }
@@ -3021,6 +3182,14 @@ fn mask_math_spans(content: &str) -> MaskedMath {
 /// `href="#…"`, which lowercases it. There the *anchorized* source goes back
 /// instead, so that `[[#A heading with $x_1$]]` still resolves — the wikilink
 /// side computes the same id from the raw buffer with `heading_anchor_id`.
+///
+/// Whether the token landed in markup or in text is tracked as it goes, and it
+/// is not a nicety: an escaped dollar goes back as `\$` only where a frontend
+/// pass will resolve it. Nothing resolves anything inside an `href` or an
+/// `alt`, so a token that landed there gets the resolved `$` instead — putting
+/// the backslash into a link destination would break the link. comrak escapes
+/// `<` and `>` everywhere else, so an unclosed `<` really does mean "inside a
+/// tag".
 fn restore_math_spans(html: &str, masked: &MaskedMath) -> String {
     if masked.spans.is_empty() {
         return html.to_owned();
@@ -3028,6 +3197,7 @@ fn restore_math_spans(html: &str, masked: &MaskedMath) -> String {
     let anchor_prefix = masked.prefix.to_ascii_lowercase();
     let mut out = String::with_capacity(html.len());
     let mut rest = html;
+    let mut in_tag = false;
     while let Some((at, anchored)) = [
         (rest.find(masked.prefix.as_str()), false),
         (rest.find(anchor_prefix.as_str()), true),
@@ -3037,6 +3207,9 @@ fn restore_math_spans(html: &str, masked: &MaskedMath) -> String {
     .min()
     {
         out.push_str(&rest[..at]);
+        if let Some(bracket) = rest[..at].rfind(['<', '>']) {
+            in_tag = rest.as_bytes()[bracket] == b'<';
+        }
         let after = &rest[at + masked.prefix.len()..];
         let digits = after
             .as_bytes()
@@ -3055,11 +3228,15 @@ fn restore_math_spans(html: &str, masked: &MaskedMath) -> String {
         };
         match index.and_then(|index| masked.spans.get(index)) {
             Some(original) if anchored => {
-                out.push_str(&Anchorizer::new().anchorize(original.clone()));
+                out.push_str(&Anchorizer::new().anchorize(original.text.clone()));
                 rest = &after[digits + suffix.len_utf8()..];
             }
             Some(original) => {
-                out.push_str(&escape_html_text(original));
+                out.push_str(&escape_html_text(if in_tag {
+                    &original.attribute
+                } else {
+                    &original.text
+                }));
                 rest = &after[digits + suffix.len_utf8()..];
             }
             None => {

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -125,6 +125,23 @@ function extractDisplayMathBlock(element: Element): string | null {
 	return math ? math : null;
 }
 
+/**
+ * Rewrites the math of one text node into delimiters KaTeX's auto-renderer can
+ * find, and resolves the dollar escapes the backend handed over intact.
+ *
+ * The output vocabulary is deliberately small and deliberately unspellable in
+ * Markdown: `\(…\)` for inline, `\[…\]` for a same-line `$$…$$`. CommonMark
+ * eats a user-typed `\(` or `\[` long before this function runs, so every one
+ * of these that exists was minted here — which is what lets KaTeX be given no
+ * `$`-based delimiter at all (see MATH_DELIMITERS in richContent.ts) and what
+ * makes this function the single place that decides what a reader sees as a
+ * formula.
+ *
+ * That in turn is why `\$` arrives here still escaped. comrak would have
+ * resolved it, and then `\$\$x\$\$` and `$$x$$` would be the same eight bytes
+ * and the reader's literal dollars would be typeset. `mask_math_spans` in
+ * src-tauri/src/lib.rs hides the escape from comrak for exactly this moment.
+ */
 function convertInlineMathDelimiters(text: string): string {
 	const parts: string[] = [];
 	let index = 0;
@@ -134,6 +151,25 @@ function convertInlineMathDelimiters(text: string): string {
 
 	while (index < text.length) {
 		const char = text[index];
+		if (char === "\\") {
+			let run = 1;
+			while (text[index + run] === "\\") run += 1;
+			if (text[index + run] !== "$") {
+				parts.push(text.slice(index, index + run));
+				previousDollarAllowsInlineOpen = false;
+				index += run;
+				continue;
+			}
+			// CommonMark's own arithmetic: each `\\` is one literal backslash,
+			// and the odd one left over is what marks the `$` as text. Whether
+			// the run is odd or even the `$` is not a delimiter — that is the
+			// rule the backend ports in `find_math_spans`, and the two have to
+			// stay the same rule.
+			parts.push("\\".repeat(run >> 1) + "$");
+			previousDollarAllowsInlineOpen = false;
+			index += run + 1;
+			continue;
+		}
 		if (char !== "$") {
 			parts.push(char);
 			previousDollarAllowsInlineOpen = false;
@@ -141,10 +177,10 @@ function convertInlineMathDelimiters(text: string): string {
 			continue;
 		}
 
-		if (text[index - 1] !== "\\" && text[index + 1] === "$") {
+		if (text[index + 1] === "$") {
 			const displayEnd = findDisplayMathEnd(text, index + 2);
 			if (displayEnd !== -1) {
-				parts.push(text.slice(index, displayEnd + 2));
+				parts.push(`\\[${text.slice(index + 2, displayEnd).trim()}\\]`);
 				previousDollarAllowsInlineOpen = true;
 				index = displayEnd + 2;
 				continue;
@@ -156,8 +192,9 @@ function convertInlineMathDelimiters(text: string): string {
 			continue;
 		}
 
+		// A backslash in front of this `$` is impossible: the branch above
+		// consumes the whole run together with the `$` it escapes.
 		if (
-			text[index - 1] === "\\" ||
 			(text[index - 1] === "$" && !previousDollarAllowsInlineOpen) ||
 			/\s/.test(text[index + 1] || "")
 		) {

--- a/src/lib/utils/richContent.ts
+++ b/src/lib/utils/richContent.ts
@@ -28,6 +28,27 @@ import { rememberDiagramSource } from './mermaidPrint.js';
  * comes from `root` — because a detached `<div>` is a first-class caller.
  */
 
+/**
+ * The delimiters KaTeX's auto-renderer is allowed to look for.
+ *
+ * Every one of them is a spelling CommonMark cannot produce. That is the whole
+ * specification: this scanner runs over comrak's *output*, where an explicitly
+ * escaped `\$\$x\$\$` and a real `$$x$$` are the same eight bytes, so any
+ * `$`-based entry here silently overrules the reader. `$$` used to be in this
+ * list, and a `\$\$…\$\$` written to mean "I want literal dollar signs" came
+ * out typeset.
+ *
+ * `\(` and `\[` reach this point only because `processMarkdownHtml` mints
+ * them — comrak eats a user-typed `\(` long before the preview exists. So the
+ * set rendered here is exactly the set `src/lib/utils/markdown.ts` decided on,
+ * and that set is what scripts/mathDelimiterContract.test.ts holds against the
+ * backend's. Adding a delimiter Markdown *can* spell reopens the gap.
+ */
+export const MATH_DELIMITERS = [
+	{ left: '\\(', right: '\\)', display: false },
+	{ left: '\\[', right: '\\]', display: true },
+];
+
 export interface RichContentLibraries {
 	hljs: any;
 	katex: any;
@@ -258,11 +279,7 @@ export async function renderRichContent(options: RenderRichContentOptions): Prom
 
 	if (renderMathInElement) {
 		renderMathInElement(root, {
-			delimiters: [
-				{ left: '$$', right: '$$', display: true },
-				{ left: '\\(', right: '\\)', display: false },
-				{ left: '\\[', right: '\\]', display: true },
-			],
+			delimiters: MATH_DELIMITERS,
 			throwOnError: false,
 		});
 	}


### PR DESCRIPTION
Two holes on the same seam — and one of them was inside the contract #402 built, which is the more interesting half.

## 1. `\$\$x\$\$` renders as math

Writing `\$\$x\$\$` means *"I want literal dollar signs."* It renders as a formula.

Traced end to end, running KaTeX's real `auto-render.mjs` with `katex.render` swapped for a recorder:

```
raw     Literal \$\$x\$\$ here.
 └ backend  find_math_spans → []          ← correct: escaped is not math
 └ comrak                   → "Literal $$x$$ here."   ← un-escapes; the evidence is gone
 └ frontend                 → cannot tell them apart
 └ KaTeX                    → ["display:x"]           ← escape defeated
```

The backend gets it right and then **throws the answer away**. Inline `\$x\$` fails the same way.

## 2. `$$x$$` inside a paragraph was outside the contract

| | `Inline prose with $$x_1$$ mixed in.` |
|---|---|
| backend `find_math_spans` | **masks** it — `("display","x_1")` |
| frontend `convertInlineMathDelimiters` | passes it through **verbatim** — no `\(…\)`, no `data-math` |
| the contract's extractor | **cannot see it** — it only reads those two artefacts |
| what actually renders it | `renderMathInElement`'s own `$$` delimiter — **a fourth channel** |

So the earlier diagnosis needs one correction: **P and R were in fact equal** — the paragraph-level `$$` really does render. What was wrong is that **the contract could not see part of R**. The corpus had thirteen display cases and *every one* was the block form, so the test was green on a path it never looked at.

## Why the frontend cannot fix the escape alone

`\$\$x\$\$` and `$$x$$` reach the frontend as **the same eight bytes**. No rule reading comrak's output can separate them — that is provable, not a judgement call.

And the corpus now demands *both* a paragraph-`$$` positive **and** an escaped negative. Those two requirements together **force** the backend to preserve what the frontend needs. The fix follows from the corpus rather than from taste:

- **Backend**: the mask now covers `\$` runs as well as math spans, restoring them verbatim — handing the decision back to the side the user can see, which is the direction #402 already chose. (Moving the decision *into* the backend does not work: restoration is a plain string substitution, and landing inside an `href`, an `alt`, or a heading anchor would break links and anchors.)
- **Frontend**: `convertInlineMathDelimiters` takes over paragraph-level `$$`, emitting `\[…\]` — symmetric with `\(…\)`, and like it, something CommonMark cannot spell and only `markdown.ts` mints — and un-escapes `\$` → `$` in place.
- **KaTeX**: `$$` removed from the delimiter list, leaving `\(…\)` and `\[…\]`.

### The equality argument is now structural, not enumerated

Every delimiter KaTeX accepts can only be produced by `markdown.ts` (`\(…\)`, `\[…\]`, `data-math`), and **CommonMark cannot spell any of them**, so a fourth channel cannot exist. That is asserted directly against the exported `MATH_DELIMITERS`, not grepped. The `KNOWN GAP` note in the corpus is deleted, because it is no longer a gap.

## Two findings that came out of it

- **A dead branch that came alive elsewhere.** `convertInlineMathDelimiters`'s `text[index - 1] === "\\"` check **has never run** — comrak ate the backslash long before. It became live when #402 ported the same rule to Rust, where the raw markdown still has it.
- **A second escaped case the scan missed**: `\$\$x\$\$` alone on its own line goes through `processDisplayMathBlocks` and gets a real `data-math="display"` — visible to the *existing* extractor, and red on the baseline.

## Misjudgement guards

**All fourteen stay green, and the corpus `math` lists are unchanged.** All 24 existing cases pass on both sides, including the four mixed guards (`\$100` next to real math, spans crossing inline code, `$a$` inside code, `$$` in a fence not flipping parity). Observable output re-measured: `It cost $100 and $200 today.` unchanged · `Costs \$5 only.` → `Costs $5 only.` with no stray backslash · `$a \$ b$` → `\(a \$ b\)`, TeX escape preserved.

## Red / green

Corpus added, implementation reverted:

| | |
|---|---|
| new frontend cases | **3 red / 2 green** — `an escaped display delimiter alone in a paragraph` (got `[display:x]`), `an escaped inline delimiter` (got `[inline:x]`), `same-line display math mixed into prose` (want `[display:x_1]`, got `[]`) |
| the fourth | **green — and that one is the blind spot itself** |
| final | `npm test` **541 / 541**, `cargo test` **141 / 141** |

Reverse-stash checks: reverting the frontend → 3 red; reverting only `lib.rs` → the live-capture test catches the HTML drift; reverting `lib.rs` **and** refreshing the captured HTML to silence it — i.e. the "just re-record the fixture" move — leaves the frontend contract **red on `Literal \$\$x\$\$ here.`**. The case the baseline could not see is now visible.

```
npm run check   438 files, 0 errors
npm test        541 / 541
cargo test      141 / 141
cargo clippy    3 warnings, identical to baseline
```

## Not covered

- Hand-written `\(…\)` / `\[…\]` in a document still do not work — comrak eats the backslash first. Listed as a separate change in #402 and still is.
- A paragraph-level formula containing a literal `\]` (or `\)` inline) truncates early. Same class as the old `$$` delimiter meeting a `$$` inside itself — not new, but the closing token changed.
- `\\$x$` is treated as not-math by both sides; strict CommonMark would disagree. Pre-existing rule, now explicit rather than accidental.
- No browser screenshots. The final link — auto-render's delimiter decision — was verified by running the real module with `katex.render` instrumented; glyph-level rendering was not inspected.
- One assertion in `scripts/renderProtocol.test.ts` pinned *"paragraph-level `$$` stays literal"* — the behaviour being fixed — so it is updated (`$$a_1$$` → `\[a_1\]`) with the fixture and other cases untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)