### PR TITLE
fix(markdown): make the code-region order an invariant instead of a sort

### DIFF
--- a/scripts/checkedReadMigration.test.ts
+++ b/scripts/checkedReadMigration.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { readSourceFiles } from './sourceTree.js';
+
 // Runes and the Tauri bridge, shimmed the way truncatedBufferGuard.test.ts
 // shims them: the stores are runes modules, and Node's test runner gives every
 // file its own process, so this cannot leak into another suite.
@@ -152,14 +154,23 @@ test('the completed buffer is refused or accepted according to that verdict', as
 
 const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
 
-test('no writable buffer in the app is filled by the unchecked command', () => {
-	for (const [name, source] of [
-		['MarkdownViewer.svelte', viewer],
-		['documentSession.svelte.ts', readFileSync('src/lib/sessions/documentSession.svelte.ts', 'utf8')],
-		['windowSession.svelte.ts', readFileSync('src/lib/sessions/windowSession.svelte.ts', 'utf8')],
-	] as const) {
-		assert.doesNotMatch(source, /invoke\('read_file_content'/, `${name} still uses the unchecked command`);
-	}
+test('the unchecked read command is gone, and nothing calls it', () => {
+	// This was a three-file allowlist — the files #379 migrated. That is the
+	// wrong shape for a rule that means "nobody, anywhere": a fourth file
+	// added the call and the test still passed. Two changes fix it. The scan
+	// below covers the whole tree, so a new file cannot slip under it. And the
+	// Rust command itself is deleted, which is what turns the rule from a
+	// convention into a fact: `read_file_content` is not registered any more,
+	// so invoking it fails loudly instead of quietly filling a buffer with
+	// mojibake nothing flagged.
+	const offenders = readSourceFiles('src')
+		.filter(({ text }) => /invoke\('read_file_content'/.test(text))
+		.map(({ path }) => path);
+	assert.deepEqual(offenders, [], 'read_file_content no longer exists; read_file_content_checked is the read');
+
+	const rust = readFileSync('src-tauri/src/lib.rs', 'utf8');
+	assert.doesNotMatch(rust, /\basync fn read_file_content\(/, 'the unchecked command must stay deleted');
+	assert.doesNotMatch(rust, /^\s*read_file_content,\s*$/m, 'and must not be registered again');
 });
 
 test('entering the editor reads the fidelity and stores it', () => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1072,6 +1072,82 @@ mod tests {
         assert!(out.contains("[jump](#real)"), "got: {out}");
     }
 
+    /// A document that has BOTH kinds of code region, with the inline span at
+    /// a lower offset than the fence.
+    ///
+    /// `in_code_region` is a binary search, so `code_region_ranges` has to
+    /// emit its regions in document order. The two kinds are found by
+    /// different parts of the scan — fences by the line walk, inline spans by
+    /// `push_inline_code_spans` over the text between fences — and a build
+    /// order that appends all of one kind after all of the other leaves the
+    /// vector unsorted for exactly this shape of document. The binary search
+    /// then walks straight past the fence and every marker inside it is
+    /// reported as ordinary prose (#375 / #389 all over again).
+    ///
+    /// Every marker below is checked, not just one. `process_wikilinks` runs
+    /// a separate pass per marker kind and each probes `in_code_region` at its
+    /// own offset, so a probe that happens to land inside the region does not
+    /// say anything about the probes beside it.
+    const FENCE_AFTER_INLINE_CODE: &str = concat!(
+        "Prose with `a code span` in it.\n",
+        "\n",
+        "```text\n",
+        "![[embed.md]]\n",
+        "[[wikilink]]\n",
+        "==highlight==\n",
+        "^[footnote]\n",
+        "```\n",
+    );
+
+    #[test]
+    fn an_inline_span_before_a_fence_does_not_expose_the_fence_to_embeds() {
+        let out = process_internal_embeds(FENCE_AFTER_INLINE_CODE);
+        assert!(
+            out.contains("![[embed.md]]") && !out.contains("<img"),
+            "an embed inside the fence was rewritten — code regions reached \
+             `in_code_region` out of document order: {out}",
+        );
+    }
+
+    #[test]
+    fn an_inline_span_before_a_fence_does_not_expose_the_fence_to_wikilinks() {
+        let out = process_wikilinks(FENCE_AFTER_INLINE_CODE);
+        for marker in ["[[wikilink]]", "==highlight==", "^[footnote]"] {
+            assert!(
+                out.contains(marker),
+                "`{marker}` inside the fence was rewritten — code regions \
+                 reached `in_code_region` out of document order: {out}",
+            );
+        }
+        // The inline span itself is still protected, and still a span.
+        assert!(out.contains("`a code span`"), "got: {out}");
+    }
+
+    #[test]
+    fn an_inline_span_before_a_fence_does_not_expose_the_fence_to_autolinks() {
+        // The third consumer. A bare URL inside a fence must stay text;
+        // comrak's own autolinker never sees a code block.
+        let input = "Prose with `a code span` in it.\n\n```text\n(https://example.com/x)y\n```\n";
+        let out = process_parenthesized_autolinks(input);
+        assert!(
+            !out.contains("]("),
+            "a URL inside the fence was linkified: {out}",
+        );
+    }
+
+    #[test]
+    fn an_inline_span_before_a_fence_does_not_expose_the_fence_to_math() {
+        // The fourth consumer. `mask_math_spans` hides math from CommonMark's
+        // inline rules; dollars inside a fence are not math and masking them
+        // rewrites the code block the user typed.
+        let input = "Prose with `a code span` in it.\n\n```text\n$x_1$ and $y_2$\n```\n";
+        let masked = mask_math_spans(input);
+        assert_eq!(
+            masked.text, input,
+            "dollars inside the fence were masked as math",
+        );
+    }
+
     #[test]
     fn multibyte_content_inside_a_fence_does_not_panic() {
         let input = "```text\n中文开头的一行\n```\n\n![[outside.png]]\n";
@@ -2088,6 +2164,73 @@ mod tests {
         }
     }
 
+    /// The body of `convert_markdown`, read back out of this source file.
+    ///
+    /// The needle is assembled at runtime so that it does not match this
+    /// file's own source text. Line endings are normalised first: git checks
+    /// this file out with CRLF wherever `core.autocrlf` is on — the default
+    /// on Windows, and what the Windows CI runner does — and the `\n`-anchored
+    /// needles are about the shape of the source, not about how the working
+    /// tree happens to store it.
+    fn convert_markdown_body() -> String {
+        let source = include_str!("lib.rs").replace("\r\n", "\n");
+        let needle = format!("\nfn {}(content: &str) -> String {{", "convert_markdown");
+        let start = source
+            .find(&needle)
+            .expect("convert_markdown must keep its `&str -> String` signature");
+        let rest = &source[start + needle.len()..];
+        rest[..rest
+            .find("\n}\n")
+            .expect("convert_markdown must be terminated")]
+            .to_string()
+    }
+
+    #[test]
+    fn convert_markdown_hands_the_fail_safe_the_raw_buffer() {
+        // `annotate_task_checkboxes` is a fail-safe only while what reaches it
+        // is the buffer the command was called with. The hazard is not the
+        // call — it is the *name*: adding a step the obvious way,
+        //
+        //     let content = process_new_thing(content);
+        //
+        // near the top rebinds the parameter, and the unchanged call at the
+        // bottom starts handing over preprocessed text. Nothing about that
+        // edit looks wrong and no behavioural test can see it, because the two
+        // sides it is supposed to cross-check now agree by definition.
+        //
+        // "This string is the one the caller passed in" is provenance, not a
+        // type, so the compiler cannot be made to check it. What can be made
+        // structural is the shadowing: `convert_markdown` copies its input to
+        // `raw_buffer` before anything else runs, which turns the shadowing
+        // edit above into a harmless one. This test pins the three properties
+        // that copy depends on.
+        let body = convert_markdown_body();
+
+        let capture = "let raw_buffer = content;";
+        let first_let = body
+            .find("\n    let ")
+            .map(|i| i + "\n    ".len())
+            .expect("convert_markdown must bind something");
+        assert!(
+            body[first_let..].starts_with(capture),
+            "the raw buffer must be captured before the first preprocessing \
+             step, or the step can shadow `content` above it:\n{body}",
+        );
+        assert_eq!(
+            body.matches(capture).count(),
+            1,
+            "`raw_buffer` is bound more than once — a second binding is the \
+             same hole under a new name:\n{body}",
+        );
+        assert!(
+            Regex::new(r"annotate_task_checkboxes\([^;]*,\s*raw_buffer\s*\)")
+                .unwrap()
+                .is_match(&body),
+            "the fail-safe is no longer handed `raw_buffer`; whatever it now \
+             receives can agree with the HTML by construction:\n{body}",
+        );
+    }
+
     #[test]
     fn every_convert_markdown_preprocessing_step_is_registered() {
         // Re-reads this file so that a fifth preprocessing step cannot be
@@ -2295,10 +2438,19 @@ fn remove_pinned_tag(app: AppHandle, name: String) -> Result<(), String> {
 /// N. One mismatched pairing (e.g. a 4-backtick inline sample, or a ~~~
 /// fence, which the old pattern did not know at all) desynchronized the
 /// protection for the entire rest of the document.
+///
+/// The result is in ascending document order, which is not cosmetic:
+/// `in_code_region` binary-searches it. That order is produced by
+/// construction rather than by a sort at the end — the scan alternates
+/// between the two kinds of region (the text before a fence, then the fence,
+/// then the text after it), so each push is at a higher offset than the last.
+/// The previous shape collected fences here and appended every inline span in
+/// a second pass afterwards, which left the vector unsorted for any document
+/// containing both, and made a single `sort_unstable()` call the only thing
+/// standing between the search and a wrong answer.
 fn code_region_ranges(content: &str) -> Vec<(usize, usize)> {
     let len = content.len();
     let mut regions: Vec<(usize, usize)> = Vec::new();
-    let mut plain_segments: Vec<(usize, usize)> = Vec::new();
     // (fence char, opener run length, region start)
     let mut fence: Option<(u8, usize, usize)> = None;
     let mut seg_start = 0usize;
@@ -2338,8 +2490,10 @@ fn code_region_ranges(content: &str) -> Vec<(usize, usize)> {
                 // The info string of a backtick fence may not contain backticks.
                 let info_ok = marker != Some(b'`') || !trimmed[run_len..].contains('`');
                 if is_fence_line && info_ok {
+                    // Before the fence region itself, so the two kinds of
+                    // region stay interleaved in document order.
                     if seg_start < line_start {
-                        plain_segments.push((seg_start, line_start));
+                        push_inline_code_spans(content, seg_start, line_start, &mut regions);
                     }
                     fence = Some((marker.unwrap(), run_len, line_start));
                 }
@@ -2352,36 +2506,47 @@ fn code_region_ranges(content: &str) -> Vec<(usize, usize)> {
         Some((_, _, start)) => regions.push((start, len)),
         None => {
             if seg_start < len {
-                plain_segments.push((seg_start, len));
+                push_inline_code_spans(content, seg_start, len, &mut regions);
             }
         }
     }
 
-    // Inline code spans in the text between fences. CommonMark parses inline
-    // elements one block at a time and a blank line ends a block, so pairing
-    // is confined to each blank-line-delimited chunk: a stray backtick in
-    // prose must not open a span that runs on until the opening backtick of a
-    // real code span paragraphs later, suppressing every embed, wikilink and
-    // highlight in between.
-    for (seg_s, seg_e) in plain_segments {
-        let mut chunk_start = seg_s;
-        let mut line_start = seg_s;
-        while line_start < seg_e {
-            let line_end = content[line_start..seg_e]
-                .find('\n')
-                .map(|i| line_start + i + 1)
-                .unwrap_or(seg_e);
-            if content[line_start..line_end].trim().is_empty() {
-                pair_inline_code_runs(content, chunk_start, line_start, &mut regions);
-                chunk_start = line_end;
-            }
-            line_start = line_end;
-        }
-        pair_inline_code_runs(content, chunk_start, seg_e, &mut regions);
-    }
-
-    regions.sort_unstable();
+    debug_assert!(
+        regions.windows(2).all(|pair| pair[0] <= pair[1]),
+        "code_region_ranges emitted regions out of document order, which \
+         makes in_code_region's binary search miss them: {regions:?}",
+    );
     regions
+}
+
+/// Splits `content[start..end]` — a stretch of text between fences — into
+/// blocks and records the inline code spans of each.
+///
+/// CommonMark parses inline elements one block at a time and a blank line
+/// ends a block, so pairing is confined to each blank-line-delimited chunk: a
+/// stray backtick in prose must not open a span that runs on until the
+/// opening backtick of a real code span paragraphs later, suppressing every
+/// embed, wikilink and highlight in between.
+fn push_inline_code_spans(
+    content: &str,
+    start: usize,
+    end: usize,
+    regions: &mut Vec<(usize, usize)>,
+) {
+    let mut chunk_start = start;
+    let mut line_start = start;
+    while line_start < end {
+        let line_end = content[line_start..end]
+            .find('\n')
+            .map(|i| line_start + i + 1)
+            .unwrap_or(end);
+        if content[line_start..line_end].trim().is_empty() {
+            pair_inline_code_runs(content, chunk_start, line_start, regions);
+            chunk_start = line_end;
+        }
+        line_start = line_end;
+    }
+    pair_inline_code_runs(content, chunk_start, end, regions);
 }
 
 /// Records the inline code spans inside `content[start..end]`, which must be
@@ -3287,6 +3452,14 @@ fn escape_html_text(text: &str) -> String {
 /// a new step here must also be registered in `line_preserving_transforms()`.
 #[tauri::command]
 fn convert_markdown(content: &str) -> String {
+    // The buffer this command was called with, captured before anything runs
+    // and never rebound. What `annotate_task_checkboxes` is handed at the end
+    // has to be this rather than the parameter name: a new step written as a
+    // `let content = ...` shadow would rebind that name and silently retarget
+    // the call without touching it. See that function's doc comment and
+    // `convert_markdown_hands_the_fail_safe_the_raw_buffer`.
+    let raw_buffer = content;
+
     let processed_autolinks = process_parenthesized_autolinks(content);
     let processed_embeds = process_internal_embeds(&processed_autolinks);
     let processed_links = process_wikilinks(&processed_embeds);
@@ -3309,7 +3482,7 @@ fn convert_markdown(content: &str) -> String {
     options.render.sourcepos = true;
 
     let html = markdown_to_html(&masked_math.text, &options);
-    annotate_task_checkboxes(restore_math_spans(&html, &masked_math), content)
+    annotate_task_checkboxes(restore_math_spans(&html, &masked_math), raw_buffer)
 }
 
 /// Marks the rendered task checkboxes the frontend is allowed to toggle.
@@ -3322,18 +3495,35 @@ fn convert_markdown(content: &str) -> String {
 /// number of the *raw* buffer (`documentSession.toggleTaskCheckbox`). The two
 /// only agree while every preprocessing step preserves line numbers. Checking
 /// the raw buffer here is what turns a broken step into "the checkbox stays
-/// disabled" instead of "the checkbox writes a `- [x]` marker into whatever
-/// happens to sit on that line" — the P0 that issue #352 fixed, where the
-/// marker could land inside a fenced code block.
+/// disabled" instead of a write aimed at the wrong line of the user's
+/// document — the P0 that issue #352 fixed.
+///
+/// What a wrong line costs is narrower than it was, and worth stating
+/// precisely, because an overstated reason invites the next reader to check
+/// it, find it false, and delete the guard as theatre. Since #352 the
+/// frontend rewrites only lines that already match
+/// `/^(\s*(?:>\s*)*(?:[-+*]|\d+[.)])\s+)\[( |x|X)\]/`
+/// (`documentSession.toggleTaskCheckbox`), so a wrong line that is ordinary
+/// prose is a no-op and the toggle reports failure — it does NOT write a
+/// `- [x]` marker into whatever happens to sit there, as this comment used to
+/// claim of the pre-#352 frontend. What still corrupts is a wrong line that
+/// is itself task-shaped, and neither spelling of that is exotic: a task list
+/// quoted inside a fenced code block is ordinary content in a notes app, and
+/// a real task elsewhere in the same document means the user clicks one
+/// checkbox and a different one silently flips.
 ///
 /// So do NOT "unify" this with the preprocessed text that produced the HTML.
 /// Passing `&processed_links` here would make the two sides agree by
 /// definition, delete the guard, and turn every future line-count regression
-/// straight into document corruption. Keep the contract honest in the
+/// straight into a mis-aimed write. Nor is passing the *parameter name*
+/// enough at the call site: `convert_markdown` captures its input as
+/// `raw_buffer` first precisely so that a later `let content = …` cannot
+/// retarget the call without touching it. Keep the contract honest in the
 /// transforms instead; `every_preprocessing_step_preserves_source_line_numbers`
-/// is what enforces it, and
+/// is what enforces it,
 /// `task_checkboxes_stay_inert_when_the_html_and_the_buffer_disagree` pins
-/// this guard.
+/// this guard, and `convert_markdown_hands_the_fail_safe_the_raw_buffer` pins
+/// the argument it is given.
 fn annotate_task_checkboxes(html: String, markdown: &str) -> String {
     let markdown_lines = markdown.lines().collect::<Vec<_>>();
 
@@ -3455,29 +3645,25 @@ async fn render_markdown(content: String) -> Result<String, String> {
     .unwrap_or_else(|e| Err(e.to_string()))
 }
 
+/// Reads a file, with the fidelity of the decode: returns `(content, lossy)`.
+/// Since every read path decodes leniently, a caller that puts the text into
+/// an EDITABLE buffer must carry `lossy` onto the tab — otherwise the first
+/// auto-save writes U+FFFD over a file that was merely in another encoding.
+///
+/// This is now the only read-to-string command. Its sibling
+/// `read_file_content` returned the text and dropped the verdict; it survived
+/// #379 for callers that re-read a file whose tab was already flagged, then
+/// lost its last call site and stayed registered — a command whose defining
+/// property is that it hides the flag, one `invoke` away from any new caller.
+/// Deleting it makes "which command should this use" a question with one
+/// answer rather than a convention.
+///
 /// Deliberately async, like every other file-touching command here. A
 /// synchronous `#[tauri::command]` runs on the main thread, so a read from a
 /// slow volume (SMB, iCloud, a failing USB stick) freezes the whole
 /// application — every window, its menus and its scrolling — until the I/O
 /// returns. `spawn_blocking` moves the wait onto the blocking pool, which is
 /// what `tauri::async_runtime` provides it for.
-#[tauri::command]
-async fn read_file_content(path: String) -> Result<String, String> {
-    tauri::async_runtime::spawn_blocking(move || {
-        read_to_string_lossy(&path)
-            .map(|decoded| decoded.content)
-            .map_err(|e| e.to_string())
-    })
-    .await
-    .unwrap_or_else(|e| Err(e.to_string()))
-}
-
-/// `read_file_content` plus the fidelity of the decode: returns
-/// `(content, lossy)`. Since every read path decodes leniently, a caller that
-/// puts the text into an EDITABLE buffer must use this one and carry `lossy`
-/// onto the tab — otherwise the first auto-save writes U+FFFD over a file
-/// that was merely in another encoding. The bare `read_file_content` remains
-/// for callers that re-read a file whose tab is already flagged.
 #[tauri::command]
 async fn read_file_content_checked(path: String) -> Result<(String, bool), String> {
     tauri::async_runtime::spawn_blocking(move || {
@@ -4459,7 +4645,6 @@ pub fn run() {
             open_markdown_preview,
             render_markdown,
             send_markdown_path,
-            read_file_content,
             read_file_content_checked,
             canonicalize_path,
             read_file_as_data_url,

--- a/src-tauri/src/window_runtime.rs
+++ b/src-tauri/src/window_runtime.rs
@@ -140,10 +140,41 @@ fn read_pinned_tags(app: &AppHandle) -> Vec<PinnedTag> {
 /// its pinned tag from its own close handler.
 ///
 /// This is the same defect the frontend fixed in #405 for the recent-files
-/// list. That fix was a re-read alone, which is sufficient there because
-/// `localStorage` is per-document and single-threaded, making an RMW cycle
-/// atomic by construction. Rust commands have no such property, so here the
-/// cycle needs an explicit lock.
+/// list, where a re-read alone was enough. The previous revision of this
+/// comment — written here, by #424, the change that added this lock —
+/// explained why by saying that `localStorage` is per-document and
+/// single-threaded,
+/// "making an RMW cycle atomic by construction". That is false, and it is
+/// corrected here rather than softened, because someone reasoning from it
+/// about some other shared `localStorage` key would conclude they need no
+/// synchronisation at all. Each *document* is single-threaded; two Markpad
+/// windows are two documents sharing one origin's storage area. The storage
+/// mutex the HTML standard describes for exactly this case is not implemented
+/// by any shipping engine, WebKit and WebView2 included, so a `getItem` …
+/// `setItem` pair in one window can interleave with the other window's and
+/// lose precisely the update drawn above.
+///
+/// What the re-read buys is a narrower window, not atomicity:
+///
+/// - Before it, the exposure was the whole lifetime of a window's in-memory
+///   copy — from the last time that window looked at the list until it next
+///   wrote, which is minutes. After it, the cycle is one synchronous turn of
+///   the event loop containing no `await`: `getItem`, a `JSON.parse` of at
+///   most nine short strings, `setItem`.
+/// - The writes happen on discrete user actions (open a file, remove an
+///   entry, rename), so colliding means two windows landing inside those
+///   microseconds.
+/// - What a collision costs is one entry of a recent-file list, which the
+///   next open puts back.
+///
+/// It is a residual race, accepted on those three grounds — not a guarantee.
+/// None of the three holds here. This cycle is a file read, a parse, a
+/// serialize and an `atomic_write`: milliseconds of I/O on a preemptively
+/// scheduled thread pool, not microseconds of straight-line JS. The collision
+/// is not a coincidence but the ordinary shape of quitting, since ⌘Q makes
+/// every window write from its own close handler at once. And a dropped pin is
+/// a thing the user made, with nothing to recreate it from. Unlocked, this
+/// cycle was measured losing updates; hence the lock.
 ///
 /// Serialising also keeps two `atomic_write` calls off the same target at
 /// once, which is not something `atomic_write` handles either: its temp file

--- a/src/lib/utils/recentFiles.ts
+++ b/src/lib/utils/recentFiles.ts
@@ -58,6 +58,15 @@ export function readStoredRecentFiles(): string[] {
  * makes each change a change to the *stored* list rather than to a stale copy
  * of it.
  *
+ * It narrows the race rather than closing it. Two windows are two documents
+ * over one storage area and the spec's storage mutex is not implemented
+ * anywhere, so the `getItem`/`setItem` pair below can still interleave with
+ * another window's. It is accepted here because the cycle is one synchronous
+ * turn of the event loop, it runs only on discrete user actions, and the worst
+ * loss is one recent-file entry the next open restores — three things that are
+ * NOT true of every shared key. `update_pinned_tags` in `window_runtime.rs`
+ * documents the contrast and takes a real lock.
+ *
  * The write goes through {@link writeStoredSetting} (#370) so that a write
  * which changes nothing does not fire a `storage` event in the other windows.
  * That is what keeps the listener below from bouncing an update back and


### PR DESCRIPTION
Four unguarded things, three of them load-bearing and one of them a wrong reason for a right conclusion. Each section states the mechanism, then what was measured.

## 1. `regions.sort_unstable()` was the whole guard, and nothing tested it

`in_code_region` is a `binary_search_by`. `code_region_ranges` therefore has to return its regions in ascending document order. It did — via `sort_unstable()` on the last line of a ~90-line function, where it reads as tidiness.

The vector genuinely needed it. Fenced regions were pushed by the line walk in document order; inline code spans were appended afterwards, by a **second pass** over `plain_segments`. So for any document containing both, the vector was two sorted runs concatenated, and the sort was the only thing making the binary search correct.

**Measured, on master with that one line deleted:** `cargo test` → **144 passed, 0 failed**. Nothing in the suite noticed. What actually happens with it gone, for a document with an inline span above a fence (prose containing `` `a code span` ``, then a ```` ```text ```` fence holding `![[embed.md]]`, `[[wikilink]]`, `==highlight==`, `^[footnote]`):

`regions` is `[(33, 98), (11, 24)]`. A probe at offset 40 sits inside the fence, but the search compares against index 1 first, decides the target lies to the right, and returns `Err`. Every marker in the fence is reported as prose and rewritten — the exact bug class `code_region_ranges` was written to end (#375 / #389).

### Removed rather than tested

A guarded invariant is worse than one that cannot be violated, and the two-pass build was the only reason the vector was ever unsorted. The scan now records a plain segment's inline spans at the moment that segment closes — immediately before the fence that ended it — so the two kinds of region interleave and every push is at a higher offset than the last. `plain_segments` is gone, the sort is gone, and the extracted `push_inline_code_spans` is the old inner loop verbatim.

A `debug_assert!` at the single construction site names the invariant and prints the offending vector. It is a diagnosis, not the guard: it cannot be satisfied by re-sorting somewhere else, because there is no longer a somewhere else.

### The tests assert the consequence, not the sortedness

"the vector is sorted" is satisfiable by adding a sort back, which is why it is not what is asserted. Four tests, one per consumer of `code_region_ranges`, each on a document with an inline span at a **lower** offset than a fence:

| test | consumer | asserts |
|---|---|---|
| `..._to_embeds` | `process_internal_embeds` | `![[embed.md]]` in the fence is not turned into `<img>` |
| `..._to_wikilinks` | `process_wikilinks` (4 passes) | `[[wikilink]]`, `==highlight==`, `^[footnote]` all stay literal |
| `..._to_autolinks` | `process_parenthesized_autolinks` | a bare URL in the fence is not linkified |
| `..._to_math` | `mask_math_spans` | `$x_1$` in the fence is not masked |

All three markers in the wikilink case are checked because `process_wikilinks` runs a separate pass per kind, each probing at its own offset — one probe landing inside the region says nothing about the ones beside it.

**Mutation check.** Reintroducing the two-pass build order on top of this change:

```
test tests::an_inline_span_before_a_fence_does_not_expose_the_fence_to_embeds ... FAILED
test tests::an_inline_span_before_a_fence_does_not_expose_the_fence_to_wikilinks ... FAILED
test tests::an_inline_span_before_a_fence_does_not_expose_the_fence_to_autolinks ... FAILED
test tests::an_inline_span_before_a_fence_does_not_expose_the_fence_to_math ... FAILED

code_region_ranges emitted regions out of document order, which makes
in_code_region's binary search miss them: [(33, 98), (11, 24)]
```

The same tests also go red against master with `sort_unstable()` deleted (verified separately: 144 passed → 3 failed, before the math test existed).

## 2. The task-checkbox fail-safe depended on a binding *name*

`annotate_task_checkboxes(html, markdown)` is a fail-safe only while `markdown` is the raw, unpreprocessed buffer. Its doc comment says so at length. What enforced it was that the last statement of `convert_markdown` happened to spell the argument `content`, which happened to still be the function parameter.

The obvious way to add a preprocessing step deletes that:

```rust
 fn convert_markdown(content: &str) -> String {
-    let processed_autolinks = process_parenthesized_autolinks(content);
-    let processed_embeds = process_internal_embeds(&processed_autolinks);
+    let content = &process_parenthesized_autolinks(content);
+    let processed_embeds = process_internal_embeds(content);
```

**Measured on master:** `cargo test` → **144 passed, 0 failed**. The guard is gone and nothing anywhere says so; the two sides it exists to cross-check now agree by definition. With a *second*, line-shifting step added later, a document renders a checkbox annotated as toggleable whose raw line 5 is `"```"` — reproduced directly.

### What was chosen, and why not the alternatives

**Not a newtype.** "This string is the one the caller passed in" is provenance, not a type. `RawBuffer(content)` compiles just as happily around a shadowed `content`, so the wrapper would move the hazard rather than remove it.

**Not the parameter name alone.** Any hardening that leaves the raw buffer reachable only through the name `content` is defeated by shadowing that name — which is exactly the accident.

**A capture, plus a source-level test.** `convert_markdown` now copies its input to `raw_buffer` as its first statement and hands *that* to the fail-safe. The shadowing edit above becomes a no-op: `raw_buffer` still points at the parameter and the guard still works. Verified — under the line-shifting shadow, the checkbox stays inert where before it was emitted enabled onto a closing code fence.

That leaves three residual holes, and `convert_markdown_hands_the_fail_safe_the_raw_buffer` re-reads `lib.rs` and closes each. Mutation check, all three:

| mutation | message |
|---|---|
| a step inserted *above* the capture | `the raw buffer must be captured before the first preprocessing step, or the step can shadow content above it` |
| `raw_buffer` bound a second time | `raw_buffer is bound more than once — a second binding is the same hole under a new name` |
| the argument changed back to `content` | `the fail-safe is no longer handed raw_buffer; whatever it now receives can agree with the HTML by construction` |

A source test is not elegant. It is what is left when the property is provenance, and this file already uses the technique for the neighbouring contract (`every_convert_markdown_preprocessing_step_is_registered`).

### The comment overstated the damage

It said a mis-aimed toggle "writes a `- [x]` marker into whatever happens to sit on that line". That was true of the **pre-#352** frontend. `documentSession.toggleTaskCheckbox` now rewrites only lines already matching `/^(\s*(?:>\s*)*(?:[-+*]|\d+[.)])\s+)\[( |x|X)\]/`, so a mis-targeted prose line is a no-op and the toggle reports failure.

The comment is corrected rather than deleted, and **the guard is still worth having** — an overstated justification is dangerous precisely because the next reader checks it, finds it false, and concludes the whole thing is theatre. What still corrupts is a mis-targeted line that is itself task-shaped, and neither spelling is exotic:

- a task list quoted inside a fenced code block — ordinary content in a Markdown editor's own notes;
- a real task elsewhere in the same document — the user clicks one checkbox and a different one silently flips.

## 3. `read_file_content` deleted

Zero `invoke('read_file_content'` call sites in `src/` (the checked variant has 7). Also checked and clear: no Rust-internal caller, no test that exercises it, nothing in `src-tauri/capabilities/` (custom commands are not named there), nothing in `tauri.conf.json`. The only other mention is `AGENTS.md`, where it is a syntax example rather than a reference — left alone, that file is the maintainer's.

The command's defining property is that it returns the text *without* the lossy-decode verdict — the flag that stops Markpad writing U+FFFD over a GBK or Shift-JIS file. It survived #379 for callers re-reading an already-flagged tab, then lost its last call site and stayed registered: a one-`invoke`-away way to fill an editable buffer with unflagged mojibake.

**Public-surface note for the maintainer:** removing a registered Tauri command is a breaking change for anything outside this repository that invokes it. Nothing inside it does.

`read_file_content_checked`'s doc comment absorbs the "deliberately async" rationale that was attached to the deleted function, so it is not lost.

### The frontend guard was an allowlist; it is now a scan

`checkedReadMigration.test.ts` guarded this with a hard-coded three-file list — the files #379 migrated. Adding the call in a *fourth* file passed, demonstrated.

Deleting the assertion outright was the other option, on the grounds that the command no longer exists so an `invoke` of it now throws. Rejected: the name would be free to come back, and the Rust command is six lines to re-add. The assertion is instead widened to `readSourceFiles('src')` — the whole-tree pattern `singleImplementationConvention.test.ts` already uses, which a new file cannot slip under — and paired with two assertions that the Rust command stays deleted and unregistered. That pairing is what makes it a fact rather than a convention.

Verified: dropping an `invoke('read_file_content', …)` into a new file under `src/lib/utils/` fails the test, naming the file.

## 4. A wrong reason for a right conclusion, and it is ours

`update_pinned_tags` explained why the frontend's #405 recent-files fix needed only a re-read while Rust needs a lock:

> `localStorage` is per-document and single-threaded, making an RMW cycle atomic by construction

**This is false, and it was written by this project — #424, the change that added this lock.** It is also in that PR's body, in bold. Correcting it rather than softening it, because the conclusion it supports is right and someone reasoning from the stated reason about a different shared key would conclude they need no synchronisation at all.

Each *document* is single-threaded. Two Markpad windows are two documents sharing one origin's storage area. The storage mutex the HTML standard describes for exactly this case is not implemented by any shipping engine — WebKit and WebView2 included — so `getItem` … `setItem` in one window interleaves with the other's and loses the same update the diagram above draws.

### The real asymmetry

**The frontend fix is adequate, but on three empirical grounds rather than by construction:**

1. **Width.** Before the fix the exposure was the whole lifetime of a window's in-memory copy — from the last time that window looked until it next wrote, i.e. minutes. After it the cycle is one synchronous turn of the event loop with no `await` in it: `getItem`, a `JSON.parse` of at most nine short strings, `setItem`.
2. **Frequency.** Writes happen on discrete user actions (open a file, remove an entry, rename). Colliding means two windows landing inside those microseconds.
3. **Cost.** One entry of a recent-file list, which the next open puts back.

**None of the three holds on the Rust side.** The cycle is a file read, a parse, a serialize and an `atomic_write` — milliseconds of I/O on a preemptively scheduled thread pool, not microseconds of straight-line JS. The collision is not a coincidence but the ordinary shape of quitting, since ⌘Q makes every window write from its own close handler at once. And a dropped pin is a thing the user made, with nothing to recreate it from. #424 measured this cycle losing 4–7 of 8 updates unlocked.

So: a difference of orders of magnitude in three independent dimensions, not a difference between atomic and not-atomic. `recentFiles.ts` gets a matching note so the same misreading cannot start from the other end.

**This is not a finding that #405 is wrong.** The residual race is real and deliberately accepted; no fix is proposed here.

## Not covered

- **The residual `localStorage` race in `updateStoredRecentFiles`.** Documented, not fixed. Closing it needs something like a lease key with a compare-and-set retry — a design change and its own issue, and the three grounds above are why it has not been worth one.
- **`convert_markdown` could be split** so the raw-buffer binding lives in a scope containing no preprocessing at all, making the shadowing structurally impossible rather than merely harmless. That repoints `every_convert_markdown_preprocessing_step_is_registered` at a new function name, and `lib.rs` has other changes in flight in this region. Left for a quieter moment.
- **`lossyDecodeSaveGuard.test.ts`'s per-file `invoke('read_file_content'` assertions** are now redundant with the tree scan. They are still correct and locally meaningful in their own tests; not touched.
- **`AGENTS.md`** uses `read_file_content` as its Tauri-command style example. Not edited — maintainer's file, and separately reported in #385.
- **The `debug_assert!` compiles out in release.** It is a development diagnosis for the invariant; the four behavioural tests are what hold the line, in every build.

## Verification

`cargo test` 149 passed (144 → +5) · `npm test` 562 passed · `npm run check` 0 errors 0 warnings · `npm run build` clean · `cargo clippy` **delta 0** — same two warnings as the pre-change baseline (`push_str` single-character literal, collapsible `if`), plus `setup.rs`'s unused `EXE_NAME` under `cargo test` · `cargo fmt` diff count unchanged at 53 (rustfmt is not enforced in this repo).

Mutation checks for items 1 and 2 are in their sections above; each violation was re-applied and the suite confirmed red with a message that names the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
