### PR TITLE
fix(save): stop a stale lossy-save refusal from silencing real auto-save failures

### DIFF
--- a/scripts/checkedReadMigration.test.ts
+++ b/scripts/checkedReadMigration.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { readSourceFiles } from './sourceTree.js';
+import { readSourceFiles, sliceBetween } from './sourceTree.js';
 
 // Runes and the Tauri bridge, shimmed the way truncatedBufferGuard.test.ts
 // shims them: the stores are runes modules, and Node's test runner gives every
@@ -197,11 +197,18 @@ test('entering split view reads the fidelity and stores it', () => {
 
 test('the session can tell a refusal from a failure', () => {
 	// `saveContent` returns false for both, which is why the auto-save timer
-	// could not tell them apart.
-	assert.match(
+	// could not tell them apart. The predicate is no longer set membership on
+	// its own: the set records what was SAID, and whether the refusal still
+	// stands is asked of the tab. `lossySaveRefusalScope.test.ts` exercises
+	// both halves for real; this only pins that the tab is consulted at all,
+	// since a predicate that answers from memory alone is the defect.
+	const body = sliceBetween(
 		readFileSync('src/lib/sessions/documentSession.svelte.ts', 'utf8'),
-		/function isLossySaveRefused\(tabId: string\): boolean \{\s*return lossySaveWarnedTabs\.has\(tabId\);/,
+		'function isLossySaveRefused(',
+		'function updateLoading',
 	);
+	assert.match(body, /lossySaveWarnedTabs\.has\(tabId\)/);
+	assert.match(body, /hasReplacementChars/, 'the live tab decides whether anything is still being refused');
 });
 
 test('a refused save does not add a generic toast to its own explanation', () => {

--- a/scripts/lossySaveRefusalScope.test.ts
+++ b/scripts/lossySaveRefusalScope.test.ts
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+/*
+ * `isLossySaveRefused` is read by the auto-save timer's FAILURE handler:
+ *
+ *     if (documentSession.isLossySaveRefused(s.id)) return;   // no toast
+ *     addToast(t('toast.autoSaveFailed'), 'error');
+ *
+ * The intent is right — a refused save already explained itself, naming the
+ * file and the way out, so "auto-save failed" on top says nothing new. But the
+ * predicate was `lossySaveWarnedTabs.has(tabId)`, membership in a set that is
+ * only ever cleared by `loadMarkdown` and `saveContentAs`. The tab's decode
+ * fidelity is re-decided by four other sites — `ensureFullContent`, entering
+ * the editor, entering split view, a cross-window arrival — every one of which
+ * can clear `hasReplacementChars` for a file converted to UTF-8 since the load,
+ * and none of which touches the set.
+ *
+ * So a tab could stop decoding lossily, start auto-saving again (the
+ * eligibility gate is `decodedLossily && isLossySaveRefused`, which correctly
+ * re-opens), and then have every subsequent auto-save failure — disk full,
+ * permission denied, a network volume that went away — silently swallow its
+ * toast, for the rest of that tab's life.
+ *
+ * The condition the name promises is "this tab's saves are being refused for
+ * the lossy-decode reason, right now", and "right now" is a property of the
+ * tab, not a memory of what was once said about it.
+ */
+
+const g = globalThis as any;
+const runeEffect = (fn: () => void) => {
+	void fn;
+};
+runeEffect.root = (fn: () => unknown) => fn();
+g.$state = (value: unknown) => value;
+g.$state.raw = (value: unknown) => value;
+g.$state.snapshot = (value: unknown) => value;
+g.$derived = (value: unknown) => value;
+g.$derived.by = (fn: () => unknown) => fn();
+g.$effect = runeEffect;
+g.window = g.window ?? {};
+Object.defineProperty(g, 'navigator', { value: { language: 'en-US' }, configurable: true });
+Object.defineProperty(g, 'localStorage', {
+	value: { getItem: () => null, setItem: () => {}, removeItem: () => {}, clear: () => {} },
+	configurable: true,
+});
+
+/** Whether `save_file_content` succeeds. Set per test. */
+let writeFails = false;
+const LOSSY = 'text with � in it';
+
+g.window.__TAURI_INTERNALS__ = {
+	invoke: (command: string, args: Record<string, unknown>) => {
+		const cmd = command.replace(/^plugin:[^|]*\|/, '');
+		if (cmd === 'get_os_type') return Promise.resolve('macos');
+		if (cmd === 'canonicalize_path') return Promise.resolve(args.path);
+		if (cmd === 'open_markdown_preview') return Promise.resolve(['', LOSSY, true, true]);
+		if (cmd === 'read_file_content_checked') return Promise.resolve([LOSSY, true]);
+		if (cmd === 'save_file_content') {
+			return writeFails ? Promise.reject(new Error('Os { code: 28, kind: StorageFull }')) : Promise.resolve(null);
+		}
+		return Promise.resolve(null);
+	},
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
+
+/** Every message the user would actually see, in order. */
+let toasts: string[] = [];
+
+function makeSession() {
+	return createDocumentSession({
+		setShowHome: () => {},
+		currentFile: () => tabManager.activeTab?.path ?? '',
+		resetScrollHistory: () => {},
+		renderMarkdown: async () => '',
+		afterLoad: async () => {},
+		saveRecentFile: () => {},
+		deleteRecentFile: () => {},
+		setLoadingTabs: () => {},
+		measureInitialViewport: () => {},
+		isScrolling: () => false,
+		renderRichContent: () => {},
+		onError: (message) => void toasts.push(message),
+		selfWriteGraceMs: 400,
+		cancelPendingAutoSave: () => {},
+		askClose: async () => 'discard' as const,
+		onCloseSaveNewerEdits: () => {},
+		onCloseAutoSaveFailed: () => {},
+	});
+}
+
+/**
+ * A tab holding a buffer that came out of a lossy decode, edited, and refused
+ * once — which is the state the refusal set records.
+ */
+async function refusedTab() {
+	tabManager.closeAll();
+	toasts = [];
+	writeFails = false;
+	const session = makeSession();
+	await session.loadMarkdown('/notes/legacy.md');
+	const tab = tabManager.activeTab!;
+	assert.equal(tab.hasReplacementChars, true, 'precondition: the decode was lossy');
+
+	tabManager.updateTabRawContent(tab.id, 'edited');
+	assert.equal(await session.saveContent(tab.id), false, 'the guard must refuse this write');
+	assert.equal(toasts.length, 1, 'and explain itself exactly once');
+	assert.equal(session.isLossySaveRefused(tab.id), true);
+	return { session, tab };
+}
+
+test('a refusal still speaks once, and stays quiet afterwards', async () => {
+	// The behaviour that must survive: while the tab still decodes lossily,
+	// every further attempt is the same standing condition, already explained.
+	const { session, tab } = await refusedTab();
+
+	tabManager.updateTabRawContent(tab.id, 'edited again');
+	assert.equal(await session.saveContent(tab.id), false);
+	tabManager.updateTabRawContent(tab.id, 'and again');
+	assert.equal(await session.saveContent(tab.id), false);
+
+	assert.equal(toasts.length, 1, 'a standing condition is not re-reported');
+	assert.equal(session.isLossySaveRefused(tab.id), true, 'and the timer keeps its toast suppressed');
+});
+
+test('a tab that no longer decodes lossily is no longer being refused', async () => {
+	// The file was converted to UTF-8 and the tab re-read it. This is what
+	// `ensureFullContent`, `toggleEdit`, split view and a cross-window arrival
+	// all do — none of them goes through `loadMarkdown`, so none of them
+	// clears the set.
+	const { session, tab } = await refusedTab();
+	tabManager.setTabDecodedLossy(tab.id, false);
+
+	assert.equal(session.isLossySaveRefused(tab.id), false, 'nothing is being refused any more');
+});
+
+test('a real auto-save failure on that tab is still reportable', async () => {
+	// End to end, in the shape the auto-save timer sees it: `saveContent`
+	// returns false, and the predicate the timer consults before deciding
+	// whether to raise `toast.autoSaveFailed` must not claim this was a
+	// refusal. Under the stale-set predicate it did, and the user was left
+	// believing a full disk had saved their work.
+	const { session, tab } = await refusedTab();
+	tabManager.setTabDecodedLossy(tab.id, false);
+	writeFails = true;
+
+	tabManager.updateTabRawContent(tab.id, 'work the user expects to be saved');
+	assert.equal(await session.saveContent(tab.id), false, 'the write really did fail');
+	assert.equal(
+		session.isLossySaveRefused(tab.id),
+		false,
+		'a failure is not a refusal, so the timer must be free to report it',
+	);
+});
+
+test('the flag goes back up if the file is lossy again', async () => {
+	// Symmetry: the predicate answers about the tab as it is now, in both
+	// directions. A tab that was converted back (or a second file opened into
+	// the same tab that is lossy) is refused again — and having already been
+	// told once, it is not told twice.
+	const { session, tab } = await refusedTab();
+	tabManager.setTabDecodedLossy(tab.id, false);
+	tabManager.setTabDecodedLossy(tab.id, true);
+
+	assert.equal(session.isLossySaveRefused(tab.id), true);
+	assert.equal(await session.saveContent(tab.id), false);
+	assert.equal(toasts.length, 1, 'still only the one explanation');
+});
+
+test('a closed tab is not remembered as refused', async () => {
+	// `closeTab` splices the tab out with no dispose hook, so the set keeps
+	// the id forever. Ids are `crypto.randomUUID()` and never reused, so this
+	// is a bounded leak rather than a correctness problem — but the predicate
+	// must not answer "yes" about a tab that no longer exists.
+	const { session, tab } = await refusedTab();
+	const id = tab.id;
+	tabManager.closeTab(id);
+
+	assert.equal(session.isLossySaveRefused(id), false);
+});

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -200,8 +200,8 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 	}
 
 	/**
-	 * True once this tab has been told, in words, that its buffer cannot be
-	 * written back over its own file.
+	 * True when this tab's saves are being refused for the lossy-decode reason
+	 * RIGHT NOW, and it has already been told so in words.
 	 *
 	 * The explanation is deduplicated per tab above, but the callers' own
 	 * failure reporting was not: `saveContent` returns `false` for a refusal
@@ -210,9 +210,27 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 	 * every keystroke, repeated it every 1.5s for as long as the user kept
 	 * typing. A refusal is not a failure to report again; it is a standing
 	 * condition the user has already been told about and given an exit from.
+	 *
+	 * Both halves are needed, and the second is why set membership alone was
+	 * not enough. `lossySaveWarnedTabs` records what was SAID; whether the
+	 * refusal still stands is a property of the tab, decided fresh by every
+	 * read that fills the buffer — `ensureFullContent`, entering the editor,
+	 * entering split view, a cross-window arrival. Any of those clears
+	 * `hasReplacementChars` for a file converted to UTF-8 since the load, and
+	 * none of them goes through `loadMarkdown`, the only place that empties the
+	 * set. A tab that had once been refused therefore went on suppressing the
+	 * generic message for the rest of its life, including for a genuine write
+	 * failure — a full disk, a revoked permission, a network volume that went
+	 * away — which is the opposite of "already explained".
+	 *
+	 * Asking the tab also answers for one that is gone: `closeTab` splices with
+	 * no dispose hook, so the set keeps closed ids, and a tab nobody can find
+	 * is refusing nothing.
 	 */
 	function isLossySaveRefused(tabId: string): boolean {
-		return lossySaveWarnedTabs.has(tabId);
+		if (!lossySaveWarnedTabs.has(tabId)) return false;
+		const tab = tabManager.tabs.find((item) => item.id === tabId);
+		return tab?.hasReplacementChars === true;
 	}
 
 	function updateLoading(tabId: string, loading: boolean) {


### PR DESCRIPTION
Two guards in `documentSession.svelte.ts` were reported to me as the same shape — a guard whose name promises more than its condition delivers. **One of them is a real bug and is fixed here. The other does not reproduce, and this PR does not change it**; the investigation is written up below so the next person does not repeat it.

---

# 1. A tab that once refused a lossy save went permanently silent about *all* auto-save failures

## The two readers of one predicate

`lossySaveWarnedTabs` is a `Set<string>` of tab ids, added to the first time `refuseIfLossilyDecoded` blocks a write. `isLossySaveRefused` exposed it verbatim:

```ts
function isLossySaveRefused(tabId: string): boolean {
	return lossySaveWarnedTabs.has(tabId);
}
```

Two call sites read it, and only one of them was safe.

**The auto-save *eligibility* gate** (`MarkdownViewer.svelte:1833`) — correct, because the `&&` supplies the missing half:

```ts
const eligible = … && !(s.decodedLossily && documentSession.isLossySaveRefused(s.id));
```

**The auto-save *failure handler*** (`MarkdownViewer.svelte:1873`) — unconditional:

```ts
if (!ok) {
	console.error('Auto-save failed for tab', s.id);
	if (documentSession.isLossySaveRefused(s.id)) return;   // ← no decodedLossily
	addToast(t('toast.autoSaveFailed', settings.language), 'error');
}
```

The comment at that site explains the intent, and the intent is right: a refusal has already named the file and the way out, so "auto-save failed" on top says nothing new. The **condition** was broader than the intent.

## The set records what was said; it does not track whether it is still true

The set is emptied in exactly three places: `loadMarkdown` (both branches) and `saveContentAs`. But `hasReplacementChars` — the fact the refusal is *about* — is re-decided by **four** other reads, each of which fills a writable buffer and therefore carries its own fidelity verdict since #379:

| site | clears `hasReplacementChars` for a file since converted to UTF-8 | clears `lossySaveWarnedTabs` |
|---|---|---|
| `loadMarkdown` (preview + full) | ✓ | ✓ |
| `saveContentAs` | ✓ | ✓ |
| `ensureFullContent` | ✓ | ✗ |
| `toggleEdit` (`MarkdownViewer.svelte:1688`) | ✓ | ✗ |
| `toggleSplitView` (`MarkdownViewer.svelte:2408`) | ✓ | ✗ |
| cross-window arrival (`windowSession.svelte.ts:207`) | ✓ | ✗ |

So the set can outlive the condition. And the *eligibility* gate lets it: once `decodedLossily` goes false the tab starts auto-saving again — which is correct and intended — while the failure handler stays permanently muted.

```
  open legacy.md, decoded lossily        hasReplacementChars = true   warned = ∅
  type → auto-save → refused             …                     true   warned = {t}
      → the one toast the user should get: "cannot save, file was decoded lossily"
  leave edit mode; user converts the file to UTF-8 externally
  re-enter edit mode → toggleEdit re-reads it
                                         hasReplacementChars = FALSE  warned = {t}  ← stale
  type → eligible again → auto-save → disk full / permission denied / volume gone
      → console.error, and isLossySaveRefused(t) still says "already explained"
      → t('toast.autoSaveFailed') is suppressed, for the rest of that tab's life
```

## Severity, stated accurately

I was told this leaves "nothing on screen". That is not quite right, and the difference matters for how the fix should be judged.

`saveContent`'s `catch` already calls `options.onError('Failed to save file', error)`, and MarkdownViewer wires `onError` to `addToast`. So a write that **throws** — the disk-full case — still surfaces a toast, an unlocalized one reading `Failed to save file: Os { code: 28, … }`. What the stale predicate suppresses is the localized `toast.autoSaveFailed` on top of it.

The genuinely silent case is a `saveContent` that returns `false` **without** throwing. Today, reached from the auto-save timer, that is only `!tab` — the tab closed between the timer arming and firing. It is about to get bigger: the per-tab in-flight save guard on `fix/one-write-per-tab-at-a-time` adds a second such return, in this same file.

So: a real defect in the user-visible messaging path, currently degrading a localized message into a raw one rather than erasing all feedback, and sitting directly in front of a change that widens it. Not a data-loss bug, and this PR does not claim to be one.

## The fix

The predicate now means what its name says — *is this tab's save being refused for the lossy-decode reason, right now* — by asking the tab as well as the memory:

```ts
function isLossySaveRefused(tabId: string): boolean {
	if (!lossySaveWarnedTabs.has(tabId)) return false;
	const tab = tabManager.tabs.find((item) => item.id === tabId);
	return tab?.hasReplacementChars === true;
}
```

Both halves are load-bearing. The set is still what makes the *first* refusal produce its explanation and the rest stay quiet. The tab is what makes "still" true.

**Why not "also clear the set in `closeTab`".** I looked; it is not needed, and the structural obstacle is real — `closeTab` is a `splice` with no dispose hook, so there is nowhere to hang the cleanup without introducing one, which is out of scope here. Asking the tab answers the closed-tab case for free: a tab nobody can find is refusing nothing. What remains is that the set keeps closed ids forever. Ids are `crypto.randomUUID()` and never reused, so this is a bounded leak — one string per lossy-refused tab per window session — not a correctness problem. Left as-is and noted below.

**Why the fix is in the session and not at the call site.** The predicate is the thing that was wrong, and it has two readers. Fixing the handler would have left the next reader to rediscover it — and `isLossySaveRefused` exists precisely so that MarkdownViewer does not have to know how refusals are tracked.

**`MarkdownViewer.svelte` is untouched.** Notably the `s.decodedLossily &&` in the eligibility gate stays, and is not now redundant: it is the *reactive* read. `isLossySaveRefused` is called from inside `untrack(…)`, so its own read of the tab creates no dependency; `s.decodedLossily` in the snapshot is what re-runs the effect when the flag changes and re-opens the tab for auto-save.

## Tests

`scripts/lossySaveRefusalScope.test.ts`, five cases against the real `TabManager` and the real `documentSession` with a stubbed backend. Each starts from a tab that decoded lossily, was edited, and was refused once.

- a tab that no longer decodes lossily is **no longer being refused** — the core claim;
- a **real** save failure on such a tab (`save_file_content` rejects with `StorageFull`) returns `false` while the predicate stays `false`, so the timer is free to report it — the bug, end to end in the shape the timer sees it;
- a closed tab is not remembered as refused;
- **the lossy case did not get noisy again**: three consecutive refusals on a still-lossy tab produce exactly one message, and the predicate stays `true` throughout;
- symmetry — a tab that becomes lossy again is refused again, and having been told once is not told twice.

The last two are the regression guard on the behaviour this must not break. They pass on `master` and must keep passing; the first three are the red-to-green.

Counter-proofs:

| mutation | result |
|---|---|
| predicate reverted to `lossySaveWarnedTabs.has(tabId)` (i.e. `master`) | **3 of 5 fail** — the two preservation cases correctly stay green |
| predicate hard-wired to `return false` | **5 of 5 fail** — the deduplication guard bites |

One existing source-text assertion in `checkedReadMigration.test.ts` pinned the old one-line body; it is updated to pin the property instead (the tab is consulted), pointing at the new file for the behaviour. The two source-text tests over the MarkdownViewer call sites are unchanged and still pass, which is the check that the component side did not need to move.

---

# 2. `resolveExternalChange`'s raw `===` — investigated, not changed

`resolveExternalChange` picks the tab that owns a changed file with string equality, in a file that imports `isSameFilePath` and uses it three times elsewhere:

```ts
active && active.path === changedPath
	? active
	: tabManager.tabs.find((tab) => tab.path === changedPath);
```

Two findings, and the second is why nothing changed.

## The echo is byte-identical, so this is latent, not live

`watch_file` (`src-tauri/src/window_runtime.rs:419`) clones the path argument into the notify callback and emits **that**, never anything from the `notify::Event`:

```rust
let watched_path = path.clone();
let mut watcher = RecommendedWatcher::new(
	move |result: Result<notify::Event, notify::Error>| {
		if result.is_ok() {
			let _ = handle.emit_to(event_label.as_str(), "file-changed", watched_path.clone());
		}
	}, …
```

The frontend hands it `currentFile`, which is `$derived(tabManager.activeTab?.path ?? '')` — the very string `resolveExternalChange` then compares against. The chain closes: payload ≡ `activeTab.path` at arm time, and `liveModeWatchedPath.test.ts` already pins both ends of it. macOS case folding, NFD/NFC, a Windows drive-letter difference and a symlinked directory can none of them get between the two, because the OS's own path never enters the payload.

## The proposed fix would not change behaviour even if it were live

This is the part that decided it. `isSameFilePath` trusts keys only when **both** sides have one, and degrades to exact path equality otherwise — deliberately, and documented as such. The watcher payload is a bare string with no `pathKey`. So `isSameFilePath({ path: changedPath }, tab)` *is* `changedPath === tab.path`, including against a fully-resolved tab:

```
                      ===      isSameFilePath   differs
macOS case fold       false    false            false
NFD vs NFC            false    false            false
Windows drive case    false    false            false
symlinked directory   false    false            false
```

(run against the real `isSameFilePath`, with the tab given a `pathKey` — the best case for the identity comparison)

Making it bite would mean canonicalizing `changedPath`, which is a Tauri round-trip on every external-change event and would turn a synchronous resolver into an async one — restructuring the external-change flow, which is a design decision for the maintainer rather than a drive-by. The performance question is moot for the same reason: `isSameFilePath` here compiles to the same string compare, and the cost only appears in the version that would actually do something.

Changing the line as proposed would have been a diff that reads like a fix, passes review, and does nothing. Left alone.

---

# Verification

On `upstream/master` (`b63ff2e`):

```
npm test        533 / 533   (528 before this branch, + 5 new)
npm run check   632 files, 0 errors, 0 warnings
npm run build   clean
```

`cargo test` not run: no Rust changed. The Rust in section 2 was read, not modified.

# Not covered

- **No run in the real app.** Both defects were exercised against the real `TabManager` and the real `documentSession` with a stubbed Tauri bridge. Nobody filled a disk under a converted-to-UTF-8 file by hand.
- **The unlocalized `Failed to save file: <error>` toast is untouched.** It is what a throwing write shows today, now alongside the localized one. Whether a failed auto-save should raise one message or two, and whether a raw `Os { code: 28 }` belongs in front of a user, is a messaging question this PR does not open.
- **`lossySaveWarnedTabs` still grows by one entry per lossy-refused tab, for the window's lifetime.** Correctness is now independent of it. The dispose hook `closeTab` would need is a separate structural change.
- **`resolveExternalChange` still compares raw strings**, for the reasons in section 2. The invariant it depends on is enforced by `liveModeWatchedPath.test.ts` on both the Rust and the frontend side; no new test was added, since a third assertion of the same fact would be noise.
- **Rebase.** This branch does not touch `saveContent`, so it should not collide with the in-flight save guard on `fix/one-write-per-tab-at-a-time`. If that lands first, note that its new "already saving" early return is a `saveContent` returning `false` without throwing — exactly the silent case section 1 restores the toast for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
