### PR TITLE
fix(preview): give each document its own heading fold state

### DIFF
--- a/scripts/editorPdfExport.test.ts
+++ b/scripts/editorPdfExport.test.ts
@@ -368,7 +368,12 @@ test('the refresh is skipped when the DOM already matches the buffer', () => {
 
 test('the refresh actually lands before the print', () => {
 	const body_ = slice(viewer, 'async function syncPreviewForPrint', 'async function exportAsPdf');
-	assert.match(body_, /await renderMarkdownPreview\(rawContent, tab\.path\)/);
+	// What matters here is WHAT is rendered — this tab's buffer and this tab's
+	// path, not the disk — and that it is awaited before the content is
+	// swapped in. The trailing arguments are deliberately not pinned: fold
+	// state is one of them and it is the renderer's business, not the
+	// export's.
+	assert.match(body_, /await renderMarkdownPreview\(rawContent, tab\.path[,)]/);
 	assert.match(body_, /tabManager\.updateTabContent\(tabId, processed\)/);
 	// Mermaid, KaTeX and highlight.js all replace nodes asynchronously. The
 	// on-screen path fires and forgets; the export cannot.

--- a/scripts/foldStatePerDocument.test.ts
+++ b/scripts/foldStatePerDocument.test.ts
@@ -1,0 +1,409 @@
+/**
+ * Heading folds belong to the document, not to the window.
+ *
+ * The fold key `processMarkdownHtml` writes and reads is the heading's id —
+ * comrak's slug — falling back to its text. That identifies a heading WITHIN a
+ * document and nowhere else: every file with an `## Introduction` gets the key
+ * `introduction`. While the viewer held one window-wide Set, folding that
+ * section in one document folded it in every open document that had the same
+ * heading, and the key outlived the document it was folded in, so the next file
+ * to contain that heading opened with the section already shut and nothing on
+ * screen to explain it.
+ *
+ * These tests run the REAL `toggleFold` and `handleLinkClick` out of
+ * MarkdownViewer.svelte, the REAL `visibleItems` out of Toc.svelte and the REAL
+ * `processMarkdownHtml`, against the REAL TabManager. Nothing here asserts on
+ * the text of an implementation file: what is checked is what a second document
+ * renders as.
+ *
+ * The rune declarations are plucked too, not restated, because the whole fix
+ * lives in one of them — whether `collapsedHeaders` is component state or a
+ * read of the active tab. Restating it here would be restating the answer.
+ */
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import ts from 'typescript';
+
+import { installShimDom, parseHtml, type ShimElement } from './renderProtocolDom.ts';
+
+// ---------------------------------------------------------------- environment
+
+const g = globalThis as any;
+const runeEffect = (fn: () => void) => {
+	void fn;
+};
+runeEffect.root = (fn: () => unknown) => fn();
+g.$state = (value: unknown) => value;
+g.$state.raw = (value: unknown) => value;
+g.$state.snapshot = (value: unknown) => value;
+g.$derived = (value: unknown) => value;
+g.$derived.by = (fn: () => unknown) => fn();
+g.$effect = runeEffect;
+g.window = g.window ?? {};
+g.window.__TAURI_INTERNALS__ = g.window.__TAURI_INTERNALS__ ?? {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
+};
+
+const localStore = new Map<string, string>();
+g.localStorage = g.localStorage ?? {
+	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
+	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
+	removeItem: (key: string) => void localStore.delete(key),
+	clear: () => localStore.clear(),
+};
+
+installShimDom();
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { processMarkdownHtml } = await import('../src/lib/utils/markdown.ts');
+
+const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
+const toc = readFileSync(new URL('../src/lib/components/Toc.svelte', import.meta.url), 'utf8');
+
+// ------------------------------------------------------------ source plucking
+
+/** Index of the `}` that closes the block opening at `open`, comment/string aware. */
+function matchBrace(source: string, open: number): number {
+	let depth = 0;
+	for (let i = open; i < source.length; i++) {
+		const c = source[i];
+		const next = source[i + 1];
+		if (c === '/' && next === '/') {
+			i = source.indexOf('\n', i);
+			continue;
+		}
+		if (c === '/' && next === '*') {
+			i = source.indexOf('*/', i) + 1;
+			continue;
+		}
+		if (c === "'" || c === '"' || c === '`') {
+			const quote = c;
+			for (i++; i < source.length; i++) {
+				if (source[i] === '\\') i++;
+				else if (source[i] === quote) break;
+			}
+			continue;
+		}
+		if (c === '{') depth++;
+		else if (c === '}' && --depth === 0) return i;
+	}
+	assert.fail(`unbalanced braces from offset ${open}`);
+}
+
+/** Slice one `function <name>(…) { … }` (async or not) out of a component. */
+function pluckFunction(source: string, name: string, required = true): string {
+	for (const marker of [`async function ${name}(`, `function ${name}(`]) {
+		const start = source.indexOf(marker);
+		if (start === -1) continue;
+		const open = source.indexOf('{', source.indexOf(')', start));
+		return source.slice(start, matchBrace(source, open) + 1);
+	}
+	assert.ok(!required, `expected the component to define ${name}`);
+	return '';
+}
+
+/**
+ * A top-level `let`/`const` declaration, with the rune peeled off.
+ *
+ * `$derived` is re-evaluated on every read, so it becomes an assignment in
+ * `refresh` rather than an initializer — that is the whole difference between
+ * a value that follows the active tab and one that does not, and the harness
+ * must not paper over it. `$state` and a plain `const` initialize once.
+ */
+type Declaration = { declare: string; refresh: string };
+
+function pluckDeclaration(source: string, name: string, required = true): Declaration | null {
+	const match = new RegExp(`\\n\\t(let|const) ${name} = ([^\\n]*);\\n`).exec(source);
+	if (!match) {
+		assert.ok(!required, `expected the component to declare ${name} on one line`);
+		return null;
+	}
+	const [, keyword, initializer] = match;
+	const derived = /^\$derived(?:\.by)?\((.*)\)$/.exec(initializer);
+	if (derived) return { declare: `let ${name};`, refresh: `${name} = ${derived[1]};` };
+	const state = /^\$state\((.*)\)$/.exec(initializer);
+	if (state) return { declare: `let ${name} = ${state[1]};`, refresh: '' };
+	return { declare: `${keyword} ${name} = ${initializer};`, refresh: '' };
+}
+
+/** Position of a declaration in the component, so the harness keeps source order. */
+function declarationOffset(source: string, name: string): number {
+	const at = source.search(new RegExp(`\\n\\t(?:let|const) ${name} = `));
+	return at === -1 ? Number.MAX_SAFE_INTEGER : at;
+}
+
+// -------------------------------------------------------------- the fixtures
+//
+// comrak's shape for two DIFFERENT documents that share a heading — the id is
+// the slug, so both call it `introduction`, which is the collision the fix is
+// about. Bodies differ so a mix-up is visible in the output rather than only in
+// a flag.
+
+const docHtml = (body: string) =>
+	'<h2 data-sourcepos="1:1-1:15"><a href="#introduction" aria-hidden="true" class="anchor" id="introduction"></a>Introduction</h2>\n' +
+	`<p data-sourcepos="3:1-3:11">${body}</p>\n`;
+
+const DOC_A = docHtml('Alpha body.');
+const DOC_B = docHtml('Beta body.');
+
+const FOLD_KEY = 'introduction';
+
+function render(html: string, path: string, folds: Set<string>): ShimElement {
+	return parseHtml(processMarkdownHtml(html, path, folds)).body;
+}
+
+function isSectionCollapsed(body: ShimElement): boolean {
+	return body.querySelector('.foldable-header.is-collapsed') !== null;
+}
+
+// ---------------------------------------------------------------- the harness
+
+type Viewer = {
+	/** The table of contents' fold button, and the keyboard route. */
+	toggleFold: (key: string) => void;
+	/** The preview chevron — also what FindBar clicks to reveal a match. */
+	clickChevron: (icon: ShimElement) => Promise<void>;
+	/** The set the viewer would hand `processMarkdownHtml` right now. */
+	foldsOnScreen: () => Set<string>;
+	/** Point the viewer at a rendered document, as `bind:this={markdownBody}` does. */
+	showDocument: (body: ShimElement) => void;
+};
+
+function buildViewer(): Viewer {
+	const names = ['NO_COLLAPSED_HEADERS', 'activeTab', 'collapsedHeaders'];
+	const declarations = names
+		.map((name) => ({ name, offset: declarationOffset(viewer, name) }))
+		.sort((a, b) => a.offset - b.offset)
+		.map(({ name }) => pluckDeclaration(viewer, name, name === 'collapsedHeaders'))
+		.filter((declaration): declaration is Declaration => declaration !== null);
+
+	const source = [
+		pluckFunction(viewer, 'setCollapsedHeaders', false),
+		pluckFunction(viewer, 'toggleFold'),
+		pluckFunction(viewer, 'handleLinkClick'),
+	]
+		.filter(Boolean)
+		.join('\n\n');
+
+	const js = ts.transpileModule(
+		[
+			declarations.map((declaration) => declaration.declare).join('\n'),
+			`const refresh = () => {\n${declarations.map((declaration) => declaration.refresh).join('\n')}\n};`,
+			source,
+		].join('\n\n'),
+		{ compilerOptions: { target: ts.ScriptTarget.ES2022 } },
+	).outputText;
+
+	// `markdownBody` is the component's `bind:this` on the preview article, and
+	// `document` is how `handleLinkClick` reaches the fold wrapper. Both are
+	// injected so the plucked source runs unmodified.
+	let preview: ShimElement | null = null;
+	const factory = new Function(
+		'deps',
+		`"use strict";
+		const { tabManager, CSS, document } = deps;
+		let markdownBody = null;
+		${js}
+		return {
+			setBody: (body) => { markdownBody = body; },
+			toggleFold: (key) => { refresh(); return toggleFold(key); },
+			handleLinkClick: (event) => { refresh(); return handleLinkClick(event); },
+			folds: () => { refresh(); return collapsedHeaders; },
+		};`,
+	);
+
+	const bound = factory({
+		tabManager,
+		CSS: { escape: (value: string) => value },
+		document: {
+			getElementById: (id: string) => preview?.querySelector(`[id="${id}"]`) ?? null,
+		},
+	});
+
+	return {
+		toggleFold: bound.toggleFold,
+		clickChevron: (icon) =>
+			bound.handleLinkClick({
+				target: icon,
+				detail: 1,
+				preventDefault: () => {},
+				stopPropagation: () => {},
+			}),
+		foldsOnScreen: bound.folds,
+		showDocument: (body) => {
+			preview = body;
+			bound.setBody(body);
+		},
+	};
+}
+
+/** The real `visibleItems` out of Toc.svelte, over a caller-supplied fold set. */
+function buildTocFilter() {
+	const marker = 'let visibleItems = $derived.by(() => ';
+	const start = toc.indexOf(marker);
+	assert.notEqual(start, -1, 'expected Toc.svelte to derive visibleItems');
+	const open = toc.indexOf('{', start + marker.length);
+	const body = toc.slice(open, matchBrace(toc, open) + 1);
+	const js = ts.transpileModule(body, { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText;
+	return new Function('items', 'collapsedHeaders', `"use strict";\n${js}`) as (
+		items: unknown[],
+		collapsedHeaders: Set<string>,
+	) => Array<{ id: string }>;
+}
+
+const tocVisibleItems = buildTocFilter();
+
+const TOC_ITEMS = [
+	{ id: FOLD_KEY, text: 'Introduction', level: 2, isBlock: false, hasChildren: true },
+	{ id: 'details', text: 'Details', level: 3, isBlock: false, hasChildren: false },
+];
+
+// ------------------------------------------------------------------ the tests
+
+function reset() {
+	tabManager.closeAll();
+	tabManager.recentlyClosed.length = 0;
+}
+
+/** Open two documents that share a heading, fold it in the first, land on the second. */
+function foldInAThenSwitchToB() {
+	reset();
+	const app = buildViewer();
+
+	tabManager.addTab('/notes/a.md', DOC_A);
+	const a = tabManager.activeTabId!;
+	tabManager.addTab('/notes/b.md', DOC_B);
+	const b = tabManager.activeTabId!;
+
+	tabManager.setActive(a);
+	app.showDocument(render(DOC_A, '/notes/a.md', app.foldsOnScreen()));
+	app.toggleFold(FOLD_KEY);
+
+	tabManager.setActive(b);
+	return { app, a, b };
+}
+
+test('folding a heading in one document does not fold the same heading in another', () => {
+	const { app } = foldInAThenSwitchToB();
+
+	const onScreen = render(DOC_B, '/notes/b.md', app.foldsOnScreen());
+	assert.equal(
+		isSectionCollapsed(onScreen),
+		false,
+		'the second document must render with its own fold state, which is none',
+	);
+	assert.match(onScreen.textContent, /Beta body\./);
+});
+
+test('the fold is still there when the user comes back to the document they folded', () => {
+	const { app, a } = foldInAThenSwitchToB();
+
+	tabManager.setActive(a);
+	assert.equal(isSectionCollapsed(render(DOC_A, '/notes/a.md', app.foldsOnScreen())), true);
+});
+
+test('a document opened after the fold does not open pre-folded', () => {
+	// The worst version of the leak: the tab that was folded is gone, so there
+	// is nothing on screen that could explain the missing section.
+	const { app, a } = foldInAThenSwitchToB();
+	tabManager.closeTab(a);
+
+	tabManager.addTab('/notes/c.md', DOC_A);
+	assert.equal(isSectionCollapsed(render(DOC_A, '/notes/c.md', app.foldsOnScreen())), false);
+});
+
+test('the table of contents hides the folded children only in the document they are folded in', () => {
+	const { app, a, b } = foldInAThenSwitchToB();
+
+	assert.deepEqual(
+		tocVisibleItems(TOC_ITEMS, app.foldsOnScreen()).map((item) => item.id),
+		[FOLD_KEY, 'details'],
+		"the second document's table of contents must show its own children",
+	);
+
+	tabManager.setActive(a);
+	assert.deepEqual(
+		tocVisibleItems(TOC_ITEMS, app.foldsOnScreen()).map((item) => item.id),
+		[FOLD_KEY],
+		'the folded document still hides them',
+	);
+
+	tabManager.setActive(b);
+	assert.equal(tocVisibleItems(TOC_ITEMS, app.foldsOnScreen()).length, 2);
+});
+
+test('the preview chevron folds the document on screen and no other', () => {
+	// The route FindBar drives to reveal a match: it dispatches a click on the
+	// `.header-fold-icon` rather than stripping the class, so this is also what
+	// re-opens a fold that is hiding a search hit.
+	reset();
+	const app = buildViewer();
+
+	tabManager.addTab('/notes/a.md', DOC_A);
+	const a = tabManager.activeTabId!;
+	tabManager.addTab('/notes/b.md', DOC_B);
+	const b = tabManager.activeTabId!;
+
+	tabManager.setActive(a);
+	const body = render(DOC_A, '/notes/a.md', app.foldsOnScreen());
+	app.showDocument(body);
+
+	const chevron = body.querySelector('.foldable-header .header-fold-icon')!;
+	return app.clickChevron(chevron).then(() => {
+		assert.equal(isSectionCollapsed(body), true, 'the click collapses the section it was in');
+		assert.equal(app.foldsOnScreen().has(FOLD_KEY), true);
+
+		tabManager.setActive(b);
+		assert.equal(app.foldsOnScreen().has(FOLD_KEY), false);
+		assert.equal(isSectionCollapsed(render(DOC_B, '/notes/b.md', app.foldsOnScreen())), false);
+
+		// And back: the same chevron re-opens it, which is what reveals a find
+		// match, rather than leaving a second fold state behind.
+		tabManager.setActive(a);
+		return app.clickChevron(chevron).then(() => {
+			assert.equal(isSectionCollapsed(body), false);
+			assert.equal(app.foldsOnScreen().has(FOLD_KEY), false);
+		});
+	});
+});
+
+test('an untitled buffer gets fold state of its own', () => {
+	// Untitled tabs have no path, so nothing keyed by file could hold their
+	// folds. They are also the tabs most likely to share a heading with each
+	// other — every new note starts the same way.
+	reset();
+	const app = buildViewer();
+
+	tabManager.addNewTab();
+	const first = tabManager.activeTabId!;
+	tabManager.addNewTab();
+	const second = tabManager.activeTabId!;
+
+	tabManager.setActive(first);
+	app.showDocument(render(DOC_A, '', app.foldsOnScreen()));
+	app.toggleFold(FOLD_KEY);
+
+	tabManager.setActive(second);
+	assert.equal(isSectionCollapsed(render(DOC_B, '', app.foldsOnScreen())), false);
+
+	tabManager.setActive(first);
+	assert.equal(isSectionCollapsed(render(DOC_A, '', app.foldsOnScreen())), true);
+});
+
+test('closing a tab takes its fold state with it', () => {
+	reset();
+	const app = buildViewer();
+
+	tabManager.addTab('/notes/a.md', DOC_A);
+	const a = tabManager.activeTabId!;
+	app.showDocument(render(DOC_A, '/notes/a.md', app.foldsOnScreen()));
+	app.toggleFold(FOLD_KEY);
+	assert.equal(app.foldsOnScreen().has(FOLD_KEY), true);
+
+	tabManager.closeTab(a);
+	tabManager.addTab('/notes/a.md', DOC_A);
+	assert.equal(app.foldsOnScreen().has(FOLD_KEY), false, 'reopening the file starts fresh');
+});

--- a/scripts/renderProtocolDom.ts
+++ b/scripts/renderProtocolDom.ts
@@ -266,11 +266,18 @@ class ShimClassList {
 		return this.tokens().length;
 	}
 
-	toggle(name: string, force?: boolean) {
+	/**
+	 * Returns whether the token is present AFTERWARDS, like the real
+	 * `DOMTokenList`. The preview's fold handler reads exactly that value to
+	 * decide which way it just folded, so a `void` copy silently makes every
+	 * fold look like an unfold.
+	 */
+	toggle(name: string, force?: boolean): boolean {
 		const present = this.contains(name);
 		const next = force ?? !present;
 		if (next) this.add(name);
 		else this.remove(name);
+		return next;
 	}
 }
 

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -202,11 +202,19 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	// in-page scroll position history for mouse 4/5 nav
 	let scrollHistory: number[] = [];
 	let scrollFuture: number[] = [];
-	let collapsedHeaders = $state(new Set<string>());
 	let zoomData = $state<{ src?: string; html?: string } | null>(null);
+
+	// What a document with no tab behind it has folded. Never written to — every
+	// write goes through `setCollapsedHeaders`, which needs an active tab.
+	const NO_COLLAPSED_HEADERS = new Set<string>();
 
 	// derived from tab manager
 	let activeTab = $derived(tabManager.activeTab);
+	// Fold state belongs to the document, so it lives on the tab (see
+	// `Tab.collapsedHeaders`). Reading it through a derived is what makes a tab
+	// switch swap the whole set: the preview render, the table of contents and
+	// find all see the folds of the document on screen and no other document's.
+	let collapsedHeaders = $derived(activeTab?.collapsedHeaders ?? NO_COLLAPSED_HEADERS);
 	let isEditing = $derived(activeTab?.isEditing ?? false);
 	let rawContent = $derived(activeTab?.rawContent ?? '');
 	let isSplit = $derived(activeTab?.isSplit ?? false);
@@ -477,7 +485,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			if (!tab) return;
 			tab.rawContent = raw;
 			tab.originalContent = raw;
-			const processed = await renderMarkdownPreview(raw, tab.path);
+			const processed = await renderMarkdownPreview(raw, tab.path, tab.collapsedHeaders);
 			if (isDisposed) return;
 			tabManager.updateTabContent(tab.id, processed);
 			if (tabManager.activeTabId === tab.id) tick().then(renderRichContent);
@@ -811,14 +819,21 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	// which means no parse/serialize round trip happens after the sanitizer has
 	// had its say. Moving the call here instead would inject a string the
 	// sanitizer never saw.
-	async function renderMarkdownPreview(raw: string, filePath: string) {
+	//
+	// `folds` is a parameter rather than a read of the active tab because this
+	// renders documents that are NOT on screen: a window restore renders every
+	// restored tab, a cross-window arrival renders itself, and the background
+	// completion of a large file lands long after the user may have switched
+	// away. Each of those must fold the document it is rendering, not whichever
+	// one happens to be active when the promise resolves.
+	async function renderMarkdownPreview(raw: string, filePath: string, folds: Set<string>) {
 		const body = getMarkdownBodyWithoutFrontMatter(raw);
 		const html = (await invoke('render_markdown', { content: body })) as string;
-		return processMarkdownHtml(html, filePath, collapsedHeaders);
+		return processMarkdownHtml(html, filePath, folds);
 	}
 
-	async function renderTabPreviewFromRaw(tab: { id: string; path: string; rawContent: string; [key: string]: any }) {
-		const processed = await renderMarkdownPreview(tab.rawContent, tab.path);
+	async function renderTabPreviewFromRaw(tab: { id: string; path: string; rawContent: string; collapsedHeaders: Set<string>; [key: string]: any }) {
+		const processed = await renderMarkdownPreview(tab.rawContent, tab.path, tab.collapsedHeaders);
 		tabManager.updateTabContent(tab.id, processed);
 		tab._lastRenderedRawContent = tab.rawContent;
 		await tick();
@@ -1318,15 +1333,22 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		syncEditorToPreviewScroll(target);
 	}
 
+	// The one place fold state is written. It goes to the tab the user is
+	// looking at, which is the document the fold is a fold OF — both toggle
+	// paths below act on the preview or the table of contents of that tab.
+	function setCollapsedHeaders(next: Set<string>) {
+		if (tabManager.activeTabId) tabManager.setTabCollapsedHeaders(tabManager.activeTabId, next);
+	}
+
 	function toggleFold(key: string) {
 		const isCurrentlyCollapsed = collapsedHeaders.has(key);
 
 		if (isCurrentlyCollapsed) {
 			const next = new Set(collapsedHeaders);
 			next.delete(key);
-			collapsedHeaders = next;
+			setCollapsedHeaders(next);
 		} else {
-			collapsedHeaders = new Set([...collapsedHeaders, key]);
+			setCollapsedHeaders(new Set([...collapsedHeaders, key]));
 		}
 
 		if (!markdownBody) return;
@@ -1430,11 +1452,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 				const isCollapsed = foldableHeader.classList.toggle('is-collapsed');
 				wrapper.classList.toggle('is-collapsed', isCollapsed);
 				if (isCollapsed) {
-					collapsedHeaders = new Set([...collapsedHeaders, key]);
+					setCollapsedHeaders(new Set([...collapsedHeaders, key]));
 				} else {
 					const next = new Set(collapsedHeaders);
 					next.delete(key);
-					collapsedHeaders = next;
+					setCollapsedHeaders(next);
 				}
 			}
 			return;
@@ -1939,7 +1961,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		if (rawContent === undefined) return;
 		if ((tab as any)._lastRenderedRawContent === rawContent) return;
 		try {
-			const processed = await renderMarkdownPreview(rawContent, tab.path);
+			const processed = await renderMarkdownPreview(rawContent, tab.path, tab.collapsedHeaders);
 			const current = tabManager.activeTab;
 			if (tabManager.activeTabId !== tabId || current?.rawContent !== rawContent) return;
 			tabManager.updateTabContent(tabId, processed);
@@ -2343,7 +2365,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			if ((tab as any)._lastRenderedRawContent === rawContent) return;
 
 			const timer = setTimeout(() => {
-				renderMarkdownPreview(rawContent, tab.path)
+				renderMarkdownPreview(rawContent, tab.path, tab.collapsedHeaders)
 					.then((processed) => {
 						const currentTab = tabManager.activeTab;
 						if (

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -41,7 +41,7 @@ type DocumentSessionOptions = {
 	setShowHome: (value: boolean) => void;
 	currentFile: () => string;
 	resetScrollHistory: () => void;
-	renderMarkdown: (raw: string, path: string) => Promise<string>;
+	renderMarkdown: (raw: string, path: string, collapsedHeaders: Set<string>) => Promise<string>;
 	afterLoad: () => Promise<unknown>;
 	saveRecentFile: (path: string) => void;
 	deleteRecentFile: (path: string) => void;
@@ -56,6 +56,18 @@ type DocumentSessionOptions = {
 	onCloseSaveNewerEdits: () => void;
 	onCloseAutoSaveFailed: () => void;
 };
+
+/**
+ * Which heading sections the tab being loaded has folded, read at render time
+ * rather than captured up front. A large file is rendered twice — the 50KB
+ * preview, then the whole document once the background read lands — and the
+ * user can fold something in between; the second render has to honour that.
+ * An unknown tab folds nothing, which is what a load of a tab that has since
+ * been closed should hand a renderer.
+ */
+function foldsForTab(tabId: string): Set<string> {
+	return tabManager.tabs.find((item) => item.id === tabId)?.collapsedHeaders ?? new Set<string>();
+}
 
 export function createDocumentSession(options: DocumentSessionOptions) {
 	const loadRevisionByTab = new Map<string, number>();
@@ -311,7 +323,7 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 				tabManager.setTabDecodedLossy(activeId, lossy);
 				lossySaveWarnedTabs.delete(activeId);
 				if (pendingNavigateTabId) tabManager.navigate(pendingNavigateTabId, filePath, pathKey);
-				const processed = await options.renderMarkdown(content, filePath);
+				const processed = await options.renderMarkdown(content, filePath, foldsForTab(activeId));
 				tabManager.updateTabContent(activeId, processed);
 				// `isFull === false` means this is only the leading slice of a
 				// large file. Marking the tab keeps anything downstream from
@@ -331,7 +343,7 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 								try {
 									if (options.isScrolling()) return void setTimeout(applyFull, 100);
 									if (!canApplyFullLoad()) return updateLoading(activeId, false);
-									options.renderMarkdown(fullContent, filePath)
+									options.renderMarkdown(fullContent, filePath, foldsForTab(activeId))
 										.then((fullProcessed) => {
 											if (!canApplyFullLoad()) return updateLoading(activeId, false);
 											tabManager.updateTabContent(activeId, fullProcessed);

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -33,6 +33,30 @@ export interface Tab {
 	splitRatio: number;
 	isScrollSynced: boolean;
 	/**
+	 * Which heading sections are folded shut in THIS document. The entries are
+	 * the fold keys `processMarkdownHtml` writes and reads: the heading's id
+	 * (comrak's slug), falling back to its trimmed text.
+	 *
+	 * Per tab, not per window, because that key only identifies a heading
+	 * WITHIN a document. Every file with an `## Introduction` gets the key
+	 * `introduction`, so a single window-wide set folded that section in all of
+	 * them at once, kept the key after the document it was folded in was
+	 * closed, and pre-folded the next document to contain that heading with
+	 * nothing on screen to say why. It is the same class of state as
+	 * `scrollTop` / `anchorLine` / `editorViewState`, which live here for the
+	 * same reason.
+	 *
+	 * A tab field also covers untitled buffers, which have no path to key by.
+	 *
+	 * Replace the set to change it — never mutate in place. The preview render
+	 * reads this value, and Svelte cannot see a mutation of a Set it is already
+	 * holding.
+	 *
+	 * Required, like `hasReplacementChars`: every consumer calls `.has()` on
+	 * it, so a construction site that forgot it would hand them `undefined`.
+	 */
+	collapsedHeaders: Set<string>;
+	/**
 	 * True while `rawContent` holds only the leading slice of a large file
 	 * (the >50KB preview read) instead of the whole document. Such a buffer
 	 * looks clean and authoritative but writing it back truncates the file,
@@ -120,6 +144,15 @@ class TabManager {
 	 * then asked the backend to read a file called `HOME`, and the failure left
 	 * a permanently unreadable phantom tab — or, when HOME was the only tab, a
 	 * window that came back empty.
+	 *
+	 * `collapsedHeaders` is deliberately NOT in here. Every other field written
+	 * below describes the window and survives whatever happened to the file
+	 * while Markpad was closed; a fold key describes a heading in a particular
+	 * revision of the document. The restore reads the file fresh from disk, so
+	 * a document edited in the meantime would come back with sections hidden
+	 * that the user never folded in the text now on screen — the failure this
+	 * per-tab state exists to remove. Scroll degrades (you scroll); a fold
+	 * hides text.
 	 */
 	serializeState(): string {
 		const stateData = {
@@ -195,6 +228,8 @@ class TabManager {
 					isSplit: saved.isSplit === true,
 					splitRatio: typeof saved.splitRatio === 'number' ? saved.splitRatio : 0.5,
 					isScrollSynced: saved.isScrollSynced === true,
+					// Not persisted — see serializeState.
+					collapsedHeaders: new Set<string>(),
 					isTruncated: false,
 					hasReplacementChars: false
 				});
@@ -316,6 +351,7 @@ class TabManager {
 			isSplit: false,
 			splitRatio: 0.5,
 			isScrollSynced: false,
+			collapsedHeaders: new Set<string>(),
 			isTruncated: false,
 			hasReplacementChars: false,
 			pathKey
@@ -349,6 +385,7 @@ class TabManager {
 			isSplit: false,
 			splitRatio: 0.5,
 			isScrollSynced: false,
+			collapsedHeaders: new Set<string>(),
 			isTruncated: false,
 			hasReplacementChars: false
 		});
@@ -382,6 +419,7 @@ class TabManager {
 			isSplit: false,
 			splitRatio: 0.5,
 			isScrollSynced: false,
+			collapsedHeaders: new Set<string>(),
 			isTruncated: false,
 			hasReplacementChars: false
 		});
@@ -550,6 +588,17 @@ class TabManager {
 		const tab = this.tabs.find((t) => t.id === id);
 		if (tab) {
 			tab.scrollPercentage = percentage;
+		}
+	}
+
+	/**
+	 * Replace this tab's folded-heading set. Callers build a NEW set rather
+	 * than mutating the old one — see `Tab.collapsedHeaders`.
+	 */
+	setTabCollapsedHeaders(id: string, collapsedHeaders: Set<string>) {
+		const tab = this.tabs.find((t) => t.id === id);
+		if (tab) {
+			tab.collapsedHeaders = collapsedHeaders;
 		}
 	}
 

--- a/src/lib/utils/tabTransfer.ts
+++ b/src/lib/utils/tabTransfer.ts
@@ -14,6 +14,13 @@ import { nextUntitledTitle } from './untitledTitle.js';
  * Excluded on purpose:
  * - `content` (rendered HTML): regenerated at the destination.
  * - `editorViewState`: a live Monaco object, not serializable.
+ * - `collapsedHeaders`: the destination re-renders the document from source,
+ *   and it re-renders it with everything open. Before fold state was per tab
+ *   the arriving document inherited whatever the DESTINATION window happened
+ *   to have folded, which is the bleed this field exists to stop; starting
+ *   open is the honest version of "this was rendered fresh here". Carrying it
+ *   would mean a new required entry in the strict validator below, which is a
+ *   change to make on its own terms.
  */
 export interface TransferableTab {
 	path: string;
@@ -179,6 +186,7 @@ export function buildTransferredTab(
 		isSplit: snap.isSplit,
 		splitRatio: snap.splitRatio,
 		isScrollSynced: snap.isScrollSynced,
+		collapsedHeaders: new Set<string>(),
 		hasReplacementChars: snap.hasReplacementChars,
 	};
 }


### PR DESCRIPTION
Fold `## Introduction` in one document and it folds in every other open document that has an `## Introduction` too. Close the tab you folded it in and the key stays behind, so the next file containing that heading opens with the section already shut — and with nothing on screen that could explain why.

## Why

The fold key is `h.id || h.textContent?.trim()` — the heading's id, comrak's slug, falling back to the text. That identifies a heading **within** a document and nowhere else: two files with the same title both get `introduction`.

`MarkdownViewer.svelte` held **one `Set` per window** and handed it to every render, to `Toc.svelte` and to `FindBar.svelte`. There is no `.clear()` and no reassignment to an empty set anywhere in the repo, so nothing ever reset it — not on tab switch, not on close.

Two things are visible today, and they are different sizes:

| | |
|---|---|
| **The outline** reads the live `Set`, so it hides the folded section's children **immediately** in the other document — while that document's preview still shows them expanded. |
| **The preview** re-reads the `Set` on the next render of that document. A fresh open, a reload, a keystroke in split view. That is where "opened pre-folded" comes from. |

`452ec96` (#219) moved the key from heading text to the deduplicated id, which fixed collisions between duplicate headings **inside one document**. It could not fix this one: there was nowhere to hang per-document fold state.

## The fix

`Tab.collapsedHeaders`, alongside `scrollTop`, `scrollPercentage`, `anchorLine` and `editorViewState` — the same class of per-document state, saved and restored on tab switch by the same mechanism (#79, #147, #420). Required rather than optional, like `hasReplacementChars`: every consumer calls `.has()` on it, so the compiler asks each of the five construction sites.

The viewer reads it through a derived:

```js
let collapsedHeaders = $derived(activeTab?.collapsedHeaders ?? NO_COLLAPSED_HEADERS);
```

so a tab switch swaps the whole set at once, and the preview render, the outline and find all see the document on screen. Every write goes through one `setCollapsedHeaders`, so both toggle paths — the preview chevron (which is also what `FindBar` clicks to reveal a match inside a collapsed section) and the outline's fold button — land on the tab the user is looking at.

**`renderMarkdownPreview` takes the fold set as an argument** rather than reading the active tab, because three of its callers render a document that is **not on screen**: a window restore renders every restored tab, a tab arriving from another window renders itself, and the background completion of a >50KB file lands whenever it lands. Reading "the active tab" there would have traded a leak between documents for a rarer and worse one. `documentSession` looks the set up **at render time**, not at load time, so folding something while a large file is still loading is not undone when the full render arrives.

No document/model object, no `ITextModel`, no lifecycle abstraction (#391). The `Set` moved onto the tab; that is the whole change.

## Decisions

**Persistence across restart: no.** The window snapshot carries scroll, and the obvious symmetry argument is real — Obsidian persists folds keyed by file path. But the restore reads each file **fresh from disk**, and a fold key describes a heading in a particular *revision* of a document. A file edited while Markpad was closed comes back with sections hidden that the user never folded in the text now in front of them — which is the failure this PR removes, reintroduced through the back door. Scroll degrades; you scroll. A fold hides text. It is a reasonable follow-up now that the state has a home, and it is a feature rather than part of this fix; `serializeState` says so where a future reader will look.

**Reload of the same file** (Live Mode external change, revision load, `loadMarkdown`): the tab keeps its set. Keys whose headings are gone never match anything and do nothing; headings that survive fold as they were. Clearing on reload would drop the user's folds every time the watcher fired.

**Untitled buffers**: work by construction. The state hangs off the tab, not off a path, which is precisely why a `path -> Set` map was not the answer — untitled tabs have no key, and they are the tabs most likely to share a heading with each other.

**Split view**: shows one document. `collapsedHeaders` follows the active tab, and the split render path passes that tab's own set. Nothing assumes two.

**Cross-window move**: arrives with everything open, joining `content` and `editorViewState` on the excluded list — the destination re-renders from source. Before this PR the arriving document inherited whatever the *destination* window had folded, which is the same bleed. Carrying it would need a new required field in the strict transfer validator; that is a change to make on its own terms.

## Tests

`scripts/foldStatePerDocument.test.ts` runs the **real** `toggleFold` and `handleLinkClick` out of `MarkdownViewer.svelte`, the **real** `visibleItems` out of `Toc.svelte` and the **real** `processMarkdownHtml`, against the **real** `TabManager`. It asserts nothing about the text of an implementation file: what is checked is what a second document renders as.

The rune declarations are plucked too, not restated — the entire fix lives in one of them, and `$derived` is re-evaluated on read where `$state` is not, so the harness models that difference instead of papering over it. That is what lets the same file run against both versions.

| | |
|---|---|
| **On master** | **6 of 7 fail**, all clean assertions: `the second document must render with its own fold state, which is none — true !== false`, and the outline returning `['introduction']` where `['introduction', 'details']` is expected. No crashes, no missing symbols. The one that passes (the folded document is still folded when you come back) passes on master for the trivial reason that a shared set still has the key. |
| **`setTabCollapsedHeaders` writes to every tab** | 4 fail |
| **The derived reads a fixed tab instead of the active one** | 4 fail |
| **Final** | 7 / 7 |

`ShimClassList.toggle` in the test DOM returned nothing where the real `DOMTokenList` returns whether the token is present afterwards — the exact value the preview's fold handler reads to tell a fold from an unfold. Fixed, or every chevron click would have looked like an unfold in every future test.

`editorPdfExport.test.ts` pinned `renderMarkdownPreview(rawContent, tab.path)` down to the closing paren. Relaxed to allow trailing arguments, for the reason #418 gives: what that test is about is *which* buffer and *which* path get rendered before the print, not the arity of the renderer.

```
npm run check   438 files, 0 errors
npm test        547 / 547
```

No Rust touched.

## Not covered

- **A fold still resets visually when you leave a tab and come back.** `{@html sanitizedHtml}` rebuilds the preview from `tab.content`, the cached HTML, and the toggle handlers deliberately do not re-render — they toggle the class on the live DOM. So the cached string never learns about the fold until the document is re-rendered for some other reason. This is pre-existing, unchanged by this PR, and now *visible* as a disagreement with the outline, which does track the fold. Fixing it means either re-rendering on every toggle or re-applying the classes after the `{@html}` swap; both are a separate change.
- **No browser round trip.** Everything above is exercised through the DOM shim and the real store, not in a running window.
- **Fold state is not persisted and not transferred between windows**, by the decisions above.
- **Stale keys accumulate** in a tab's set when a heading is renamed or deleted while the tab stays open. Bounded by how many headings the user folded, and a key that matches nothing does nothing — but nothing prunes them either.
- The fixture is comrak-*shaped*, not comrak-produced, following the existing convention in `renderProtocolFixtures.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
