### PR TITLE
perf(markdown): stop rescanning the whole document for every math token

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1543,6 +1543,91 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------
+    // `restore_math_spans` must stay linear in the size of the HTML
+    //
+    // It was not. It asked `str::find` for both spellings of the mask
+    // token at every step, and the anchorized spelling occurs only in a
+    // heading — so in any document without one, each token paid a scan of
+    // the *whole remaining HTML* to be told "not found", and then paid it
+    // again for the next token. On a 10 000-formula document that was
+    // 1.36 s of a 1.39 s `convert_markdown`.
+    //
+    // Removing the carrying again would not change one byte of output, so
+    // no output test can see the regression; and a wall-clock assertion
+    // would be measuring how busy the CI runner is, which is why there is
+    // not one here. The two tests below pin the mechanism instead: that
+    // the carried offset really is reused, and that the pass does not go
+    // around it.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn a_carried_search_reuses_its_answer_instead_of_searching_again() {
+        // Both properties are asserted by handing the scan a *different*
+        // haystack: an implementation that searched again could not
+        // produce the expected answer from it.
+        let mut scan = TokenScan::new("..NEEDLE..", "NEEDLE");
+        assert_eq!(scan.at_or_after("..NEEDLE..", 0), Some(2));
+        // Still ahead of the cursor, so the haystack is never consulted —
+        // it does not matter that this one has no needle in it at all.
+        assert_eq!(scan.at_or_after("xxxxxxxxxx", 2), Some(2));
+        // The cursor has passed it, so now it must search, and it searches
+        // the haystack it is handed.
+        assert_eq!(scan.at_or_after("xxxxxxxxxx", 3), None);
+
+        // "No occurrence from here on" is the answer that used to be paid
+        // for over and over, and it has to stay sticky.
+        let mut exhausted = TokenScan::new("xxxxxxxxxx", "NEEDLE");
+        assert_eq!(exhausted.at_or_after("..NEEDLE..", 0), None);
+
+        // The answers themselves are the ones a fresh search gives.
+        let haystack = "a NEEDLE b NEEDLE c";
+        let mut walk = TokenScan::new(haystack, "NEEDLE");
+        for from in 0..=haystack.len() {
+            assert_eq!(
+                walk.at_or_after(haystack, from),
+                haystack[from..].find("NEEDLE").map(|at| from + at),
+                "the carried scan disagrees with a fresh search at {from}",
+            );
+        }
+    }
+
+    #[test]
+    fn restore_math_spans_scans_only_through_a_carried_search() {
+        // Re-reads this file, the way
+        // `every_convert_markdown_preprocessing_step_is_registered` does,
+        // because the property is about the shape of the pass rather than
+        // about its output. Line endings are normalised first: git checks
+        // this file out with CRLF wherever `core.autocrlf` is on, which is
+        // the default on Windows and what the Windows CI runner does.
+        let source = include_str!("lib.rs").replace("\r\n", "\n");
+        let needle = format!(
+            "\nfn {}(html: &str, masked: &MaskedMath) -> String {{",
+            "restore_math_spans",
+        );
+        let start = source
+            .find(&needle)
+            .expect("restore_math_spans must keep its signature");
+        let rest = &source[start + needle.len()..];
+        let body = &rest[..rest
+            .find("\n}\n")
+            .expect("restore_math_spans must be terminated")];
+
+        assert!(
+            body.contains("TokenScan::new("),
+            "restore_math_spans no longer walks the HTML with a carried \
+             search — see TokenScan for why that made the pass quadratic",
+        );
+        assert!(
+            !body.contains(".find("),
+            "restore_math_spans searches the remaining HTML by itself \
+             again. That is the shape the pass had when it was quadratic: \
+             one scan per token, each one able to run to the end of the \
+             document. Search through TokenScan, or, if this really is a \
+             bounded search, say so here and relax the check.",
+        );
+    }
+
     #[test]
     fn math_in_a_link_destination_keeps_the_link_working() {
         // The token has to survive `escape_href` too, which is why it is
@@ -3185,6 +3270,54 @@ fn mask_math_spans(content: &str) -> MaskedMath {
     }
 }
 
+/// A forward-only search for one fixed needle, carrying its last answer.
+///
+/// `restore_math_spans` looks for two spellings of the token at once and walks
+/// a cursor that only ever moves forward. Asking `str::find` for both
+/// spellings at every step is what made that pass quadratic: the anchorized
+/// spelling only occurs in a heading, so in a document without one, every
+/// token paid a full scan of the remaining HTML to conclude "not found" — and
+/// concluded it again for the next token, and the next.
+///
+/// Carrying the answer removes the repetition without changing a single
+/// result. An offset that is the first occurrence at or after some cursor is
+/// still the first occurrence at or after any *later* cursor it survives, so a
+/// needle is only searched for again once the cursor has passed its last
+/// answer, and `None` — "no occurrence from here on" — stays true forever.
+/// Consecutive searches therefore start where the previous one stopped and
+/// cover disjoint stretches of the haystack: linear in total, whatever the
+/// number of tokens.
+///
+/// The haystack is passed in rather than held, so the carried offset is the
+/// scan's entire state. The test named at the top of `mod tests`' section on
+/// this pass leans on that: it hands one scan a haystack the needle does not
+/// occur in at all, which no implementation that searched again could answer
+/// correctly. Reuse is otherwise invisible — it changes no result, only how
+/// many bytes were read to reach it.
+struct TokenScan<'needle> {
+    needle: &'needle str,
+    carried: Option<usize>,
+}
+
+impl<'needle> TokenScan<'needle> {
+    fn new(haystack: &str, needle: &'needle str) -> Self {
+        Self {
+            needle,
+            carried: haystack.find(needle),
+        }
+    }
+
+    /// The offset of the first `needle` at or after `from`.
+    ///
+    /// `from` must not go backwards between calls.
+    fn at_or_after(&mut self, haystack: &str, from: usize) -> Option<usize> {
+        if self.carried.is_some_and(|at| at < from) {
+            self.carried = haystack[from..].find(self.needle).map(|at| from + at);
+        }
+        self.carried
+    }
+}
+
 /// Puts the masked source back into the rendered HTML.
 ///
 /// The span is re-escaped the way comrak escapes a text node, not inserted
@@ -3212,21 +3345,33 @@ fn restore_math_spans(html: &str, masked: &MaskedMath) -> String {
     }
     let anchor_prefix = masked.prefix.to_ascii_lowercase();
     let mut out = String::with_capacity(html.len());
-    let mut rest = html;
+    let mut cursor = 0usize;
     let mut in_tag = false;
-    while let Some((at, anchored)) = [
-        (rest.find(masked.prefix.as_str()), false),
-        (rest.find(anchor_prefix.as_str()), true),
-    ]
-    .into_iter()
-    .filter_map(|(at, anchored)| at.map(|at| (at, anchored)))
-    .min()
-    {
-        out.push_str(&rest[..at]);
-        if let Some(bracket) = rest[..at].rfind(['<', '>']) {
-            in_tag = rest.as_bytes()[bracket] == b'<';
+    // All scanning goes through `TokenScan` — see it for why, and see
+    // `restore_math_spans_scans_only_through_a_carried_search` for the test
+    // that keeps it that way.
+    let mut plain = TokenScan::new(html, masked.prefix.as_str());
+    let mut anchor = TokenScan::new(html, anchor_prefix.as_str());
+    loop {
+        // The plain spelling wins a tie, as it did when both candidates were
+        // compared as `(offset, anchored)` pairs.
+        let (at, anchored) = match (
+            plain.at_or_after(html, cursor),
+            anchor.at_or_after(html, cursor),
+        ) {
+            (Some(upper), Some(lower)) if lower < upper => (lower, true),
+            (Some(upper), _) => (upper, false),
+            (None, Some(lower)) => (lower, true),
+            (None, None) => break,
+        };
+
+        let gap = &html[cursor..at];
+        out.push_str(gap);
+        if let Some(bracket) = gap.rfind(['<', '>']) {
+            in_tag = gap.as_bytes()[bracket] == b'<';
         }
-        let after = &rest[at + masked.prefix.len()..];
+        let body = at + masked.prefix.len();
+        let after = &html[body..];
         let digits = after
             .as_bytes()
             .iter()
@@ -3245,7 +3390,7 @@ fn restore_math_spans(html: &str, masked: &MaskedMath) -> String {
         match index.and_then(|index| masked.spans.get(index)) {
             Some(original) if anchored => {
                 out.push_str(&Anchorizer::new().anchorize(&original.text));
-                rest = &after[digits + suffix.len_utf8()..];
+                cursor = body + digits + suffix.len_utf8();
             }
             Some(original) => {
                 out.push_str(&escape_html_text(if in_tag {
@@ -3253,15 +3398,15 @@ fn restore_math_spans(html: &str, masked: &MaskedMath) -> String {
                 } else {
                     &original.text
                 }));
-                rest = &after[digits + suffix.len_utf8()..];
+                cursor = body + digits + suffix.len_utf8();
             }
             None => {
-                out.push_str(&rest[at..at + masked.prefix.len()]);
-                rest = after;
+                out.push_str(&html[at..body]);
+                cursor = body;
             }
         }
     }
-    out.push_str(rest);
+    out.push_str(&html[cursor..]);
     out
 }
 


### PR DESCRIPTION
## The defect

`mask_math_spans` replaces every math span and every escaped-dollar run with a token — `MPMATHMASK<n>E` — so comrak cannot rewrite the formula. `restore_math_spans` then walks the rendered HTML and puts the source back.

It has to look for **two** spellings of that token. Everywhere else it lands verbatim, but comrak anchorizes a heading's rendered text into `id=` and `href="#…"`, which lowercases it, and there the *anchorized* source must go back instead so `[[#A heading with $x_1$]]` still resolves. So the loop asked for both:

```rust
while let Some((at, anchored)) = [
    (rest.find(masked.prefix.as_str()), false),
    (rest.find(anchor_prefix.as_str()), true),
].into_iter().filter_map(…).min()
{
    …
    rest = &after[digits + suffix.len_utf8()..];   // advance past this token
}
```

`rest` advances, so this *looks* linear. It is not. **The lowercase spelling only occurs in a heading that contains a formula.** In a document without one, `rest.find(anchor_prefix)` reads every remaining byte to return `None` — and the next token reads them again, minus one token's worth. That is `O(tokens × bytes)`: a document is not slow because it is long, it is slow because it is long *and* full of formulas.

The uppercase search hides the shape rather than causing it. It terminates quickly precisely because tokens are dense — which is the same condition that makes the failing lowercase search run so many times.

## Measured, not assumed

Documents of one inline formula per line. One run, minimum of several reps at each size, `opt-level = 2`; `growth` is each row against the one above it.

**Before**

| formulas | HTML | `restore_math_spans` | growth | `convert_markdown` | restore's share |
|---:|---:|---:|---:|---:|---:|
| 1 000 | 157 KB | 16.2 ms | — | 17.7 ms | 92% |
| 2 000 | 318 KB | 57.0 ms | 3.5× | 62.1 ms | 92% |
| 5 000 | 801 KB | 350 ms | 6.1× | 360 ms | 97% |
| 10 000 | 1.6 MB | 1 364 ms | 3.9× | 1 372 ms | 99% |
| 20 000 | 3.2 MB | 6 341 ms | 4.7× | 6 359 ms | 99% |

Four times the time for twice the input, six for two and a half. That is quadratic, and it is effectively all of `convert_markdown` — which runs on **every keystroke** in reading mode.

**After**

| formulas | HTML | `restore_math_spans` | growth | `convert_markdown` | restore's share |
|---:|---:|---:|---:|---:|---:|
| 1 000 | 157 KB | 0.22 ms | — | 2.5 ms | 8.9% |
| 2 000 | 318 KB | 0.43 ms | 1.9× | 5.0 ms | 8.6% |
| 5 000 | 801 KB | 1.07 ms | 2.5× | 12.6 ms | 8.5% |
| 10 000 | 1.6 MB | 2.18 ms | 2.0× | 26.5 ms | 8.2% |
| 20 000 | 3.2 MB | 4.41 ms | 2.0× | 86.8 ms | 5.1% |

Growth now tracks the input exactly: 2× the formulas costs 2.0×, 2.5× costs 2.49×. A separate run extended the line to 40 000 formulas (6.6 MB of HTML) at 13.9 ms, still 2.1× per doubling.

The `convert_markdown` column carries far more run-to-run variance than the `restore` column — it allocates and frees several megabytes, and this machine was not idle. Across four runs the 20 000-formula figure ranged 56–157 ms while `restore` stayed at 4.4–7.8 ms and the 10 000-formula "before" figure reproduced at 1 364 ms three times out of four. The growth columns, which are what the claim rests on, were stable in every run.

**What the bottleneck is now.** At 20 000 formulas, on a quiet machine, `convert_markdown` (56.4 ms) breaks down as `mask_math_spans` 22.5 ms (40%), comrak 21.1 ms (37%), the three pre-passes 5.4 ms (10%), `restore_math_spans` 4.4 ms (8%), `annotate_task_checkboxes` 0.9 ms (2%). Halving to 10 000 halves each of them, so no second quadratic is hiding behind this one on this document shape.

**A control that isolates the cause.** The same document with a math-bearing heading every 100 lines — identical token count, but now the anchorized spelling really occurs — ran the *old* code at 2.5 / 4.5 / 10.5 / 22.2 / 48.9 ms across the same five sizes. Near-linear, because the failing search terminates at the next heading instead of at end of document. Same code, same tokens, 130× apart at 20 000. That difference is the bug.

## The fix

Each spelling carries its last answer:

```rust
struct TokenScan<'needle> {
    needle: &'needle str,
    carried: Option<usize>,
}

fn at_or_after(&mut self, haystack: &str, from: usize) -> Option<usize> {
    if self.carried.is_some_and(|at| at < from) {
        self.carried = haystack[from..].find(self.needle).map(|at| from + at);
    }
    self.carried
}
```

The correctness argument is that the cursor only ever moves forward. An offset that is the first occurrence at or after some cursor is still the first occurrence at or after any *later* cursor it survives — anything earlier would already have been found by the earlier search. And `None`, "no occurrence from here on", stays true forever. So a needle is only searched for again once the cursor has passed its answer, and consecutive searches begin where the previous one stopped: disjoint stretches, linear in total, whatever the token count.

`rest: &str` became `cursor: usize` so both scans can index the same buffer. Nothing else in the pass changed — the tie-break still favours the plain spelling, `in_tag` is still decided by the last `<` or `>` in the gap since the previous token, and every branch emits exactly what it emitted before.

## Byte-equality evidence

The old implementation was kept alongside the new one during development and both were run through the full `convert_markdown` pipeline over **40 082 documents**, asserting byte equality of the HTML:

- **40 000 generated** by a deterministic fragment shuffler over 40 fragments chosen to stress this seam — both delimiter forms, escapes, code spans and fences, headings, link destinations, `alt` text, raw HTML, CRLF, CJK, emoji, lone `$` and `\`, wikilinks, and mask-sentinel lookalikes. Branch coverage over that corpus: 39 365 documents produced masked spans, 4 153 reached the anchorized branch, 3 438 left an unparsed token behind, 30 341 needed a grown prefix.
- **29 cases** of `scripts/mathDelimiterCorpus.json`.
- **8 `.md` files** in the repo.
- **42 hand-written adversarial** documents: no math; exactly one span; a span at the first byte and at the last; adjacent spans with nothing between them; non-ASCII and emoji immediately either side; a span inside a fenced block, an inline code span, a heading, an `href`, an `alt`, a table cell, a task item, a blockquote, a raw-HTML attribute; an unclosed `<` before a span; a span containing all four of `&<>"`; a truncated `$$` opener; CRLF; no trailing newline.

Not one differed. The differential harness is not in this PR — shipping it would mean shipping the old implementation.

**The mask-sentinel collision, unchanged.** Worth stating because it is unusual and this PR deliberately preserves it. `mask_math_spans` establishes uniqueness by construction: it grows the prefix with `X` until the *source* no longer contains it, case-insensitively. So a user who types `MPMATHMASK0E` gets tokens spelled `MPMATHMASKX…E`, and their text is left alone — the four adversarial cases covering that are byte-identical. The gap is that uniqueness is checked against the **source** while restoration runs on **comrak's output**, so an HTML entity can synthesise a token the check never saw: `&#77;PMATHMASK0E` reaches `restore_math_spans` as `MPMATHMASK0E` and is replaced by the first masked span. `&#77;PMATHMASK` alone, with nothing token-shaped after it, is emitted verbatim. Both behaviours are identical before and after this change. Whether the first one should be fixed is a separate decision.

## Regression test

A wall-clock assertion here would be measuring how busy the CI runner is, and there is no timing test anywhere in this repo. But the property is also invisible to an output test: **deleting the carrying changes no byte of any document.** That was verified rather than assumed — with `TokenScan` mutated to search every time, all 40 082 differential documents and every other test in the suite still passed, and only the new mechanism test failed.

So the two tests added pin the mechanism instead, in the same `include_str!` idiom `every_convert_markdown_preprocessing_step_is_registered` already uses:

- `a_carried_search_reuses_its_answer_instead_of_searching_again` hands one scan a haystack **the needle does not occur in at all** and requires the previous answer back. No implementation that searched again could answer that correctly. It also asserts the sticky `None`, and that the answers agree with a fresh `str::find` at every cursor position.
- `restore_math_spans_scans_only_through_a_carried_search` extracts the function body from `include_str!("lib.rs")` and asserts it contains `TokenScan::new(` and no `.find(` — the shape it had when it was quadratic. Line endings are normalised first, because git hands the file to Windows CI with CRLF.

Both were confirmed to fail against a deliberately reverted implementation, and the second one's message says what to do if a future bounded search legitimately needs to relax it.

## Checks

`cargo test` (146 pass), `cargo clippy` (three warnings, the same three as `master` — `EXE_NAME` unused, one collapsible `if`, one single-character `push_str`; zero delta), `npm test` (562 pass), `npm run check` (0 errors). `cargo fmt --check` reports the same 53 pre-existing hunks before and after; the new code adds none.

## Not covered

- **`mask_math_spans` is now the largest single cost** (40% at 20 000 formulas) and was not touched. It is linear on the documents measured here, but it has two nested scans that could bite on other shapes: `find_escaped_dollar_spans` checks each escape against every math span (`O(escapes × spans)`), and `find_display_close` checks each line against every code region. Both need a document that is simultaneously escape-heavy and math-heavy, or code-region-heavy, to matter. Separate work.
- **No behaviour change, so no new corpus case.** `scripts/mathDelimiterCorpus.json` is untouched; `the_math_contract_corpus_is_a_live_capture` passes unchanged, which is itself a byte-equality check over 29 documents.
- **The line-number contract is not affected.** `restore_math_spans` runs on rendered HTML, after `sourcepos` numbers exist, and is already listed in `not_a_transform` for exactly that reason. It emits what it emitted before, so no source line can have moved.
- **Not measured in a release build.** All numbers are `opt-level = 2`; the release profile is `opt-level = "s"` with LTO, so absolute times will differ. The growth shape will not.
- **The frontend was not profiled.** This measures `convert_markdown` only. Whether the preview is now bounded by KaTeX or by DOM work on a math-heavy document is unknown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
