### PR TITLE
chore(markdown): upgrade comrak 0.18 → 0.54

### DIFF
--- a/scripts/mathDelimiterCorpus.json
+++ b/scripts/mathDelimiterCorpus.json
@@ -106,7 +106,7 @@
 		{
 			"name": "a span may not cross an inline code span",
 			"markdown": "$a `x` b$ and $c_1$.\n",
-			"html": "<p data-sourcepos=\"1:1-1:27\">$a <code data-sourcepos=\"1:5-1:5\">x</code> b$ and $c_1$.</p>\n",
+			"html": "<p data-sourcepos=\"1:1-1:27\">$a <code data-sourcepos=\"1:4-1:6\">x</code> b$ and $c_1$.</p>\n",
 			"math": [
 				{
 					"kind": "inline",
@@ -117,7 +117,7 @@
 		{
 			"name": "dollars inside inline code are not math",
 			"markdown": "Use `$a$` and $b_1$ here.\n",
-			"html": "<p data-sourcepos=\"1:1-1:32\">Use <code data-sourcepos=\"1:6-1:8\">$a$</code> and $b_1$ here.</p>\n",
+			"html": "<p data-sourcepos=\"1:1-1:32\">Use <code data-sourcepos=\"1:5-1:9\">$a$</code> and $b_1$ here.</p>\n",
 			"math": [
 				{
 					"kind": "inline",

--- a/scripts/renderProtocol.test.ts
+++ b/scripts/renderProtocol.test.ts
@@ -312,18 +312,28 @@ const HEADING_FIXTURES = [
 
 const HEADING_SELECTOR = 'h1, h2, h3, h4, h5, h6';
 
-/** The ids comrak put on the inner `a.anchor` of each heading. */
-function rendererAnchorIds(name: FixtureName): string[] {
+/**
+ * The id comrak assigned to each heading, read from wherever comrak put it.
+ *
+ * comrak 0.18 put it on the empty inner `a.anchor`, which is why
+ * `processMarkdownHtml` promotes it onto the heading at all. comrak 0.54 puts
+ * it on the heading itself and leaves the anchor bare, so the promotion is now
+ * a no-op — but the invariant this test exists for is unchanged and is not
+ * about which element the renderer chose: the heading ends up carrying the id,
+ * and the anchor does not. Reading both keeps that assertion a live capture
+ * rather than a copy of one renderer's layout.
+ */
+function rendererHeadingIds(name: FixtureName): string[] {
 	return parseHtml(renderFixtures[name].html)
 		.body.querySelectorAll(HEADING_SELECTOR)
-		.map((heading) => heading.querySelectorAll('a.anchor')[0]?.id ?? '');
+		.map((heading) => heading.id || (heading.querySelectorAll('a.anchor')[0]?.id ?? ''));
 }
 
 test("each heading adopts comrak's anchor id and leaves the anchor without one", () => {
 	for (const name of HEADING_FIXTURES) {
 		const body = render(name);
 		const headings = body.querySelectorAll(HEADING_SELECTOR);
-		const expected = rendererAnchorIds(name);
+		const expected = rendererHeadingIds(name);
 
 		assert.equal(headings.length, expected.length, `${name}: heading count changed`);
 		assert.deepEqual(

--- a/scripts/renderProtocolFixtures.ts
+++ b/scripts/renderProtocolFixtures.ts
@@ -6,17 +6,19 @@
  * the frontend does with it. Nothing here re-asserts comrak's own behaviour —
  * that is `src-tauri/src/lib.rs`'s `mod tests` job, and it already covers it.
  *
- * Provenance: produced by running comrak 0.18 with the exact
- * `ComrakOptions`/`ComrakExtensionOptions` of `convert_markdown`, followed by
- * verbatim copies of `protect_display_math_underscores` and
- * `annotate_task_checkboxes`. The capture harness was validated by reproducing,
- * byte for byte, the HTML literals asserted in the Rust test module (for
- * example `task_list_checkbox_is_emitted_at_the_start_of_its_list_item`).
+ * Provenance: every `html` below is the return value of `convert_markdown`
+ * itself — the real function, not a restatement of it — for the `markdown`
+ * beside it, most recently captured against comrak 0.54. Earlier captures were
+ * assembled from comrak plus verbatim copies of the post-passes, and seven of
+ * the `math*` entries had drifted out of date that way, which is why the whole
+ * table is now taken from one call.
+ *
  * The wikilink/embed/autolink pre-passes are no-ops on every input below.
  *
- * To refresh after a comrak upgrade or a renderer change, re-run the pipeline
- * over `markdown` and replace `html`. Do not hand-edit `html`: a fixture that
- * no longer matches the renderer makes every assertion here a lie.
+ * To refresh after a comrak upgrade or a renderer change, re-run
+ * `convert_markdown` over `markdown` and replace `html`. Do not hand-edit
+ * `html`: a fixture that no longer matches the renderer makes every assertion
+ * here a lie.
  */
 
 export type RenderFixture = {
@@ -30,11 +32,11 @@ export const renderFixtures = {
 	// --- protocol 1 — task-list markers and source positions ---
 	taskSimple: {
 		markdown: "- [ ] open task\n- [x] completed task\n",
-		html: "<ul data-sourcepos=\"1:1-2:20\">\n<li data-sourcepos=\"1:1-1:15\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> open task</li>\n<li data-sourcepos=\"2:1-2:20\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" checked=\"\" /> completed task</li>\n</ul>\n",
+		html: "<ul data-sourcepos=\"1:1-2:20\">\n<li data-sourcepos=\"1:1-1:15\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> open task</li>\n<li data-sourcepos=\"2:1-2:20\"><input type=\"checkbox\" data-task-checkbox=\"\" checked=\"\" disabled=\"\" /> completed task</li>\n</ul>\n",
 	},
 	taskNested: {
 		markdown: "- [ ] parent\n  - [x] nested\n",
-		html: "<ul data-sourcepos=\"1:1-2:14\">\n<li data-sourcepos=\"1:1-2:14\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> parent\n<ul data-sourcepos=\"2:3-2:14\">\n<li data-sourcepos=\"2:3-2:14\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" checked=\"\" /> nested</li>\n</ul>\n</li>\n</ul>\n",
+		html: "<ul data-sourcepos=\"1:1-2:14\">\n<li data-sourcepos=\"1:1-2:14\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> parent\n<ul data-sourcepos=\"2:3-2:14\">\n<li data-sourcepos=\"2:3-2:14\"><input type=\"checkbox\" data-task-checkbox=\"\" checked=\"\" disabled=\"\" /> nested</li>\n</ul>\n</li>\n</ul>\n",
 	},
 	taskQuoted: {
 		markdown: "> - [ ] quoted task\n",
@@ -42,23 +44,23 @@ export const renderFixtures = {
 	},
 	taskOrdered: {
 		markdown: "1. [ ] ordered open\n2. [x] ordered done\n",
-		html: "<ol data-sourcepos=\"1:1-2:19\">\n<li data-sourcepos=\"1:1-1:19\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> ordered open</li>\n<li data-sourcepos=\"2:1-2:19\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" checked=\"\" /> ordered done</li>\n</ol>\n",
+		html: "<ol data-sourcepos=\"1:1-2:19\">\n<li data-sourcepos=\"1:1-1:19\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> ordered open</li>\n<li data-sourcepos=\"2:1-2:19\"><input type=\"checkbox\" data-task-checkbox=\"\" checked=\"\" disabled=\"\" /> ordered done</li>\n</ol>\n",
 	},
 	taskSurrounded: {
 		markdown: "# Title\n\nIntro paragraph.\n\n- [ ] after prose\n\nTrailing prose.\n\n- [x] after blank\n",
-		html: "<h1 data-sourcepos=\"1:1-1:7\"><a href=\"#title\" aria-hidden=\"true\" class=\"anchor\" id=\"title\"></a>Title</h1>\n<p data-sourcepos=\"3:1-3:16\">Intro paragraph.</p>\n<ul data-sourcepos=\"5:1-6:0\">\n<li data-sourcepos=\"5:1-6:0\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> after prose</li>\n</ul>\n<p data-sourcepos=\"7:1-7:15\">Trailing prose.</p>\n<ul data-sourcepos=\"9:1-9:17\">\n<li data-sourcepos=\"9:1-9:17\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" checked=\"\" /> after blank</li>\n</ul>\n",
+		html: "<h1 id=\"title\" data-sourcepos=\"1:1-1:7\">Title<a href=\"#title\" aria-label=\"Link to heading 'Title'\" data-heading-content=\"Title\" class=\"anchor\"></a></h1>\n<p data-sourcepos=\"3:1-3:16\">Intro paragraph.</p>\n<ul data-sourcepos=\"5:1-5:17\">\n<li data-sourcepos=\"5:1-5:17\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> after prose</li>\n</ul>\n<p data-sourcepos=\"7:1-7:15\">Trailing prose.</p>\n<ul data-sourcepos=\"9:1-9:17\">\n<li data-sourcepos=\"9:1-9:17\"><input type=\"checkbox\" data-task-checkbox=\"\" checked=\"\" disabled=\"\" /> after blank</li>\n</ul>\n",
 	},
 	taskCrlf: {
 		markdown: "- [ ] crlf open\r\n- [x] crlf done\r\n",
-		html: "<ul data-sourcepos=\"1:1-2:15\">\n<li data-sourcepos=\"1:1-1:15\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> crlf open</li>\n<li data-sourcepos=\"2:1-2:15\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" checked=\"\" /> crlf done</li>\n</ul>\n",
+		html: "<ul data-sourcepos=\"1:1-2:15\">\n<li data-sourcepos=\"1:1-1:15\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> crlf open</li>\n<li data-sourcepos=\"2:1-2:15\"><input type=\"checkbox\" data-task-checkbox=\"\" checked=\"\" disabled=\"\" /> crlf done</li>\n</ul>\n",
 	},
 	taskLoose: {
 		markdown: "- [ ] loose one\n\n- [x] loose two\n",
-		html: "<ul data-sourcepos=\"1:1-3:15\">\n<li data-sourcepos=\"1:1-2:0\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> \n<p data-sourcepos=\"1:7-1:15\">loose one</p>\n</li>\n<li data-sourcepos=\"3:1-3:15\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" checked=\"\" /> \n<p data-sourcepos=\"3:7-3:15\">loose two</p>\n</li>\n</ul>\n",
+		html: "<ul data-sourcepos=\"1:1-3:15\">\n<li data-sourcepos=\"1:1-1:15\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> \n<p data-sourcepos=\"1:7-1:15\">loose one</p>\n</li>\n<li data-sourcepos=\"3:1-3:15\"><input type=\"checkbox\" data-task-checkbox=\"\" checked=\"\" disabled=\"\" /> \n<p data-sourcepos=\"3:7-3:15\">loose two</p>\n</li>\n</ul>\n",
 	},
 	taskContinuation: {
 		markdown: "- [ ] first line\n  continued line\n- [x] second task\n",
-		html: "<ul data-sourcepos=\"1:1-3:17\">\n<li data-sourcepos=\"1:1-2:16\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> first line<br data-sourcepos=\"1:17-1:17\" />\ncontinued line</li>\n<li data-sourcepos=\"3:1-3:17\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" checked=\"\" /> second task</li>\n</ul>\n",
+		html: "<ul data-sourcepos=\"1:1-3:17\">\n<li data-sourcepos=\"1:1-2:16\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> first line<br data-sourcepos=\"1:17-1:17\" />\ncontinued line</li>\n<li data-sourcepos=\"3:1-3:17\"><input type=\"checkbox\" data-task-checkbox=\"\" checked=\"\" disabled=\"\" /> second task</li>\n</ul>\n",
 	},
 	taskParenOrdered: {
 		markdown: "1) [ ] paren marker\n",
@@ -66,65 +68,65 @@ export const renderFixtures = {
 	},
 	taskStarPlus: {
 		markdown: "* [ ] star marker\n+ [x] plus marker\n",
-		html: "<ul data-sourcepos=\"1:1-1:17\">\n<li data-sourcepos=\"1:1-1:17\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> star marker</li>\n</ul>\n<ul data-sourcepos=\"2:1-2:17\">\n<li data-sourcepos=\"2:1-2:17\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" checked=\"\" /> plus marker</li>\n</ul>\n",
+		html: "<ul data-sourcepos=\"1:1-1:17\">\n<li data-sourcepos=\"1:1-1:17\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> star marker</li>\n</ul>\n<ul data-sourcepos=\"2:1-2:17\">\n<li data-sourcepos=\"2:1-2:17\"><input type=\"checkbox\" data-task-checkbox=\"\" checked=\"\" disabled=\"\" /> plus marker</li>\n</ul>\n",
 	},
 	// --- protocol 2 — $$…$$ underscore protection (issue #174 shapes) ---
 	mathBracedSubscripts: {
 		markdown: "$$\\bar{b}_{1} + \\bar{b}_{2}$$\n",
-		html: "<p data-sourcepos=\"1:1-1:33\">$$\\bar{b}_{1} + \\bar{b}_{2}$$</p>\n",
+		html: "<p data-sourcepos=\"1:1-1:12\">$$\\bar{b}_{1} + \\bar{b}_{2}$$</p>\n",
 	},
 	mathPlainSubscripts: {
 		markdown: "$$x_1 + y_2 + z_3$$\n",
-		html: "<p data-sourcepos=\"1:1-1:25\">$$x_1 + y_2 + z_3$$</p>\n",
+		html: "<p data-sourcepos=\"1:1-1:12\">$$x_1 + y_2 + z_3$$</p>\n",
 	},
 	mathBlockOwnLines: {
 		markdown: "$$\na_i = b_i + c_i\n$$\n",
-		html: "<p data-sourcepos=\"1:1-3:2\">$$<br data-sourcepos=\"1:3-1:3\" />\na_i = b_i + c_i<br data-sourcepos=\"2:22-2:22\" />\n$$</p>\n",
+		html: "<p data-sourcepos=\"1:1-3:12\">$$<br data-sourcepos=\"1:13-1:13\" />\na_i = b_i + c_i<br data-sourcepos=\"2:13-2:13\" />\n$$</p>\n",
 	},
 	mathTwoBlocksOneLine: {
 		markdown: "before $$a_1$$ middle $$b_2$$ after\n",
-		html: "<p data-sourcepos=\"1:1-1:39\">before $$a_1$$ middle $$b_2$$ after</p>\n",
+		html: "<p data-sourcepos=\"1:1-1:45\">before $$a_1$$ middle $$b_2$$ after</p>\n",
 	},
 	mathEscapedUnderscore: {
 		markdown: "$$x\\_y_z$$\n",
-		html: "<p data-sourcepos=\"1:1-1:14\">$$x\\_y_z$$</p>\n",
+		html: "<p data-sourcepos=\"1:1-1:12\">$$x\\_y_z$$</p>\n",
 	},
 	mathEmphasisOutsideStillWorks: {
 		markdown: "_emphasis_ then $$p_1 + q_2$$ then _more_\n",
-		html: "<p data-sourcepos=\"1:1-1:45\"><em data-sourcepos=\"1:1-1:10\">emphasis</em> then $$p_1 + q_2$$ then <em data-sourcepos=\"1:40-1:45\">more</em></p>\n",
+		html: "<p data-sourcepos=\"1:1-1:40\"><em data-sourcepos=\"1:1-1:10\">emphasis</em> then $$p_1 + q_2$$ then <em data-sourcepos=\"1:35-1:40\">more</em></p>\n",
 	},
 	mathInsideListItem: {
 		markdown: "- $$u_1 + v_2$$\n",
-		html: "<ul data-sourcepos=\"1:1-1:19\">\n<li data-sourcepos=\"1:1-1:19\">$$u_1 + v_2$$</li>\n</ul>\n",
+		html: "<ul data-sourcepos=\"1:1-1:14\">\n<li data-sourcepos=\"1:1-1:14\">$$u_1 + v_2$$</li>\n</ul>\n",
 	},
 	// --- protocol 3 — heading ids and fold anchors (#371) ---
 	headingPunctuation: {
 		markdown: "## Hello, World!\n",
-		html: "<h2 data-sourcepos=\"1:1-1:16\"><a href=\"#hello-world\" aria-hidden=\"true\" class=\"anchor\" id=\"hello-world\"></a>Hello, World!</h2>\n",
+		html: "<h2 id=\"hello-world\" data-sourcepos=\"1:1-1:16\">Hello, World!<a href=\"#hello-world\" aria-label=\"Link to heading 'Hello, World!'\" data-heading-content=\"Hello, World!\" class=\"anchor\"></a></h2>\n",
 	},
 	headingDuplicates: {
 		markdown: "# Title\n\nfirst\n\n# Title\n\nsecond\n\n# Title\n\nthird\n",
-		html: "<h1 data-sourcepos=\"1:1-1:7\"><a href=\"#title\" aria-hidden=\"true\" class=\"anchor\" id=\"title\"></a>Title</h1>\n<p data-sourcepos=\"3:1-3:5\">first</p>\n<h1 data-sourcepos=\"5:1-5:7\"><a href=\"#title-1\" aria-hidden=\"true\" class=\"anchor\" id=\"title-1\"></a>Title</h1>\n<p data-sourcepos=\"7:1-7:6\">second</p>\n<h1 data-sourcepos=\"9:1-9:7\"><a href=\"#title-2\" aria-hidden=\"true\" class=\"anchor\" id=\"title-2\"></a>Title</h1>\n<p data-sourcepos=\"11:1-11:5\">third</p>\n",
+		html: "<h1 id=\"title\" data-sourcepos=\"1:1-1:7\">Title<a href=\"#title\" aria-label=\"Link to heading 'Title'\" data-heading-content=\"Title\" class=\"anchor\"></a></h1>\n<p data-sourcepos=\"3:1-3:5\">first</p>\n<h1 id=\"title-1\" data-sourcepos=\"5:1-5:7\">Title<a href=\"#title-1\" aria-label=\"Link to heading 'Title'\" data-heading-content=\"Title\" class=\"anchor\"></a></h1>\n<p data-sourcepos=\"7:1-7:6\">second</p>\n<h1 id=\"title-2\" data-sourcepos=\"9:1-9:7\">Title<a href=\"#title-2\" aria-label=\"Link to heading 'Title'\" data-heading-content=\"Title\" class=\"anchor\"></a></h1>\n<p data-sourcepos=\"11:1-11:5\">third</p>\n",
 	},
 	headingChinese: {
 		markdown: "## 中文标题\n",
-		html: "<h2 data-sourcepos=\"1:1-1:15\"><a href=\"#中文标题\" aria-hidden=\"true\" class=\"anchor\" id=\"中文标题\"></a>中文标题</h2>\n",
+		html: "<h2 id=\"中文标题\" data-sourcepos=\"1:1-1:15\">中文标题<a href=\"#中文标题\" aria-label=\"Link to heading '中文标题'\" data-heading-content=\"中文标题\" class=\"anchor\"></a></h2>\n",
 	},
 	headingNumericDot: {
 		markdown: "## 1. 概述\n",
-		html: "<h2 data-sourcepos=\"1:1-1:12\"><a href=\"#1-概述\" aria-hidden=\"true\" class=\"anchor\" id=\"1-概述\"></a>1. 概述</h2>\n",
+		html: "<h2 id=\"1-概述\" data-sourcepos=\"1:1-1:12\">1. 概述<a href=\"#1-概述\" aria-label=\"Link to heading '1. 概述'\" data-heading-content=\"1. 概述\" class=\"anchor\"></a></h2>\n",
 	},
 	headingApostrophe: {
 		markdown: "## Ticks aren't in\n",
-		html: "<h2 data-sourcepos=\"1:1-1:18\"><a href=\"#ticks-arent-in\" aria-hidden=\"true\" class=\"anchor\" id=\"ticks-arent-in\"></a>Ticks aren't in</h2>\n",
+		html: "<h2 id=\"ticks-arent-in\" data-sourcepos=\"1:1-1:18\">Ticks aren't in<a href=\"#ticks-arent-in\" aria-label=\"Link to heading 'Ticks aren't in'\" data-heading-content=\"Ticks aren't in\" class=\"anchor\"></a></h2>\n",
 	},
 	headingUnderscore: {
 		markdown: "## under_score here\n",
-		html: "<h2 data-sourcepos=\"1:1-1:19\"><a href=\"#under_score-here\" aria-hidden=\"true\" class=\"anchor\" id=\"under_score-here\"></a>under_score here</h2>\n",
+		html: "<h2 id=\"under_score-here\" data-sourcepos=\"1:1-1:19\">under_score here<a href=\"#under_score-here\" aria-label=\"Link to heading 'under_score here'\" data-heading-content=\"under_score here\" class=\"anchor\"></a></h2>\n",
 	},
 	headingNesting: {
 		markdown: "# A\n\nbody a\n\n## B\n\nbody b\n\n# C\n\nbody c\n",
-		html: "<h1 data-sourcepos=\"1:1-1:3\"><a href=\"#a\" aria-hidden=\"true\" class=\"anchor\" id=\"a\"></a>A</h1>\n<p data-sourcepos=\"3:1-3:6\">body a</p>\n<h2 data-sourcepos=\"5:1-5:4\"><a href=\"#b\" aria-hidden=\"true\" class=\"anchor\" id=\"b\"></a>B</h2>\n<p data-sourcepos=\"7:1-7:6\">body b</p>\n<h1 data-sourcepos=\"9:1-9:3\"><a href=\"#c\" aria-hidden=\"true\" class=\"anchor\" id=\"c\"></a>C</h1>\n<p data-sourcepos=\"11:1-11:6\">body c</p>\n",
+		html: "<h1 id=\"a\" data-sourcepos=\"1:1-1:3\">A<a href=\"#a\" aria-label=\"Link to heading 'A'\" data-heading-content=\"A\" class=\"anchor\"></a></h1>\n<p data-sourcepos=\"3:1-3:6\">body a</p>\n<h2 id=\"b\" data-sourcepos=\"5:1-5:4\">B<a href=\"#b\" aria-label=\"Link to heading 'B'\" data-heading-content=\"B\" class=\"anchor\"></a></h2>\n<p data-sourcepos=\"7:1-7:6\">body b</p>\n<h1 id=\"c\" data-sourcepos=\"9:1-9:3\">C<a href=\"#c\" aria-label=\"Link to heading 'C'\" data-heading-content=\"C\" class=\"anchor\"></a></h1>\n<p data-sourcepos=\"11:1-11:6\">body c</p>\n",
 	},
 	// --- protocol 4 — raw HTML checkboxes are not markdown tasks (#319) ---
 	rawCheckboxListItem: {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -407,6 +407,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +564,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "caseless"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
+dependencies = [
+ "unicode-normalization",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,20 +697,25 @@ dependencies = [
 
 [[package]]
 name = "comrak"
-version = "0.18.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "482aa5695bca086022be453c700a40c02893f1ba7098a2c88351de55341ae894"
+checksum = "0d5910408554659ed848ff469e67ec83b30f179e72cec286cfdae64d1616f466"
 dependencies = [
+ "bon",
+ "caseless",
  "clap",
+ "emojis",
  "entities",
- "memchr",
- "once_cell",
- "regex",
+ "finl_unicode",
+ "fmt2io",
+ "jetscii",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "rustc-hash",
  "shell-words",
- "slug",
+ "smallvec",
  "syntect",
  "typed-arena",
- "unicode_categories",
  "xdg",
 ]
 
@@ -958,12 +997,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deunicode"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1161,15 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "emojis"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a4d5d50b0b58df5173d8ff1192b4d1422ceae5d981b30d4b6f8ed1d673a2bc4"
+dependencies = [
+ "phf 0.13.1",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1299,6 +1341,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,6 +1361,12 @@ name = "float-ord"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
+
+[[package]]
+name = "fmt2io"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b6129284da9f7e5296cc22183a63f24300e945e297705dcc0672f7df01d62c8"
 
 [[package]]
 name = "fnv"
@@ -2344,6 +2398,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "jetscii"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3292,6 +3352,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3309,6 +3379,16 @@ checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3339,6 +3419,16 @@ checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3391,6 +3481,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.2",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher 1.0.2",
 ]
@@ -3904,6 +4003,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4362,16 +4467,6 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "slug"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
-dependencies = [
- "deunicode",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "smallvec"
@@ -5190,6 +5285,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5513,6 +5623,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5523,12 +5642,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "untrusted"
@@ -6636,9 +6749,9 @@ dependencies = [
 
 [[package]]
 name = "xdg"
-version = "2.5.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "yaml-rust"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,7 +29,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-window-state = ">=2.2.2, <3"
 serde = { version = "1", features = ["derive"] }
-comrak = "0.18"
+comrak = "0.54"
 serde_json = "1"
 tauri-plugin-prevent-default = "2.0.0-rc.1"
 tauri-plugin-updater = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-use comrak::{markdown_to_html, Anchorizer, ComrakExtensionOptions, ComrakOptions};
+use comrak::{markdown_to_html, Anchorizer, Options};
 use regex::{Captures, Regex};
 use std::borrow::Cow;
 use std::fs;
@@ -42,9 +42,18 @@ static HIGHLIGHT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"==([^=\n]+)
 /// the newline also keeps the line contract: collapsing a wrapped `^[…]` into
 /// one `[^ifn-N]` reference renumbered every line below it.
 static INLINE_FOOTNOTE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\^\[([^\]\n]+)\]").unwrap());
+/// The rendered task-list `<input>` this pass is allowed to mark.
+///
+/// The boolean attributes are matched as an unordered set rather than in a
+/// fixed order. comrak 0.18 emitted `disabled="" checked=""` and 0.54 emits
+/// `checked="" disabled=""`; the old pattern spelled the 0.18 order out, so
+/// under 0.54 it stopped matching *completed* tasks only — every `- [x]` item
+/// silently lost `data-task-checkbox` and became untoggleable while every
+/// `- [ ]` item kept working. Nothing about the contract depends on the order,
+/// so the pattern no longer depends on it either.
 static TASK_ITEM_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r#"<li data-sourcepos="(?<sourcepos>(?<line>\d+):\d+-\d+:\d+)">(?<input><input type="checkbox" disabled=""(?: checked="")? />)"#,
+        r#"<li data-sourcepos="(?<sourcepos>(?<line>\d+):\d+-\d+:\d+)">(?<input><input type="checkbox"(?: (?:checked|disabled)="")* />)"#,
     )
     .unwrap()
 });
@@ -342,7 +351,7 @@ fn escape_html_attribute(value: &str) -> String {
 /// appends `-1`, `-2`, … per *document*, and a link target can only ever
 /// address the first heading with a given text.
 fn heading_anchor_id(target: &str) -> String {
-    Anchorizer::new().anchorize(target.trim().to_string())
+    Anchorizer::new().anchorize(target.trim())
 }
 
 /// File extensions the viewer will open as a document. Mirrors
@@ -934,13 +943,20 @@ mod tests {
 
     #[test]
     fn task_list_checkbox_is_emitted_at_the_start_of_its_list_item() {
+        // The attribute order here is comrak's, captured, not a requirement:
+        // 0.18 wrote `disabled="" checked=""` and 0.54 writes them the other
+        // way round. What this pins is that `data-task-checkbox` is present on
+        // *both* items and that the marker sits at the start of the `<li>`.
+        // `TASK_ITEM_RE` deliberately no longer depends on the order, so a
+        // future reordering fails here — loudly — instead of quietly
+        // un-marking one of the two.
         let html = convert_markdown("- [ ] open task\n- [x] completed task\n");
         assert!(
             html.contains("<li data-sourcepos=\"1:1-1:15\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> open task</li>"),
             "unexpected task-list HTML: {html}",
         );
         assert!(
-            html.contains("<li data-sourcepos=\"2:1-2:20\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" checked=\"\" /> completed task</li>"),
+            html.contains("<li data-sourcepos=\"2:1-2:20\"><input type=\"checkbox\" data-task-checkbox=\"\" checked=\"\" disabled=\"\" /> completed task</li>"),
             "unexpected task-list HTML: {html}",
         );
     }
@@ -3228,7 +3244,7 @@ fn restore_math_spans(html: &str, masked: &MaskedMath) -> String {
         };
         match index.and_then(|index| masked.spans.get(index)) {
             Some(original) if anchored => {
-                out.push_str(&Anchorizer::new().anchorize(original.text.clone()));
+                out.push_str(&Anchorizer::new().anchorize(&original.text));
                 rest = &after[digits + suffix.len_utf8()..];
             }
             Some(original) => {
@@ -3276,21 +3292,19 @@ fn convert_markdown(content: &str) -> String {
     let processed_links = process_wikilinks(&processed_embeds);
     let masked_math = mask_math_spans(&processed_links);
 
-    let mut options = ComrakOptions {
-        extension: ComrakExtensionOptions {
-            strikethrough: true,
-            table: true,
-            autolink: true,
-            tasklist: true,
-            superscript: false,
-            footnotes: true,
-            description_lists: true,
-            header_ids: Some(String::new()),
-            ..ComrakExtensionOptions::default()
-        },
-        ..ComrakOptions::default()
-    };
-    options.render.unsafe_ = true;
+    let mut options = Options::default();
+    options.extension.strikethrough = true;
+    options.extension.table = true;
+    options.extension.autolink = true;
+    options.extension.tasklist = true;
+    options.extension.superscript = false;
+    options.extension.footnotes = true;
+    options.extension.description_lists = true;
+    // `header_ids` in 0.18; the option only ever set the *prefix* prepended to
+    // the anchorized heading text, and 0.52 renamed it to say so. `Some("")`
+    // means "ids on, no prefix" in both spellings.
+    options.extension.header_id_prefix = Some(String::new());
+    options.render.r#unsafe = true;
     options.render.hardbreaks = true;
     options.render.sourcepos = true;
 
@@ -3331,9 +3345,12 @@ fn annotate_task_checkboxes(html: String, markdown: &str) -> String {
                 return captures[0].to_string();
             }
 
+            // Anchored on the tag name, not on one of the boolean attributes,
+            // for the same reason `TASK_ITEM_RE` no longer spells their order
+            // out: `disabled` is not guaranteed to be the first one.
             let input = captures["input"].replacen(
-                " disabled=\"\"",
-                " data-task-checkbox=\"\" disabled=\"\"",
+                "<input type=\"checkbox\"",
+                "<input type=\"checkbox\" data-task-checkbox=\"\"",
                 1,
             );
             format!(


### PR DESCRIPTION
`src-tauri/Cargo.toml` pinned `comrak = "0.18"`. On a 0.x crate that is `>=0.18.0, <0.19.0` — a hard pin, not a lag. `git log -S comrak -- src-tauri/Cargo.toml` returns exactly one commit, `97b77ec`, dated 2023-12-21: in 459 commits over two and a half years the Markdown parser was never upgraded. This moves it to 0.54.0, the newest release.

## The API changes are mechanical; one behaviour change is not

| | 0.18 | 0.54 |
|---|---|---|
| options type | `ComrakOptions` / `ComrakExtensionOptions` | `Options` (the aliases were deleted in 0.54 with every other deprecation) |
| heading ids | `header_ids: Option<String>` | `header_id_prefix: Option<String>` (0.52 — the value was always a prefix) |
| raw HTML | `render.unsafe_` | `render.r#unsafe` |
| anchorizer | `anchorize(String)` | `anchorize(&str)` (0.42) |

The one that matters is the task-list checkbox. **comrak 0.18 emitted `disabled="" checked=""`; 0.54 emits `checked="" disabled=""`** — and `TASK_ITEM_RE` spelled the 0.18 order out literally:

```
<input type="checkbox" disabled=""(?: checked="")? />
```

Under 0.54 that stops matching **completed tasks and only completed tasks**. Every `- [x]` item silently loses `data-task-checkbox` and becomes untoggleable in reading mode; every `- [ ]` item keeps working, so the failure is half-invisible. Four existing tests went red on it, which is what they are for.

The fix is not to respell the order. `TASK_ITEM_RE` now matches the boolean attributes as an unordered set, and `annotate_task_checkboxes` inserts the marker after the tag name instead of after ` disabled=""`, so neither side depends on an ordering comrak never promised.

## No hand-rolled rewrite was replaced

Three parser options were proposed as replacements for regex passes. All three exist and arrived when the changelog says. **None of them does the same job**, measured against this repo's own reference corpus rather than the changelog:

**`math_dollars` / `math_code` (0.22)** — agrees with `scripts/mathDelimiterCorpus.json` on 25 of 29 cases. It disagrees on two, in the dangerous direction: it pairs `$` **across a line break** (soft *and* hard) and **across an inline code span**, both of which the corpus explicitly requires be refused. Measured against comrak 0.54 directly:

```
$a⏎b$              → <span data-math-style="inline">a b</span>      (soft break crossed)
$a␣␣⏎b$            → <span data-math-style="inline">a   b</span>    (hard break crossed)
a $b `c$d` e$f     → <span data-math-style="inline">b `c</span>d`   (code span swallowed)
```

A correction to an earlier draft of this description: it claimed the corpus's refusal is what keeps adjacent-line currency (`Costs $5` / `Sale $10`) from being typeset. That is not so — comrak produces **zero** math nodes for that input on its own, as it does for `$5 and $10` on one line. The divergence above is real; that particular consequence was not. The remaining two differences are HTML entity escaping inside the span, which the DOM undoes. `mask_math_spans` stays.

comrak *does* distinguish `\$\$x\$\$` from `$$x$$` at parse time, so a future change could move #422's escape masking into the parser — but only together with the frontend half, and not at the cost of those two corpus cases.

**wikilinks (0.24)** — comrak implements Obsidian's bare `[[Note]]`, which `process_wikilinks` documents as deliberately *not* claimed. Measured against the exact cases that comment names:

| input | comrak 0.54 | what Markpad needs |
|---|---|---|
| `[[Notes#Setup]]` | `href="Notes#Setup"` | `Notes.md#setup` — anchorized, extension resolved |
| `[[1]]` | becomes a link | left alone (citation numbering) |
| `[[1#x]](https://example.com)` | strands the `(url)` | left alone |
| `[[foo]]` + `[foo]: url` | pre-empts the reference link | left alone |

It does no heading anchorization at all, which is the entire point of the pass.

**`math_latex` (0.54.0, 2026-07-12)** — real, and it does add the `\(…\)` / `\[…\)` support that `lib.rs` records as having never worked. Not enabled here: it emits `<span data-math-style>`, which nothing in the preview renders, so it needs a frontend counterpart. See below.

Because nothing was removed, `line_preserving_transforms()` is untouched and `every_convert_markdown_preprocessing_step_is_registered` did not have to be argued with.

## Rendering differences

Diffed `convert_markdown` output, old build vs new, over **82 documents**: every `.md` in the repo, all 29 math-corpus cases, all 29 render fixtures, and hand-written CommonMark edge cases for lists, links, autolinks, emphasis, escapes, block structure, headings, alerts and raw HTML. 36 documents differ. Every difference falls into these classes:

| change | classification |
|---|---|
| heading anchor: id moves from the empty inner `<a>` onto the heading; anchor moves to the end; `aria-hidden` → `aria-label` + `data-heading-content` | **intended** (0.54 accessibility change). Anchor id *values* are byte-identical on every case tested, so `#anchor` links and `[[Notes#Setup]]` still resolve |
| block-end sourcepos stops overshooting onto the next line — `<ul data-sourcepos="5:1-6:0">` → `5:1-5:17`, same for `<li>`, `<ol>`, `<hr>` | **benign fix**; start lines never move |
| inline `<code>` sourcepos now spans its backticks; hard-break `<br>` reports its own line instead of the previous one; a description list's `<dt>` reported the *definition's* line in 0.18 | **benign fix** |
| autolinks now carry `data-sourcepos` at all | **benign** |
| footnote ids derived from the label — `fn-1` → `fn-standard`, plus `data-footnote-backref-idx` and a more specific `aria-label` | **benign**; every frontend selector for these is prefix-based (`a[href^="#fnref-"]`, `#fn-`), so they still match. Non-ASCII labels percent-encode consistently on both the id and the href |
| `Term\n: Definition` **without** a blank line is now a `<dl>`; in 0.18 it was a paragraph | **intended, newly reachable.** `description_lists` has been enabled since 2023 and the blank-line form already produced `<dl>`; only the tight form changed. `dl`/`dt`/`dd` are already styled in `styles.css` |

No regressions found.

## The line-number contract (#389, #352)

`sourcepos` describes the *preprocessed* text while the frontend edits the *raw* buffer by line number, so this was checked directly rather than inferred from green tests. Over the same 82 documents:

- **all 48 rendered task checkboxes** map to the same source line with the same checked state as before, and
- no element's start line changed anywhere, except the `<br>` hard-break correction above.

`annotate_task_checkboxes` still reads the **raw** buffer. That is the fail-safe for exactly this, it is not unified with the processed text, and it was not touched.

## Fixtures were refreshed, not hand-edited

`scripts/mathDelimiterCorpus.json` is the hand-authored reference. Its `markdown` and `math` fields are **unchanged** — the backend recognises exactly the same spans it did before. Only two captured `html` strings moved, both by a single `<code>` sourcepos column.

`scripts/renderProtocolFixtures.ts` is regenerated from `convert_markdown` itself. Worth flagging separately: **seven of its `math*` entries were already stale against comrak 0.18** before this change, so the file was asserting against HTML the renderer had stopped producing. The whole table now comes from one call, and the provenance comment says so.

One test changed shape. `each heading adopts comrak's anchor id and leaves the anchor without one` derived its expectation by reading the id off the inner `a.anchor` — the element comrak 0.18 put it on. It now reads the heading's own id first and falls back to the anchor. The invariant is unchanged and still live; only the place the renderer keeps the id moved.

## Not covered

- **The frontend's GitHub-alerts SVG injection** in `src/lib/utils/markdown.ts`. comrak's `alerts` extension could replace it and 0.54 adds semantic-HTML alert output, but that is a separate change and `markdown.ts` is being edited elsewhere.
- **`math_latex`**, above. Turning it on without the frontend half would render user-typed `\(x\)` as bare `x` — worse than today's `(x)`.
- **`processMarkdownHtml`'s heading-id promotion** is now dead code: comrak already puts the id on the heading, so `headingAnchor.id` is always empty and the branch never fires. It is harmless and correctly guarded, and removing it means touching `markdown.ts`. Left in place deliberately.
- **`process_internal_embeds` and `process_parenthesized_autolinks`** — comrak has no equivalent.
- The corpus is 82 documents, not the CommonMark spec suite. It covers what this app renders, not everything comrak can parse.

## Verification

`cargo test` 141 passed · `npm test` 546 passed · `npm run check` 0 errors 0 warnings · `cargo clippy` 2 warnings, byte-identical to the pre-change baseline on master · `cargo build --release` clean · `cargo fmt` diff count unchanged at 53 (rustfmt is not enforced in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

