### PR TITLE
perf(editor): load Monaco when the editor is opened, not at startup

### DIFF
--- a/scripts/monacoStartupGraph.test.ts
+++ b/scripts/monacoStartupGraph.test.ts
@@ -1,0 +1,228 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import test from 'node:test';
+
+// Monaco is ~86% of Markpad's startup JavaScript (measured: a 4.4 MB chunk out
+// of 4.7 MB on first paint, ~360ms of parse+eval, paid once per window because
+// every window is its own webview) and a reader who only ever views Markdown
+// never touches it. It is therefore loaded with `await import()` from
+// Editor.svelte's `onMount`, not with a top-level `import`.
+//
+// WHAT THIS FILE PROVES: walking only *static* imports from the app's entry
+// module (`src/routes/+page.svelte`), no reachable module names `monaco-editor`
+// or `monaco-vim` as a static import. That is the property a bundler turns into
+// "not in the startup chunk", and it is the property a careless edit destroys —
+// re-adding `import * as monaco from 'monaco-editor'` anywhere in the reachable
+// graph, in Editor.svelte or in any util it pulls in, fails this test.
+//
+// WHAT IT DOES NOT PROVE: that Rollup actually emitted a separate chunk. Chunk
+// splitting is the bundler's decision, and `vite.config.js` could still be
+// changed to inline everything (e.g. a `manualChunks` that merges it, or
+// `inlineDynamicImports`). Verifying that needs a real build; the numbers from
+// one are recorded in the PR description instead. Source-level reachability is
+// the half that can run in CI without a 45-second build, so it is the half
+// that is locked here.
+//
+// Type-only imports (`import type ...`) are deliberately ignored: TypeScript
+// erases them, so they cost nothing at runtime and Editor.svelte relies on one.
+
+const ENTRY = 'src/routes/+page.svelte';
+const FORBIDDEN = ['monaco-editor', 'monaco-vim'];
+
+/** `import ... from 'x'`, `export ... from 'x'`, and bare `import 'x'`. */
+const STATIC_IMPORT = /(?:^|[\s;}])(?:import|export)\s+(?!type\s)(?:[^'"();]*?\sfrom\s*)?['"]([^'"]+)['"]/g;
+/** `import type ... from 'x'` / `export type ... from 'x'` — erased at compile time. */
+const TYPE_IMPORT = /\b(?:import|export)\s+type\s[^'"();]*?from\s*['"][^'"]+['"]/g;
+
+function readSource(file: string): string {
+	const raw = readFileSync(file, 'utf8');
+	if (!file.endsWith('.svelte')) return raw;
+	// Only the <script> blocks can import; the markup and <style> cannot.
+	return [...raw.matchAll(/<script[^>]*>([\s\S]*?)<\/script>/g)].map((m) => m[1]).join('\n');
+}
+
+/**
+ * Specifiers of the statements that survive to runtime.
+ *
+ * Type-only statements are deleted from the text before matching rather than
+ * subtracted from the result set afterwards. Subtracting by specifier string is
+ * what a first draft of this file did, and it had a hole big enough to drive the
+ * regression through: Editor.svelte imports `monaco-editor` for its types, so a
+ * `import * as monaco from "monaco-editor"` added next to it would have been
+ * cancelled out by its own type import and reported clean.
+ */
+function staticSpecifiers(source: string): string[] {
+	const runtimeOnly = source.replace(TYPE_IMPORT, '');
+	return [...runtimeOnly.matchAll(STATIC_IMPORT)].map((m) => m[1]);
+}
+
+/**
+ * Resolve a specifier to a file on disk, or `null` for a bare package name.
+ * SvelteKit sources use the `.js` extension for relative TypeScript imports, so
+ * `./x.js` has to be probed as `./x.ts` too.
+ */
+function resolveLocal(specifier: string, fromFile: string): string | null {
+	let target: string;
+	if (specifier.startsWith('.')) target = resolve(dirname(fromFile), specifier);
+	else if (specifier.startsWith('$lib/')) target = resolve('src/lib', specifier.slice('$lib/'.length));
+	else if (specifier.startsWith('$app/') || !specifier.startsWith('/')) return null;
+	else return null;
+
+	const candidates = [
+		target,
+		target.replace(/\.js$/, '.ts'),
+		target.replace(/\.js$/, '.svelte.ts'),
+		`${target}.ts`,
+		`${target}.js`,
+		`${target}.svelte`,
+	];
+	return candidates.find((c) => existsSync(c) && !c.endsWith('/')) ?? null;
+}
+
+function walkStaticGraph(entry: string): Map<string, string[]> {
+	const reached = new Map<string, string[]>();
+	const queue = [resolve(entry)];
+
+	while (queue.length > 0) {
+		const file = queue.pop()!;
+		if (reached.has(file)) continue;
+
+		const specifiers = staticSpecifiers(readSource(file));
+		reached.set(file, specifiers);
+
+		for (const specifier of specifiers) {
+			const local = resolveLocal(specifier, file);
+			if (local) queue.push(local);
+		}
+	}
+
+	return reached;
+}
+
+test('the parser sees the imports it is supposed to see', () => {
+	// A graph walk that silently resolves nothing would pass this file forever.
+	const graph = walkStaticGraph(ENTRY);
+	const files = [...graph.keys()].map((f) => relative(process.cwd(), f));
+
+	assert.ok(files.includes('src/lib/MarkdownViewer.svelte'), 'reached the viewer from the entry');
+	assert.ok(files.includes('src/lib/components/Editor.svelte'), 'reached Editor.svelte, which is still statically imported');
+	assert.ok(files.includes('src/lib/stores/settings.svelte.ts'), 'followed a $lib specifier with a .js extension');
+	assert.ok(files.length > 30, `walked a real graph, not a stub (got ${files.length} files)`);
+
+	// The negative check below is only meaningful if a static Monaco import
+	// would in fact be seen. Plant the exact regressions this file exists to
+	// catch and prove the matcher reports each one.
+	assert.deepEqual(
+		staticSpecifiers('import * as monaco from "monaco-editor";'),
+		['monaco-editor'],
+		'a static Monaco import is detected when present',
+	);
+	assert.deepEqual(
+		staticSpecifiers('import type * as Monaco from "monaco-editor";'),
+		[],
+		'a type-only import is erased at compile time and does not count',
+	);
+	assert.deepEqual(
+		// The shape Editor.svelte actually has: the type import stays, and a
+		// value import of the same module is added beside it.
+		staticSpecifiers(
+			'import type * as Monaco from "monaco-editor";\nimport * as monaco from "monaco-editor";',
+		),
+		['monaco-editor'],
+		'a value import is not masked by a type import of the same module',
+	);
+	assert.deepEqual(
+		staticSpecifiers('const monaco = await import("monaco-editor");'),
+		[],
+		'a dynamic import is not a static one',
+	);
+});
+
+test('Monaco is not reachable by static import from the app entry', () => {
+	const graph = walkStaticGraph(ENTRY);
+
+	const offenders: string[] = [];
+	for (const [file, specifiers] of graph) {
+		for (const specifier of specifiers) {
+			if (FORBIDDEN.some((pkg) => specifier === pkg || specifier.startsWith(`${pkg}/`))) {
+				// Vite's `?worker` imports compile to a URL plus a `new Worker(url)`
+				// wrapper and emit the worker bundle as its own file, so they are
+				// already lazy — verified against a production build: zero worker
+				// requests on first paint.
+				if (specifier.endsWith('?worker')) continue;
+				offenders.push(`${relative(process.cwd(), file)} -> ${specifier}`);
+			}
+		}
+	}
+
+	assert.deepEqual(
+		offenders,
+		[],
+		'Monaco must be reached with await import(), never a static import, or it lands back in the startup chunk',
+	);
+});
+
+test('Editor.svelte loads Monaco with a dynamic import', () => {
+	const editor = readFileSync('src/lib/components/Editor.svelte', 'utf8');
+
+	assert.match(
+		editor,
+		/monaco = await import\("monaco-editor"\)/,
+		'the module is fetched on mount',
+	);
+	assert.match(
+		editor,
+		/import type \* as Monaco from "monaco-editor"/,
+		'types come from a type-only import, which is erased',
+	);
+
+	// `onMount` must stay synchronous: Svelte only accepts a synchronously
+	// returned function as the unmount cleanup, so an `async` callback would
+	// hand it a promise and leak the editor and its listeners.
+	assert.doesNotMatch(editor, /onMount\(async/, 'onMount is not async');
+	assert.match(editor, /cancelled = true;/, 'an in-flight import is cancellable on unmount');
+});
+
+test('every effect that drives the editor waits for editorReady', () => {
+	// `editor` is a plain `let`, assigned after an await. An effect gated on it
+	// alone runs once against nothing and is never re-triggered, which silently
+	// drops scroll sync, the zoom-aware font size, the theme and Vim mode.
+	const editor = readFileSync('src/lib/components/Editor.svelte', 'utf8');
+	const effects = [...editor.matchAll(/\$effect\(\(\) => \{([\s\S]*?)\n\t\}\);/g)].map((m) => m[1]);
+	assert.ok(effects.length >= 5, `found the effects (got ${effects.length})`);
+
+	for (const body of effects) {
+		if (!/\beditor\b/.test(body)) continue;
+		assert.match(
+			body,
+			/editorReady/,
+			`an effect touching the editor is not gated on editorReady:\n${body.slice(0, 160)}`,
+		);
+	}
+});
+
+test('no source file outside Editor.svelte reintroduces a static Monaco import', () => {
+	// Belt and braces for modules the graph walk cannot reach statically (a file
+	// only pulled in through a dynamic import elsewhere): grep the whole tree.
+	const offenders: string[] = [];
+
+	const visit = (dir: string) => {
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			const path = `${dir}/${entry.name}`;
+			if (entry.isDirectory()) {
+				visit(path);
+			} else if (/\.(svelte|ts|js)$/.test(entry.name)) {
+				for (const specifier of staticSpecifiers(readSource(path))) {
+					if (specifier.endsWith('?worker')) continue;
+					if (FORBIDDEN.some((pkg) => specifier === pkg || specifier.startsWith(`${pkg}/`))) {
+						offenders.push(`${path} -> ${specifier}`);
+					}
+				}
+			}
+		}
+	};
+
+	visit('src');
+	assert.deepEqual(offenders, []);
+});

--- a/scripts/scrollSyncInput.test.ts
+++ b/scripts/scrollSyncInput.test.ts
@@ -3,7 +3,12 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 const editor = readFileSync('src/lib/components/Editor.svelte', 'utf8');
-const syncEffect = editor.slice(editor.indexOf('if (editor && onscrollsync)'), editor.indexOf('\n\t$effect(() => {', editor.indexOf('if (editor && onscrollsync)') + 1));
+// Anchor on the tail of the guard, not the whole condition: the effect gained an
+// `editorReady &&` term when Monaco moved behind a dynamic import, and an
+// exact-match marker silently sliced an empty string instead of failing loudly.
+const syncStart = editor.indexOf('&& onscrollsync)');
+assert.notEqual(syncStart, -1, 'expected to find the scroll-sync effect guard');
+const syncEffect = editor.slice(syncStart, editor.indexOf('\n\t$effect(() => {', syncStart + 1));
 
 test('typing does not initiate split scroll synchronization', () => {
 	assert.match(syncEffect, /editor\.onDidScrollChange/);

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -6,7 +6,20 @@
 	import { managedImageFromCopy, type ManagedImage } from '../utils/managedImages.js';
 	import { MARKDOWN_LANGUAGE_ID, shouldLinkifyPastedUrl } from '../utils/pasteContext.js';
 
-	import * as monaco from "monaco-editor";
+	// Monaco is ~86% of the startup JavaScript (a 4.4 MB chunk, ~360ms of
+	// parse+eval, paid once per window because every window is its own webview)
+	// and a reader who only ever views Markdown never touches a line of it. So
+	// the module is pulled in from `onMount` below instead of here: a static
+	// `import` would put it back in the startup graph no matter how rarely this
+	// component mounts. Only the *types* are imported statically — `import type`
+	// is erased entirely, so it costs nothing at runtime.
+	//
+	// The `?worker` imports below stay static on purpose. Vite compiles each of
+	// them to a URL string plus a `new Worker(url)` wrapper and emits the worker
+	// bundle as its own file, so they are already lazy: nothing is fetched until
+	// Monaco actually asks `getWorker()` for one. Making them dynamic would move
+	// a few hundred bytes and buy nothing.
+	import type * as Monaco from "monaco-editor";
 	import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
 	import jsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
 	import cssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
@@ -61,11 +74,15 @@
 
 	let container: HTMLDivElement;
 	let vimStatusNode = $state<HTMLDivElement>();
-	let editor: monaco.editor.IStandaloneCodeEditor;
+	// Assigned by the dynamic `import()` in `onMount`, before anything reads it:
+	// every use of a Monaco *value* in this file sits behind an `editor` /
+	// `editorReady` guard, and `editor` only exists once the module has landed.
+	let monaco: typeof Monaco;
+	let editor: Monaco.editor.IStandaloneCodeEditor;
 	let isApplyingExternalScroll = false;
 	const managedImages: ManagedImage[] = $state([]);
 
-	let cursorPosition = $state<monaco.Position | null>(null);
+	let cursorPosition = $state<Monaco.Position | null>(null);
 	let selectionCount = $state(0);
 	let cursorCount = $state(0);
 	let wordCount = $state(0);
@@ -82,9 +99,13 @@
 	//
 	// `editorReady` has to be `$state` rather than a plain `if (editor)` guard:
 	// `editor` is assigned inside `onMount` and is not reactive, so an effect
-	// that bailed out on it would never re-run once the editor appeared.
+	// that bailed out on it would never re-run once the editor appeared. That
+	// was already true when the editor was built synchronously on mount; now
+	// that `onMount` first awaits the Monaco chunk, *every* effect that touches
+	// the editor has to gate on this flag, or it runs once against a missing
+	// editor and never runs again.
 	let editorReady = $state(false);
-	let localizedActions: monaco.IDisposable[] = [];
+	let localizedActions: Monaco.IDisposable[] = [];
 
 	// `settings.osType` is resolved asynchronously from the Rust side, so it can
 	// still be 'unknown' while the editor registers its keybindings. Fall back to
@@ -133,6 +154,29 @@
 	};
 
 	onMount(() => {
+		let cancelled = false;
+		let teardown: (() => void) | null = null;
+
+		// `onMount` itself stays synchronous: Svelte only treats a *synchronously*
+		// returned function as the unmount cleanup, so an `async` callback would
+		// hand it a promise and silently leak the editor, its listeners and the
+		// `window.open` patch. The await lives in this inner task instead, and the
+		// synchronous return closes over both the cancel flag (the component can
+		// be destroyed while the chunk is still in flight — Ctrl+E then Ctrl+E
+		// again) and whatever cleanup `createEditor` produced.
+		void (async () => {
+			monaco = await import("monaco-editor");
+			if (cancelled) return;
+			teardown = createEditor();
+		})();
+
+		return () => {
+			cancelled = true;
+			teardown?.();
+		};
+	});
+
+	function createEditor() {
 		const originalOpen = window.open;
 		window.open = function (
 			url?: string | URL,
@@ -184,6 +228,14 @@
 		};
 
 		defineThemes();
+
+		// The active tab can change while the Monaco chunk is downloading (open a
+		// document in edit mode, then Ctrl+Tab before it lands). The effect that
+		// normally handles a tab switch bailed out on the missing editor, so
+		// re-read the id here: the view state saved on unmount has to be filed
+		// against the tab the editor is really showing, not the one that was
+		// active when this component was created.
+		currentTabId = tabManager.activeTabId;
 
 		const getTheme = () => {
 			if (theme && theme.startsWith("vscode:")) return "vscode-custom";
@@ -297,7 +349,7 @@
 
 			if (model && selections.length > 0) {
 				selectionCount = selections.reduce(
-					(acc: number, selection: monaco.Selection) => {
+					(acc: number, selection: Monaco.Selection) => {
 						return acc + model.getValueInRange(selection).length;
 					},
 					0,
@@ -384,7 +436,7 @@
 							word.endColumn,
 						);
 
-						const suggestions: monaco.languages.CompletionItem[] = [
+						const suggestions: Monaco.languages.CompletionItem[] = [
 							...currentEntries.map((e) => ({
 								label: e,
 								kind: e.endsWith("/")
@@ -592,7 +644,7 @@
 
 			editor.dispose();
 		};
-	});
+	}
 
 	// Editing primitives used by the context-menu actions. They live at
 	// component scope, not inside `onMount`, because the actions that call them
@@ -748,8 +800,8 @@
 	 * multi-cursor selection would cost far more than the edge case is worth.
 	 */
 	function isLinkifyPasteTarget(
-		model: monaco.editor.ITextModel,
-		selection: monaco.Selection,
+		model: Monaco.editor.ITextModel,
+		selection: Monaco.Selection,
 	): boolean {
 		return shouldLinkifyPastedUrl({
 			languageId: model.getLanguageId(),
@@ -1231,8 +1283,13 @@
 		});
 	}
 
+	// Every effect below reads `editorReady` first, and only then `editor`. See
+	// the declaration of `editorReady`: `editor` is a plain `let`, so an effect
+	// gated on it alone would run once before the Monaco chunk resolves, find
+	// nothing, and never be re-triggered — losing scroll sync, the zoom-aware
+	// font size, the theme and Vim mode for the whole life of the editor.
 	$effect(() => {
-		if (editor && onscrollsync) {
+		if (editorReady && editor && onscrollsync) {
 			const emitSync = () => {
 				if (isApplyingExternalScroll) return;
 
@@ -1254,7 +1311,7 @@
 		const activeTabId = tabManager.activeTabId;
 		const content = value;
 
-		if (!editor) return;
+		if (!editorReady || !editor) return;
 
 		if (activeTabId !== currentTabId) {
 			if (currentTabId) {
@@ -1282,7 +1339,7 @@
 	});
 
 	$effect(() => {
-		if (editor) {
+		if (editorReady && editor) {
 			editor.updateOptions({
 				minimap: { enabled: settings.minimap },
 				wordWrap: settings.wordWrap as
@@ -1309,7 +1366,7 @@
 
 
 	$effect(() => {
-		if (editor && theme) {
+		if (editorReady && editor && theme) {
 			if (theme.startsWith("vscode:")) return;
 			const targetTheme =
 				theme === "system"
@@ -1324,7 +1381,7 @@
 	});
 
 	$effect(() => {
-		if (editor && settings.vimMode && vimStatusNode) {
+		if (editorReady && editor && settings.vimMode && vimStatusNode) {
 			let disposed = false;
 			let vim: { dispose: () => void } | null = null;
 			const currentEditor = editor;
@@ -1526,6 +1583,23 @@
 		class="editor-container"
 		bind:this={container}
 	></div>
+	<!--
+		Measured: fetching, parsing and evaluating the Monaco chunk takes ~390ms
+		on an Apple-silicon Mac (~360ms of that is parse+eval, not transfer), so
+		the first switch into edit mode leaves this pane blank long enough to read
+		as a dropped keypress. Same wordless spinner the app already shows while
+		it boots, so there is no new string to translate and nothing to mistake
+		for an error. It costs nothing after the first mount in a window: the
+		chunk is in the module cache, `editorReady` flips in the same tick, and
+		this never paints again.
+	-->
+	{#if !editorReady}
+		<div class="editor-loading">
+			<svg class="spinner" viewBox="0 0 50 50">
+				<circle class="path" cx="25" cy="25" r="20" fill="none" stroke-width="4"></circle>
+			</svg>
+		</div>
+	{/if}
 </div>
 
 {#if settings.vimMode}
@@ -1564,12 +1638,55 @@
 
 <style>
 	.editor-outer {
+		position: relative;
 		flex: 1;
 		height: 100%;
 		width: 100%;
 		display: flex;
 		background-color: var(--color-canvas-default);
 		overflow: hidden;
+	}
+
+	.editor-loading {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: var(--color-canvas-default);
+	}
+
+	.spinner {
+		width: 50px;
+		height: 50px;
+		animation: rotate 2s linear infinite;
+	}
+
+	.spinner .path {
+		stroke: var(--color-accent-fg);
+		stroke-linecap: round;
+		animation: dash 1.5s ease-in-out infinite;
+	}
+
+	@keyframes rotate {
+		100% {
+			transform: rotate(360deg);
+		}
+	}
+
+	@keyframes dash {
+		0% {
+			stroke-dasharray: 1, 150;
+			stroke-dashoffset: 0;
+		}
+		50% {
+			stroke-dasharray: 90, 150;
+			stroke-dashoffset: -35;
+		}
+		100% {
+			stroke-dasharray: 90, 150;
+			stroke-dashoffset: -124;
+		}
 	}
 
 	.editor-container {


### PR DESCRIPTION
Every window loads Monaco before painting anything — including windows that only ever show rendered Markdown. Each window is its own webview, so the cost repeats per window.

```
                    requests   KB decoded   largest chunk
before  first paint     14        4770        4410 KB   (Monaco + app in one chunk)
after   first paint     14         904         686 KB   (app only)
                                ────────
                                 −3866 KB   (−81 %)

after   entering edit mode:  +4 requests / +3868 KB / 327 ms
```

**904 + 3868 = 4772 ≈ 4770** — nothing is duplicated or lost; it is deferred.

Measured with the repo's own config (`svelte-kit sync && vite build`), served over `python3 -m http.server` so decoded equals transferred, read from `performance.getEntriesByType('resource')`.

## The workers were already lazy — so the weight is Monaco itself

Checked before changing anything, three ways:

| | |
|---|---|
| Build output | emitted as standalone files under `_app/immutable/workers/`, not chunks in the main graph |
| Reference in the parent chunk | `new Worker(""+new URL("../workers/editor.worker-….js",import.meta.url))` — a URL string, nothing more |
| First paint, before **and** after | **0** worker requests |
| Runtime | `editor.worker` on the first keystroke; ts/json/css/html workers **never** fetched for a Markdown document |

So the four `?worker` imports stay static — making them dynamic would move a few hundred bytes of URL string and buy nothing. That is written at the import site and asserted in the test, which explicitly skips `?worker` specifiers.

## `MarkdownViewer.svelte` is untouched

Making the import inside `Editor.svelte` dynamic was enough: nothing statically reachable from the entry names `monaco-editor` any more, so Rollup splits it. `MarkdownViewer` keeps its static `import Editor`, which is now a cheap component shell.

Three structural consequences had to be handled, and two of them would have failed silently:

- **`onMount` stays synchronous.** Svelte only accepts a *synchronously returned* teardown; an `async` callback hands it a promise and leaks the editor, its listeners and the `window.open` patch. The await lives in an inner task, and the sync return closes over a `cancelled` flag.
- **Every effect touching the editor gates on a reactive `editorReady`.** `editor` is a plain `let`, so `if (editor)` runs once against nothing and **never re-fires** — that would have silently dropped scroll sync, zoom-aware font size, theme and Vim mode for anyone who had them on at mount. The file already carried this warning for the localised-actions effect; it now covers the other five.
- **The tab id is re-read at create time**, since the tab can change while the chunk is in flight, and the tab-switch effect bails during that window.

## Every entry point, verified

`startInEditor` · `newFileDefaultMode` · restored session tabs · Ctrl+E / pencil / context menu · Ctrl+\ split · typing into the preview · Ctrl+L live mode — **all funnel through one `{#if isEditing || isSplit}` block**, so one fix covers them. Every `editorPane.*` call site is `?.`-guarded or behind a truthiness check, and every exported method self-guards, so calls during the load window are no-ops rather than crashes.

**Saving is safe during the window**: `saveContent` reads `tab.rawContent` from the store, never `editor.getValue()`, so a save landing mid-load cannot write an empty file.

## First entry costs 327 ms, so it gets the spinner the app already has

| Chunk | Total | Parse+eval |
|---|---|---|
| before, monolith (4410 KB) | 391 / 401 / 420 ms | ~360 ms |
| after, startup chunk (686 KB) | 60 / 60 / 52 ms | ~50 ms |
| after, full edit-mode entry | **327 ms** | ~264 ms |

Well past "tens of ms", so it shows the **same wordless SVG spinner the app already displays while booting**, scoped inside `.editor-outer` — no new i18n string, nothing that reads as an error. It paints once per window; re-entering edit mode later fetches nothing and shows no spinner frame.

**No idle prefetch.** It would restore most of the parse cost for viewer-only users, multiplied per window — exactly the cost this removes.

**The cost is not moved from one group to another.** For `startInEditor` users:

```
before  ~400 ms blocking startup JS ──────────────────────► editor
after   ~50 ms startup JS ─► shell paints ─► +327 ms ─────► editor
```

Roughly a wash on time-to-editor, and the shell is interactive ~340 ms earlier.

## Verified by running the built app

With the Tauri IPC layer stubbed (in scratch, never in the repo), driving the real production build:

- boots to the home screen with **0 Monaco requests**
- new file → spinner → editor mounts → spinner gone; typed text, status bar tracked to 列 18, tab went dirty
- localised actions registered (`fmt-bold` → 粗体, `toggle-vim-mode` → Vim模式); `updateOptions` re-ran reactively (minimap, wordWrap); theme class applied, `defineTheme` still ordered before `create`; Vim toggled on → `--NORMAL--` → off
- **the decisive case**: left Vim **and** minimap on, unmounted the Editor, remounted → Vim bar back, minimap rendered, content preserved, actions registered, **0 new requests**. That is precisely the scenario a non-reactive `if (editor)` gate would have dropped.
- 0 console errors throughout

## Tests

`scripts/monacoStartupGraph.test.ts` walks the **static** import graph from `src/routes/+page.svelte` — resolving `$lib/`, `.js`→`.ts`, `.svelte`, and stripping type-only statements — and asserts nothing reachable names `monaco-editor` or `monaco-vim`. Its header states what it proves (no static source path) and what it does not (that Rollup actually emitted a separate chunk — `vite.config.js` could still merge it, which needs a real build, hence the numbers above).

| Mutation | Result |
|---|---|
| baseline | 533/533, 5/5 in the new file |
| static `import * as monaco` restored | **3 of 5 red** |
| transitive static import via a reachable util | **2 of 5 red**, naming `src/lib/utils/__probe.ts -> monaco-editor` |
| one `editorReady` gate dropped (Vim) | **1 of 5 red** |

The first red run **caught a bug in the test's own first draft**: type-only imports were subtracted by specifier string, so `Editor.svelte`'s own type import masked a value import of the same module. Fixed by deleting type statements from the text before matching, with a planted-regression self-check.

`scripts/scrollSyncInput.test.ts` sliced on the literal `if (editor && onscrollsync)` and silently produced an **empty string** once the guard gained `editorReady &&`. Re-anchored with an explicit `notEqual(-1)` so it fails loudly instead of passing vacuously.

```
npm run check   438 files, 0 errors
npm test        545 / 545
cargo test      141 / 141
npm run build   clean
```

## Not covered

- **`theme.ts` still pulls Monaco at startup for `vscode:*` theme users** — `parseAndApplyVscodeTheme` does its own `await import('monaco-editor')` from a boot-time effect. Those users are **no worse off** (it used to be a blocking static import and is now async, off the critical path) but they do not get the full win. Deferring it is a separate behavioural change.
- Measurements are Chromium over localhost. Tauri serves over its own protocol into WKWebView / WebView2 / WebKitGTK; transfer should be cheaper, and parse+eval dominates and is engine-dependent. JavaScriptCore was not measured.
- The cancel-while-loading path is asserted and correct by construction, but could not be raced by hand once the module was cached.
- Split view mounts one Editor, so two concurrent Monaco instances in one window were not exercised.
- `window.open` is patched ~330 ms later on first entry. Nothing in the editor path calls it inside that window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)