### PR TITLE
chore(check): type-check scripts/, and fix an assertion that could not fail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
 				"@sveltejs/kit": "^2.70.2",
 				"@sveltejs/vite-plugin-svelte": "^5.1.1",
 				"@tauri-apps/cli": "^2",
+				"@types/node": "^24.13.3",
 				"svelte": "^5.56.8",
 				"svelte-check": "^4.7.4",
 				"tsx": "^4.22.4",
@@ -1595,6 +1596,16 @@
 			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
 			"integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
 			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "24.13.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+			"integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.18.0"
+			}
 		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.7",
@@ -3476,6 +3487,13 @@
 			"version": "1.6.3",
 			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
 			"integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+			"license": "MIT"
+		},
+		"node_modules/undici-types": {
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"@sveltejs/kit": "^2.70.2",
 		"@sveltejs/vite-plugin-svelte": "^5.1.1",
 		"@tauri-apps/cli": "^2",
+		"@types/node": "^24.13.3",
 		"svelte": "^5.56.8",
 		"svelte-check": "^4.7.4",
 		"tsx": "^4.22.4",

--- a/scripts/findCollapsedMatches.test.ts
+++ b/scripts/findCollapsedMatches.test.ts
@@ -2,15 +2,9 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const findBar = readFileSync('src/lib/components/FindBar.svelte', 'utf8');
+import { sliceBetween } from './sourceTree.js';
 
-function slice(source: string, start: string, end: string): string {
-	const from = source.indexOf(start);
-	assert.notEqual(from, -1, `expected to find ${start}`);
-	const to = source.indexOf(end, from + start.length);
-	assert.notEqual(to, -1, `expected to find ${end} after ${start}`);
-	return source.slice(from, to);
-}
+const findBar = readFileSync('src/lib/components/FindBar.svelte', 'utf8');
 
 test('find keeps counting matches inside collapsed folds', () => {
 	// Reference systems all keep hidden-but-present text findable and reveal
@@ -18,7 +12,7 @@ test('find keeps counting matches inside collapsed folds', () => {
 	// `hidden=until-found` / closed `<details>` content matchable precisely
 	// because it can reveal it. Dropping the matches from the count would be
 	// the `display: none` rule, which is not what a collapsed fold is.
-	const acceptNode = slice(findBar, 'function isHostElement(', 'function isInsideHost(');
+	const acceptNode = sliceBetween(findBar, 'function isHostElement(', 'function isInsideHost(');
 
 	assert.doesNotMatch(acceptNode, /is-collapsed/);
 	assert.doesNotMatch(acceptNode, /foldable-content-wrapper/);
@@ -31,7 +25,7 @@ test('find knows both kinds of collapsed fold container', () => {
 });
 
 test('activating a match reveals the folds hiding it before scrolling to it', () => {
-	const setActive = slice(findBar, 'function setActive(', 'export function next()');
+	const setActive = sliceBetween(findBar, 'function setActive(', 'export function next()');
 
 	const reveal = setActive.indexOf('revealFoldsAround(');
 	const scroll = setActive.indexOf('scrollIntoView(');
@@ -46,7 +40,7 @@ test('revealing a fold goes through the viewer toggle instead of stripping the c
 	// fold state: it re-applies `is-collapsed` on every re-render and feeds
 	// the ToC. Clearing the class here would create a second source of truth
 	// that the next render silently reverts.
-	const reveal = slice(findBar, 'function foldToggleFor(', 'export function clearHighlights()');
+	const reveal = sliceBetween(findBar, 'function foldToggleFor(', 'export function clearHighlights()');
 
 	assert.match(reveal, /\.header-fold-icon/);
 	assert.match(reveal, /\.callout-toggle/);
@@ -57,7 +51,7 @@ test('revealing a fold goes through the viewer toggle instead of stripping the c
 });
 
 test('nested folds are opened outermost first', () => {
-	const reveal = slice(findBar, 'function revealFoldsAround(', 'export function clearHighlights()');
+	const reveal = sliceBetween(findBar, 'function revealFoldsAround(', 'export function clearHighlights()');
 
 	assert.match(reveal, /while \(curr && curr !== root\)/);
 	assert.match(reveal, /collapsed\.reverse\(\)/);
@@ -66,7 +60,7 @@ test('nested folds are opened outermost first', () => {
 test('the scroll is re-aimed once the fold height transition has settled', () => {
 	// styles.css animates `.foldable-content-wrapper` height for 0.25s, so the
 	// first scrollIntoView aims at a target that is still moving.
-	const setActive = slice(findBar, 'function setActive(', 'export function next()');
+	const setActive = sliceBetween(findBar, 'function setActive(', 'export function next()');
 
 	assert.match(setActive, /setTimeout\(/);
 	assert.match(setActive, /FOLD_TRANSITION_MS/);

--- a/scripts/issue261EditorPdf.test.ts
+++ b/scripts/issue261EditorPdf.test.ts
@@ -2,12 +2,13 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { sliceBetween, sliceFrom } from './sourceTree.js';
+
 const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
 const styles = readFileSync('src/styles.css', 'utf8');
 
 test('editor context menu is not intercepted by the document menu', () => {
-	const start = viewer.indexOf('function handleContextMenu(e: MouseEvent)');
-	const handler = viewer.slice(start, viewer.indexOf('\n\tfunction handleMouseOver', start));
+	const handler = sliceBetween(viewer, 'function handleContextMenu(e: MouseEvent)', '\n\tfunction handleMouseOver');
 	const editorReturn = handler.indexOf('if (isInsideEditor) return;');
 	const preventDefault = handler.indexOf('e.preventDefault();');
 
@@ -45,10 +46,7 @@ test('print layout lets the viewer pane escape the interactive split flex ratio'
 });
 
 test('floating toc toggle keeps a visible translucent surface outside edit mode', () => {
-	const selector = viewer.slice(
-		viewer.indexOf('\t.toc-toggle-floating {'),
-		viewer.indexOf('\n\t.toc-toggle-floating.expanded {'),
-	);
+	const selector = sliceBetween(viewer, '\t.toc-toggle-floating {', '\n\t.toc-toggle-floating.expanded {');
 
 	assert.match(selector, /background-color:\s*color-mix\(in srgb, var\(--color-canvas-default\) 82%, transparent\);/);
 	assert.match(selector, /border:\s*1px solid var\(--color-border-default\);/);
@@ -59,7 +57,7 @@ test('floating toc toggle keeps a visible translucent surface outside edit mode'
 });
 
 test('print layout gives document content paper-specific rhythm and boundaries', () => {
-	const printStyles = styles.slice(styles.indexOf('@media print {'));
+	const printStyles = sliceFrom(styles, '@media print {');
 
 	assert.match(printStyles, /\.markdown-body h1,[\s\S]*?line-height:\s*1\.2;/);
 	assert.match(printStyles, /\.markdown-body p\s*\{[\s\S]*?margin:\s*0 0 0\.75em;/);
@@ -72,8 +70,7 @@ test('print layout gives document content paper-specific rhythm and boundaries',
 });
 
 test('print layout paints a theme-independent page and keeps Markdown alerts intact', () => {
-	const printStyles = styles.slice(styles.indexOf('@media print {'));
-	const viewerPrintStyles = viewer.slice(viewer.indexOf('\t@media print {'));
+	const printStyles = sliceFrom(styles, '@media print {');
 
 	assert.match(printStyles, /@page\s*\{[\s\S]*?margin:\s*0;/);
 	assert.match(printStyles, /\.markdown-body\s*\{[\s\S]*?box-sizing:\s*border-box\s*!important;/);
@@ -88,11 +85,22 @@ test('print layout paints a theme-independent page and keeps Markdown alerts int
 	assert.match(printStyles, /\.markdown-body \.markdown-alert\s*\{[\s\S]*?box-decoration-break:\s*clone\s*!important;/);
 	assert.match(printStyles, /\.markdown-body details\.markdown-alert\s*\{[\s\S]*?break-inside:\s*avoid\s*!important;/);
 	assert.match(printStyles, /\.markdown-body tr\s*\{[\s\S]*?break-inside:\s*avoid;/);
-	assert.doesNotMatch(viewerPrintStyles, /\.markdown-body\s*\{[\s\S]*?padding:\s*0\s*!important;/);
+
+	// The paper padding above is set globally, so a component-scoped print rule
+	// in MarkdownViewer.svelte would beat it: Svelte adds a hash class to its
+	// own selectors, and `.markdown-body.svelte-xxxx { padding: 0 !important }`
+	// outranks `.markdown-body { padding: 0.75in !important }`. Exactly that
+	// rule lived in the component until 37b3693 removed it.
+	//
+	// This is searched over the whole component rather than over a slice from
+	// `@media print {`: the component now has no print block at all, so slicing
+	// to that marker sliced from -1 — the last character of the file — and the
+	// assertion could not fail for the entire time it existed.
+	assert.doesNotMatch(viewer, /@media print\s*\{[\s\S]*?\.markdown-body\s*\{[\s\S]*?padding:\s*0\s*!important;/);
 });
 
 test('print layout keeps wide metadata tables readable', () => {
-	const printStyles = styles.slice(styles.indexOf('@media print {'));
+	const printStyles = sliceFrom(styles, '@media print {');
 
 	// Diagram colours are no longer patched from CSS — the export re-renders
 	// them with Mermaid's light theme instead (see utils/mermaidPrint.ts).

--- a/scripts/lossyDecodeSaveGuard.test.ts
+++ b/scripts/lossyDecodeSaveGuard.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 
 import type { Tab } from '../src/lib/stores/tabs.svelte.js';
 import { buildTransferredTab, snapshotTab, validateTransferPayload } from '../src/lib/utils/tabTransfer.js';
+import { sliceBetween } from './sourceTree.js';
 
 // Every read path decodes leniently (#371): a file in a legacy encoding
 // (GBK, Big5, Shift-JIS, EUC-KR, CP1251 ...) opens as U+FFFD mojibake instead
@@ -24,18 +25,10 @@ const windowSession = readFileSync('src/lib/sessions/windowSession.svelte.ts', '
 const tabs = readFileSync('src/lib/stores/tabs.svelte.ts', 'utf8');
 const rust = readFileSync('src-tauri/src/lib.rs', 'utf8');
 
-function slice(source: string, start: string, end: string): string {
-	const from = source.indexOf(start);
-	assert.notEqual(from, -1, `expected to find ${start}`);
-	const to = source.indexOf(end, from + start.length);
-	assert.notEqual(to, -1, `expected to find ${end} after ${start}`);
-	return source.slice(from, to);
-}
-
-const loadMarkdown = () => slice(session, 'async function loadMarkdown', 'async function saveContent');
-const saveContent = () => slice(session, 'async function saveContent(', 'async function saveContentAs');
-const saveContentAs = () => slice(session, 'async function saveContentAs', 'async function toggleTaskCheckbox');
-const guard = () => slice(session, 'function refuseIfLossilyDecoded', 'function updateLoading');
+const loadMarkdown = () => sliceBetween(session, 'async function loadMarkdown', 'async function saveContent');
+const saveContent = () => sliceBetween(session, 'async function saveContent(', 'async function saveContentAs');
+const saveContentAs = () => sliceBetween(session, 'async function saveContentAs', 'async function toggleTaskCheckbox');
+const guard = () => sliceBetween(session, 'function refuseIfLossilyDecoded', 'function updateLoading');
 
 test('one decoder, and it reports what it destroyed', () => {
 	// The fact is known exactly once — when the bytes are decoded — and was
@@ -57,7 +50,7 @@ test('a preview cut inside a multi-byte character is not called lossy', () => {
 	// The preview stops at a fixed byte count, so a perfectly valid UTF-8 file
 	// is routinely cut mid-character. Reporting that as lossy would lock every
 	// large CJK/emoji document out of saving — a guard worse than the bug.
-	const preview = slice(rust, 'fn build_markdown_preview', '#[tauri::command]');
+	const preview = sliceBetween(rust, 'fn build_markdown_preview', '#[tauri::command]');
 	const trim = preview.indexOf('utf8_truncation_boundary');
 	assert.notEqual(trim, -1, 'the split tail must be dropped before decoding');
 	assert.ok(trim < preview.indexOf('decode_utf8_lossy'), 'trim first, then judge fidelity');
@@ -101,11 +94,11 @@ test('the editable-pane shortcut reports fidelity too', () => {
 	const bare = session.match(/invoke\('read_file_content'/g)?.length ?? 0;
 	assert.equal(bare, 0, 'no writable buffer may be filled by the unchecked command');
 	assert.match(
-		slice(session, 'async function ensureFullContent', 'const lossySaveWarnedTabs'),
+		sliceBetween(session, 'async function ensureFullContent', 'const lossySaveWarnedTabs'),
 		/invoke\('read_file_content_checked'/,
 	);
 	assert.match(
-		slice(session, 'async function ensureFullContent', 'const lossySaveWarnedTabs'),
+		sliceBetween(session, 'async function ensureFullContent', 'const lossySaveWarnedTabs'),
 		/setTabDecodedLossy\(tabId, lossy\)/,
 	);
 });
@@ -216,6 +209,7 @@ function makeTab(overrides: Partial<Tab> = {}): Tab {
 		splitRatio: 0.5,
 		isScrollSynced: false,
 		hasReplacementChars: true,
+		collapsedHeaders: new Set<string>(),
 		...overrides,
 	};
 }
@@ -243,7 +237,7 @@ test('a payload without the flag is rejected, not defaulted', () => {
 	// The file's own doctrine: no coercion, no defaults. Defaulting a missing
 	// flag to false would silently re-open the hole for any sender that
 	// forgets it.
-	const snap = snapshotTab(makeTab()) as Record<string, unknown>;
+	const snap: Record<string, unknown> = { ...snapshotTab(makeTab()) };
 	delete snap.hasReplacementChars;
 	assert.equal(validateTransferPayload(JSON.stringify(snap)), null);
 });

--- a/scripts/mermaidPrintTheme.test.ts
+++ b/scripts/mermaidPrintTheme.test.ts
@@ -54,9 +54,12 @@ function makeMermaid(behaviour: (source: string) => string) {
 	};
 }
 
+/** The fake seen as the `Element` the helper's signature asks for. */
+const asElement = (element: FakeElement) => element as unknown as Element;
+
 function diagram(source: string | null, html: string) {
 	const element = new FakeElement('mermaid-diagram');
-	if (source !== null) rememberDiagramSource(element, source);
+	if (source !== null) rememberDiagramSource(asElement(element), source);
 	element.innerHTML = html;
 	return element;
 }
@@ -75,7 +78,7 @@ test('the diagram theme follows the app appearance', () => {
 
 test('the source is kept on the container so the diagram can be rebuilt', () => {
 	const element = diagram('flowchart TD\n A --> B', '<svg>screen</svg>');
-	assert.equal(readDiagramSource(element), 'flowchart TD\n A --> B');
+	assert.equal(readDiagramSource(asElement(element)), 'flowchart TD\n A --> B');
 	assert.equal(findRestorableDiagrams(new FakeRoot([element]) as unknown as ParentNode).length, 1);
 	// A diagram rendered before this change carries no source and is skipped
 	// rather than blanked.

--- a/scripts/monaco-internals.d.ts
+++ b/scripts/monaco-internals.d.ts
@@ -1,0 +1,34 @@
+// monaco-editor publishes types for its public surface only
+// (`monaco-editor/esm/vs/editor/editor.api.d.ts`). The ESM internals ship as
+// plain `.js` with no declarations beside them.
+//
+// pasteUrlContext.test.ts drives Monarch directly — `monaco.editor.tokenize()`
+// needs a browser-backed editor, which the Node test runner has no way to
+// create — so it reaches for three of those internals. Declared here with the
+// shapes that test actually uses, rather than left implicitly `any`.
+
+declare module 'monaco-editor/esm/vs/editor/standalone/common/monarch/monarchCompile.js' {
+	import type { languages } from 'monaco-editor';
+
+	/** Compiles a Monarch language definition into the lexer the tokenizer runs. */
+	export function compile(languageId: string, json: languages.IMonarchLanguage): unknown;
+}
+
+declare module 'monaco-editor/esm/vs/editor/standalone/common/monarch/monarchLexer.js' {
+	/**
+	 * Constructed with (languageService, themeService, languageId, lexer,
+	 * configurationService). The services are stubs here, so the parameters stay
+	 * `unknown` — only the tokenization surface below is relied on.
+	 */
+	export const MonarchTokenizer: new (...args: unknown[]) => {
+		getInitialState(): unknown;
+		tokenize(line: string, hasEOL: boolean, state: unknown): { tokens: unknown[]; endState: unknown };
+	};
+}
+
+declare module 'monaco-editor/esm/vs/basic-languages/markdown/markdown.js' {
+	import type { languages } from 'monaco-editor';
+
+	export const conf: languages.LanguageConfiguration;
+	export const language: languages.IMonarchLanguage;
+}

--- a/scripts/pasteUrlContext.test.ts
+++ b/scripts/pasteUrlContext.test.ts
@@ -60,7 +60,7 @@ function createMarkdownTokenizer() {
 		onDidChangeConfiguration: () => ({ dispose() {} }),
 	};
 
-	const tokenizer = new (MonarchTokenizer as any)(
+	const tokenizer = new MonarchTokenizer(
 		languageService,
 		themeService,
 		'markdown',

--- a/scripts/settingsPersistence.test.ts
+++ b/scripts/settingsPersistence.test.ts
@@ -114,12 +114,12 @@ function createRecordingStore(): { proxy: InstanceType<typeof SettingsStore>; re
 	const reads = new Set<string>();
 	resetStorage();
 	const real = new SettingsStore();
-	const proxy = new Proxy(real as Record<string, unknown>, {
+	const proxy = new Proxy(real, {
 		get(target, property, receiver) {
 			if (typeof property === 'string') reads.add(property);
 			return Reflect.get(target, property, receiver);
 		},
-	}) as InstanceType<typeof SettingsStore>;
+	});
 	return { proxy, reads };
 }
 

--- a/scripts/sourceTree.ts
+++ b/scripts/sourceTree.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert/strict';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -13,6 +14,41 @@ import { join } from 'node:path';
 // maintained twice. One copy each, here.
 
 export type SourceFile = { path: string; text: string };
+
+/**
+ * `source` from the first occurrence of `start` onwards.
+ *
+ * The assertion is the whole point. `source.slice(source.indexOf(marker))` with
+ * an absent marker slices from -1, which yields the last *character* of the file
+ * rather than nothing — so an `assert.doesNotMatch` against the result can never
+ * fail, and an `assert.match` fails while blaming the wrong thing.
+ *
+ * Both instances found in this suite so far were silent for their whole life:
+ * scrollSyncInput.test.ts (the anchor drifted when the code around it changed)
+ * and issue261EditorPdf.test.ts (the subject was deleted in the same commit that
+ * added the assertion). Neither was noticed by a test run, because neither
+ * failed.
+ */
+export function sliceFrom(source: string, start: string): string {
+	const from = source.indexOf(start);
+	assert.notEqual(from, -1, `expected to find ${JSON.stringify(start)}`);
+	return source.slice(from);
+}
+
+/**
+ * `source` from the first `start` to the first `end` that follows it.
+ *
+ * Searching `end` from the end of `start` rather than from 0 is deliberate: an
+ * `end` that happens to occur earlier in the file produces an empty string, and
+ * an empty subject is degenerate for the same reason -1 is.
+ */
+export function sliceBetween(source: string, start: string, end: string): string {
+	const from = source.indexOf(start);
+	assert.notEqual(from, -1, `expected to find ${JSON.stringify(start)}`);
+	const to = source.indexOf(end, from + start.length);
+	assert.notEqual(to, -1, `expected to find ${JSON.stringify(end)} after ${JSON.stringify(start)}`);
+	return source.slice(from, to);
+}
 
 /** Every compilable source file under `dir`, with forward-slash paths. */
 export function walkSourceFiles(dir: string): string[] {

--- a/scripts/tabTransfer.test.ts
+++ b/scripts/tabTransfer.test.ts
@@ -38,8 +38,18 @@ function makeTab(overrides: Partial<Tab> = {}): Tab {
 		splitRatio: 0.3,
 		isScrollSynced: true,
 		hasReplacementChars: false,
+		collapsedHeaders: new Set<string>(),
 		...overrides,
 	};
+}
+
+/**
+ * The snapshot as a mutable bag, for the tests that corrupt one field and
+ * re-serialize. A copy, so the `TransferableTab` contract stays intact for
+ * every other caller.
+ */
+function snapshotBag(tab: Tab): Record<string, unknown> {
+	return { ...snapshotTab(tab) };
 }
 
 function roundTrip(tab: Tab): TransferableTab {
@@ -96,7 +106,7 @@ test('snapshot never mutates the source tab', () => {
 });
 
 test('the snapshot excludes rendered content and editorViewState', () => {
-	const snap = snapshotTab(makeTab()) as Record<string, unknown>;
+	const snap = snapshotBag(makeTab());
 	assert.ok(!('content' in snap));
 	assert.ok(!('editorViewState' in snap));
 	assert.ok(!('id' in snap));
@@ -114,25 +124,25 @@ test('validation rejects non-object payloads', () => {
 });
 
 test('validation rejects a missing rawContent — no default, no coercion', () => {
-	const snap = snapshotTab(makeTab()) as Record<string, unknown>;
+	const snap = snapshotBag(makeTab());
 	delete snap.rawContent;
 	assert.equal(validateTransferPayload(JSON.stringify(snap)), null);
 });
 
 test('validation rejects a non-string rawContent', () => {
-	const snap = snapshotTab(makeTab()) as Record<string, unknown>;
+	const snap = snapshotBag(makeTab());
 	snap.rawContent = 5;
 	assert.equal(validateTransferPayload(JSON.stringify(snap)), null);
 });
 
 test('validation rejects a history that is not an array', () => {
-	const snap = snapshotTab(makeTab()) as Record<string, unknown>;
+	const snap = snapshotBag(makeTab());
 	snap.history = 'nope';
 	assert.equal(validateTransferPayload(JSON.stringify(snap)), null);
 });
 
 test('validation rejects history entries that are not strings', () => {
-	const snap = snapshotTab(makeTab()) as Record<string, unknown>;
+	const snap = snapshotBag(makeTab());
 	snap.history = [1, 2];
 	assert.equal(validateTransferPayload(JSON.stringify(snap)), null);
 });
@@ -152,14 +162,14 @@ test('validation is strict for every field — even cosmetic numerics get no def
 		'anchorLine',
 		'historyIndex',
 	]) {
-		const snap = snapshotTab(makeTab()) as Record<string, unknown>;
+		const snap = snapshotBag(makeTab());
 		delete snap[field];
 		assert.equal(validateTransferPayload(JSON.stringify(snap)), null, `missing ${field}`);
 	}
 });
 
 test('validation rejects non-finite numbers (NaN serializes to null)', () => {
-	const snap = snapshotTab(makeTab()) as Record<string, unknown>;
+	const snap = snapshotBag(makeTab());
 	snap.scrollTop = NaN; // JSON.stringify turns this into null
 	assert.equal(validateTransferPayload(JSON.stringify(snap)), null);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
+    // scripts/*.test.ts import their subjects with an explicit `.ts`
+    // extension, which is what `tsx` (the test runner's loader) resolves.
+    // Legal because the whole project is `noEmit` — nothing here is compiled
+    // to JS, so there is no output path for the extension to be wrong in.
+    "allowImportingTsExtensions": true,
     "allowJs": true,
     "checkJs": true,
     "esModuleInterop": true,
@@ -10,10 +15,37 @@
     "sourceMap": true,
     "strict": true,
     "moduleResolution": "bundler"
-  }
+  },
+  // TypeScript does not merge `include` across `extends`, so this list is a
+  // copy of the one in .svelte-kit/tsconfig.json (rewritten relative to this
+  // file, which sits one level up) plus `scripts/`.
+  //
+  // `scripts/` holds the whole Node test suite. SvelteKit only ever generates
+  // `test/` and `tests/` entries, so without this override every *.test.ts was
+  // invisible to `npm run check`: renaming an exported function left the type
+  // check green and only the test run red.
+  //
+  // Keep in sync with .svelte-kit/tsconfig.json when SvelteKit is upgraded.
+  "include": [
+    ".svelte-kit/ambient.d.ts",
+    ".svelte-kit/env.d.ts",
+    ".svelte-kit/non-ambient.d.ts",
+    ".svelte-kit/types/**/$types.d.ts",
+    "vite.config.js",
+    "vite.config.ts",
+    "src/**/*.js",
+    "src/**/*.ts",
+    "src/**/*.svelte",
+    "test/**/*.js",
+    "test/**/*.ts",
+    "test/**/*.svelte",
+    "tests/**/*.js",
+    "tests/**/*.ts",
+    "tests/**/*.svelte",
+    "scripts/**/*.js",
+    "scripts/**/*.mjs",
+    "scripts/**/*.ts"
+  ]
   // Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
   // except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
-  //
-  // If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
-  // from the referenced tsconfig.json - TypeScript does not merge them in
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from "vite";
 import { sveltekit } from "@sveltejs/kit/vite";
 
-// @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
 
 // https://vite.dev/config/


### PR DESCRIPTION
Two defects in the test tooling. They are independent; they share a PR because both were found by reading the same file.

# 1. The test files were never type-checked

`npm run check` is `svelte-check --tsconfig ./tsconfig.json`, and that config extends `.svelte-kit/tsconfig.json`. SvelteKit generates that file's `include` from a fixed list of directories:

```json
"include": [ "../src/**/*.ts", "../src/**/*.svelte", "../test/**/*.ts", "../tests/**/*.ts", ... ]
```

`scripts/` is not on it, and never was. All 89 test files sat outside the program.

## Measured, both ways

A deliberate `const injectedTypeError: number = "not a number";` appended to `scripts/foldKeys.test.ts`:

| | result |
|---|---|
| before | `COMPLETED 439 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS` |
| after | `ERROR "scripts/foldKeys.test.ts" 31:7 "Type 'string' is not assignable to type 'number'."` |

The practical cost of the gap: renaming an exported function gave a contributor a green `npm run check` and dozens of red tests with no tooling pointing at the cause. In one measured rename (`loadMarkdown` → `openDocument`), 26 of 36 failures were `TypeError: … is not a function`.

## Why the fix is in the root tsconfig

`.svelte-kit/tsconfig.json` is regenerated by `svelte-kit sync` on every `check`, so editing it is not an option. SvelteKit exposes no configuration for extra include directories. The supported path is the one the root `tsconfig.json` already documents in its own comment:

> If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes from the referenced tsconfig.json — TypeScript does not merge them in

So the root config now carries a copy of the generated list, rewritten one level up, plus `scripts/`. `test/` and `tests/` are kept even though neither directory exists: dropping them would silently re-create this exact bug for whoever adds one. The comment says to re-sync on a SvelteKit upgrade.

Two supporting changes:

- **`@types/node` (devDependency).** Every test file imports `node:test`, `node:fs` and `node:assert/strict`. None of them were typed — the first run reported 343 errors, ~300 of which were `Cannot find module 'node:test'`.
- **`allowImportingTsExtensions`.** 18 imports across 7 test files name their subject with an explicit `.ts` extension (`await import('../src/lib/utils/markdown.ts')`), which is what `tsx` — the loader `npm test` uses — resolves. The flag requires `noEmit`, which this project already sets, so there is no output path for the extension to be wrong in. The alternative, rewriting 18 working imports to `.js` to satisfy a config default, is churn with runtime risk on the side that actually runs.

## The 38 errors it surfaced

Across 13 files. None suppressed — no `any`, no `@ts-ignore`, no exclusions.

| count | error | fix |
|---|---|---|
| 18 | `An import path can only end with a '.ts' extension…` | `allowImportingTsExtensions`, above |
| 9 | `Conversion of type 'TransferableTab' to 'Record<string, unknown>' may be a mistake` | the tests corrupt one field of a snapshot and re-serialize. `{ ...snapshotTab(tab) }` is an anonymous object type, which *does* get an implicit index signature — no cast at all |
| 3 | `Could not find a declaration file for module 'monaco-editor/esm/vs/…'` | monaco publishes types for its public surface only. `scripts/monaco-internals.d.ts` declares the three internals `pasteUrlContext.test.ts` drives, with the shapes it uses. This **removes** an existing `as any` on `MonarchTokenizer` |
| 2 | `'{ id: string; … }' is not assignable to type 'Tab'` | genuine fixture bugs: `makeTab()` in `tabTransfer.test.ts` and `lossyDecodeSaveGuard.test.ts` both declare `: Tab` while omitting the required `collapsedHeaders: Set<string>` |
| 2 | `Argument of type 'FakeElement' is not assignable to 'Element'` | one `asElement()` helper, matching the `as unknown as ParentNode` the same file already used for `FakeRoot` |
| 2 | `Conversion of type 'Record<string, unknown>' to 'SettingsStore'…` | the `Proxy` target was cast to `Record<string, unknown>` going in and back to `SettingsStore` coming out. Dropping both casts types it correctly |
| 1 | `Unused '@ts-expect-error' directive` (`vite.config.js`) | `// @ts-expect-error process is a nodejs global` became stale the moment `@types/node` landed |

Two of these are real defects rather than annotation noise. The `collapsedHeaders` omissions mean both fixtures have been claiming to be `Tab` while not being one — precisely the class of drift this change exists to catch.

# 2. An assertion that could not fail

`scripts/issue261EditorPdf.test.ts:76`:

```ts
const viewerPrintStyles = viewer.slice(viewer.indexOf('\t@media print {'));
```

`src/lib/MarkdownViewer.svelte` contains no `@media` rule of any kind. Verified directly:

```
indexOf = -1
slice length = 1
slice JSON = "\n"
```

`slice(-1)` takes the last *character*, not zero characters. So `assert.doesNotMatch(viewerPrintStyles, …)` at line 91 was testing a one-character string against a multi-line pattern. It could not fail.

**It was degenerate from birth.** 37b3693 (#359) removed this block from `MarkdownViewer.svelte`:

```css
@media print {
	.markdown-body {
		height: auto !important;
		overflow: visible !important;
		padding: 0 !important;
	}
}
```

and added the assertion guarding against its return — in the same commit. Deleting the subject is what made the anchor miss.

## What the claim was, and whether it still holds

It holds. `src/styles.css` sets `.markdown-body { padding: 0.75in !important }` for print. A component-scoped rule in `MarkdownViewer.svelte` compiles to `.markdown-body.svelte-xxxx`, which outranks it on specificity even with both `!important`. Re-introducing that block would silently drop the page margins from PDF export again.

So the assertion is **re-anchored, not deleted**: same regex intent, searched over the whole component instead of over a slice that does not exist.

```ts
assert.doesNotMatch(viewer, /@media print\s*\{[\s\S]*?\.markdown-body\s*\{[\s\S]*?padding:\s*0\s*!important;/);
```

Nothing new is asserted — the pattern is the old one with the slice's anchor folded into it.

## Falsifiability, checked by re-introducing the regression

The block was re-inserted into `MarkdownViewer.svelte` two ways and the file restored afterwards:

| regression re-introduced | old (sliced) form | new (whole-file) form |
|---|---|---|
| exactly as removed in 37b3693, tab-indented | catches it | catches it |
| same rule, space-indented | **passes — bug undetected** | catches it |

The second row is the point. The old form depended on a literal `\t` in the anchor; any re-introduction that indented differently, or that lived outside a `@media print {` line matching that exact prefix, sailed through. And with the marker absent entirely, as today, it could not fail at all.

# The sweep

Every `.slice()` / `.substring()` / `.substr()` in `scripts/` whose bounds come from `.indexOf()` / `.lastIndexOf()` / `.search()`, found by walking each file's TypeScript AST rather than grepping (several span multiple lines):

**72 sites across 23 files.**

Degenerate-vs-fragile was then measured rather than eyeballed: `String.prototype.slice`/`substring`/`substr` were wrapped to record any call receiving `-1` as a bound, and the full suite was run.

| | count |
|---|---|
| **degenerate** (search string absent today) | **1** |
| **fragile** (present today, unguarded) | **71** |

The one degenerate site is `issue261EditorPdf.test.ts:76` — `.slice(-1)` against a 149,066-character subject. The only other `-1` bounds observed anywhere in the suite were literal `slice(0, -1)` / `slice(1, -1)` quote-trimming on 2–4 character strings.

A separate instrumented run confirmed **all 72 sites execute** during `npm test`, so "not degenerate" means "the anchor was found", not "never ran".

## Helper, not per-site guards

The identical guarded helper was already copied verbatim into two files (`findCollapsedMatches.test.ts:7-13`, `lossyDecodeSaveGuard.test.ts:26-33`). It moves into `scripts/sourceTree.ts` — the module whose own header records that three copies of `walk()` were collapsed into it for the same reason — and gains the shape it was missing:

- `sliceBetween(source, start, end)` — the lifted helper, both duplicates deleted and routed through it (12 call sites).
- `sliceFrom(source, start)` — new, for the tail-of-file shape. This is the shape that produced **both** known instances of this bug, and neither existing copy covered it.

Migrated in this PR: the two de-duplicated files plus every site in `issue261EditorPdf.test.ts` — 17 anchors, verified individually (below).

**The remaining 66 sites in 22 files are reported, not migrated.** Justification: they are fragile, not broken; the helper's two shapes do not cover all of them (several search the end anchor from a bespoke offset); and rewriting 66 call sites across 22 files inside a PR that also changes `tsconfig.json` would make the diff unreviewable. Several of those files are also being deleted on `chore/drop-tests-that-only-detect-renames`, so migrating them now would conflict for no benefit. The helper is in the shared module and has 3 users on day one, so the next one is a one-line import rather than a fourth copy.

## Every migrated anchor, broken and confirmed loud

Each of the 17 anchors was replaced with `'NO SUCH ANCHOR ZZZ'` in turn, that test file run, and the file restored:

```
anchors broken: 17   loud failures: 17   silent passes: 0
```

Each failed with `expected to find "NO SUCH ANCHOR ZZZ"` rather than an assertion about the wrong subject.

# Not covered

- **66 fragile slices in 22 files**, listed above by count: `checkedReadMigration` 7, `externalChangeReload` 8, `windowStateRestore` 7, `truncatedBufferGuard` 6, `viewModeWithoutSaving` 5, `reopenDirtyDocument`/`tabTransferHandoff`/`windowClosePerTab` 4 each, `editorPdfExport`/`settingsPersistence`/`tabTransfer` 3 each, `printFindHighlight` 2, and 1 each in 10 more. All find their anchors today.
- **`scrollSyncInput.test.ts` is still half-guarded.** It got a top-level `assert.notEqual(index, -1)` on its *start* anchor; its *end* anchor (`editor.indexOf('\n\t$effect(() => {', syncStart + 1)`) is unguarded, and a miss there would slice to the end of the file rather than to the end of the effect. Left alone — it is one of the 66, and fixing it in isolation would repeat the pattern this section is about.
- **`build-test-bundle.mjs`** is inside the new `include` glob but has no type errors to report; nothing was done to it.
- **`AGENTS.md` is untouched.** It still says "Frontend: No test framework currently configured", which was already stale before this PR and is reported in #385. Not this PR's file to correct.
- **The claim that a Svelte-scoped print rule outranks the global one** is argued from specificity, not measured in a browser. It is the same reasoning 37b3693 acted on when it removed the block.
- **No Rust touched**, so `cargo test` was not run.

# Verification

`npm test` 562 passed, 0 failed · `npm run check` `644 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS` · `npm run build` clean · type-error injection caught (`644 FILES 1 ERRORS`) and removed · 17/17 broken anchors fail loudly · working tree clean, `MarkdownViewer.svelte` and `foldKeys.test.ts` restored byte-identical after every experiment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
