### PR TITLE
test(scripts): answer scope questions by parsing, and guard 71 slice bounds

### DIFF
--- a/scripts/checkedReadMigration.test.ts
+++ b/scripts/checkedReadMigration.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { readSourceFiles, sliceBetween } from './sourceTree.js';
+import { offsetOf, readSourceFiles, sliceBetween } from './sourceTree.js';
 
 // Runes and the Tauri bridge, shimmed the way truncatedBufferGuard.test.ts
 // shims them: the stores are runes modules, and Node's test runner gives every
@@ -174,22 +174,19 @@ test('the unchecked read command is gone, and nothing calls it', () => {
 });
 
 test('entering the editor reads the fidelity and stores it', () => {
-	const toggle = viewer.slice(viewer.indexOf('async function toggleEdit'), viewer.indexOf('async function saveContent'));
+	const toggle = sliceBetween(viewer, 'async function toggleEdit', 'async function saveContent');
 	assert.match(toggle, /\[content, lossy\] = \(await invoke\('read_file_content_checked', \{ path: tab\.path \}\)\)/);
-	const read = toggle.indexOf('read_file_content_checked');
-	const flag = toggle.indexOf('setTabDecodedLossy(tab.id, lossy)');
-	const store = toggle.indexOf('setTabRawContent(tab.id, content)');
-	assert.notEqual(flag, -1, 'the verdict must reach the tab');
+	const read = offsetOf(toggle, 'read_file_content_checked');
+	const flag = offsetOf(toggle, 'setTabDecodedLossy(tab.id, lossy)');
+	const store = offsetOf(toggle, 'setTabRawContent(tab.id, content)');
 	assert.ok(read < flag && flag < store, 'flag the tab before the buffer is published');
 });
 
 test('entering split view reads the fidelity and stores it', () => {
-	const split = viewer.slice(viewer.indexOf('async function toggleSplitView'));
-	const enter = split.slice(0, split.indexOf('} else {'));
+	const enter = sliceBetween(viewer, 'async function toggleSplitView', '} else {');
 	assert.match(enter, /\[content, lossy\] = \(await invoke\('read_file_content_checked', \{ path: tab\.path \}\)\)/);
-	const flag = enter.indexOf('setTabDecodedLossy(tab.id, lossy)');
-	const store = enter.indexOf('setTabRawContent(tab.id, content)');
-	assert.notEqual(flag, -1, 'the verdict must reach the tab');
+	const flag = offsetOf(enter, 'setTabDecodedLossy(tab.id, lossy)');
+	const store = offsetOf(enter, 'setTabRawContent(tab.id, content)');
 	assert.ok(flag < store, 'flag the tab before the buffer is published');
 });
 
@@ -212,13 +209,10 @@ test('the session can tell a refusal from a failure', () => {
 });
 
 test('a refused save does not add a generic toast to its own explanation', () => {
-	const effect = viewer.slice(viewer.indexOf('Auto-save effect.'));
-	const body = effect.slice(0, effect.indexOf('for (const id of ['));
-	const check = body.indexOf('if (documentSession.isLossySaveRefused(s.id)) return;');
-	const toast = body.indexOf("t('toast.autoSaveFailed'");
-	assert.notEqual(check, -1, 'the refusal must be recognised');
-	assert.notEqual(toast, -1);
-	assert.ok(check < toast, 'and recognised before the generic toast is raised');
+	const body = sliceBetween(viewer, 'Auto-save effect.', 'for (const id of [');
+	const check = offsetOf(body, 'if (documentSession.isLossySaveRefused(s.id)) return;');
+	const toast = offsetOf(body, "t('toast.autoSaveFailed'");
+	assert.ok(check < toast, 'the refusal must be recognised before the generic toast is raised');
 });
 
 test('a tab that can only be refused stops re-arming the timer', () => {
@@ -226,8 +220,7 @@ test('a tab that can only be refused stops re-arming the timer', () => {
 	// again every 1.5s for as long as the user kept typing — each time
 	// producing the console warning, the wasted round trip, and (before the
 	// test above) the toast.
-	const effect = viewer.slice(viewer.indexOf('Auto-save effect.'));
-	const body = effect.slice(0, effect.indexOf('for (const id of ['));
+	const body = sliceBetween(viewer, 'Auto-save effect.', 'for (const id of [');
 	assert.match(body, /decodedLossily: tab\.hasReplacementChars/);
 	assert.match(body, /const eligible = [^;]*!\(s\.decodedLossily && documentSession\.isLossySaveRefused\(s\.id\)\)/);
 	// The FIRST attempt must still happen: it is what produces the explanation.

--- a/scripts/documentWatcherSession.test.ts
+++ b/scripts/documentWatcherSession.test.ts
@@ -2,10 +2,12 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { sliceFrom } from './sourceTree.js';
+
 const session = readFileSync('src/lib/sessions/documentSession.svelte.ts', 'utf8');
 
 test('self writes suppress watcher reloads only during their grace period', () => {
-	const handler = session.slice(session.indexOf('function shouldReloadExternalChange'));
+	const handler = sliceFrom(session, 'function shouldReloadExternalChange');
 	assert.match(handler, /if \(Date\.now\(\) < until\) return false;/);
 	assert.match(handler, /selfWriteUntilByPath\.delete\(path\);/);
 	assert.match(handler, /return true;/);

--- a/scripts/editorOptionWiring.test.ts
+++ b/scripts/editorOptionWiring.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { sliceBetween } from './sourceTree.js';
+
 // Editor.svelte translates the settings store into Monaco options and
 // keybindings. Every regression locked here came from that translation layer
 // being wired to the wrong shape: a string option read as a boolean, a
@@ -13,14 +15,6 @@ const settingsStore = readFileSync('src/lib/stores/settings.svelte.ts', 'utf8');
 
 function count(source: string, pattern: RegExp): number {
 	return source.match(pattern)?.length ?? 0;
-}
-
-function sliceBlock(source: string, startMarker: string, endMarker: string): string {
-	const start = source.indexOf(startMarker);
-	assert.notEqual(start, -1, `expected to find ${startMarker}`);
-	const end = source.indexOf(endMarker, start + startMarker.length);
-	assert.notEqual(end, -1, `expected to find ${endMarker} after ${startMarker}`);
-	return source.slice(start, end);
 }
 
 test('renderLineHighlight is a Monaco string enum, not a boolean flag', () => {
@@ -54,7 +48,7 @@ test('editor options are applied by a single updateOptions effect', () => {
 	// without the zoom factor — so the winner depended on effect ordering.
 	assert.equal(count(editor, /editor\.updateOptions\(\{/g), 1, 'exactly one updateOptions call site');
 
-	const block = sliceBlock(editor, 'editor.updateOptions({', '});');
+	const block = sliceBetween(editor, 'editor.updateOptions({', '});');
 	assert.match(block, /wordWrapColumn: settings\.editorMaxWidth/, 'wordWrapColumn survived the merge');
 	assert.match(block, /fontSize: settings\.editorFontSize \* \(zoomLevel \/ 100\)/, 'zoom-aware font size is the surviving one');
 	for (const option of [
@@ -110,7 +104,7 @@ test('platform detection reads settings.osType and never writes it', () => {
 	// the keybindings are registered once, at mount, rather than re-registered
 	// when settings.osType resolves. Full argument: the comment on
 	// isMacPlatform() in Editor.svelte.
-	const helper = sliceBlock(editor, 'function isMacPlatform', '\n\t}');
+	const helper = sliceBetween(editor, 'function isMacPlatform', '\n\t}');
 	assert.match(helper, /settings\.osType !== 'unknown'/, 'prefers the resolved Tauri os type');
 	assert.match(helper, /settings\.osType === 'macos'/);
 	assert.match(helper, /navigator\.platform/, 'falls back while osType is still resolving');
@@ -139,7 +133,7 @@ test('custom copy keeps Monaco\'s whole-line copy on an empty selection', () => 
 	// (editor.emptySelectionClipboard) and Sublime Text behave the same. Since
 	// custom-copy overrides the native copy action, bailing out on an empty
 	// selection deleted the behaviour outright.
-	const copyAction = sliceBlock(editor, 'id: "custom-copy"', 'id: "toggle-minimap"');
+	const copyAction = sliceBetween(editor, 'id: "custom-copy"', 'id: "toggle-minimap"');
 
 	assert.doesNotMatch(
 		copyAction,

--- a/scripts/editorPdfExport.test.ts
+++ b/scripts/editorPdfExport.test.ts
@@ -4,6 +4,8 @@ import test from 'node:test';
 
 import { compile } from 'svelte/compiler';
 
+import { offsetOf, sliceBetween, sliceFrom } from './sourceTree.js';
+
 /*
  * Export PDF from plain edit mode produced a blank page, for two independent
  * reasons. This file covers both.
@@ -317,9 +319,8 @@ test('the reveal does not depend on which sheet the browser applies last', () =>
 	// is not guaranteed. The resolver above already places the component last,
 	// which is the losing arrangement for the print rules; assert that the
 	// winning declaration is `!important` so order cannot decide it either way.
-	const printBlock = styles.slice(styles.indexOf('@media print'));
-	const override = printBlock.slice(printBlock.indexOf('#app .pane.viewer-pane'));
-	const rule = override.slice(0, override.indexOf('}'));
+	const printBlock = sliceFrom(styles, '@media print');
+	const rule = sliceBetween(printBlock, '#app .pane.viewer-pane', '}');
 	for (const property of ['width', 'flex', 'opacity']) {
 		assert.match(rule, new RegExp(`${property}:[^;]*!important`), `${property} must be !important`);
 	}
@@ -333,14 +334,6 @@ test('the reveal does not depend on which sheet the browser applies last', () =>
 // the resulting DOM is complete — that is what the awaited `renderRichContent`
 // is for, and only a real browser can confirm it.
 
-const slice = (source: string, start: string, end: string) => {
-	const from = source.indexOf(start);
-	assert.notEqual(from, -1, `expected to find ${start}`);
-	const to = source.indexOf(end, from + start.length);
-	assert.notEqual(to, -1, `expected to find ${end} after ${start}`);
-	return source.slice(from, to);
-};
-
 test('the preview is only kept live while it is on screen', () => {
 	// The premise of the second half. If this condition ever widens to cover
 	// plain edit mode the export-time render below becomes a no-op rather than
@@ -349,17 +342,16 @@ test('the preview is only kept live while it is on screen', () => {
 });
 
 test('exporting a PDF renders the buffer before the DOM is printed', () => {
-	const body_ = slice(viewer, 'async function exportAsPdf', 'function handleNewFile');
-	const sync = body_.indexOf('await syncPreviewForPrint()');
-	assert.notEqual(sync, -1, 'the export must refresh the preview first');
+	const body_ = sliceBetween(viewer, 'async function exportAsPdf', 'function handleNewFile');
+	const sync = offsetOf(body_, 'await syncPreviewForPrint()');
 	// Before the diagram pass, which reads the nodes that render produces, and
 	// before the print itself.
-	assert.ok(sync < body_.indexOf('renderDiagramsForPrint'), 'refresh before re-theming the diagrams');
-	assert.ok(sync < body_.indexOf('_exportPdf('), 'refresh before printing');
+	assert.ok(sync < offsetOf(body_, 'renderDiagramsForPrint'), 'refresh before re-theming the diagrams');
+	assert.ok(sync < offsetOf(body_, '_exportPdf('), 'refresh before printing');
 });
 
 test('the refresh is skipped when the DOM already matches the buffer', () => {
-	const body_ = slice(viewer, 'async function syncPreviewForPrint', 'async function exportAsPdf');
+	const body_ = sliceBetween(viewer, 'async function syncPreviewForPrint', 'async function exportAsPdf');
 	// Reading mode is rendered by loadMarkdown from this same buffer, and
 	// re-rendering it would discard the scroll, fold and find state on screen.
 	assert.match(body_, /if \(!tab \|\| !\(tab\.isEditing \|\| tab\.isSplit\)\) return;/);
@@ -367,7 +359,7 @@ test('the refresh is skipped when the DOM already matches the buffer', () => {
 });
 
 test('the refresh actually lands before the print', () => {
-	const body_ = slice(viewer, 'async function syncPreviewForPrint', 'async function exportAsPdf');
+	const body_ = sliceBetween(viewer, 'async function syncPreviewForPrint', 'async function exportAsPdf');
 	// What matters here is WHAT is rendered — this tab's buffer and this tab's
 	// path, not the disk — and that it is awaited before the content is
 	// swapped in. The trailing arguments are deliberately not pinned: fold
@@ -382,7 +374,7 @@ test('the refresh actually lands before the print', () => {
 });
 
 test('a failed refresh does not pass off a stale export as a fresh one', () => {
-	const body_ = slice(viewer, 'async function syncPreviewForPrint', 'async function exportAsPdf');
+	const body_ = sliceBetween(viewer, 'async function syncPreviewForPrint', 'async function exportAsPdf');
 	assert.match(body_, /catch \(error\)/);
 	assert.match(body_, /addToast\(/);
 });

--- a/scripts/externalChangeReload.test.ts
+++ b/scripts/externalChangeReload.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { sliceBetween } from './sourceTree.js';
+
 // Live Mode watches the open file and reloads it when something else writes
 // it — git checkout, a cloud sync, a second Markpad window. The reload path
 // replaces rawContent AND originalContent, so a buffer with unsaved edits is
@@ -135,8 +137,7 @@ test('our own writes still suppress the reload', async () => {
 // --- wiring that cannot be executed outside a Svelte runtime ---
 
 test('the watcher listener routes every event through the guarded resolution', () => {
-	const listener = viewer.slice(viewer.indexOf("listen('file-changed'"));
-	const body = listener.slice(0, listener.indexOf('}),'));
+	const body = sliceBetween(viewer, "listen('file-changed'", '}),');
 	assert.match(body, /resolveExternalChange/);
 	// The old body called loadMarkdown(currentFile) directly.
 	assert.doesNotMatch(body, /loadMarkdown\(currentFile\)/);
@@ -152,8 +153,7 @@ test('the debounced auto-save is held back while a conflict is unanswered', () =
 	// Otherwise the 1.5s timer fires while the bar is still asking "reload or
 	// keep mine": the user's edits survive, but the external change is gone
 	// from disk before either answer can be given.
-	const effect = viewer.slice(viewer.indexOf('Auto-save effect.'));
-	const body = effect.slice(0, effect.indexOf('for (const id of ['));
+	const body = sliceBetween(viewer, 'Auto-save effect.', 'for (const id of [');
 	assert.match(body, /hasPendingConflict: externalChangeConflicts\[tab\.id\] === true/);
 	assert.match(body, /const eligible = [^;]*!s\.hasPendingConflict/);
 });
@@ -161,15 +161,13 @@ test('the debounced auto-save is held back while a conflict is unanswered', () =
 test('an explicit save answers the conflict and takes the bar down', () => {
 	// Pressing Cmd+S is a decision. Leaving the bar up afterwards would ask a
 	// question the user already answered.
-	const wrapper = viewer.slice(viewer.indexOf('async function saveContent(tabId?: string)'));
-	const body = wrapper.slice(0, wrapper.indexOf('async function saveContentAs'));
+	const body = sliceBetween(viewer, 'async function saveContent(tabId?: string)', 'async function saveContentAs');
 	assert.match(body, /clearExternalChangeConflict/);
 });
 
 test('turning Live Mode on installs the watcher without reloading', () => {
 	// Enabling a watcher is not a request to discard the buffer, and this was
 	// the one loadMarkdown call in the app with no canCloseTab in front of it.
-	const toggle = viewer.slice(viewer.indexOf('function toggleLiveMode'));
-	const body = toggle.slice(0, toggle.indexOf('\n\t}') + 3);
+	const body = sliceBetween(viewer, 'function toggleLiveMode', '\n\t}');
 	assert.doesNotMatch(body, /loadMarkdown/);
 });

--- a/scripts/foldKeys.test.ts
+++ b/scripts/foldKeys.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { sliceFrom } from './sourceTree.js';
+
 // Fold state is keyed by `h.id || textContent`. comrak emits the
 // deduplicated heading id on an empty inner <a class="anchor">, not on the
 // heading element, so without promotion every fold consumer falls back to
@@ -11,7 +13,7 @@ import test from 'node:test';
 test('processMarkdownHtml promotes the anchor id onto the heading element', () => {
 	const source = readFileSync('src/lib/utils/markdown.ts', 'utf8');
 
-	const headingLoop = source.slice(source.indexOf('querySelectorAll("h1, h2, h3, h4, h5, h6")'));
+	const headingLoop = sliceFrom(source, 'querySelectorAll("h1, h2, h3, h4, h5, h6")');
 	assert.match(headingLoop, /querySelector\("a\.anchor"\)/, 'heading loop looks up the comrak anchor');
 	assert.match(headingLoop, /h\.id = \w+\.id/, 'anchor id is promoted onto the heading');
 	assert.match(headingLoop, /removeAttribute\("id"\)/, 'anchor id is removed so document ids stay unique');

--- a/scripts/foldStatePerDocument.test.ts
+++ b/scripts/foldStatePerDocument.test.ts
@@ -27,6 +27,7 @@ import test from 'node:test';
 import ts from 'typescript';
 
 import { installShimDom, parseHtml, type ShimElement } from './renderProtocolDom.ts';
+import { offsetOf } from './sourceTree.js';
 
 // ---------------------------------------------------------------- environment
 
@@ -98,7 +99,7 @@ function pluckFunction(source: string, name: string, required = true): string {
 	for (const marker of [`async function ${name}(`, `function ${name}(`]) {
 		const start = source.indexOf(marker);
 		if (start === -1) continue;
-		const open = source.indexOf('{', source.indexOf(')', start));
+		const open = offsetOf(source, '{', offsetOf(source, ')', start));
 		return source.slice(start, matchBrace(source, open) + 1);
 	}
 	assert.ok(!required, `expected the component to define ${name}`);
@@ -243,9 +244,8 @@ function buildViewer(): Viewer {
 /** The real `visibleItems` out of Toc.svelte, over a caller-supplied fold set. */
 function buildTocFilter() {
 	const marker = 'let visibleItems = $derived.by(() => ';
-	const start = toc.indexOf(marker);
-	assert.notEqual(start, -1, 'expected Toc.svelte to derive visibleItems');
-	const open = toc.indexOf('{', start + marker.length);
+	const start = offsetOf(toc, marker);
+	const open = offsetOf(toc, '{', start + marker.length);
 	const body = toc.slice(open, matchBrace(toc, open) + 1);
 	const js = ts.transpileModule(body, { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText;
 	return new Function('items', 'collapsedHeaders', `"use strict";\n${js}`) as (

--- a/scripts/issue261EditorPdf.test.ts
+++ b/scripts/issue261EditorPdf.test.ts
@@ -2,17 +2,16 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { sliceBetween, sliceFrom } from './sourceTree.js';
+import { offsetOf, sliceBetween, sliceFrom } from './sourceTree.js';
 
 const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
 const styles = readFileSync('src/styles.css', 'utf8');
 
 test('editor context menu is not intercepted by the document menu', () => {
 	const handler = sliceBetween(viewer, 'function handleContextMenu(e: MouseEvent)', '\n\tfunction handleMouseOver');
-	const editorReturn = handler.indexOf('if (isInsideEditor) return;');
-	const preventDefault = handler.indexOf('e.preventDefault();');
+	const editorReturn = offsetOf(handler, 'if (isInsideEditor) return;');
+	const preventDefault = offsetOf(handler, 'e.preventDefault();');
 
-	assert.ok(editorReturn !== -1, 'editor context menus must stay with Monaco');
 	assert.ok(editorReturn < preventDefault, 'Monaco must receive the event before the document menu prevents it');
 });
 

--- a/scripts/issue281MinimalMacosMenu.test.ts
+++ b/scripts/issue281MinimalMacosMenu.test.ts
@@ -2,15 +2,17 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { sliceBetween } from './sourceTree.js';
+
 const tauriLib = readFileSync('src-tauri/src/lib.rs', 'utf8');
 const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
 
 test('macOS native menu keeps only application-level actions', () => {
-	const menuStart = tauriLib.indexOf('#[cfg(target_os = "macos")]\n            {\n                use tauri::menu');
-	assert.notEqual(menuStart, -1, 'macOS native menu setup must exist');
-
-	const menuEnd = tauriLib.indexOf('\n            let config_dir', menuStart);
-	const menuSetup = tauriLib.slice(menuStart, menuEnd);
+	const menuSetup = sliceBetween(
+		tauriLib,
+		'#[cfg(target_os = "macos")]\n            {\n                use tauri::menu',
+		'\n            let config_dir',
+	);
 
 	assert.match(menuSetup, /MenuItemBuilder::with_id\("menu-app-settings", "Settings…"\)\s*\.accelerator\("CmdOrCtrl\+,"\)/);
 	assert.match(menuSetup, /MenuItemBuilder::with_id\("check-updates", "Check for Updates…"\)/);

--- a/scripts/liveModeWatchedPath.test.ts
+++ b/scripts/liveModeWatchedPath.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { sliceBetween } from './sourceTree.js';
+
 const runtime = readFileSync('src-tauri/src/window_runtime.rs', 'utf8');
 const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
 
@@ -22,6 +24,6 @@ test('Live Mode routes a watcher notification to its watched path', () => {
 test('Live Mode follows the active file instead of retaining a previous tab watcher', () => {
 	assert.match(viewer, /if \(liveMode && currentFile\) \{\n\t\t\tinvoke\('watch_file', \{ path: currentFile \}\)/);
 	assert.doesNotMatch(readFileSync('src/lib/sessions/documentSession.svelte.ts', 'utf8'), /isLiveMode\(\)\) invoke\('watch_file'/);
-	const toggleLiveMode = viewer.slice(viewer.indexOf('function toggleLiveMode'), viewer.indexOf('async function saveImageAs'));
+	const toggleLiveMode = sliceBetween(viewer, 'function toggleLiveMode', 'async function saveImageAs');
 	assert.doesNotMatch(toggleLiveMode, /loadMarkdown\(/);
 });

--- a/scripts/localFileLinks.test.ts
+++ b/scripts/localFileLinks.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import { resolveLocalFileLinkPath } from '../src/lib/utils/localFileLinks.js';
+import { offsetOf, sliceBetween } from './sourceTree.js';
 
 /*
  * `[data](./data.csv)` did nothing on macOS and Linux, and opened a dead page
@@ -90,19 +91,11 @@ test('a markdown link still resolves to a path, so branch order is what keeps it
 // --- wiring ------------------------------------------------------------------
 
 const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
-const handler = (() => {
-	const from = viewer.indexOf('async function handleDocumentClick');
-	assert.notEqual(from, -1);
-	const to = viewer.indexOf('let zoomLevel', from);
-	assert.notEqual(to, -1);
-	return viewer.slice(from, to);
-})();
+const handler = sliceBetween(viewer, 'async function handleDocumentClick', 'let zoomLevel');
 
 test('markdown targets are still claimed before the local-file branch', () => {
-	const markdown = handler.indexOf('getRelativeMarkdownTarget(rawHref)');
-	const local = handler.indexOf('resolveLocalFileLinkPath(rawHref, currentFile)');
-	assert.notEqual(markdown, -1);
-	assert.notEqual(local, -1);
+	const markdown = offsetOf(handler, 'getRelativeMarkdownTarget(rawHref)');
+	const local = offsetOf(handler, 'resolveLocalFileLinkPath(rawHref, currentFile)');
 	assert.ok(markdown < local, '`./other.md` must open in a tab, not in an external editor');
 });
 
@@ -111,9 +104,8 @@ test('a local file is handed to the OS as a path, not as a URL', () => {
 	// The raw attribute, not `anchor.href`: the latter is the origin-resolved
 	// URL that caused the bug.
 	assert.match(handler, /resolveLocalFileLinkPath\(rawHref, currentFile\)/);
-	const local = handler.indexOf('resolveLocalFileLinkPath');
-	const url = handler.indexOf('await openUrl(anchor.href)');
-	assert.notEqual(url, -1, 'genuine web links must still go to the browser');
+	const local = offsetOf(handler, 'resolveLocalFileLinkPath');
+	const url = offsetOf(handler, 'await openUrl(anchor.href)');
 	assert.ok(local < url, 'a local file must be caught before the URL fallback');
 });
 
@@ -135,13 +127,11 @@ test('neither OS call can leave an unhandled rejection behind', () => {
 	// try/catch, that rejection was the whole visible symptom on macOS: nothing
 	// happened, and nothing said why.
 	for (const call of ['await openPath(localFilePath)', 'await openUrl(anchor.href)']) {
-		const at = handler.indexOf(call);
-		assert.notEqual(at, -1, call);
+		const at = offsetOf(handler, call);
 		const before = handler.slice(0, at);
 		const tryAt = before.lastIndexOf('try {');
-		const catchAfter = handler.indexOf('} catch (error) {', at);
 		assert.notEqual(tryAt, -1, `${call} must be inside a try block`);
-		assert.notEqual(catchAfter, -1, `${call} must have a catch`);
+		offsetOf(handler, '} catch (error) {', at); // must have a catch after it
 		assert.ok(before.slice(tryAt).split('} catch').length === 1, `${call} must be inside the nearest try`);
 	}
 	assert.equal(handler.match(/addToast\(`Failed to open/g)?.length, 2, 'both failures are reported');

--- a/scripts/lossyDecodeSaveGuard.test.ts
+++ b/scripts/lossyDecodeSaveGuard.test.ts
@@ -4,7 +4,7 @@ import test from 'node:test';
 
 import type { Tab } from '../src/lib/stores/tabs.svelte.js';
 import { buildTransferredTab, snapshotTab, validateTransferPayload } from '../src/lib/utils/tabTransfer.js';
-import { sliceBetween } from './sourceTree.js';
+import { offsetOf, sliceBetween } from './sourceTree.js';
 
 // Every read path decodes leniently (#371): a file in a legacy encoding
 // (GBK, Big5, Shift-JIS, EUC-KR, CP1251 ...) opens as U+FFFD mojibake instead
@@ -51,9 +51,8 @@ test('a preview cut inside a multi-byte character is not called lossy', () => {
 	// is routinely cut mid-character. Reporting that as lossy would lock every
 	// large CJK/emoji document out of saving — a guard worse than the bug.
 	const preview = sliceBetween(rust, 'fn build_markdown_preview', '#[tauri::command]');
-	const trim = preview.indexOf('utf8_truncation_boundary');
-	assert.notEqual(trim, -1, 'the split tail must be dropped before decoding');
-	assert.ok(trim < preview.indexOf('decode_utf8_lossy'), 'trim first, then judge fidelity');
+	const trim = offsetOf(preview, 'utf8_truncation_boundary');
+	assert.ok(trim < offsetOf(preview, 'decode_utf8_lossy'), 'the split tail is dropped before fidelity is judged');
 });
 
 test('the tab carries the fidelity of its buffer', () => {
@@ -105,10 +104,8 @@ test('the editable-pane shortcut reports fidelity too', () => {
 
 test('the flag is set before the buffer can reach a writer', () => {
 	const body = loadMarkdown();
-	const set = body.indexOf('setTabDecodedLossy(activeId, lossy)');
-	const firstAwait = body.indexOf('options.renderMarkdown(content');
-	assert.notEqual(set, -1, 'the preview branch must set the flag');
-	assert.notEqual(firstAwait, -1);
+	const set = offsetOf(body, 'setTabDecodedLossy(activeId, lossy)');
+	const firstAwait = offsetOf(body, 'options.renderMarkdown(content');
 	assert.ok(set < firstAwait, 'the flag must be set before the first await that follows the load');
 });
 
@@ -123,11 +120,10 @@ test('window restore cannot launder the flag away', () => {
 
 test('saveContent refuses to write a lossy buffer over its own file', () => {
 	const body = saveContent();
-	const refusal = body.indexOf('refuseIfLossilyDecoded');
-	assert.notEqual(refusal, -1, 'saveContent must consult the guard');
+	const refusal = offsetOf(body, 'refuseIfLossilyDecoded');
 	assert.match(body.slice(refusal, refusal + 120), /return false;/);
 	assert.ok(
-		refusal < body.indexOf("invoke('save_file_content'"),
+		refusal < offsetOf(body, "invoke('save_file_content'"),
 		'the guard must run before save_file_content is invoked',
 	);
 });
@@ -165,10 +161,9 @@ test('Save As onto the same file is still a destructive overwrite', () => {
 	// same bytes. The guard is therefore handed the target's resolved identity
 	// as well as its path. See pathIdentityCaseFolding.test.ts, which drives
 	// that refusal for real instead of reading for it.
-	const refusal = body.indexOf('refuseIfLossilyDecoded(tab, selected');
-	assert.notEqual(refusal, -1, 'picking the source file again must be refused');
+	const refusal = offsetOf(body, 'refuseIfLossilyDecoded(tab, selected');
 	assert.ok(
-		refusal < body.indexOf("invoke('save_file_content'"),
+		refusal < offsetOf(body, "invoke('save_file_content'"),
 		'the guard must run before save_file_content is invoked',
 	);
 });

--- a/scripts/macosPdfExport.test.ts
+++ b/scripts/macosPdfExport.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { sliceBetween } from './sourceTree.js';
+
 test('all Markpad webviews may invoke Tauri native printing', () => {
 	const capability = JSON.parse(readFileSync('src-tauri/capabilities/default.json', 'utf8')) as {
 		windows: string[];
@@ -26,12 +28,8 @@ test('both PDF commands the exporter invokes are registered with Tauri', () => {
 	const exporter = readFileSync('src/lib/utils/export.ts', 'utf8');
 	const tauriLib = readFileSync('src-tauri/src/lib.rs', 'utf8');
 
-	const handlerStart = tauriLib.indexOf('tauri::generate_handler![');
-	assert.notEqual(handlerStart, -1, 'lib.rs must keep a generate_handler! list');
-	const handlerEnd = tauriLib.indexOf(']', handlerStart);
 	const registered = new Set(
-		tauriLib
-			.slice(handlerStart, handlerEnd)
+		sliceBetween(tauriLib, 'tauri::generate_handler![', ']')
 			.split(',')
 			.map((entry) => entry.trim().replace(/^.*::/, '')),
 	);

--- a/scripts/monacoStartupGraph.test.ts
+++ b/scripts/monacoStartupGraph.test.ts
@@ -3,6 +3,8 @@ import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { dirname, relative, resolve } from 'node:path';
 import test from 'node:test';
 
+import { callbackBodies } from './sourceTree.js';
+
 // Monaco is ~86% of Markpad's startup JavaScript (measured: a 4.4 MB chunk out
 // of 4.7 MB on first paint, ~360ms of parse+eval, paid once per window because
 // every window is its own webview) and a reader who only ever views Markdown
@@ -189,7 +191,22 @@ test('every effect that drives the editor waits for editorReady', () => {
 	// alone runs once against nothing and is never re-triggered, which silently
 	// drops scroll sync, the zoom-aware font size, the theme and Vim mode.
 	const editor = readFileSync('src/lib/components/Editor.svelte', 'utf8');
-	const effects = [...editor.matchAll(/\$effect\(\(\) => \{([\s\S]*?)\n\t\}\);/g)].map((m) => m[1]);
+
+	// The bodies come from the parsed component, not from
+	// `/\$effect\(\(\) => \{([\s\S]*?)\n\t\}\);/`. That pattern needed a
+	// tab-indented `});` to end a body, so an effect written on one line had no
+	// terminator of its own and the lazy match ran on to the *next* effect's —
+	// returning the two as a single body whose text contains the `editorReady`
+	// the first half was missing. Measured, by planting
+	// `$effect(() => { if (editor) editor.layout(); });` in Editor.svelte: the
+	// ungated read passed, and `effects.length >= 5` did not notice because the
+	// merge kept the count at six. scripts/sourceTree.test.ts pins that form.
+	const effects = callbackBodies(editor, '$effect');
+
+	// Vacuity guard, restated so it cannot be satisfied by a body going missing:
+	// the parse must account for every `$effect` the file spells.
+	const spelled = (editor.match(/\$effect\s*\(/g) ?? []).length;
+	assert.equal(effects.length, spelled, `every $effect(…) yielded a body (spelled ${spelled})`);
 	assert.ok(effects.length >= 5, `found the effects (got ${effects.length})`);
 
 	for (const body of effects) {

--- a/scripts/printFindHighlight.test.ts
+++ b/scripts/printFindHighlight.test.ts
@@ -2,15 +2,16 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { offsetOf, sliceBetween, sliceFrom } from './sourceTree.js';
+
 const styles = readFileSync('src/styles.css', 'utf8');
 const findBar = readFileSync('src/lib/components/FindBar.svelte', 'utf8');
 
 /** The `@media print` block only — not everything that follows it in the file. */
 function extractPrintBlock(source: string): string {
-	const start = source.indexOf('@media print {');
-	assert.notEqual(start, -1, 'src/styles.css must keep an @media print block');
+	const start = offsetOf(source, '@media print {');
 	let depth = 0;
-	for (let i = source.indexOf('{', start); i < source.length; i += 1) {
+	for (let i = offsetOf(source, '{', start); i < source.length; i += 1) {
 		if (source[i] === '{') depth += 1;
 		else if (source[i] === '}') {
 			depth -= 1;
@@ -70,9 +71,9 @@ test('the neutralising rule outranks the component styles it overrides', () => {
 	// specificity, and stylesheet order between a component style and
 	// styles.css is not guaranteed, so `!important` is what decides.
 	const body = printRuleBody('.markdown-body mark.markpad-find-match');
-	const findBarRule = findBar.slice(findBar.indexOf(':global(.markdown-body mark.markpad-find-match)'));
+	const findBarRule = sliceBetween(findBar, ':global(.markdown-body mark.markpad-find-match)', '</style>');
 
-	assert.doesNotMatch(findBarRule.slice(0, findBarRule.indexOf('</style>')), /!important/);
+	assert.doesNotMatch(findBarRule, /!important/);
 	for (const property of ['background-color', 'box-shadow']) {
 		assert.match(body, new RegExp(`(?<![\\w-])${property}:[^;]*!important;`));
 	}

--- a/scripts/printOversizedMedia.test.ts
+++ b/scripts/printOversizedMedia.test.ts
@@ -2,14 +2,15 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { offsetOf } from './sourceTree.js';
+
 const styles = readFileSync('src/styles.css', 'utf8');
 
 /** The `@media print` block only — not everything that follows it in the file. */
 function extractPrintBlock(source: string): string {
-	const start = source.indexOf('@media print {');
-	assert.notEqual(start, -1, 'src/styles.css must keep an @media print block');
+	const start = offsetOf(source, '@media print {');
 	let depth = 0;
-	for (let i = source.indexOf('{', start); i < source.length; i += 1) {
+	for (let i = offsetOf(source, '{', start); i < source.length; i += 1) {
 		if (source[i] === '{') depth += 1;
 		else if (source[i] === '}') {
 			depth -= 1;

--- a/scripts/renderProtocol.test.ts
+++ b/scripts/renderProtocol.test.ts
@@ -20,6 +20,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { installShimDom, parseHtml, type ShimElement } from './renderProtocolDom.ts';
+import { offsetOf } from './sourceTree.js';
 
 installShimDom();
 
@@ -223,7 +224,10 @@ const DISPLAY_MATH_FIXTURES = [
 
 /** The text between the outermost `$$` pair of a fixture's Markdown. */
 function displayMathSource(markdown: string): string {
-	return markdown.slice(markdown.indexOf('$$') + 2, markdown.lastIndexOf('$$')).trim();
+	const open = offsetOf(markdown, '$$');
+	const close = markdown.lastIndexOf('$$');
+	assert.notEqual(close, open, 'a display-math fixture must close its $$ pair');
+	return markdown.slice(open + 2, close).trim();
 }
 
 test('display math reaches KaTeX with its underscores intact', () => {

--- a/scripts/reopenDirtyDocument.test.ts
+++ b/scripts/reopenDirtyDocument.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { sliceBetween } from './sourceTree.js';
+
 // Opening a file that is ALREADY open in a tab with unsaved edits must not
 // re-read it from disk. `setTabRawContent` replaces rawContent AND
 // originalContent, so the edits would not merely be overwritten — the tab
@@ -144,8 +146,7 @@ test('following a link into a new tab shows the tab that already holds the file'
 });
 
 test('the call shape this guards is still the one MarkdownViewer uses', () => {
-	const body = viewer.slice(viewer.indexOf('async function openMarkdownTargetInNewTab'));
-	const fn = body.slice(0, body.indexOf('\n\tasync function', 1));
+	const fn = sliceBetween(viewer, 'async function openMarkdownTargetInNewTab', '\n\tasync function');
 	assert.match(fn, /tabManager\.addTab\(/);
 	assert.match(fn, /loadMarkdown\([^)]*\{[^}]*skipTabManagement: true/);
 });
@@ -226,8 +227,7 @@ test('an edited tab following a link to a DIFFERENT file still loads it', async 
 // passing this flag is a caller claiming the user chose to lose work.
 for (const name of ['resolveExternalChangeByReloading', 'reloadFromDisk']) {
 	test(`${name} declares that it is discarding the buffer`, () => {
-		const body = viewer.slice(viewer.indexOf(`async function ${name}`));
-		const fn = body.slice(0, body.indexOf('\n\t}') + 3);
+		const fn = sliceBetween(viewer, `async function ${name}`, '\n\t}');
 		assert.match(fn, /loadMarkdown\(/);
 		assert.match(fn, /discardUnsavedBuffer: true/);
 	});

--- a/scripts/saveFromReadingMode.test.ts
+++ b/scripts/saveFromReadingMode.test.ts
@@ -2,14 +2,12 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { offsetOf, sliceBetween } from './sourceTree.js';
+
 const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
 
 function keydownSaveBranch(): string {
-	const start = viewer.indexOf("if (cmdOrCtrl && key === 's') {");
-	assert.notEqual(start, -1, 'the Ctrl/Cmd+S keydown branch should exist');
-	const end = viewer.indexOf("if (cmdOrCtrl && e.shiftKey && key === 't')", start);
-	assert.notEqual(end, -1, 'expected a following branch to bound the slice');
-	return viewer.slice(start, end);
+	return sliceBetween(viewer, "if (cmdOrCtrl && key === 's') {", "if (cmdOrCtrl && e.shiftKey && key === 't')");
 }
 
 // Reported in #168 by @dayeggpi: with a document that was never saved,
@@ -42,7 +40,7 @@ test('the browser save dialog is always suppressed', () => {
 	// preventDefault has to run for every mode, including the no-op case,
 	// or reading mode would surface the webview's own Save Page dialog.
 	const branch = keydownSaveBranch();
-	const beforeGuard = branch.slice(0, branch.indexOf('const saveTarget'));
+	const beforeGuard = branch.slice(0, offsetOf(branch, 'const saveTarget'));
 	assert.match(beforeGuard, /e\.preventDefault\(\);/);
 });
 

--- a/scripts/saveImageAsAssetUrl.test.ts
+++ b/scripts/saveImageAsAssetUrl.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import { normalizeAssetPath } from '../src/lib/utils/exportHtml.js';
+import { offsetOf, sliceBetween } from './sourceTree.js';
 
 /*
  * "Save image as" could never save a remote image, and on Windows it could not
@@ -28,13 +29,7 @@ import { normalizeAssetPath } from '../src/lib/utils/exportHtml.js';
  */
 
 const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
-const body = (() => {
-	const from = viewer.indexOf('async function saveImageAs');
-	assert.notEqual(from, -1);
-	const to = viewer.indexOf('async function saveDiagramAs', from);
-	assert.notEqual(to, -1);
-	return viewer.slice(from, to);
-})();
+const body = sliceBetween(viewer, 'async function saveImageAs', 'async function saveDiagramAs');
 
 test('a Windows asset URL names the same file as the asset: form', () => {
 	// The property the old `startsWith('asset:')` test lacked. Running it here
@@ -80,9 +75,8 @@ test('a local image is copied on the Rust side', () => {
 	assert.match(body, /invoke\('copy_file', \{ src: realPath, dest \}\)/);
 	// And the save dialog is only offered for a file that can actually be
 	// written; the remote case bails out before it.
-	const bail = body.indexOf("addToast('Saving a remote image is not supported yet'");
-	const dialog = body.indexOf('await save(');
-	assert.notEqual(bail, -1, 'the unsupported case must say so');
+	const bail = offsetOf(body, "addToast('Saving a remote image is not supported yet'");
+	const dialog = offsetOf(body, 'await save(');
 	assert.ok(bail < dialog, 'do not ask for a destination that cannot be written');
 });
 

--- a/scripts/scrollSyncInput.test.ts
+++ b/scripts/scrollSyncInput.test.ts
@@ -2,13 +2,24 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { callbackBodies } from './sourceTree.js';
+
+// The effect is identified by what it does — it is the one that reads
+// `onscrollsync` — not by where its text starts and stops.
+//
+// It used to be sliced between `'&& onscrollsync)'` and `'\n\t$effect(() => {'`,
+// and both halves of that were the same kind of fragile. The start anchor had
+// already drifted once, silently: the original marker spelled the whole guard
+// condition, the effect gained an `editorReady &&` term when Monaco moved behind
+// a dynamic import, and the slice became empty rather than failing — which is
+// what the shortened anchor and its `notEqual(-1)` were added for. The end
+// anchor never got that guard, and it depends on the *next* effect being
+// tab-indented and spelled `$effect(() => {`; write it any other way and this
+// file silently starts asserting about the rest of the component.
 const editor = readFileSync('src/lib/components/Editor.svelte', 'utf8');
-// Anchor on the tail of the guard, not the whole condition: the effect gained an
-// `editorReady &&` term when Monaco moved behind a dynamic import, and an
-// exact-match marker silently sliced an empty string instead of failing loudly.
-const syncStart = editor.indexOf('&& onscrollsync)');
-assert.notEqual(syncStart, -1, 'expected to find the scroll-sync effect guard');
-const syncEffect = editor.slice(syncStart, editor.indexOf('\n\t$effect(() => {', syncStart + 1));
+const syncEffects = callbackBodies(editor, '$effect').filter((body) => body.includes('onscrollsync'));
+assert.equal(syncEffects.length, 1, `expected exactly one $effect reading onscrollsync (got ${syncEffects.length})`);
+const syncEffect = syncEffects[0];
 
 test('typing does not initiate split scroll synchronization', () => {
 	assert.match(syncEffect, /editor\.onDidScrollChange/);

--- a/scripts/settingsPersistence.test.ts
+++ b/scripts/settingsPersistence.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { callbackBodies, sliceBetween } from './sourceTree.js';
+
 /*
  * `settings.svelte.ts` is a runes module, so it cannot be imported the way the
  * other suites import plain utils. Node's test runner gives every file its own
@@ -399,8 +401,7 @@ test('spin buttons clamp with the same rules as typing', () => {
 test('numeric setting inputs are one-way bound and commit through the clamp', () => {
 	const numericInputIds = ['editor-font-size', 'editor-max-width', 'preview-font-size', 'code-font-size'];
 	for (const id of numericInputIds) {
-		const block = componentSource.slice(componentSource.indexOf(`id="${id}"`));
-		const input = block.slice(0, block.indexOf('/>'));
+		const input = sliceBetween(componentSource, `id="${id}"`, '/>');
 		assert.doesNotMatch(input, /bind:value/, `${id} still uses a two-way number binding`);
 		assert.match(input, /oninput=\{\(e\) => handleNumberInput\(/, `${id} does not validate input`);
 		assert.match(input, /onchange=\{\(e\) => commitNumberInput\(/, `${id} does not clamp on change`);
@@ -481,9 +482,13 @@ test('a stored language is validated against the catalogue', () => {
  */
 
 test('the open effect neither reads the app version nor re-enters itself', () => {
-	const effectStart = componentSource.indexOf('$effect(() => {\n\t\tif (show) {');
-	assert.ok(effectStart > 0, 'settings open effect not found');
-	const effectBody = componentSource.slice(effectStart, componentSource.indexOf('\n\t});', effectStart));
+	// The open effect is identified by what it reads, not by its indentation and
+	// closing brace: the previous anchors were `'$effect(() => {\n\t\tif (show) {'`
+	// and `'\n\t});'`, so reformatting the component silently moved this
+	// assertion onto a different span of source.
+	const openEffects = callbackBodies(componentSource, '$effect').filter((body) => /\bshow\b/.test(body));
+	assert.equal(openEffects.length, 1, `expected exactly one $effect gated on show (got ${openEffects.length})`);
+	const effectBody = openEffects[0];
 
 	// Reading a state it also writes is what made the effect re-run and
 	// re-capture the focus target from inside the dialog.

--- a/scripts/sourceTree.test.ts
+++ b/scripts/sourceTree.test.ts
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { callbackBodies, enclosingFunctionName, offsetOf, sliceBetween, sliceFrom } from './sourceTree.js';
+
+// scripts/sourceTree.ts is the plumbing four convention tests state their claims
+// through, so a hole in it is a hole in all of them at once, and it is invisible
+// from those files: they keep passing. Both holes below were real.
+//
+//  - `enclosingFunctionName` matched `\n\t…function NAME(` and nothing else. A
+//    raw `invoke('render_markdown')` inside `const f = async () => {}` was
+//    therefore attributed to the classic `function` above it, which in
+//    MarkdownViewer.svelte is the wrapper renderPipelineConvention.test.ts
+//    demands. Measured: the bypass planted, the whole suite green.
+//  - The `$effect` bodies monacoStartupGraph.test.ts checks were sliced with
+//    `/\$effect\(\(\) => \{([\s\S]*?)\n\t\}\);/`, which needs a tab-indented
+//    closing brace. Measured: a one-line effect merged into its successor and
+//    the ungated `editor` read inside it went unreported.
+//
+// So the forms are pinned here, on the helpers, where a regression is one
+// failure with a name rather than four tests quietly asserting nothing. These
+// run against string literals, not against `src/` — refactoring the app cannot
+// make them fail, and changing the helper is the only thing that can.
+
+/** `enclosingFunctionName` over one `<script>`, at the offset of `needle`. */
+function scopeOf(script: string, needle = 'HERE'): string | null {
+	const source = `<script lang="ts">\n${script}\n</script>\n`;
+	return enclosingFunctionName(source, offsetOf(source, needle));
+}
+
+test('every declaration form in src/ names its enclosing function', () => {
+	// The four shapes `src/` actually uses: 451 classic declarations, 74
+	// `const f = (…) =>` / `const f = async (…) =>`, the class methods in
+	// stores/, and object-literal shorthand (MarkdownViewer's `acceptNode`).
+	assert.equal(scopeOf('function classic() {\n\tHERE;\n}'), 'classic');
+	assert.equal(scopeOf('export async function exported() {\n\tHERE;\n}'), 'exported');
+	assert.equal(scopeOf('const arrow = () => {\n\tHERE;\n};'), 'arrow');
+	assert.equal(scopeOf('const asyncArrow = async (raw: string) => {\n\tHERE;\n};'), 'asyncArrow');
+	assert.equal(scopeOf('const typed: () => void = () => {\n\tHERE;\n};'), 'typed');
+	assert.equal(scopeOf('const expression = function () {\n\tHERE;\n};'), 'expression');
+	assert.equal(scopeOf('const named = function inner() {\n\tHERE;\n};'), 'inner');
+	assert.equal(scopeOf('const obj = {\n\tshorthand() {\n\t\tHERE;\n\t},\n};'), 'shorthand');
+	assert.equal(scopeOf('const obj = {\n\tprop: () => {\n\t\tHERE;\n\t},\n};'), 'prop');
+	assert.equal(scopeOf('class C {\n\tmethod() {\n\t\tHERE;\n\t}\n}'), 'method');
+	assert.equal(scopeOf('class C {\n\tfield = () => {\n\t\tHERE;\n\t};\n}'), 'field');
+	assert.equal(scopeOf('obj.assigned = () => {\n\tHERE;\n};'), 'assigned');
+
+	// The regression that motivated the rewrite: an arrow function declared
+	// after a classic one used to inherit the classic one's name.
+	assert.equal(
+		scopeOf('function wrapper() {\n\treturn 1;\n}\n\nconst bypass = async () => {\n\tHERE;\n};'),
+		'bypass',
+	);
+});
+
+test('an offset outside every named function has no enclosing name', () => {
+	assert.equal(scopeOf('const x = HERE;'), null);
+	assert.equal(scopeOf('function f() {\n\treturn 1;\n}\nconst x = HERE;'), null);
+
+	// An inline handler in the markup is not inside any named function either,
+	// so a caller comparing against a wrapper name fails on it rather than
+	// silently inheriting the last function declared above.
+	const markup = '<script lang="ts">\n\tfunction f() {}\n</script>\n\n<button onclick={() => HERE}>x</button>\n';
+	assert.equal(enclosingFunctionName(markup, offsetOf(markup, 'HERE')), null);
+});
+
+test('the innermost named function wins, and anonymous ones are transparent', () => {
+	assert.equal(scopeOf('function outer() {\n\tfunction inner() {\n\t\tHERE;\n\t}\n}'), 'inner');
+	assert.equal(scopeOf('function outer() {\n\tconst inner = () => {\n\t\tHERE;\n\t};\n}'), 'inner');
+
+	// Lexically still inside `outer`, which is what the callers ask about.
+	assert.equal(scopeOf('function outer() {\n\tqueue.then(() => {\n\t\tHERE;\n\t});\n}'), 'outer');
+});
+
+test('a callback body is its own body, whatever the closing brace looks like', () => {
+	// The exact hole: with no `\n\t});` of its own, the one-line effect used to
+	// merge into the next one — and the merged text carried the `editorReady`
+	// the first effect was missing.
+	const source = [
+		'<script lang="ts">',
+		'\t$effect(() => { if (editor) editor.layout(); });',
+		'\t$effect(() => {',
+		'\t\tif (editorReady) sync();',
+		'\t});',
+		'\t$effect.pre(() => {\n\t\tpre();\n\t});',
+		'</script>',
+	].join('\n');
+
+	assert.deepEqual(callbackBodies(source, '$effect'), [
+		'{ if (editor) editor.layout(); }',
+		'{\n\t\tif (editorReady) sync();\n\t}',
+	]);
+	assert.deepEqual(callbackBodies(source, '$effect.pre'), ['{\n\t\tpre();\n\t}']);
+	assert.deepEqual(callbackBodies(source, 'onMount'), []);
+});
+
+test('the parsers read .ts files as well as components', () => {
+	const module = 'export function fromModule() {\n\tHERE;\n}\n';
+	assert.equal(enclosingFunctionName(module, offsetOf(module, 'HERE')), 'fromModule');
+	assert.deepEqual(callbackBodies('queueMicrotask(() => {\n\trun();\n});\n', 'queueMicrotask'), ['{\n\trun();\n}']);
+});
+
+test('a missing anchor fails loudly instead of slicing from -1', () => {
+	// `'abc'.slice(-1)` is `'c'`, not `''` — which is why an unguarded
+	// `slice(indexOf(...))` produces a one-character subject that no
+	// `doesNotMatch` can fail against.
+	assert.equal('abc'.slice('abc'.indexOf('zzz')), 'c');
+
+	assert.throws(() => sliceFrom('abc', 'zzz'), /expected to find "zzz"/);
+	assert.throws(() => sliceBetween('abc', 'zzz', 'b'), /expected to find "zzz"/);
+	assert.throws(() => sliceBetween('abc', 'a', 'zzz'), /expected to find "zzz" after "a"/);
+	assert.throws(() => offsetOf('abc', 'zzz'), /expected to find "zzz"/);
+	assert.throws(() => offsetOf('abcb', 'b', 4), /expected to find "b"/);
+
+	assert.equal(sliceFrom('abc', 'b'), 'bc');
+	assert.equal(sliceBetween('abcd', 'b', 'd'), 'bc');
+	assert.equal(offsetOf('abcb', 'b', 2), 3);
+
+	// `end` is searched from the end of `start`, so an earlier occurrence of
+	// `end` is a failure rather than an empty subject.
+	assert.throws(() => sliceBetween('xabc', 'b', 'x'), /expected to find "x" after "b"/);
+});

--- a/scripts/sourceTree.ts
+++ b/scripts/sourceTree.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { parse } from 'svelte/compiler';
+
 // Shared plumbing for the few tests that have to read `src/` as text.
 //
 // They exist because some contracts are invisible to the compiler: a Tauri
@@ -50,6 +52,22 @@ export function sliceBetween(source: string, start: string, end: string): string
 	return source.slice(from, to);
 }
 
+/**
+ * The offset of `marker` in `source`, which must be present.
+ *
+ * The third shape, for the assertions that compare two offsets rather than
+ * slice with them: `assert.ok(a < b)` reads as "a comes first" but is also
+ * satisfied by `a === -1`, so a marker that stopped existing turns the
+ * ordering claim into a claim about nothing — the same failure `sliceFrom`
+ * exists for, one operator away. `from` mirrors `String#indexOf`'s second
+ * argument for the "…after this point" cases.
+ */
+export function offsetOf(source: string, marker: string, from = 0): number {
+	const at = source.indexOf(marker, from);
+	assert.notEqual(at, -1, `expected to find ${JSON.stringify(marker)}`);
+	return at;
+}
+
 /** Every compilable source file under `dir`, with forward-slash paths. */
 export function walkSourceFiles(dir: string): string[] {
 	const out: string[] = [];
@@ -85,25 +103,206 @@ export function filesMatching(sources: SourceFile[], marker: RegExp): string[] {
  */
 export const SANITIZER_FILES = ['src/lib/utils/richContent.ts', 'src/lib/utils/sanitize.ts'];
 
+// ------------------------------------------------------------ syntax, parsed
+//
+// The three helpers below answer questions about *scope* — "which function is
+// this offset inside", "what is the body of this callback". Those were regexes
+// until they were shown to be answerable by writing the code differently:
+//
+//   const renderRawBypass = async (raw: string) => {
+//       return (await invoke('render_markdown', { content: raw })) as string;
+//   };
+//
+// dropped into MarkdownViewer.svelte left the whole suite green, because
+// `enclosingFunctionName` matched `\n\t…function NAME(` and nothing else, so the
+// call was attributed to whichever `function` happened to precede it — which was
+// the wrapper the convention test demands. Fixing that by adding arrow functions
+// to the pattern fixes one spelling. The forms actually in `src/` are 451 classic
+// declarations, 74 `const f = (…) =>` / `const f = async (…) =>`, the class
+// methods in `stores/`, and object-literal shorthand (`acceptNode(node) {`) — and
+// the next contributor is free to invent a 5th.
+//
+// So the scope questions are answered from the real AST instead. `svelte/compiler`
+// is already a dependency and `homeTabRender.test.ts` already parses a component
+// with it; a function node is a function node whatever the spelling, and there is
+// no pattern left to write around. The cost is ~170ms for the largest component,
+// paid once per file thanks to the cache below.
+
+type FunctionScope = { start: number; end: number; name: string | null };
+
+/** Node kinds that introduce a function scope. */
+const FUNCTION_TYPES = new Set(['FunctionDeclaration', 'FunctionExpression', 'ArrowFunctionExpression']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+function offsetsOf(node: Record<string, unknown>): { start: number; end: number } | null {
+	return typeof node.start === 'number' && typeof node.end === 'number'
+		? { start: node.start, end: node.end }
+		: null;
+}
+
 /**
- * The name of the top-level `<script>`/module function whose body contains
- * `index`, or null if the offset sits outside every function.
+ * The parsed component, plus the shift from AST offsets back to `text` offsets.
+ *
+ * A `.ts` file is not a component, so it is wrapped in a `<script>` before
+ * parsing and the wrapper's length is subtracted from every offset afterwards.
+ * Svelte's parser reads TypeScript in a `lang="ts"` block, which is what every
+ * `.svelte` file in `src/` uses anyway.
+ */
+const parseCache = new Map<string, { root: unknown; shift: number }>();
+
+function parsedSource(text: string): { root: unknown; shift: number } {
+	const cached = parseCache.get(text);
+	if (cached) return cached;
+
+	const prefix = '<script lang="ts">\n';
+	const isComponent = /<script[\s>]/.test(text);
+	const parsed = {
+		root: parse(isComponent ? text : `${prefix}${text}\n</script>`, { modern: true }) as unknown,
+		shift: isComponent ? 0 : -prefix.length,
+	};
+	parseCache.set(text, parsed);
+	return parsed;
+}
+
+/** Depth-first walk of every node in the tree, with the binding name in scope. */
+function walkAst(
+	node: unknown,
+	visit: (node: Record<string, unknown>, boundName: string | null) => void,
+	boundName: string | null = null,
+	seen: Set<object> = new Set(),
+): void {
+	if (Array.isArray(node)) {
+		for (const child of node) walkAst(child, visit, boundName, seen);
+		return;
+	}
+	if (!isRecord(node) || seen.has(node)) return;
+	seen.add(node);
+
+	if (typeof node.type === 'string') visit(node, boundName);
+
+	for (const [key, value] of Object.entries(node)) {
+		if (key === 'loc' || key === 'range' || key === 'parent' || key === 'metadata') continue;
+		walkAst(value, visit, nameBoundTo(node, key), seen);
+	}
+}
+
+/** `foo` for `const foo = …`, `{ foo: … }`, `foo() {}`, `x.foo = …`. */
+function nameBoundTo(parent: Record<string, unknown>, key: string): string | null {
+	switch (parent.type) {
+		case 'VariableDeclarator':
+			return key === 'init' ? identifierName(parent.id) : null;
+		case 'Property':
+		case 'PropertyDefinition':
+		case 'MethodDefinition':
+			return key === 'value' ? identifierName(parent.key) : null;
+		case 'AssignmentExpression':
+			return key === 'right' ? identifierName(parent.left) : null;
+		default:
+			return null;
+	}
+}
+
+function identifierName(node: unknown): string | null {
+	if (!isRecord(node)) return null;
+	switch (node.type) {
+		case 'Identifier':
+			return typeof node.name === 'string' ? node.name : null;
+		case 'PrivateIdentifier':
+			return typeof node.name === 'string' ? `#${node.name}` : null;
+		case 'Literal':
+			return typeof node.value === 'string' ? node.value : null;
+		case 'MemberExpression':
+			return identifierName(node.property);
+		default:
+			return null;
+	}
+}
+
+const scopeCache = new Map<string, FunctionScope[]>();
+
+/** Every function scope in `text`, outermost first, with the name it is bound to. */
+function functionScopes(text: string): FunctionScope[] {
+	const cached = scopeCache.get(text);
+	if (cached) return cached;
+
+	const { root, shift } = parsedSource(text);
+	const scopes: FunctionScope[] = [];
+	walkAst(root, (node, boundName) => {
+		if (typeof node.type !== 'string' || !FUNCTION_TYPES.has(node.type)) return;
+		const span = offsetsOf(node);
+		if (!span) return;
+		scopes.push({
+			start: span.start + shift,
+			end: span.end + shift,
+			name: identifierName(node.id) ?? boundName,
+		});
+	});
+	scopes.sort((a, b) => a.start - b.start || b.end - a.end);
+
+	scopeCache.set(text, scopes);
+	return scopes;
+}
+
+/**
+ * The name of the innermost *named* function whose body contains `index`, or
+ * null if the offset sits outside every named function.
  *
  * Used instead of "the two strings appear within N characters of each other":
  * a proximity window silently stops guarding when the function grows, and it
- * cannot see a *second* call site that escaped the wrapper entirely. Both files
- * this serves declare their functions at one level of indentation, which is
- * what makes the enclosing function findable without parsing braces (and
- * without being fooled by braces inside strings, regexes or Svelte templates).
+ * cannot see a *second* call site that escaped the wrapper entirely.
+ *
+ * Anonymous functions are transparent rather than fatal: a call inside
+ * `.then(() => …)` inside `renderMarkdownPreview` is still lexically inside
+ * `renderMarkdownPreview`, which is the question the callers ask. An offset
+ * inside an anonymous function with no named function above it — an inline
+ * `onclick={() => …}` in the markup, say — is null, and a caller comparing
+ * against a wrapper name fails loudly on it.
  */
 export function enclosingFunctionName(text: string, index: number): string | null {
-	const declarations = [...text.matchAll(/\n\t(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(/g)];
-	let enclosing: string | null = null;
-	for (const declaration of declarations) {
-		if (declaration.index! > index) break;
-		enclosing = declaration[1];
+	let name: string | null = null;
+	for (const scope of functionScopes(text)) {
+		if (scope.start > index) break;
+		if (index < scope.end && scope.name) name = scope.name;
 	}
-	return enclosing;
+	return name;
+}
+
+/**
+ * The source text of each function argument passed to `callee(…)`, braces
+ * included.
+ *
+ * For the checks that state something about the *body* of a callback — every
+ * `$effect` in Editor.svelte reads `editorReady` before it touches `editor`.
+ * Slicing those out with `/\$effect\(\(\) => \{([\s\S]*?)\n\t\}\);/` was a
+ * demonstrated hole: an effect written on one line has no `\n\t});` of its own,
+ * so the lazy match ran on to the *next* effect's closing brace and returned
+ * both effects as one body — whose text contains the `editorReady` the first
+ * half was missing. Verified: a planted
+ * `$effect(() => { if (editor) editor.layout(); });` passed that check, and the
+ * `effects.length >= 5` guard did not notice because the merge kept the count at
+ * six.
+ */
+export function callbackBodies(text: string, callee: string): string[] {
+	const { root, shift } = parsedSource(text);
+	const bodies: string[] = [];
+
+	walkAst(root, (node) => {
+		if (node.type !== 'CallExpression' || !isRecord(node.callee)) return;
+		const target = offsetsOf(node.callee);
+		if (!target || text.slice(target.start + shift, target.end + shift) !== callee) return;
+
+		for (const argument of Array.isArray(node.arguments) ? node.arguments : []) {
+			if (!isRecord(argument) || typeof argument.type !== 'string') continue;
+			if (!FUNCTION_TYPES.has(argument.type) || !isRecord(argument.body)) continue;
+			const body = offsetsOf(argument.body);
+			if (body) bodies.push(text.slice(body.start + shift, body.end + shift));
+		}
+	});
+
+	return bodies;
 }
 
 /** Byte offsets of every `name(` call in `text`, skipping import statements. */

--- a/scripts/tabTransfer.test.ts
+++ b/scripts/tabTransfer.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { sliceBetween } from './sourceTree.js';
+
 import type { Tab } from '../src/lib/stores/tabs.svelte.js';
 import {
 	buildTransferredTab,
@@ -208,9 +210,7 @@ test('file-backed arrivals keep their title', () => {
 // checked statically; all decision logic above is exercised directly.
 test('insertTransferredTab is a thin wrapper: build, push, activate, return the id', () => {
 	const tabs = readFileSync('src/lib/stores/tabs.svelte.ts', 'utf8');
-	const start = tabs.indexOf('insertTransferredTab(');
-	assert.ok(start !== -1, 'insertTransferredTab not found');
-	const fn = tabs.slice(start, tabs.indexOf('closeTab(', start));
+	const fn = sliceBetween(tabs, 'insertTransferredTab(', 'closeTab(');
 
 	assert.match(fn, /buildTransferredTab\(/);
 	// untitled re-numbering uses this window's titles and localized base
@@ -224,7 +224,7 @@ test('insertTransferredTab is a thin wrapper: build, push, activate, return the 
 
 test('serializeState still persists window shape only (untouched by transfer)', () => {
 	const tabs = readFileSync('src/lib/stores/tabs.svelte.ts', 'utf8');
-	const fn = tabs.slice(tabs.indexOf('serializeState()'), tabs.indexOf('restoreState('));
+	const fn = sliceBetween(tabs, 'serializeState()', 'restoreState(');
 	assert.doesNotMatch(fn, /rawContent/);
 	assert.doesNotMatch(fn, /TransferableTab/);
 });
@@ -234,7 +234,7 @@ test('source removal waits for destination completion', () => {
 	const session = readFileSync('src/lib/sessions/windowSession.svelte.ts', 'utf8');
 
 	assert.match(broker, /pub fn complete_detached_tab/);
-	const claim = broker.slice(broker.indexOf('pub fn claim_detached_tab'), broker.indexOf('pub fn complete_detached_tab'));
+	const claim = sliceBetween(broker, 'pub fn claim_detached_tab', 'pub fn complete_detached_tab');
 	assert.doesNotMatch(claim, /tab-transfer-claimed/);
 	assert.match(session, /invoke\('complete_detached_tab', \{ token \}\)/);
 });

--- a/scripts/tabTransferHandoff.test.ts
+++ b/scripts/tabTransferHandoff.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { sliceBetween, sliceFrom } from './sourceTree.js';
+
 const session = readFileSync(new URL('../src/lib/sessions/windowSession.svelte.ts', import.meta.url), 'utf8');
 const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
 const broker = readFileSync(new URL('../src-tauri/src/tab_transfer.rs', import.meta.url), 'utf8');
@@ -14,7 +16,7 @@ const broker = readFileSync(new URL('../src-tauri/src/tab_transfer.rs', import.m
 test('the source keeps waiting when the destination has already claimed', () => {
 	// The 15s timeout is a guess about a window that may simply be slow to
 	// render. Cancelling regardless is what stranded a copy on each side.
-	const cancel = session.slice(session.indexOf('const cancel = async ()'));
+	const cancel = sliceFrom(session, 'const cancel = async ()');
 	assert.match(cancel, /outcome\.cancelled/);
 	assert.match(cancel, /outcome\.claimed/);
 	assert.match(cancel, /if \(!outcome\.cancelled && outcome\.claimed\) return;/);
@@ -24,10 +26,7 @@ test('the destination releases its claim when it cannot finish', () => {
 	// Because a claimed transfer is immune to the source's timeout, the
 	// destination is the only party that can end a claim it cannot complete.
 	assert.match(session, /async function releaseClaim\(token: string\)/);
-	const accept = session.slice(
-		session.indexOf('async function acceptOfferedTransfer'),
-		session.indexOf('async function claimTransferredTab'),
-	);
+	const accept = sliceBetween(session, 'async function acceptOfferedTransfer', 'async function claimTransferredTab');
 	// Invalid payload, a refusing destination, and a thrown render all release.
 	assert.equal((accept.match(/releaseClaim\(token\)/g) ?? []).length, 3);
 	assert.match(accept, /if \(claimed\) await releaseClaim\(token\);/);
@@ -36,10 +35,7 @@ test('the destination releases its claim when it cannot finish', () => {
 test('a claim is distinguished from "no such token"', () => {
 	// Releasing a token that was never claimed would be a no-op at best and a
 	// cancel of someone else's transfer at worst.
-	const accept = session.slice(
-		session.indexOf('async function acceptOfferedTransfer'),
-		session.indexOf('async function claimTransferredTab'),
-	);
+	const accept = sliceBetween(session, 'async function acceptOfferedTransfer', 'async function claimTransferredTab');
 	assert.match(accept, /if \(payload === null\)/);
 	assert.match(accept, /claimed = true;/);
 });
@@ -47,10 +43,7 @@ test('a claim is distinguished from "no such token"', () => {
 test('a failed render undoes the inserted tab', () => {
 	// The tab must exist before it can be rendered, so the destination owns a
 	// document the source still shows until the render succeeds.
-	const accept = viewer.slice(
-		viewer.indexOf('acceptTransferredTab: async (snapshot)'),
-		viewer.indexOf('onError: (message, error)'),
-	);
+	const accept = sliceBetween(viewer, 'acceptTransferredTab: async (snapshot)', 'onError: (message, error)');
 	assert.match(accept, /\} catch \(error\) \{\s*\n\s*tabManager\.closeTab\(id\);\s*\n\s*throw error;/);
 	assert.match(accept, /if \(isDisposed\) \{\s*\n\s*tabManager\.closeTab\(id\);/);
 });

--- a/scripts/truncatedBufferGuard.test.ts
+++ b/scripts/truncatedBufferGuard.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { sliceBetween, sliceFrom } from './sourceTree.js';
+
 // A markdown file larger than 50KB is opened twice: `open_markdown_preview`
 // returns the first 50KB so something renders immediately, and a background
 // `read_file_content` fills in the rest. Between the two, the tab's ONLY
@@ -241,8 +243,7 @@ test('entering split view completes a partial buffer instead of trusting it', ()
 	// The old guard was `!tab.rawContent`, which a partial buffer satisfies:
 	// split view opened on the truncated text, the first keystroke made it
 	// dirty, and auto-save wrote it back 1.5s later.
-	const split = viewer.slice(viewer.indexOf('async function toggleSplitView'));
-	const enter = split.slice(0, split.indexOf('} else {'));
+	const enter = sliceBetween(viewer, 'async function toggleSplitView', '} else {');
 	assert.match(enter, /ensureFullContent/);
 	// And it has to stop when the buffer could not be completed, rather than
 	// opening an editor over the partial text anyway.
@@ -255,16 +256,27 @@ test('entering split view completes a partial buffer instead of trusting it', ()
 test('a partial buffer cannot be handed to another window', () => {
 	// The destination rebuilds the tab from the payload alone and has no way
 	// to know the text is incomplete, so its auto-save would truncate the file.
-	const canTransfer = viewer.slice(viewer.indexOf('canTransfer: (tabId)'), viewer.indexOf('transferPayload:'));
+	const canTransfer = sliceBetween(viewer, 'canTransfer: (tabId)', 'transferPayload:');
 	assert.match(canTransfer, /isTruncated/);
-	const detach = viewer.slice(viewer.indexOf('async function handleDetach'), viewer.indexOf('async function carryActiveTabToNextWindow'));
+	const detach = sliceBetween(viewer, 'async function handleDetach', 'async function carryActiveTabToNextWindow');
 	assert.match(detach, /ensureFullContent/);
 });
 
 test('front matter edits in preview mode complete the buffer first', () => {
 	for (const entry of ['async function handleFrontMatterEdit', 'async function handleFrontMatterListChange']) {
-		const handler = viewer.slice(viewer.indexOf(entry));
-		const body = handler.slice(0, handler.indexOf('\n\tfunction ') + 1 || handler.indexOf('\n\tasync function ') + 1);
+		// One handler is followed by a `function`, the other by an `async
+		// function`, so the slice ends at whichever comes first. The previous
+		// expression was `indexOf(a) + 1 || indexOf(b) + 1`, which reads as
+		// "or else" but is really "or else, if the first is absent *or at
+		// offset 0*" — and when the first form appeared later in the file than
+		// the second it won anyway, widening the body past the handler and
+		// letting a neighbouring function satisfy the `assert.match` below.
+		const handler = sliceFrom(viewer, entry);
+		const ends = ['\n\tfunction ', '\n\tasync function ']
+			.map((marker) => handler.indexOf(marker))
+			.filter((at) => at !== -1);
+		assert.ok(ends.length > 0, `${entry} must be followed by a declaration that bounds it`);
+		const body = handler.slice(0, Math.min(...ends));
 		assert.match(body, /ensureFullContent/, `${entry} must not edit a partial buffer`);
 	}
 });

--- a/scripts/untitledTitle.test.ts
+++ b/scripts/untitledTitle.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { sliceBetween } from './sourceTree.js';
+
 import { nextUntitledTitle } from '../src/lib/utils/untitledTitle.js';
 
 // Untitled tabs get distinct numbered titles ("Untitled 1", "Untitled 2", …)
@@ -40,6 +42,6 @@ test('new tabs are created with numbered untitled titles', () => {
 	const tabs = readFileSync('src/lib/stores/tabs.svelte.ts', 'utf8');
 	assert.match(tabs, /nextUntitledTitle\(/);
 	// both creation paths go through the helper
-	const addNewTab = tabs.slice(tabs.indexOf('addNewTab()'), tabs.indexOf('addHomeTab()'));
+	const addNewTab = sliceBetween(tabs, 'addNewTab()', 'addHomeTab()');
 	assert.match(addNewTab, /nextUntitledTitle\(/);
 });

--- a/scripts/viewModeWithoutSaving.test.ts
+++ b/scripts/viewModeWithoutSaving.test.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
+
+import { offsetOf, sliceBetween, sliceFrom } from './sourceTree.js';
 import ts from 'typescript';
 
 // Issue #168, second report by @dayeggpi: "allow user to switch to rendered
@@ -65,7 +67,7 @@ function pluck(name: string, required = true): string {
 		assert.ok(!required, `expected MarkdownViewer.svelte to define ${name}`);
 		return '';
 	}
-	let i = viewer.indexOf('{', viewer.indexOf(')', start));
+	let i = offsetOf(viewer, '{', offsetOf(viewer, ')', start));
 	let depth = 0;
 	for (; i < viewer.length; i++) {
 		const c = viewer[i];
@@ -423,12 +425,12 @@ test('closing the window still reviews unsaved tabs', () => {
 	// `appExit` and the window close handler are untouched by this change; the
 	// confirmation there is load-bearing because the buffer dies with the
 	// window. Source-level, because they are wired to Tauri window events.
-	const exit = viewer.slice(viewer.indexOf('async function appExit()'), viewer.indexOf('async function toggleEdit'));
+	const exit = sliceBetween(viewer, 'async function appExit()', 'async function toggleEdit');
 	assert.match(exit, /tabManager\.tabs\.some\(\(t\) => t\.isDirty \|\| \(t\.path === '' && t\.rawContent\.trim\(\) !== ''\)\)/);
 	assert.match(exit, /modal\.areYouSureYouWantToExit/);
 
-	const closeHandler = viewer.slice(viewer.indexOf('appWindow.onCloseRequested'));
-	assert.match(closeHandler.slice(0, closeHandler.indexOf('onDragDropEvent')), /await canCloseTab\(dirty\.id\)/);
+	const closeHandler = sliceBetween(viewer, 'appWindow.onCloseRequested', 'onDragDropEvent');
+	assert.match(closeHandler, /await canCloseTab\(dirty\.id\)/);
 });
 
 test('the view toggles no longer re-read the file to leave an editable pane', () => {
@@ -436,12 +438,12 @@ test('the view toggles no longer re-read the file to leave an editable pane', ()
 	// the disk again. `renderTabPreviewFromRaw` is the shared "render THIS
 	// tab's buffer under its own path" helper (it also serves the PDF export).
 	const toggleEdit = pluck('toggleEdit');
-	const leaveEditMode = toggleEdit.slice(0, toggleEdit.indexOf('// Switch to edit'));
+	const leaveEditMode = toggleEdit.slice(0, offsetOf(toggleEdit, '// Switch to edit'));
 	assert.doesNotMatch(leaveEditMode, /loadMarkdown/);
 	assert.doesNotMatch(leaveEditMode, /askCustom/);
 
 	const toggleSplit = pluck('toggleSplitView');
-	const closeSplit = toggleSplit.slice(toggleSplit.indexOf('setSplitEnabled(tab.id, false)'));
+	const closeSplit = sliceFrom(toggleSplit, 'setSplitEnabled(tab.id, false)');
 	assert.doesNotMatch(closeSplit, /loadMarkdown/);
 	assert.doesNotMatch(toggleSplit, /askCustom/);
 });

--- a/scripts/windowClosePerTab.test.ts
+++ b/scripts/windowClosePerTab.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { existsSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { offsetOf, sliceBetween, sliceFrom } from './sourceTree.js';
+
 const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
 const documentSessionPath = 'src/lib/sessions/documentSession.svelte.ts';
 const documentSession = existsSync(documentSessionPath) ? readFileSync(documentSessionPath, 'utf8') : '';
@@ -13,9 +15,7 @@ const documentSession = existsSync(documentSessionPath) ? readFileSync(documentS
 // stays open with the remaining tabs.
 
 function closeHandler(): string {
-	const start = viewer.indexOf('appWindow.onCloseRequested');
-	assert.ok(start !== -1, 'close handler registration not found');
-	return viewer.slice(start, viewer.indexOf('onDragDropEvent', start));
+	return sliceBetween(viewer, 'appWindow.onCloseRequested', 'onDragDropEvent');
 }
 
 test('the aggregate unsaved-files modal is gone from the close handler', () => {
@@ -42,18 +42,17 @@ test('cancelling the per-tab dialog stops the walk and keeps the window open', (
 
 test('the close is prevented synchronously before the per-tab walk', () => {
 	const handler = closeHandler();
-	const branchStart = handler.indexOf('if (dirtyTabs.length > 0) {');
-	assert.ok(branchStart !== -1, 'dirty branch not found');
-	const prevent = handler.indexOf('event.preventDefault()', branchStart);
-	const walk = handler.indexOf('canCloseTab(dirty.id)', branchStart);
-	assert.ok(prevent !== -1 && walk !== -1 && prevent < walk);
+	const branchStart = offsetOf(handler, 'if (dirtyTabs.length > 0) {');
+	const prevent = offsetOf(handler, 'event.preventDefault()', branchStart);
+	const walk = offsetOf(handler, 'canCloseTab(dirty.id)', branchStart);
+	assert.ok(prevent < walk, 'the close is prevented before the walk starts');
 });
 
 test('the window closes only after every dirty tab is resolved', () => {
 	const handler = closeHandler();
-	const walk = handler.indexOf('canCloseTab(dirty.id)');
-	const close = handler.indexOf('appWindow.close()', walk);
-	assert.ok(walk !== -1 && close !== -1 && walk < close);
+	const walk = offsetOf(handler, 'canCloseTab(dirty.id)');
+	const close = offsetOf(handler, 'appWindow.close()', walk);
+	assert.ok(walk < close, 'the window closes after the walk, not during it');
 });
 
 test('a second close request cannot start a competing walk', () => {
@@ -75,13 +74,12 @@ test('the walk proceeds in strict tab-strip order', () => {
 });
 
 test('the untitled save dialog prefills the numbered tab title', () => {
-	const fn = documentSession.slice(documentSession.indexOf('async function saveContent'));
-	const scope = fn.slice(0, fn.indexOf('async function saveContentAs'));
+	const scope = sliceBetween(documentSession, 'async function saveContent', 'async function saveContentAs');
 	assert.match(scope, /defaultPath: tab\.title/);
 });
 
 test('save-as keeps snapshot-based dirty tracking in documentSession', () => {
-	const fn = documentSession.slice(documentSession.indexOf('async function saveContentAs'));
+	const fn = sliceFrom(documentSession, 'async function saveContentAs');
 	assert.match(fn, /const snapshot = tab\.rawContent;/);
 	assert.match(fn, /tab\.isDirty = tab\.rawContent !== snapshot;/);
 });

--- a/scripts/windowStateRestore.test.ts
+++ b/scripts/windowStateRestore.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { offsetOf, sliceBetween } from './sourceTree.js';
+
 const tabs = readFileSync('src/lib/stores/tabs.svelte.ts', 'utf8');
 const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
 const session = readFileSync('src/lib/sessions/windowSession.svelte.ts', 'utf8');
@@ -12,16 +14,13 @@ const documentSession = readFileSync('src/lib/sessions/documentSession.svelte.ts
 // always lives on disk — the snapshot never carries rawContent, so unsaved
 // changes are handled exclusively by the per-tab close dialogs.
 
-function slice(source: string, from: string, to: string): string {
-	const start = source.indexOf(from);
-	assert.ok(start !== -1, `${from} not found`);
-	const end = source.indexOf(to, start);
-	assert.ok(end !== -1, `${to} not found after ${from}`);
-	return source.slice(start, end);
+/** The `onCloseRequested` registration, up to the next window listener. */
+function closeHandler(): string {
+	return sliceBetween(viewer, 'appWindow.onCloseRequested', 'onDragDropEvent');
 }
 
 test('serializeState writes window state only', () => {
-	const fn = slice(tabs, 'serializeState()', 'restoreState(');
+	const fn = sliceBetween(tabs, 'serializeState()', 'restoreState(');
 	assert.match(fn, /version: 2/);
 	// untitled tabs have no disk backing; they are resolved at close, never
 	// persisted — and neither is the home tab, whose path is the sentinel
@@ -36,7 +35,7 @@ test('serializeState writes window state only', () => {
 });
 
 test('restoreState rebuilds clean tabs and drops legacy untitled entries', () => {
-	const fn = slice(tabs, 'restoreState(', 'addTab(');
+	const fn = sliceBetween(tabs, 'restoreState(', 'addTab(');
 	// path is the identity of a restored tab; entries without a real file path
 	// are skipped, including 'HOME' entries left by older builds
 	assert.match(fn, /!hasRealFilePath\(saved\.path\)\) continue;/);
@@ -48,7 +47,7 @@ test('restoreState rebuilds clean tabs and drops legacy untitled entries', () =>
 });
 
 test('startup restore reads content from disk, not from the snapshot', () => {
-	const restore = slice(session, 'async function restore', 'async function claimTransferredTab');
+	const restore = sliceBetween(session, 'async function restore', 'async function claimTransferredTab');
 	assert.match(restore, /read_file_content/);
 	// a file that cannot be read keeps its tab and its place in the snapshot —
 	// dropping it here also dropped it from the snapshot written moments later
@@ -61,18 +60,15 @@ test('startup restore reads content from disk, not from the snapshot', () => {
 });
 
 test('the discard choice reverts the tab to its last saved content', () => {
-	const fn = slice(documentSession, 'async function canCloseTab', 'return { loadMarkdown');
+	const fn = sliceBetween(documentSession, 'async function canCloseTab', 'return { loadMarkdown');
 	assert.match(fn, /tab\.rawContent = tab\.originalContent;/);
 	assert.match(fn, /tab\.isDirty = false;/);
 });
 
 test('the close flow resolves dirty tabs before serializing window state', () => {
-	const handlerStart = viewer.indexOf('appWindow.onCloseRequested');
-	const handler = viewer.slice(handlerStart, viewer.indexOf('onDragDropEvent', handlerStart));
-	const walk = handler.indexOf('canCloseTab(dirty.id)');
-	const persist = handler.indexOf('persistWindowState()');
-	assert.ok(walk !== -1, 'per-tab walk not found');
-	assert.ok(persist !== -1, 'window-state serialization not found');
+	const handler = closeHandler();
+	const walk = offsetOf(handler, 'canCloseTab(dirty.id)');
+	const persist = offsetOf(handler, 'persistWindowState()');
 	assert.ok(walk < persist, 'dirty tabs must be resolved before the snapshot is written');
 });
 
@@ -84,8 +80,7 @@ test('v2 snapshots are invisible to legacy builds (Rust file, localStorage keys 
 	// process and loses a flush race when the last window's close ends the
 	// process); both localStorage keys are removed on write, so a downgraded
 	// build starts a fresh session instead of misreading anything.
-	const persistStart = session.indexOf('async function persistState');
-	const scope = session.slice(persistStart, session.indexOf('async function restore', persistStart));
+	const scope = sliceBetween(session, 'async function persistState', 'async function restore');
 	assert.match(scope, /invoke\('save_window_state'/);
 	assert.doesNotMatch(scope, /setItem\(/);
 	assert.match(scope, /removeItem\(options\.windowStateKey\)/);
@@ -104,28 +99,24 @@ test('v2 snapshots are invisible to legacy builds (Rust file, localStorage keys 
 	// The shared helper clears the Rust snapshot and both localStorage keys.
 	// Only explicit exit uses it: a restore that goes wrong must never delete
 	// the record of which documents were open (interruptedSessionRestore.test.ts).
-	const discardStart = session.indexOf('async function discardPersistedState');
-	const discardScope = session.slice(discardStart, session.indexOf('\n\t}\n\n\tfunction readProgress', discardStart));
+	const discardScope = sliceBetween(session, 'async function discardPersistedState', '\n\t}\n\n\tfunction readProgress');
 	assert.match(discardScope, /clear_window_state/);
 	assert.match(discardScope, /removeItem\(options\.windowStateKey\)/);
 	assert.match(discardScope, /removeItem\(options\.legacyStateKey\)/);
 	// Explicit exit delegates to the same cleanup path.
-	const exitFn = viewer.slice(viewer.indexOf('async function appExit'));
-	const exitScope = exitFn.slice(0, exitFn.indexOf('\n\t}'));
+	const exitScope = sliceBetween(viewer, 'async function appExit', '\n\t}');
 	assert.match(exitScope, /await discardPersistedWindowState\(\)/);
 });
 
 test('with restore enabled resolved titled tabs stay open for the snapshot', () => {
-	const handlerStart = viewer.indexOf('appWindow.onCloseRequested');
-	const handler = viewer.slice(handlerStart, viewer.indexOf('onDragDropEvent', handlerStart));
+	const handler = closeHandler();
 	// tabs are closed one-by-one only when restore is off (or untitled)
 	assert.match(handler, /restoreStateOnReopen \|\| dirty\.path === ''/);
 });
 
 test('auto-save fast path silently saves titled tabs before the walk', () => {
-	const handlerStart = viewer.indexOf('appWindow.onCloseRequested');
-	const handler = viewer.slice(handlerStart, viewer.indexOf('onDragDropEvent', handlerStart));
-	const fastPath = handler.indexOf('settings.autoSave && !settings.confirmBeforeSave');
-	const walk = handler.indexOf('canCloseTab(dirty.id)');
-	assert.ok(fastPath !== -1 && walk !== -1 && fastPath < walk);
+	const handler = closeHandler();
+	const fastPath = offsetOf(handler, 'settings.autoSave && !settings.confirmBeforeSave');
+	const walk = offsetOf(handler, 'canCloseTab(dirty.id)');
+	assert.ok(fastPath < walk, 'the silent save runs before the per-tab walk');
 });

--- a/scripts/windowTags.test.ts
+++ b/scripts/windowTags.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { offsetOf } from './sourceTree.js';
+
 const tabs = readFileSync('src/lib/stores/tabs.svelte.ts', 'utf8');
 const runtime = readFileSync('src-tauri/src/window_runtime.rs', 'utf8');
 const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
@@ -29,10 +31,10 @@ test('the title bar exposes a named color chip and pin control', () => {
 });
 
 test('the Home menu groups window organization below export actions', () => {
-	const exportIndex = titleBar.indexOf("t('menu.exportPdf', currentLanguage)");
-	const tagIndex = titleBar.indexOf("t('menu.setWindowTag', currentLanguage)");
-	const mergeIndex = titleBar.indexOf("t('menu.mergeAllWindows', currentLanguage)");
-	const exitIndex = titleBar.indexOf("t('menu.exit', currentLanguage)");
+	const exportIndex = offsetOf(titleBar, "t('menu.exportPdf', currentLanguage)");
+	const tagIndex = offsetOf(titleBar, "t('menu.setWindowTag', currentLanguage)");
+	const mergeIndex = offsetOf(titleBar, "t('menu.mergeAllWindows', currentLanguage)");
+	const exitIndex = offsetOf(titleBar, "t('menu.exit', currentLanguage)");
 
 	assert.ok(exportIndex < tagIndex);
 	assert.ok(tagIndex < mergeIndex);

--- a/scripts/youtubeExternalFallback.test.ts
+++ b/scripts/youtubeExternalFallback.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { offsetOf, sliceBetween } from './sourceTree.js';
+
 const markdown = readFileSync('src/lib/utils/markdown.ts', 'utf8');
 const markdownViewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
 const tauriConfig = readFileSync('src-tauri/tauri.conf.json', 'utf8');
@@ -24,12 +26,15 @@ test('the app no longer permits YouTube frames', () => {
 });
 
 test('linked YouTube thumbnails are not intercepted by image zoom', () => {
-	const linkHandlerStart = markdownViewer.indexOf('async function handleLinkClick(e: MouseEvent)');
-	const linkHandler = markdownViewer.slice(linkHandlerStart, markdownViewer.indexOf('\n\tasync function toggleTaskCheckbox', linkHandlerStart));
-	const anchorGuard = linkHandler.indexOf("const a = target.closest('a');");
-	const imageZoom = linkHandler.indexOf("const img = target.closest('img');");
+	const linkHandler = sliceBetween(
+		markdownViewer,
+		'async function handleLinkClick(e: MouseEvent)',
+		'\n\tasync function toggleTaskCheckbox',
+	);
+	const anchorGuard = offsetOf(linkHandler, "const a = target.closest('a');");
+	const imageZoom = offsetOf(linkHandler, "const img = target.closest('img');");
 
-	assert.ok(anchorGuard !== -1 && imageZoom !== -1 && anchorGuard < imageZoom);
+	assert.ok(anchorGuard < imageZoom, 'the anchor branch claims the click before image zoom sees it');
 	assert.match(
 		linkHandler,
 		/if \(a\) \{[\s\S]*?if \(relativeMarkdownTarget\) \{[\s\S]*?return;[\s\S]*?\}\n\s*return;\n\s*\}\n\n\s*\/\/ media zoom handling/,


### PR DESCRIPTION
Two holes in the test tooling. They are independent; they share a PR because
`scripts/sourceTree.ts` is where both are fixed. Both were reproduced before
they were touched.

# 1. A convention test was bypassed by writing an arrow function

`enclosingFunctionName` decides which function an offset sits inside. It matched
one spelling:

```
\n\t(?:export\s+)?(?:async\s+)?function\s+NAME\s*\(
```

So a call site inside `const f = async () => {}` was attributed to whichever
classic `function` happened to precede it — and in `MarkdownViewer.svelte` the
function preceding the obvious place to add one is `renderMarkdownPreview`, the
exact wrapper the test demands.

## Measured, both ways

Planted immediately after `renderMarkdownPreview`:

```ts
const renderRawBypass = async (raw: string) => {
	return (await invoke('render_markdown', { content: raw })) as string;  // no front-matter strip
};
```

| | `npm test` |
|---|---|
| before | `tests 524  pass 524  fail 0` |
| after | `fail 1` — `actual: [ 'renderMarkdownPreview', 'renderRawBypass' ]` |

`renderPipelineConvention` and `singleImplementationConvention` were both green
with the bypass in place. Nothing else in the suite saw it either.

## The same weakness in monacoStartupGraph, confirmed

"every effect that drives the editor waits for `editorReady`" sliced effect
bodies with `/\$effect\(\(\) => \{([\s\S]*?)\n\t\}\);/`. That needs a
tab-indented `});` to end a body, so an effect written on one line has no
terminator of its own and the lazy match runs on to the *next* effect's:

```ts
$effect(() => { if (editor) editor.layout(); });   // planted in Editor.svelte
```

| | result |
|---|---|
| before | passes — the merged body carries the next effect's `editorReady` |
| after | fails: `an effect touching the editor is not gated on editorReady: { if (editor) editor.layout(); }` |

The `effects.length >= 5` vacuity guard did not notice, because merging two
effects into one body kept the count at six.

## Parsing, not a longer pattern

`svelte/compiler` is already a dependency and `homeTabRender.test.ts` already
parses a component with it. `enclosingFunctionName` and the new `callbackBodies`
now walk the real AST: `parse(source, { modern: true })`, collect every
`FunctionDeclaration` / `FunctionExpression` / `ArrowFunctionExpression` span
with the name it is bound to, and answer containment against that. Parses are
cached per source string; the largest component costs ~170ms once.

A survey of `src/` first, because the alternative was to widen the regex to
whatever is there today:

| form | count in `src/` |
|---|---|
| `function f()` / `export async function f()` | 451 |
| `const f = () => {}` / `const f = async () => {}` | 74 |
| class methods (`stores/`) | all of `TabManager` |
| object shorthand (`acceptNode(node) {`) | 2 |

A regex covering those four fails the next time someone writes a fifth. A
function node is a function node whatever the spelling, so there is no longer a
pattern to write around. The cost is one dependency the suite already had and
~170ms; the alternative saves that and keeps a hole whose size is "whatever
nobody thought of".

Two decisions inside it, both deliberate:

- **Anonymous functions are transparent.** A call inside `.then(() => …)` inside
  `renderMarkdownPreview` is still lexically inside `renderMarkdownPreview`,
  which is the question the callers ask. An offset with no named function above
  it at all — an inline `onclick={() => …}` in the markup — is `null`, and a
  caller comparing against a wrapper name fails loudly on it.
- **`.ts` files are supported** by wrapping them in a `<script>` before parsing
  and subtracting the wrapper length, so a caller that passes a store instead of
  a component gets an answer rather than a silent `null` everywhere.

`scripts/sourceTree.test.ts` (new) pins all twelve declaration forms, the
nesting rules, and the one-line-effect case against string literals rather than
against `src/` — refactoring the app cannot make it fail, and changing the
helper is the only thing that can.

## No violation was hiding behind the old regex

Both convention tests are green on the real tree after the tightening. The
bypass had to be planted to make either fail.

# 2. 71 unguarded slice and ordering bounds

`slice(x.indexOf(m))` with an absent `m` slices from -1, which yields the last
*character* of the file — so `assert.doesNotMatch` against it can never fail.
#432 fixed two instances and added `sliceFrom`/`sliceBetween`; the rest were
left.

## Re-derived, because #433 deleted 14 files since

At `e196547` (merge base), counting `indexOf` calls on source text whose result
becomes a slice bound or an ordering operand, with nothing asserting they are
not -1:

| | bound-forming `indexOf` | unguarded |
|---|---|---|
| `4251f0a` (#432 landed) | 113 | 74 |
| `e196547` (after #433) | 108 | 71 |
| this branch | 3 | 1 |

The remaining one is `assert.equal('abc'.slice('abc'.indexOf('zzz')), 'c')` in
the new unit test, which exists to demonstrate the defect.

155 raw `indexOf` bounds are replaced by 110 helper call sites across 31 files.
Seven files carried a private copy of `sliceBetween` under another name
(`sliceBlock`, `slice`, `pluck`, an IIFE) — those are deleted and the shared one
used, which is also how three of them acquired a guard on their end anchor.

## One new shape, `offsetOf`

The migration exposed a second form the two existing helpers do not cover:

```ts
const a = body.indexOf('foo');
const b = body.indexOf('bar');
assert.ok(a < b, 'foo comes first');
```

`a < b` reads as an ordering claim but is also satisfied by `a === -1`, so an
anchor that stopped existing turns it into a claim about nothing. `offsetOf`
asserts and returns; 56 of the migrated sites are this shape, which is what
justifies a third helper rather than a fourth copy of `assert.notEqual(…, -1)`.

Two sites had bespoke bounds that no helper covers and were rewritten in place:

- `truncatedBufferGuard.test.ts` ended a handler at
  `indexOf('\n\tfunction ') + 1 || indexOf('\n\tasync function ') + 1`. That
  reads as "or else" but is really "or else, if the first is absent *or at
  offset 0*", and when the first form appeared later in the file than the second
  it won anyway — widening the body past the handler, which for an
  `assert.match` is a false green. It now takes the earlier of the two that
  exist, and asserts at least one does.
- `renderProtocol.test.ts` sliced between `indexOf('$$')` and
  `lastIndexOf('$$')`; those coincide for a fixture with one `$$`, which is now
  a failure.

## Two anchors replaced by a parse instead of a guard

`scrollSyncInput.test.ts` — the file #432 named as the *prior* fix, and flagged
as still half-guarded — was sliced between `'&& onscrollsync)'` and
`'\n\t$effect(() => {'`. Its start anchor had already drifted once, silently,
when the effect gained an `editorReady &&` term; its end anchor never got a
guard and depended on the next effect's indentation. It now selects the one
`$effect` whose body reads `onscrollsync` and asserts there is exactly one.
`settingsPersistence.test.ts`'s open-effect anchor
(`'$effect(() => {\n\t\tif (show) {'`) is replaced the same way.

## Falsifiability, checked by breaking every anchor

Each string anchor passed to `sliceFrom` / `sliceBetween` / `offsetOf` was
corrupted in turn — `ZZNOPE` inserted before the closing quote — and its test
file run:

| | count |
|---|---|
| anchors mutated | 194 |
| failed naming the missing anchor | 193 |
| failed for another reason | 0 |
| did not fail | 1 |

The one that did not fail is the second argument of
`assert.throws(() => sliceBetween('abc', 'zzz', 'b'), /expected to find "zzz"/)`
in the new unit test — unreachable by construction, since the first anchor
throws first.

# Not covered

- **24 `indexOf` calls remain in `scripts/`, deliberately.** CSS and comment
  tokenizers that already branch on `-1` (`editorPdfExport`, `exportFoldParity`,
  `i18nCoverage`); `Array#indexOf` on DOM shims and event logs, where `-1` means
  "not a child" rather than "anchor missing"; and `exportSanitize.test.ts`,
  already guarded with messages more specific than `offsetOf`'s.
- **Three comment-skipping loops** (`foldStatePerDocument`,
  `viewModeWithoutSaving`) do `i = source.indexOf('\n', i)` with no guard. A
  `-1` there hangs the loop rather than passing a degenerate assertion, so it is
  a different failure mode; it cannot trigger while every source file ends with
  a newline. Left as is.
- **The AST helpers answer scope, not dataflow.** "The raw command is invoked
  from `renderMarkdownPreview`" is still lexical containment. That the value
  reaching it had its front matter stripped is not established here, and was not
  established by the regex either.
- **~25 sites still slice one function out by naming the next one**
  (`sliceBetween(viewer, 'async function a', 'async function b')`). They are
  guarded now, so a rename fails loudly instead of silently, but a
  `functionSource(text, name)` built on the same parse would remove the second
  anchor entirely. Not done here — it changes what those slices contain.
- **No behaviour change.** `src/` and `src-tauri/` are untouched;
  `npm test` (530), `npm run check` (631 files, 0 errors) and `npm run build`
  are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
