### PR TITLE
chore(preview): delete six declarations nothing reads

### DIFF
--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -107,10 +107,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	let recentFiles = $state<string[]>([]);
 	let isFocused = $state(true);
 	
-	let containerEl: HTMLElement;
 	let markdownBody: HTMLElement | null = $state(null);
-	const renderDebounceMs = 50;
-	let renderTimeout: ReturnType<typeof setTimeout> | null = null;
 	let stopObservingFoldLayout: (() => void) | null = null;
 	
 	const highlightColorMap: Record<string, string> = {
@@ -251,7 +248,6 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	let canGoForwardInFileHistory = $derived(tabManager.activeTabId ? tabManager.canGoForward(tabManager.activeTabId) : false);
 
 	let loadingTabs = $state<string[]>([]);
-	const loadRevisionByTab = new Map<string, number>();
 	let isAtBottom = $state(false);
 
 	let showHome = $state(false);
@@ -322,8 +318,6 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 
 	// ui state
 	let tooltip = $state({ show: false, text: '', shortcut: '', html: '', isFootnote: false, x: 0, y: 0, align: 'top' as 'top' | 'right' | 'left' | 'below' });
-	let caretEl: HTMLElement;
-	let caretAbsoluteTop = 0;
 	let modalState = $state<{
 		show: boolean;
 		title: string;


### PR DESCRIPTION
`MarkdownViewer.svelte` declares six top-level bindings the file never mentions again. They read as live state, so anyone tracing how rendering or scroll sync works has to prove each one is inert before ruling it out.

| declaration | introduced | occurrences in the introducing commit |
|---|---|---|
| `let containerEl: HTMLElement` | `b46a283` | 1 |
| `const renderDebounceMs = 50` | `b46a283` | 1 |
| `let renderTimeout: ReturnType<typeof setTimeout> \| null` | `b46a283` | 1 |
| `let caretEl: HTMLElement` | `ef219cf` | 1 |
| `let caretAbsoluteTop = 0` | `ef219cf` | 1 |
| `const loadRevisionByTab = new Map<string, number>()` | `41de13b` (#247) | **4** |

**Five were never used at all.** One occurrence in the commit that introduces them means the declaration and nothing else. `renderDebounceMs = 50` next to `renderTimeout` is the one most likely to mislead — together they describe a render debounce that does not exist anywhere in the file.

**One is refactor residue.** `loadRevisionByTab` had four occurrences when #247 added it here. `bb8dbf3` (#274) extracted document loading into `src/lib/sessions/documentSession.svelte.ts`, which carries its own map and all three call sites; the declaration here stayed behind, dropping to one occurrence. Two identically named maps in two files, one of them dead, is worse than either alone — a reader who greps the name finds both.

## How "unreferenced" was established

Grep alone is not sufficient in a Svelte component: `bind:this={containerEl}` in the template is a real use, and a name can be reached from the markup without appearing in the script block. So:

1. Counted occurrences across the whole file, template included — each is exactly 1.
2. Grepped `src/` and `scripts/` for each name outside this file — none.
3. **`npm run check` (438 files, 0 errors) and `npm run build`** — the compiler resolving the template is the check that matters. A template reference to a deleted binding fails the build.

`scripts/largeFileLoadRevision.test.ts` pins the live map in `documentSession.svelte.ts` and is untouched.

## Verification

```
npm run check   438 files, 0 errors, 0 warnings
npm test        546 / 546
npm run build   clean
```

## Not covered

- Only top-level `let`/`const` in this one file. Unused imports, unused function parameters, and dead code in other files were not swept — a wider sweep would be a different change with a different review surface.
- `caretEl`/`caretAbsoluteTop` came in with split view and scroll syncing (`ef219cf`). They were dead on arrival, so removing them cannot change scroll sync, but it also does not tell you whether the caret-tracking they were meant for is missing on purpose. That question is left where it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)