### PR TITLE
fix(save): let one write per tab be in flight at a time

### DIFF
--- a/scripts/oneWritePerTabInFlight.test.ts
+++ b/scripts/oneWritePerTabInFlight.test.ts
@@ -1,0 +1,272 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+// #436 closed one direction of the save race: `saveContent` now disarms the
+// auto-save debounce itself, so an *armed* timer can no longer fire during an
+// explicit save.
+//
+// The other direction stays open. The timer callback deletes itself from
+// `autoSaveTimers` as its FIRST statement and only then calls `saveContent`, so
+// once the timer has fired there is nothing left for `cancelPendingAutoSave` to
+// cancel — and `saveContent` has no in-flight guard. A Cmd+S landing while the
+// auto-save write is still awaiting `invoke('save_file_content')` starts a
+// second concurrent write:
+//
+//   auto-save    snapshot A ──┐
+//   user types (buffer is B)  ├── both in flight, both racing to the rename
+//   Cmd+S        snapshot B ──┘
+//
+// `atomic_write` (also #436) makes that safe — neither writer can corrupt the
+// file or fail the other — but safety is not ordering. If A's rename lands
+// last the disk holds A while the user's buffer holds B.
+//
+// These tests pin the ordering property `atomic_write` cannot supply: at most
+// one write per tab is ever in flight. Not "one write" — the second caller
+// still writes, because it is saving edits the first one never saw — but it
+// writes *after*, from a snapshot taken *after*, so the last rename is the
+// newest text.
+
+const g = globalThis as any;
+const runeEffect = (fn: () => void) => {
+	void fn;
+};
+runeEffect.root = (fn: () => unknown) => fn();
+g.$state = (value: unknown) => value;
+g.$state.raw = (value: unknown) => value;
+g.$state.snapshot = (value: unknown) => value;
+g.$derived = (value: unknown) => value;
+g.$derived.by = (fn: () => unknown) => fn();
+g.$effect = runeEffect;
+g.window = g.window ?? {};
+
+const localStore = new Map<string, string>();
+g.localStorage = {
+	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
+	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
+	removeItem: (key: string) => void localStore.delete(key),
+	clear: () => localStore.clear(),
+};
+
+const disk = new Map<string, string>();
+/** Writes that have started but not yet reached their rename. */
+let unsettledWrites = 0;
+/**
+ * Set the moment a write starts while another is still unsettled. That is the
+ * whole defect: two renames aimed at one file with no ordering between them.
+ */
+let sawOverlap = false;
+/**
+ * How long each successive write takes to reach its rename, in ms, in call
+ * order. Giving the FIRST write the longer delay is what makes the race
+ * observable rather than merely possible: unguarded, the second write renames
+ * first and the first write's older snapshot lands on top of it.
+ */
+let writeDurationsMs: number[] = [];
+let writeCount = 0;
+/** What the Save/Save As dialog returns next. `null` is the user cancelling. */
+let nextSaveTarget: string | null = null;
+
+g.window.__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string, args: any) => {
+		if (cmd === 'canonicalize_path') return Promise.resolve(args.path);
+		if (cmd === 'read_file_content_checked') return Promise.resolve([disk.get(args.path) ?? '', false]);
+		if (cmd === 'open_markdown_preview') return Promise.resolve(['', disk.get(args.path) ?? '', true, false]);
+		if (cmd === 'save_file_content') {
+			const duration = writeDurationsMs[writeCount] ?? 0;
+			writeCount += 1;
+			if (unsettledWrites > 0) sawOverlap = true;
+			unsettledWrites += 1;
+			return new Promise((resolve) => {
+				setTimeout(() => {
+					// The rename. `invoke` resolves after it, which is why
+					// resolution order tracks rename order.
+					disk.set(args.path, args.content);
+					unsettledWrites -= 1;
+					resolve(null);
+				}, duration);
+			});
+		}
+		if (cmd === 'plugin:dialog|save') return Promise.resolve(nextSaveTarget);
+		if (cmd === 'get_os_type') return Promise.resolve('macos');
+		return Promise.resolve(null);
+	},
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { settings } = await import('../src/lib/stores/settings.svelte.js');
+const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
+
+function makeSession() {
+	return createDocumentSession({
+		setShowHome: () => {},
+		currentFile: () => tabManager.activeTab?.path ?? '',
+		resetScrollHistory: () => {},
+		renderMarkdown: async (raw: string) => raw,
+		afterLoad: async () => {},
+		saveRecentFile: () => {},
+		deleteRecentFile: () => {},
+		setLoadingTabs: () => {},
+		measureInitialViewport: () => {},
+		isScrolling: () => false,
+		renderRichContent: () => {},
+		onError: () => {},
+		selfWriteGraceMs: 400,
+		cancelPendingAutoSave: () => {},
+		askClose: async () => 'discard' as const,
+		onCloseSaveNewerEdits: () => {},
+		onCloseAutoSaveFailed: () => {},
+	});
+}
+
+function reset() {
+	tabManager.closeAll();
+	tabManager.recentlyClosed.length = 0;
+	localStore.clear();
+	disk.clear();
+	unsettledWrites = 0;
+	sawOverlap = false;
+	writeDurationsMs = [];
+	writeCount = 0;
+	nextSaveTarget = null;
+}
+
+/** Open `path` in a tab and leave the buffer holding `edited`. */
+async function openDirtyTab(session: ReturnType<typeof makeSession>, path: string, edited: string) {
+	disk.set(path, 'original');
+	await session.loadMarkdown(path);
+	const tabId = tabManager.activeTabId!;
+	tabManager.updateTabRawContent(tabId, edited);
+	return tabId;
+}
+
+test('a second save waits for the write already in flight on that tab', async () => {
+	reset();
+	const session = makeSession();
+	const tabId = await openDirtyTab(session, '/notes/a.md', 'A');
+
+	// The first write is the slow one. Unguarded, the second overtakes it and
+	// the first lands last, publishing 'A' over 'B'.
+	writeDurationsMs = [30, 5];
+
+	// The auto-save timer has already fired, so its `saveContent` is running
+	// and there is no timer left to cancel. `saveContent` reaches its `invoke`
+	// synchronously for a tab that already has a path, so this write is in
+	// flight by the time the call returns its promise.
+	const autoSave = session.saveContent(tabId);
+	// The user types on.
+	tabManager.updateTabRawContent(tabId, 'B');
+	// The user presses Cmd+S.
+	const explicit = session.saveContent(tabId);
+
+	assert.deepEqual(await Promise.all([autoSave, explicit]), [true, true]);
+
+	assert.equal(sawOverlap, false, 'two writes to one file were in flight at once');
+	assert.equal(disk.get('/notes/a.md'), 'B', 'the newest text must be what survives on disk');
+	const tab = tabManager.tabs.find((item) => item.id === tabId)!;
+	assert.equal(tab.isDirty, false, 'the buffer matches the disk, so the tab must read clean');
+});
+
+test('the waiting save writes the buffer as it is after the wait, not before', async () => {
+	// Waiting is only half of it. A guard that returned the in-flight promise
+	// instead would report success for a write that predates the keystrokes the
+	// user pressed Cmd+S to protect. The snapshot has to be taken on the far
+	// side of the wait.
+	reset();
+	const session = makeSession();
+	const tabId = await openDirtyTab(session, '/notes/b.md', 'A');
+	writeDurationsMs = [30, 5];
+
+	const autoSave = session.saveContent(tabId);
+	tabManager.updateTabRawContent(tabId, 'B');
+	const explicit = session.saveContent(tabId);
+	// Still typing while the first write drains — this is the text the second
+	// save must publish.
+	tabManager.updateTabRawContent(tabId, 'C');
+
+	await Promise.all([autoSave, explicit]);
+
+	assert.equal(sawOverlap, false);
+	assert.equal(disk.get('/notes/b.md'), 'C');
+	assert.equal(tabManager.tabs.find((item) => item.id === tabId)!.isDirty, false);
+});
+
+test('three saves stacked on one tab still produce one write at a time', async () => {
+	// The reason the guard is a chain and not a bare `await inFlight`: several
+	// callers awaiting the same promise all wake together and then all write
+	// concurrently, which is the bug again with extra steps.
+	reset();
+	const session = makeSession();
+	const tabId = await openDirtyTab(session, '/notes/c.md', 'A');
+	writeDurationsMs = [30, 20, 10];
+
+	const first = session.saveContent(tabId);
+	tabManager.updateTabRawContent(tabId, 'B');
+	const second = session.saveContent(tabId);
+	tabManager.updateTabRawContent(tabId, 'C');
+	const third = session.saveContent(tabId);
+
+	await Promise.all([first, second, third]);
+
+	assert.equal(sawOverlap, false);
+	assert.equal(writeCount, 3, 'each caller still writes; they are ordered, not dropped');
+	assert.equal(disk.get('/notes/c.md'), 'C');
+});
+
+test('saveContentAs waits behind the same tab guard', async () => {
+	// `saveContentAs` writes too, and it mutates the same per-tab bookkeeping
+	// (`originalContent`, `isDirty`, and the tab's path). Its target is usually
+	// a different file, so the renames do not collide — but the two
+	// continuations still race for the tab's dirty flag, and picking the tab's
+	// own file in the dialog is an allowed overwrite that collides outright.
+	reset();
+	const session = makeSession();
+	const tabId = await openDirtyTab(session, '/notes/d.md', 'A');
+	writeDurationsMs = [30, 5];
+
+	const autoSave = session.saveContent(tabId);
+	tabManager.updateTabRawContent(tabId, 'B');
+	nextSaveTarget = '/notes/copy.md';
+	const saveAs = session.saveContentAs();
+
+	assert.deepEqual(await Promise.all([autoSave, saveAs]), [true, true]);
+
+	assert.equal(sawOverlap, false);
+	assert.equal(disk.get('/notes/copy.md'), 'B', 'the copy must hold the newest text');
+	const tab = tabManager.tabs.find((item) => item.id === tabId)!;
+	assert.equal(tab.path, '/notes/copy.md');
+	assert.equal(tab.isDirty, false, 'the older write must not leave the moved tab reading dirty');
+});
+
+test('closing a tab mid-write does not leave the older snapshot on disk', async () => {
+	// The one path on which this race is SILENT, and the reason it is worth
+	// fixing at all.
+	//
+	// Everywhere else the tab survives to tell the user: the older write's
+	// continuation runs last and sets `originalContent` to the older snapshot,
+	// so `isDirty` goes true and the dirty dot honestly reports that the buffer
+	// and the disk disagree. Here the tab is gone before that can happen.
+	// `canCloseTab` saves, sees `isDirty` false, and closes; the older write
+	// then renames on top, and there is no longer a tab to raise a flag on.
+	reset();
+	settings.autoSave = true;
+	settings.confirmBeforeSave = false;
+	const session = makeSession();
+	const tabId = await openDirtyTab(session, '/notes/e.md', 'A');
+	writeDurationsMs = [30, 5];
+
+	// The auto-save timer has fired; its write is in flight and past cancelling.
+	const autoSave = session.saveContent(tabId);
+	// The user types, then closes the tab. With auto-save on and no confirm
+	// prompt, `canCloseTab` saves silently and reports the tab closable.
+	tabManager.updateTabRawContent(tabId, 'B');
+	assert.equal(await session.canCloseTab(tabId), true);
+	tabManager.closeTab(tabId);
+
+	// The close already looked clean to the user. What matters is what the
+	// still-draining write does after the tab is gone.
+	await autoSave;
+
+	assert.equal(sawOverlap, false);
+	assert.equal(disk.get('/notes/e.md'), 'B', 'the closed tab’s newest text must be what is left on disk');
+});

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -82,6 +82,58 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		selfWriteUntilByPath.delete(path);
 	}
 
+	/**
+	 * Per tab: a promise that settles once every save queued for it so far has
+	 * finished. Absent means nothing is in flight.
+	 */
+	const writeChainByTab = new Map<string, Promise<void>>();
+
+	/**
+	 * Run `write` only once the tab's previous write has settled.
+	 *
+	 * Two saves can be aimed at one tab at the same instant. #436 stopped an
+	 * *armed* auto-save debounce from firing during an explicit save, but the
+	 * timer callback drops itself from the timer map as its first statement and
+	 * only then calls `saveContent` — so a debounce that has ALREADY fired is
+	 * past cancelling, and its write is free to race a Cmd+S that arrives while
+	 * it awaits. `atomic_write` (also #436) makes two concurrent writers safe
+	 * for the file, but that is a safety property, not an ordering one: the
+	 * older snapshot can still rename last and publish itself over the newer.
+	 *
+	 * Waiting, rather than handing the in-flight promise back to the second
+	 * caller — those are different answers. The second caller pressed Cmd+S
+	 * *after* typing more, so returning the running write would report success
+	 * for a file that does not contain those keystrokes. Waiting costs one disk
+	 * write and ends with the text the user actually asked to save on disk.
+	 *
+	 * Keyed by tab rather than by path: the state these writes corrupt is the
+	 * tab's own (`originalContent`, `isDirty`, its path), the two racers are by
+	 * construction one tab's, and an untitled tab has no path to key on until
+	 * its Save dialog closes. Two tabs pointing at one file still write
+	 * concurrently — that is last-writer-wins between two documents, which this
+	 * app permits by allowing the second tab at all, and is not this race.
+	 *
+	 * A chain and not a bare `await inFlight`, because several callers awaiting
+	 * one promise all wake together and then all write at once — the race again.
+	 */
+	function writeExclusively<T>(tabId: string, write: () => Promise<T>): Promise<T> {
+		const previous = writeChainByTab.get(tabId);
+		const result = previous ? previous.then(write) : write();
+		// Outcome-free by design: a save that fails must not strand the queue
+		// behind it, and nothing here is the owner of that rejection.
+		const settled = result.then(
+			() => {},
+			() => {},
+		);
+		writeChainByTab.set(tabId, settled);
+		void settled.then(() => {
+			// Only the tail clears the entry. An earlier link finishing must not
+			// drop a chain that later callers are still queued behind.
+			if (writeChainByTab.get(tabId) === settled) writeChainByTab.delete(tabId);
+		});
+		return result;
+	}
+
 	function shouldReloadExternalChange(path: string) {
 		const until = selfWriteUntilByPath.get(path);
 		if (until === undefined) return true;
@@ -435,23 +487,27 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		// auto-save effect only arms tabs that already have a path.
 		options.cancelPendingAutoSave(tab.id);
 		if (refuseIfLossilyDecoded(tab, targetPath, targetKey)) return false;
-		const snapshot = tab.rawContent;
-		markSelfWrite(targetPath);
-		try {
-			await invoke('save_file_content', { path: targetPath, content: snapshot });
+		return writeExclusively(tab.id, async () => {
+			// Snapshot taken on the far side of the wait. Anything typed while
+			// the previous write drained is part of what this save is for.
+			const snapshot = tab.rawContent;
 			markSelfWrite(targetPath);
-			if (tab.path === '') {
-				tabManager.updateTabPath(tab.id, targetPath, targetKey);
-				options.saveRecentFile(targetPath);
+			try {
+				await invoke('save_file_content', { path: targetPath, content: snapshot });
+				markSelfWrite(targetPath);
+				if (tab.path === '') {
+					tabManager.updateTabPath(tab.id, targetPath, targetKey);
+					options.saveRecentFile(targetPath);
+				}
+				tab.originalContent = snapshot;
+				tab.isDirty = tab.rawContent !== snapshot;
+				return true;
+			} catch (error) {
+				clearSelfWrite(targetPath);
+				options.onError('Failed to save file', error);
+				return false;
 			}
-			tab.originalContent = snapshot;
-			tab.isDirty = tab.rawContent !== snapshot;
-			return true;
-		} catch (error) {
-			clearSelfWrite(targetPath);
-			options.onError('Failed to save file', error);
-			return false;
-		}
+		});
 	}
 
 	async function saveContentAs(): Promise<boolean> {
@@ -476,25 +532,32 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		// which land on the very same file.
 		const selectedKey = await canonicalizePath(selected);
 		if (refuseIfLossilyDecoded(tab, selected, selectedKey)) return false;
-		const snapshot = tab.rawContent;
-		markSelfWrite(selected);
-		try {
-			await invoke('save_file_content', { path: selected, content: snapshot });
+		// Shares the tab's guard with `saveContent`. The target is usually a
+		// different file, so the renames need not collide — but both
+		// continuations write the same tab's `originalContent`, `isDirty` and
+		// path, and picking the tab's own file in the dialog is an allowed
+		// overwrite that collides outright.
+		return writeExclusively(tab.id, async () => {
+			const snapshot = tab.rawContent;
 			markSelfWrite(selected);
-			tabManager.updateTabPath(tab.id, selected, selectedKey);
-			// The buffer now has a UTF-8 file of its own that it matches
-			// exactly, so it is safe to save from here on.
-			tabManager.setTabDecodedLossy(tab.id, false);
-			lossySaveWarnedTabs.delete(tab.id);
-			options.saveRecentFile(selected);
-			tab.originalContent = snapshot;
-			tab.isDirty = tab.rawContent !== snapshot;
-			return true;
-		} catch (error) {
-			clearSelfWrite(selected);
-			options.onError('Failed to save file as', error);
-			return false;
-		}
+			try {
+				await invoke('save_file_content', { path: selected, content: snapshot });
+				markSelfWrite(selected);
+				tabManager.updateTabPath(tab.id, selected, selectedKey);
+				// The buffer now has a UTF-8 file of its own that it matches
+				// exactly, so it is safe to save from here on.
+				tabManager.setTabDecodedLossy(tab.id, false);
+				lossySaveWarnedTabs.delete(tab.id);
+				options.saveRecentFile(selected);
+				tab.originalContent = snapshot;
+				tab.isDirty = tab.rawContent !== snapshot;
+				return true;
+			} catch (error) {
+				clearSelfWrite(selected);
+				options.onError('Failed to save file as', error);
+				return false;
+			}
+		});
 	}
 
 	async function toggleTaskCheckbox(sourceLine: number, nowChecked: boolean) {


### PR DESCRIPTION
#436 fixed one direction of the save race and, in its own "Not covered", named the other and left it:

> **A write slower than the 1.5s debounce.** The timer can still be re-armed by typing and fire during a very long explicit save. Part 1 makes that safe; the residual is the transient stale-on-disk described above, which heals on the next keystroke. Serialising writes per path would close it, at the cost of a promise-chain and snapshot relocation — not taken, as the remaining exposure is narrow and no longer unsafe.

That was the right call on the evidence available. This picks it up, having measured what the residual actually does — which is **less bad than #436 assumed on every path but one, and worse than it assumed on that one**.

## 1. The mechanism, and why `cancelPendingAutoSave` cannot reach it

The auto-save timer callback (`MarkdownViewer.svelte`) deletes itself from `autoSaveTimers` as its **first** statement, then calls `saveContent`:

```js
const timer = setTimeout(() => {
    autoSaveTimers.delete(s.id);
    saveContent(s.id).then(...)
}, AUTO_SAVE_DEBOUNCE_MS);
```

So #436's fix covers exactly the window before the timer fires. Once it has fired, `options.cancelPendingAutoSave(tab.id)` finds nothing to cancel, and `saveContent` had no in-flight guard of its own. A Cmd+S landing while the auto-save write is still awaiting `invoke('save_file_content')` started a **second concurrent write to the same path**.

`atomic_write` (#436 part 1) makes that safe — neither writer can corrupt the file or fail the other. It is a safety property, not an ordering one. The older snapshot can still rename last.

**The trigger window is one disk write.** The auto-save debounce fires 1.5s after the last keystroke, so reaching this by hand means going idle for 1.5s and then pressing Cmd+S inside the few hundred microseconds the write takes. On a local SSD with a small file that is effectively unreachable. It widens with the write: a large document, a network volume, a busy or encrypted filesystem.

## 2. Severity: narrower than #436's, with one exception that is not

#436's bug was silent data loss — a clean-looking buffer over an older file. **This one is not, on almost every path**, and that is measured, not reasoned.

Driving the real `documentSession` and `TabManager` with a stubbed backend: auto-save takes snapshot `A`, the user types `B`, Cmd+S takes snapshot `B`, and the first (older) write is made to rename last:

```
OVERLAP: true
DISK:    "A"
BUFFER:  "B"   isDirty: true   originalContent: "A"
```

`await invoke(...)` resolves after Rust's rename, so resolution order tracks rename order — which means the continuation that lands last is the one whose snapshot is on disk:

```js
tab.originalContent = snapshot;
tab.isDirty = tab.rawContent !== snapshot;
```

The end state is **self-consistent**. `isDirty` is not a spurious flag; it correctly says "the buffer and the disk disagree", and the dirty dot tells the user. Reading the auto-save effect, it also **self-heals**: `isDirty` flipping true with no timer armed re-arms the debounce, so the buffer is rewritten ~1.5s later without the user touching anything. #436's residual note said "heals on the next keystroke" — it is better than that; no keystroke is needed.

**The exception is the close path, and it is silent loss.** With auto-save on and confirm-before-save off, `canCloseTab` saves and closes if the save reports success and the tab reads clean. Measured:

```
canClose: true | at close time disk: "B" isDirty: false
AFTER the older write lands -> disk: "A" | tab still open: false
```

The user closes the tab, everything looks clean, and the older snapshot then renames on top. There is no tab left to raise the dirty flag, and no effect left to re-arm. The user's last edits are gone with no indication. That single path is the reason this is worth fixing; without it I would have argued for closing this as not worth the code, in the spirit of #430 and #431.

## 3. `markSelfWrite` under overlap — the more interesting consequence

`markSelfWrite(path)` is called both before and after the invoke, to stop the file watcher treating our own write as an external change. Two questions, both measured.

**Both writes succeed:** the four `markSelfWrite` calls only ever push the deadline *further out*, so the suppression window is extended, not broken. The mechanism degrades safely.

```
BOTH-OK -> our own write treated as external? false
```

**One fails, the other succeeds:** `clearSelfWrite(path)` in the `catch` deletes the entry unconditionally — including the one the *successful* write had just installed.

```
ONE-FAILS -> our own write treated as external? true
             tab isDirty: false => resolveExternalChange: {"action":"reload",...}
```

The app re-reads the file it just wrote. With a clean tab that is a spurious reload; with a dirty tab `resolveExternalChange` returns `conflict`, i.e. the "this file changed on disk" bar raised about our own write. #436's `atomic_write` means concurrent writers no longer fail *each other*, so this now needs an independent failure (ENOSPC, permissions, a disconnected volume) landing on one of the two — narrow, but real.

Serialising removes it structurally rather than by special-casing: ordered, the failing write's `catch` runs before the next write's `markSelfWrite`, so a clear can never reach a later write's guard.

## 4. The fix

`writeExclusively(tabId, write)` in `documentSession.svelte.ts`. Three choices, each of which could have gone the other way:

**Wait and then write, rather than return the in-flight promise.** They are different answers, not two spellings of one. The second caller pressed Cmd+S *after* typing more, so handing back the running write would report success for a file that does not contain those keystrokes — and would leave the tab dirty while telling the caller it saved. Waiting costs one disk write and ends with the text the user asked to save actually on disk. The snapshot is therefore taken **inside** the queued closure, on the far side of the wait; taking it before would serialise the writes and still publish stale text.

**Keyed by tab, not by path.** The state these two writes corrupt is the tab's own — `originalContent`, `isDirty`, its path — and the two racers are by construction one tab's, since both come from the same tab's debounce and the same tab's Cmd+S. A path key also could not be taken where it is needed: an untitled tab has no path until its Save dialog closes, which is an `await`. Two tabs pointing at one file still write concurrently; that is last-writer-wins between two *documents*, which the app permits by allowing the second tab at all, and is a different question. **This is deliberately not a general per-path write queue** — the window is one disk write, and the fix is sized to it.

**A chain, not a bare `await inFlight`.** Several callers awaiting one promise all wake in the same microtask and then all write at once — the race again, with extra steps. The chain is ~10 lines and self-clearing: only the tail deletes the map entry, so a link finishing cannot drop a queue others are still behind.

`saveContentAs` shares the same guard. Its target is usually a different file, so the renames need not collide — but both continuations write the same tab's `originalContent`, `isDirty` and path, and picking the tab's own file in the dialog is an allowed overwrite (as its existing comment notes) that collides outright.

The guard sits after `cancelPendingAutoSave` and after the Save dialog, so #436's two contracts are untouched: the cancel still precedes the write, and nothing is disarmed before a modal the user can still back out of.

## Tests

`scripts/oneWritePerTabInFlight.test.ts`, five cases against the real `TabManager` and the real `documentSession`. The stub gives the *first* write the longer duration, which is what makes the race observable rather than merely possible.

| test | asserts |
|---|---|
| a second save waits for the write in flight | no overlap; the newest text survives on disk; the tab reads clean |
| the snapshot is taken after the wait | text typed *during* the wait is what gets written |
| three saves stacked on one tab | still one write at a time, and all three still write — ordered, not dropped |
| `saveContentAs` shares the guard | no overlap; the older write does not leave the moved tab dirty |
| closing a tab mid-write | the closed tab's newest text is what is left on disk |

Counter-proofs:

| change | result |
|---|---|
| neutralise the wait (`const result = write()`) | 5 of 5 fail, first on `two writes to one file were in flight at once` |
| hoist the snapshot back outside the wait | only the snapshot-placement test fails |

The second is there to show the tests are not all pinning one thing.

All four of #436's `explicitSaveCancelsAutoSave.test.ts` cases still pass and still mean what they meant — including its two source-text assertions, which require `cancelPendingAutoSave` to precede `invoke('save_file_content')` inside `saveContent` and forbid a call site taking the duty back. Both remain true.

# Verification

On `upstream/master` (`b63ff2e`):

```
npm test        533 / 533   (528 before, 5 new)
npm run check   0 errors, 0 warnings   (632 files)
npm run build   clean
```

`cargo test` not run: no Rust changed. #436's `atomic_write` hardening is what this rests on and is not touched.

# Not covered

- **Cross-window and cross-process writers.** Two windows can hold the same document with independent timers and independent `isDirty`, and the guard is per-session state that does not reach across them — the same limit #436 recorded. This is exactly why `atomic_write` must stay the safety layer; the frontend can only supply ordering within one window.
- **Two tabs on one file in one window.** Serialised per tab, not per path, so they still write concurrently. Left deliberately: that is two documents disagreeing about one file, which the app already permits, and closing it means the per-path queue this change is explicitly sized not to build.
- **The self-heal claim is read, not measured.** That `isDirty` going true re-arms the debounce comes from reading the auto-save effect in `MarkdownViewer.svelte`; the tests stub `$effect` out, so no test exercises it. It affects the severity argument, not the fix.
- **A tab closed while a save is queued behind another.** The queued write now runs slightly later than it used to, possibly after the tab is gone. It writes the buffer as of that moment — the newest text, which is more correct than before, not less — and the discard path does not call `saveContent` at all, so no reverted buffer can be queued. No guard was added for it; noting it as the one ordering consequence a reviewer might want to push back on.
- **No live app run.** Verified against the real `documentSession` with a stubbed Tauri backend, not by hand in the running app on a slow volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
