### PR TITLE
fix(home): render the home screen when the home tab is active

### DIFF
--- a/scripts/homeTabRender.test.ts
+++ b/scripts/homeTabRender.test.ts
@@ -1,0 +1,289 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import { parse } from 'svelte/compiler';
+
+/*
+ * Issue #392, second half (reported by @PathGao): "the Home tab it opens
+ * renders blank".
+ *
+ * MarkdownViewer.svelte draws the whole application body from one `{#if}`:
+ * the consequent is the markdown container (editor + preview), the alternate
+ * is `<HomePage>`. The home screen therefore appears only when that condition
+ * is FALSE, and the condition was
+ *
+ *     activeTab && (activeTab.path !== '' || activeTab.title !== 'Recents') && !showHome
+ *
+ * which is a description of a tab that no longer exists. When the gate was
+ * written (0694991, 24 Jan) the home tab really was `{ path: '', title:
+ * 'Recents' }`, so both halves went false and the alternate ran. A week later
+ * edfb555 changed it to `{ path: 'HOME', title: 'Home' }` — a commit about
+ * scroll position, which happened to pass through the tab store — and the two
+ * halves became permanently true. From then on the home tab fell into the
+ * markdown container and rendered an empty document. The later i18n pass
+ * turned the title into `t('tabs.home', lang)`, which merely made the dead
+ * half unrecoverable in 26 languages instead of one.
+ *
+ * Nothing could see that coupling: a template string compared against a
+ * localised title is invisible to the compiler, to `npm run check`, and to
+ * every test that imports the store rather than reading the component.
+ *
+ * So this file reads the REAL gate. It parses the component, finds the `{#if}`
+ * whose `{:else}` renders `<HomePage>`, and evaluates that exact expression
+ * against the REAL `TabManager`. It asserts nothing about how the condition is
+ * spelled — rewrite it any way that keeps the home tab out of the document
+ * container and these tests stay green.
+ *
+ * What this does not establish: that `<HomePage>` itself renders anything
+ * useful, or anything about CSS. It establishes which branch the app takes.
+ */
+
+// ---------------------------------------------------------------- environment
+// Svelte runes and the Tauri bridge, faked exactly as homeSentinelSnapshot.ts
+// does, so `tabs.svelte.ts` and `settings.svelte.ts` import under plain node.
+
+const g = globalThis as any;
+const runeEffect = (fn: () => void) => {
+	void fn;
+};
+runeEffect.root = (fn: () => unknown) => fn();
+g.$state = (value: unknown) => value;
+g.$state.raw = (value: unknown) => value;
+g.$state.snapshot = (value: unknown) => value;
+g.$derived = (value: unknown) => value;
+g.$derived.by = (fn: () => unknown) => fn();
+g.$effect = runeEffect;
+g.window = g.window ?? {};
+
+const localStore = new Map<string, string>();
+g.localStorage = {
+	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
+	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
+	removeItem: (key: string) => void localStore.delete(key),
+	clear: () => localStore.clear(),
+};
+g.window.__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { HOME_TAB_PATH, isHomePath } = await import('../src/lib/utils/homeTab.js');
+const { hasRealFilePath } = await import('../src/lib/utils/tabFileActions.js');
+const { getSupportedLanguages, t } = await import('../src/lib/utils/i18n.js');
+
+// ------------------------------------------------------- the gate, as written
+
+const VIEWER = 'src/lib/MarkdownViewer.svelte';
+const source = readFileSync(VIEWER, 'utf8');
+
+type Node = Record<string, any>;
+
+function collect(node: unknown, hit: (node: Node) => void): void {
+	if (!node || typeof node !== 'object') return;
+	if (Array.isArray(node)) {
+		for (const child of node) collect(child, hit);
+		return;
+	}
+	hit(node as Node);
+	for (const key of Object.keys(node as Node)) {
+		if (key === 'parent') continue;
+		collect((node as Node)[key], hit);
+	}
+}
+
+/**
+ * Every `{#if}` whose `{:else}` branch renders `<HomePage>`, and which is not
+ * merely an ancestor of one that does.
+ *
+ * The whole component body sits inside the `mode === 'loading' / 'installer' /
+ * 'uninstall'` chain, so those outer blocks contain `<HomePage>` too. Only the
+ * innermost one is the gate — the one that actually decides between the home
+ * screen and a document.
+ */
+function homeScreenGates(): Node[] {
+	const ast = parse(source, { modern: true, filename: VIEWER });
+	const rendersHomePage = (node: Node) => {
+		let found = false;
+		collect(node, (inner) => {
+			if (inner.type === 'Component' && inner.name === 'HomePage') found = true;
+		});
+		return found;
+	};
+
+	const candidates: Node[] = [];
+	collect(ast.fragment, (node) => {
+		if (node.type === 'IfBlock' && node.alternate && rendersHomePage(node.alternate)) candidates.push(node);
+	});
+
+	return candidates.filter((gate) => {
+		let nested = false;
+		collect(gate.alternate, (inner) => {
+			if (inner !== gate && candidates.includes(inner)) nested = true;
+		});
+		return !nested;
+	});
+}
+
+const gateNode = (() => {
+	const gates = homeScreenGates();
+	assert.equal(
+		gates.length,
+		1,
+		`expected exactly one {#if} in ${VIEWER} whose {:else} renders <HomePage>, found ${gates.length} — ` +
+			'if the home screen moved out of this branch, move these tests with it',
+	);
+	return gates[0];
+})();
+
+const gateSource = source.slice(gateNode.test.start, gateNode.test.end);
+
+/**
+ * The gate as a callable, over whatever it happens to reference today.
+ *
+ * Free identifiers are read off the parsed expression rather than hard-coded,
+ * so a rewrite that uses a different helper fails with "the gate references X"
+ * instead of a bare ReferenceError from inside `new Function`.
+ */
+const evaluateGate = (() => {
+	const names = new Set<string>();
+	const skip = new Set<unknown>();
+	collect(gateNode.test, (node) => {
+		if (node.type === 'MemberExpression' && !node.computed) skip.add(node.property);
+		if (node.type === 'Property' && !node.computed) skip.add(node.key);
+	});
+	collect(gateNode.test, (node) => {
+		if (node.type === 'Identifier' && !skip.has(node)) names.add(node.name);
+	});
+
+	const available: Record<string, unknown> = { tabManager, isHomePath, hasRealFilePath };
+	const ordered = [...names].sort();
+	for (const name of ordered) {
+		if (name === 'showHome') continue;
+		assert.ok(
+			name in available,
+			`the home-screen gate references \`${name}\`, which these tests cannot supply — ` +
+				`add it to \`available\` in ${'scripts/homeTabRender.test.ts'} so the gate can still be evaluated`,
+		);
+	}
+
+	const params = ordered.filter((name) => name !== 'showHome');
+	const body = `return Boolean(${gateSource});`;
+	const fn = new Function('showHome', ...params, body) as (showHome: boolean, ...rest: unknown[]) => boolean;
+	return (showHome: boolean) => fn(showHome, ...params.map((name) => available[name]));
+})();
+
+/** True when the app draws the document container; false when it draws HomePage. */
+const showsDocumentContainer = (showHome = false) => evaluateGate(showHome);
+
+function reset() {
+	tabManager.closeAll();
+	localStore.clear();
+}
+
+// --------------------------------------------------------------- the regression
+
+test('the home tab renders the home screen, not an empty document', () => {
+	reset();
+	tabManager.addHomeTab();
+
+	assert.equal(tabManager.activeTab?.path, HOME_TAB_PATH, 'precondition: the home tab is active');
+	assert.equal(
+		showsDocumentContainer(),
+		false,
+		'the active home tab fell into the markdown container instead of the {:else} branch that ' +
+			`renders <HomePage> — the user sees a blank page. Gate: ${gateSource}`,
+	);
+});
+
+test('a home tab opened next to files still renders the home screen', () => {
+	// Ctrl+T from a window that already has documents open — the reported path.
+	reset();
+	tabManager.addTab('/notes/a.md');
+	tabManager.addTab('/notes/b.md');
+	tabManager.addHomeTab();
+
+	assert.equal(showsDocumentContainer(), false, `blank home tab alongside open files. Gate: ${gateSource}`);
+});
+
+test('the home screen is reached by tab kind, never by the tab title', () => {
+	// The dead half of the old gate. `title` is user-facing text: localised,
+	// and for a file tab it is just a filename, so a document called
+	// `Recents` used to be enough to hide the editor. Nothing about which
+	// branch runs may depend on it.
+	reset();
+	tabManager.addHomeTab();
+	const home = tabManager.activeTab!;
+
+	for (const { code } of getSupportedLanguages()) {
+		home.title = t('tabs.home', code);
+		assert.equal(showsDocumentContainer(), false, `the home screen disappears in locale ${code}`);
+	}
+
+	home.title = 'Recents';
+	assert.equal(showsDocumentContainer(), false, 'the pre-i18n English title must not be what makes this work');
+
+	reset();
+	tabManager.addTab('/notes/Recents');
+	assert.equal(showsDocumentContainer(), true, 'a document named Recents is a document');
+});
+
+// ---------------------------------------------------------------- the neighbours
+//
+// The three states that already worked. They are the fence: a gate that simply
+// always chose HomePage would pass the tests above and fail every one of these.
+
+test('a saved file renders the document container', () => {
+	reset();
+	tabManager.addTab('/notes/a.md');
+
+	assert.equal(showsDocumentContainer(), true);
+});
+
+test('an untitled buffer renders the document container', () => {
+	// The distinction the fix rests on: an untitled tab has no file either, so
+	// `hasRealFilePath` is false for both — but it IS a document, and gating on
+	// that predicate would have hidden the editor for every new file.
+	reset();
+	tabManager.addNewTab();
+
+	assert.equal(tabManager.activeTab?.path, '', 'precondition: an untitled tab has no path');
+	assert.equal(hasRealFilePath(''), false, 'precondition: and no real file either');
+	assert.equal(isHomePath(''), false, 'but it is not the home tab');
+	assert.equal(showsDocumentContainer(), true, 'a new file must still get an editor');
+});
+
+test('an empty window renders the home screen', () => {
+	reset();
+
+	assert.equal(tabManager.activeTab, undefined);
+	assert.equal(showsDocumentContainer(), false);
+});
+
+test('the Home toolbar button still overlays the home screen on any tab', () => {
+	// `showHome` is the other, older route to the same screen: a transient flag
+	// set by the toolbar/menu item, independent of any tab. It must keep
+	// winning over whatever tab is active.
+	reset();
+	tabManager.addTab('/notes/a.md');
+	assert.equal(showsDocumentContainer(true), false, 'a file tab with showHome set');
+
+	tabManager.addNewTab();
+	assert.equal(showsDocumentContainer(true), false, 'an untitled tab with showHome set');
+
+	tabManager.addHomeTab();
+	assert.equal(showsDocumentContainer(true), false, 'the home tab with showHome set');
+});
+
+test('switching from the home tab back to a file returns to the document', () => {
+	reset();
+	tabManager.addTab('/notes/a.md');
+	const file = tabManager.activeTab!.id;
+	tabManager.addHomeTab();
+	assert.equal(showsDocumentContainer(), false);
+
+	tabManager.setActive(file);
+
+	assert.equal(showsDocumentContainer(), true, 'the document container must come back');
+});

--- a/scripts/singleImplementationConvention.test.ts
+++ b/scripts/singleImplementationConvention.test.ts
@@ -119,6 +119,16 @@ const RULES: Rule[] = [
 		allowed: ['src/lib/MarkdownViewer.svelte'],
 	},
 	{
+		name: 'the home tab sentinel is spelled in one place',
+		why: "The home screen lives in a tab whose `path` is a sentinel rather than a file. Every reader of that field has to know the sentinel, and the one that did not — the render gate, which identified the home tab as `path === '' && title === 'Recents'` — went stale the day the sentinel was introduced and rendered the home tab as a blank page for six months (#392). A literal only some readers know about is a literal that can fall out of step in silence.",
+		// The string itself, not the `isHomePath` helper: a second site would
+		// spell the sentinel again rather than call the helper, so the helper's
+		// name is exactly what such a site does NOT contain. Comments say
+		// `HOME_TAB_PATH`, which is a symbol a rename can carry.
+		marker: /(['"])HOME\1/g,
+		allowed: ['src/lib/utils/homeTab.ts'],
+	},
+	{
 		name: 'highlight color palette has one definition',
 		why: 'A second palette drifts from the one bound to the --highlight-color custom property, so find highlights and the settings preview disagree.',
 		// Pins the custom property the palette feeds — the actual contract with

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -22,6 +22,8 @@
 	import FindBar from './components/FindBar.svelte';
 	import { exportAsHtml as _exportHtml, exportAsPdf as _exportPdf } from './utils/export';
 	import { askToOpenExportedFile } from './utils/openExportedFile.js';
+	import { isHomePath } from './utils/homeTab.js';
+	import { hasRealFilePath } from './utils/tabFileActions.js';
 	import ZoomOverlay from './components/ZoomOverlay.svelte';
 import { processMarkdownHtml } from './utils/markdown';
 import { sanitizeMarkdownHtml } from './utils/sanitize.js';
@@ -499,11 +501,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		// complete the buffer first; these predicates are the backstop.
 		canTransfer: (tabId) => {
 			const tab = tabManager.tabs.find((item) => item.id === tabId);
-			return !isCloseWalkActive && tab !== undefined && tab.path !== 'HOME' && !tab.isTruncated;
+			return !isCloseWalkActive && tab !== undefined && !isHomePath(tab.path) && !tab.isTruncated;
 		},
 		canDetach: (tabId) => {
 			const tab = tabManager.tabs.find((item) => item.id === tabId);
-			return !isCloseWalkActive && tab !== undefined && tab.path !== 'HOME' && !tab.isTruncated && tabManager.tabs.length >= 2;
+			return !isCloseWalkActive && tab !== undefined && !isHomePath(tab.path) && !tab.isTruncated && tabManager.tabs.length >= 2;
 		},
 		transferPayload: (tabId) => {
 			const tab = tabManager.tabs.find((item) => item.id === tabId);
@@ -562,7 +564,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	async function savePinnedTagIfNeeded() {
 		const tag = tabManager.windowTag;
 		if (!tag?.pinned) return;
-		const files = tabManager.tabs.filter((tab) => tab.path !== '' && tab.path !== 'HOME').map((tab) => tab.path);
+		const files = tabManager.tabs.filter((tab) => hasRealFilePath(tab.path)).map((tab) => tab.path);
 		await invoke('save_pinned_tag', { name: tag.name, color: tag.color, files });
 	}
 
@@ -2688,7 +2690,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	async function mergeSelfInto(targetLabel: string) {
 		if (isCloseWalkActive) return;
 		for (const tab of [...tabManager.tabs]) {
-			if (tab.path === 'HOME') {
+			if (isHomePath(tab.path)) {
 				tabManager.closeTab(tab.id);
 				continue;
 			}
@@ -3246,7 +3248,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		</div>
 	{/if}
 
-	{#if tabManager.activeTab && (tabManager.activeTab.path !== '' || tabManager.activeTab.title !== 'Recents') && !showHome}
+	{#if tabManager.activeTab && !isHomePath(tabManager.activeTab.path) && !showHome}
 			<div
 				class="markdown-container"
 				style="zoom: {isEditing && !isSplit ? 1 : zoomLevel / 100}; --code-font: {settings.codeFont}, monospace; --code-font-size: {settings.codeFontSize}px; --highlight-color: {highlightColorMap[settings.highlightColor] || highlightColorMap.yellow};"

--- a/src/lib/components/Tab.svelte
+++ b/src/lib/components/Tab.svelte
@@ -7,6 +7,7 @@
 	import { t } from '../utils/i18n.js';
 	import { settings } from '../stores/settings.svelte.js';
 	import { getTabFileActions, hasRealFilePath } from '../utils/tabFileActions.js';
+	import { isHomePath } from '../utils/homeTab.js';
 
 	let { tab, isActive, isLast, onclick, onclose } = $props<{
 		tab: Tab;
@@ -98,7 +99,7 @@
 				.filter((window) => window.label !== selfLabel)
 				.map((window) => ({
 					label: `${t('menu.moveToWindow', currentLang)} ${windowDisplay(window, currentLang)}`,
-					disabled: tab.path === 'HOME',
+					disabled: isHomePath(tab.path),
 					onHover: () => emitTo(window.label, 'window-identify', windowDisplay(window, currentLang)),
 					onClick: () => emitTo(selfLabel, 'menu-tab-move', { tabId: tab.id, targetLabel: window.label }),
 				}));
@@ -115,7 +116,7 @@
 				{ label: t('menu.undoCloseTab', currentLang), shortcut: 'Ctrl+Shift+T', onClick: () => emitTo(getCurrentWindow().label, 'menu-tab-undo') },
 				{
 					label: t('menu.rename', currentLang),
-					// Rename renames the file on disk; untitled/HOME tabs have
+					// Rename renames the file on disk; untitled and home tabs have
 					// no file, and the handler previously no-oped silently.
 					disabled: !hasRealFilePath(tab.path),
 					onClick: () => emitTo(getCurrentWindow().label, 'menu-tab-rename', tab.id),
@@ -125,9 +126,9 @@
 				{ separator: true },
 				{
 					label: t('menu.moveToNewWindow', currentLang),
-					// Moving the only tab would just churn windows, and the HOME
+					// Moving the only tab would just churn windows, and the home
 					// tab is recreatable anywhere; both stay in place.
-					disabled: tab.path === 'HOME' || tabManager.tabs.length < 2,
+					disabled: isHomePath(tab.path) || tabManager.tabs.length < 2,
 					onClick: () => emitTo(getCurrentWindow().label, 'menu-tab-detach', tab.id),
 				},
 				...moveToWindowItems,
@@ -146,7 +147,7 @@
 	class="tab {isActive ? 'active' : ''}"
 	class:last={isLast}
 	role="group"
-	title={tab.path || 'Recents'}
+	title={hasRealFilePath(tab.path) ? tab.path : tab.title}
 	oncontextmenu={handleContextMenu}
 	onmouseenter={startTitleMarquee}
 	onmouseleave={stopTitleMarquee}>

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -10,6 +10,7 @@
 	import { settings } from '../stores/settings.svelte.js';
 	import { t } from '../utils/i18n.js';
 	import { getConfiguredTitlebarToolbarIds } from '../utils/titlebarToolbar.js';
+	import { hasRealFilePath } from '../utils/tabFileActions.js';
 	import { getVersion } from '@tauri-apps/api/app';
 
 	let currentLanguage = $state(settings.language);
@@ -152,7 +153,7 @@
 			tabManager.setWindowTag({ ...tag, pinned: false });
 			return;
 		}
-		const files = tabManager.tabs.filter((tab) => tab.path !== '' && tab.path !== 'HOME').map((tab) => tab.path);
+		const files = tabManager.tabs.filter((tab) => hasRealFilePath(tab.path)).map((tab) => tab.path);
 		invoke('save_pinned_tag', { name: tag.name, color: tag.color, files }).catch(console.error);
 		tabManager.setWindowTag({ ...tag, pinned: true });
 	}

--- a/src/lib/sessions/windowSession.svelte.ts
+++ b/src/lib/sessions/windowSession.svelte.ts
@@ -182,9 +182,9 @@ export function createWindowSession(options: WindowSessionOptions) {
 				options.restoreState(savedData);
 				for (const tab of options.restoredTabs()) {
 					// The home screen is not a document. Snapshots from builds that
-					// wrote its `'HOME'` sentinel must not turn into a read of a
-					// file by that name — and unlike a file that merely failed to
-					// read, there is nothing here to come back to later.
+					// wrote its `HOME_TAB_PATH` sentinel must not turn into a read
+					// of a file by that name — and unlike a file that merely failed
+					// to read, there is nothing here to come back to later.
 					if (!hasRealFilePath(tab.path)) {
 						options.dropRestoredTab(tab.id);
 						continue;

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -2,6 +2,7 @@ import { t } from '../utils/i18n.js';
 import { nextUntitledTitle } from '../utils/untitledTitle.js';
 import { settings } from './settings.svelte.js';
 import { hasRealFilePath } from '../utils/tabFileActions.js';
+import { HOME_TAB_PATH, isHomePath } from '../utils/homeTab.js';
 import { buildTransferredTab, type TransferableTab } from '../utils/tabTransfer.js';
 import { canonicalizePath, isSameFilePath } from '../utils/pathIdentity.js';
 import {
@@ -139,11 +140,11 @@ class TabManager {
 	 * are not persisted.
 	 *
 	 * The filter is `hasRealFilePath`, not `path !== ''`: the home screen sits
-	 * in a tab whose path is the sentinel string `'HOME'`, which passes the
-	 * non-empty test and used to be written into the snapshot. Restoring it
-	 * then asked the backend to read a file called `HOME`, and the failure left
-	 * a permanently unreadable phantom tab — or, when HOME was the only tab, a
-	 * window that came back empty.
+	 * in a tab whose path is `HOME_TAB_PATH`, which passes the non-empty test
+	 * and used to be written into the snapshot. Restoring it then asked the
+	 * backend to read a file under that name, and the failure left a
+	 * permanently unreadable phantom tab — or, when the home tab was the only
+	 * one, a window that came back empty.
 	 *
 	 * `collapsedHeaders` is deliberately NOT in here. Every other field written
 	 * below describes the window and survives whatever happened to the file
@@ -184,9 +185,9 @@ class TabManager {
 	 * (legacy untitled entries are dropped).
 	 *
 	 * Entries are accepted only for real file paths. Snapshots written by
-	 * earlier builds can still contain the `'HOME'` sentinel, so the read side
-	 * has to reject it too — otherwise those users keep restoring a tab that
-	 * can never be read.
+	 * earlier builds can still contain `HOME_TAB_PATH`, so the read side has to
+	 * reject it too — otherwise those users keep restoring a tab that can never
+	 * be read.
 	 */
 	restoreState(jsonBuffer: string) {
 		try {
@@ -394,7 +395,7 @@ class TabManager {
 	}
 
 	addHomeTab() {
-		const homeTab = this.tabs.find(t => t.path === 'HOME');
+		const homeTab = this.tabs.find(t => isHomePath(t.path));
 		if (homeTab) {
 			this.activeTabId = homeTab.id;
 			return;
@@ -403,7 +404,7 @@ class TabManager {
 		const id = crypto.randomUUID();
 		this.tabs.push({
 			id,
-			path: 'HOME',
+			path: HOME_TAB_PATH,
 			title: t('tabs.home', settings.language),
 			content: '',
 			rawContent: '',
@@ -466,7 +467,7 @@ class TabManager {
 		}
 
 		const tab = this.tabs[index];
-		if (tab.path && tab.path !== 'HOME') {
+		if (hasRealFilePath(tab.path)) {
 			this.recentlyClosed.push(tab.path);
 		}
 		this.tabs.splice(index, 1);

--- a/src/lib/utils/homeTab.ts
+++ b/src/lib/utils/homeTab.ts
@@ -1,0 +1,29 @@
+/**
+ * The home screen is not a document, but it lives in a tab — and a tab
+ * identifies itself by `path`. So the home tab carries a sentinel string where
+ * every other tab carries a filesystem path.
+ *
+ * The sentinel is spelled here and nowhere else. It used to be spelled at ten
+ * separate comparison sites, and the one place that mattered most — the render
+ * gate in MarkdownViewer.svelte — was not among them: it recognised the home
+ * tab as `path === '' && title === 'Recents'`, which described the home tab as
+ * it was first written and nothing since (#392). A literal that only some of
+ * its readers know about is a literal that can fall out of step in silence, so
+ * `singleImplementationConvention.test.ts` pins the string to this file.
+ *
+ * A tab kind is not really a path, and nothing stops a document from being
+ * opened at a relative path spelled exactly `HOME`. Neither is fixed here, but
+ * both are now a single edit rather than a search-and-replace.
+ */
+export const HOME_TAB_PATH = 'HOME';
+
+/**
+ * True for the tab that holds the home screen.
+ *
+ * Distinct from `!hasRealFilePath(path)`, which is also true of an untitled
+ * buffer: an untitled tab has no file but is still a document, and every
+ * document surface — the editor, the preview, saving — applies to it.
+ */
+export function isHomePath(path: string): boolean {
+	return path === HOME_TAB_PATH;
+}

--- a/src/lib/utils/tabFileActions.ts
+++ b/src/lib/utils/tabFileActions.ts
@@ -1,3 +1,5 @@
+import { isHomePath } from './homeTab.js';
+
 export type TabFileActionId = 'copy-path' | 'open-location';
 
 export type TabFileAction = {
@@ -6,8 +8,14 @@ export type TabFileAction = {
 	disabled: boolean;
 };
 
+/**
+ * True when `path` names a file on disk — false for an untitled buffer and for
+ * the home tab's sentinel. Expressed in terms of `isHomePath` rather than
+ * repeating the sentinel, so the two predicates cannot disagree about what the
+ * home tab is.
+ */
 export function hasRealFilePath(path: string): boolean {
-	return path !== '' && path !== 'HOME';
+	return path !== '' && !isHomePath(path);
 }
 
 export function getTabFileActions(path: string): TabFileAction[] {


### PR DESCRIPTION
Addresses the blank-render half of #392 (thanks @PathGao):

> The Home tab is also broken on arrival … it falls through to the markdown container with empty content — a blank page.

**The `Ctrl+T` half of that issue is deliberately untouched and stays open.** No keybinding, no menu wiring, and no change to which tab type `Ctrl+T` creates — which of the three meanings it should settle on is a product decision, not a bug fix.

## One `{#if}` draws the whole app

The consequent is the markdown container (editor + preview); the `{:else}` is `<HomePage>`. The home screen therefore appears only when the condition is **false**, and the condition was:

```js
tabManager.activeTab && (tabManager.activeTab.path !== '' || tabManager.activeTab.title !== 'Recents') && !showHome
```

That is an accurate description of a tab that stopped existing in January. `git log -S` dates it exactly:

| | |
|---|---|
| `0694991` — 24 Jan | tabs land. The home tab is `{ path: '', title: 'Recents' }`. Both halves go false, the `{:else}` runs, **the gate is correct** |
| `edfb555` — 31 Jan, *"roughly match viewer-editor scroll location"* | the home tab becomes `{ path: 'HOME', title: 'Home' }`. Both halves are now permanently true. The gate is byte-for-byte unchanged and **has been wrong ever since** |
| `d14bb33` — 31 Mar, i18n | `title` becomes `t('tabs.home', lang)`. The dead half is now dead in 26 languages instead of one |

Note what the breaking commit was *about*. The tab-shape change was incidental to a scroll fix, and the coupling was invisible: a template comparing a **user-facing localised string** against an English literal is not something `npm run check` can type, `svelte-check` can flag, or any store-level test can see. It only shows up by looking at the branch the app actually takes.

`showHome` could not rescue it either. It is a separate, older route to the same screen — a transient flag set by the Home toolbar button — and an `$effect` keyed on `activeTabId` sets it to `false` on every tab switch, including the one `addHomeTab()` performs on itself.

## The sentinel gets a name

`'HOME'` is a magic string sitting in the field that otherwise holds a filesystem path. It was spelled at **ten** comparison sites across five files, and the reader that mattered most was not one of them — it had invented its own idea of what a home tab is. That is the reason this could rot silently, so the fix is to make there be one idea.

New `src/lib/utils/homeTab.ts` (29 lines) owns `HOME_TAB_PATH` and `isHomePath`. Every site now calls one of them, and `hasRealFilePath` — the project's existing "is this path a file" predicate, already used by `serializeState`, `restoreState`, the window-session restore and the tab context menu — is **redefined in terms of `isHomePath`** so the two cannot disagree.

**The gate asks `isHomePath`, not `hasRealFilePath`.** That distinction is the whole fix. `hasRealFilePath` is false for an untitled buffer too, and an untitled buffer is a document — it needs the editor. Gating the container on it would have traded a blank home tab for a blank *new file*, which is why `an untitled buffer renders the document container` is in the suite (and is the test that goes red if you try it — verified below).

Four call sites collapsed into `hasRealFilePath` rather than `isHomePath`, because `path !== '' && path !== 'HOME'` **is** that predicate, spelled out.

## Why it cannot rot the same way twice

A new rule in `singleImplementationConvention.test.ts` pins the literal `'HOME'` to `homeTab.ts` and nowhere else in `src`. The marker is the **string**, not the helper: a second site re-implementing the check is precisely a site that spells the string and does *not* mention `isHomePath`. Doc comments were reworded to say `HOME_TAB_PATH`, a symbol a rename carries.

This is the guard the old code lacked. Verified directly: rewriting the fixed gate as `tabManager.activeTab.path !== 'HOME'` is **behaviourally correct** and every behaviour test stays green — only the convention rule fails. That is the case the rule exists for.

## Tests

`scripts/homeTabRender.test.ts` parses `MarkdownViewer.svelte` with the project's own `svelte/compiler`, locates the `{#if}` whose `{:else}` renders `<HomePage>` (skipping the `mode === 'loading' / 'installer' / 'uninstall'` ancestors, which contain it too), and **evaluates that exact expression against the real `TabManager`**. Free identifiers are read off the parsed expression, so a rewrite using a different helper fails with *"the gate references X"* rather than a bare `ReferenceError`.

It asserts nothing about how the condition is spelled. Rewrite it any way that keeps the home tab out of the document container and it stays green.

| | |
|---|---|
| baseline (`git checkout HEAD~1 -- src/`) | **4 pass / 4 fail** |
| final | 8 / 8 |

Baseline red, verbatim: `the active home tab fell into the markdown container instead of the {:else} branch that renders <HomePage> — the user sees a blank page. Gate: tabManager.activeTab && (tabManager.activeTab.path !== '' || …)`

The **4 green on both sides are the fence** — a gate that simply always chose `HomePage` would pass the repro and fail all of these: a saved file gets the container, an untitled buffer gets the container, an empty window gets the home screen, and `showHome` still overlays the home screen on any tab.

### Mutation checks

| Deliberate break | Result |
|---|---|
| gate uses `hasRealFilePath` instead of `isHomePath` | 1 red — `an untitled buffer renders the document container` |
| `isHomePath` answers on `''` instead of the sentinel | 11 red across 4 files |
| a second site re-spells `'HOME'` (behaviour unchanged) | 1 red — the new convention rule, and only it |
| change `HOME_TAB_PATH` to `'__markpad_home__'` | render tests all green; `homeSentinelSnapshot` goes red on the two legacy-snapshot cases |

That last row is the useful one — see *Not covered*.

## Seen rendering, not only reasoned about

Reasoning about an `{#if}` from source is weak evidence, so the SvelteKit frontend was driven in a browser behind a temporary local Tauri-bridge stub (**not committed** — `src/app.html` is untouched in this diff). New file → `Ctrl+T` with focus outside Monaco:

- **pre-fix gate**: the `主页` tab activates and the body is **empty white** — the reported symptom, reproduced
- **this branch**: the welcome screen, the Open/New buttons and the Recent Files list render; `document.querySelector('.markdown-container')` is `null`
- **home tab as the only tab**: same, home screen renders

## A second reading of the same stale assumption

`Tab.svelte` set its tooltip to `tab.path || 'Recents'`, written under the same obsolete premise. In today's app that shows the **raw sentinel `HOME`** on the home tab, and the untranslated string `Recents` on every untitled buffer. Now `hasRealFilePath(tab.path) ? tab.path : tab.title` — a real path where there is one, the tab's own localised title otherwise. Confirmed in the browser: `主页` and `无标题 1`. This is the last occurrence of `'Recents'` in `src`.

```
npm run check   439 files, 0 errors
npm test        562 / 562   (553 on this base + 8 render + 1 convention rule)
cargo test      not run — no Rust in this change
```

## Not covered

- **The sentinel can still collide with a real path.** A document opened at a relative path spelled exactly `HOME` would be mistaken for the home tab. Every path the app takes in is absolute (dialog, drag-drop, file association, wikilink resolution, Save As), and the consequences are cosmetic — disabled context-menu items, no session persistence — so this is not fixed here. It is now a **one-line** change instead of a search-and-replace, but not a free one: `homeSentinelSnapshot.test.ts` rejects the literal `'HOME'` out of snapshots written by older builds, so changing the value means keeping the old one on the reject list. The mutation run above confirms that test is what catches it.
- **The real fix is a tab kind, not a path.** A `kind: 'file' | 'untitled' | 'home'` discriminant on `Tab` would make the collision impossible and let the compiler check exhaustiveness. It touches `serializeState` / `restoreState` / the cross-window transfer payload and their migrations — much wider than a render bug warrants. Left for whoever wants it; this change makes it a smaller job than it was.
- **`Ctrl+T`'s three meanings.** Untouched, and #392 stays open for it.
- The gate is verified by evaluating the parsed expression, not by mounting the component. Combined with the browser run above, but neither is an end-to-end test in the packaged Tauri app.
- The browser run used a stubbed Tauri bridge; the WebView the app actually ships in was not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
