### PR TITLE
fix(export): gate the export menu on the buffer, not the render cache

### DIFF
--- a/scripts/renderedHtmlField.test.ts
+++ b/scripts/renderedHtmlField.test.ts
@@ -1,0 +1,458 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import { parse } from 'svelte/compiler';
+import ts from 'typescript';
+
+/*
+ * The Home menu decided whether to offer "Export as HTML" / "Export as PDF" by
+ * looking at `tab.content`, which is not the document. A `Tab` carries three
+ * same-shaped strings:
+ *
+ *   rawContent      the live Markdown — what the editor edits and what the
+ *                   exports read
+ *   originalContent that buffer as it last came off / went onto disk; read
+ *                   only by the isDirty comparison
+ *   content         the RENDERED preview HTML, injected via {@html}
+ *
+ * `content` is a cache of a render, and MarkdownViewer only refreshes it while
+ * the preview is on screen — split view, or the editor with the TOC open. In
+ * plain edit mode with the TOC closed it is whatever was last rendered, which
+ * for a buffer that has never been rendered is the empty string. So an
+ * untitled, unsaved, actively-edited document had `content === ''` while
+ * `rawContent` held the user's text, and the menu hid two commands that would
+ * have run. `exportAsHtml` itself gates on `ctx.rawContent`, so the menu was
+ * strictly stricter than the operation it fronts.
+ *
+ * That state became reachable when #421 let the preview and the exports work
+ * on an unsaved buffer; before it, an untitled tab had nothing to export
+ * either way. `showToc` and `newFileDefaultMode` both default such that
+ * Ctrl+T -> type is exactly this state.
+ *
+ * These tests do not assert how the gate is spelled. They lift three real
+ * expressions out of the shipping source and evaluate them against the real
+ * TabManager:
+ *
+ *   1. the `{#if}` in TitleBar.svelte that wraps the two export buttons,
+ *   2. the `$effect` condition in MarkdownViewer.svelte that decides whether
+ *      `tab.content` is refreshed at all — so the repro's `content === ''` is
+ *      derived from the shipping rule rather than assumed by the test,
+ *   3. the early return in `exportAsHtml` — so "the export would have worked"
+ *      is checked against the export's own precondition.
+ *
+ * The last section covers the other direction of the same confusion: `addTab`
+ * seeding `content` from a Markdown-shaped argument.
+ *
+ * What this does not establish: anything about the PDF path's own rendering
+ * (`syncPreviewForPrint` re-renders before printing, which is why Export PDF
+ * is correct to be enabled here too), or that the buttons are visible given
+ * CSS. It establishes which branch the menu takes.
+ */
+
+// ---------------------------------------------------------------- environment
+// Svelte runes and the Tauri bridge, faked as homeTabRender.test.ts does, so
+// `tabs.svelte.ts` and `settings.svelte.ts` import under plain node.
+
+const g = globalThis as any;
+const runeEffect = (fn: () => void) => {
+	void fn;
+};
+runeEffect.root = (fn: () => unknown) => fn();
+g.$state = (value: unknown) => value;
+g.$state.raw = (value: unknown) => value;
+g.$state.snapshot = (value: unknown) => value;
+g.$derived = (value: unknown) => value;
+g.$derived.by = (fn: () => unknown) => fn();
+g.$effect = runeEffect;
+g.window = g.window ?? {};
+
+const localStore = new Map<string, string>();
+g.localStorage = {
+	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
+	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
+	removeItem: (key: string) => void localStore.delete(key),
+	clear: () => localStore.clear(),
+};
+g.window.__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { settings } = await import('../src/lib/stores/settings.svelte.js');
+
+// ------------------------------------------------------------------ AST walk
+
+type Node = Record<string, any>;
+
+function collect(node: unknown, hit: (node: Node) => void): void {
+	if (!node || typeof node !== 'object') return;
+	if (Array.isArray(node)) {
+		for (const child of node) collect(child, hit);
+		return;
+	}
+	hit(node as Node);
+	for (const key of Object.keys(node as Node)) {
+		if (key === 'parent') continue;
+		collect((node as Node)[key], hit);
+	}
+}
+
+/** Free identifiers of an expression — property names and object keys excluded. */
+function freeIdentifiers(expression: Node): string[] {
+	const skip = new Set<unknown>();
+	collect(expression, (node) => {
+		if (node.type === 'MemberExpression' && !node.computed) skip.add(node.property);
+		if (node.type === 'Property' && !node.computed) skip.add(node.key);
+	});
+	const names = new Set<string>();
+	collect(expression, (node) => {
+		if (node.type === 'Identifier' && !skip.has(node)) names.add(node.name);
+	});
+	return [...names].sort();
+}
+
+/**
+ * Turn a source expression into a predicate over the names it happens to
+ * reference, so a rewrite that reaches for a different helper fails with "the
+ * gate references X" rather than a bare ReferenceError out of `new Function`.
+ */
+function compileGate(source: string, expression: Node, available: Record<string, () => unknown>, where: string) {
+	const names = freeIdentifiers(expression).filter((name) => name !== 'undefined');
+	for (const name of names) {
+		assert.ok(
+			name in available,
+			`${where} references \`${name}\`, which these tests cannot supply — add it to \`available\` ` +
+				'in scripts/renderedHtmlField.test.ts so the gate can still be evaluated',
+		);
+	}
+	const text = source.slice(expression.start, expression.end);
+	const fn = new Function(...names, `return Boolean(${text});`) as (...args: unknown[]) => boolean;
+	return { text, run: () => fn(...names.map((name) => available[name]())) };
+}
+
+// ------------------------------------------- 1. the export gate, as written
+
+const TITLE_BAR = 'src/lib/components/TitleBar.svelte';
+const titleBarSource = readFileSync(TITLE_BAR, 'utf8');
+
+const exportMenuGate = (() => {
+	const ast = parse(titleBarSource, { modern: true, filename: TITLE_BAR });
+
+	const candidates: Node[] = [];
+	collect(ast.fragment, (node) => {
+		if (node.type !== 'IfBlock') return;
+		const text = titleBarSource.slice(node.start, node.end);
+		if (text.includes('onexportHtml?.()') && text.includes('onexportPdf?.()')) candidates.push(node);
+	});
+	// Innermost only: every ancestor `{#if}` contains the buttons too.
+	const innermost = candidates.filter(
+		(gate) => !candidates.some((other) => other !== gate && other.start >= gate.start && other.end <= gate.end),
+	);
+
+	assert.equal(
+		innermost.length,
+		1,
+		`expected exactly one {#if} in ${TITLE_BAR} wrapping both export buttons, found ${innermost.length} — ` +
+			'if the export entries moved, move these tests with them',
+	);
+	return innermost[0];
+})();
+
+const exportsOffered = compileGate(
+	titleBarSource,
+	exportMenuGate.test,
+	{
+		tabManager: () => tabManager,
+		// MarkdownViewer.svelte:229 — `$derived(tabManager.activeTab?.path ?? '')`.
+		currentFile: () => tabManager.activeTab?.path ?? '',
+	},
+	'the export menu gate',
+);
+
+// ------------------------------- 2. the condition that refreshes tab.content
+
+const VIEWER = 'src/lib/MarkdownViewer.svelte';
+const viewerSource = readFileSync(VIEWER, 'utf8');
+
+const previewCacheRefreshes = (() => {
+	const ast = parse(viewerSource, { modern: true, filename: VIEWER });
+	const matches: Node[] = [];
+	collect(ast.instance, (node) => {
+		if (node.type !== 'IfStatement') return;
+		const test = viewerSource.slice(node.test.start, node.test.end);
+		const body = viewerSource.slice(node.consequent.start, node.consequent.end);
+		if (test.includes('settings.showToc') && body.includes('updateTabContent')) matches.push(node);
+	});
+	assert.equal(
+		matches.length,
+		1,
+		`expected exactly one condition in ${VIEWER} guarding the preview-cache render, found ${matches.length}`,
+	);
+
+	return compileGate(
+		viewerSource,
+		matches[0].test,
+		{
+			tab: () => tabManager.activeTab,
+			settings: () => settings,
+			// MarkdownViewer.svelte passes the active tab's own flag down as
+			// the `isEditing` prop.
+			isEditing: () => tabManager.activeTab?.isEditing ?? false,
+		},
+		'the preview-cache refresh condition',
+	);
+})();
+
+// ------------------------------------- 3. exportAsHtml's own precondition
+
+const EXPORT = 'src/lib/utils/export.ts';
+const exportSource = readFileSync(EXPORT, 'utf8');
+
+/** `if (!ctx.rawContent) return null;` — evaluated, not matched. */
+const exportWouldRun = (() => {
+	const file = ts.createSourceFile(EXPORT, exportSource, ts.ScriptTarget.ES2022, true);
+	let guard: ts.Expression | null = null;
+	const visit = (node: ts.Node) => {
+		if (ts.isFunctionDeclaration(node) && node.name?.text === 'exportAsHtml' && node.body) {
+			const first = node.body.statements.find(ts.isIfStatement);
+			assert.ok(first, 'exportAsHtml no longer opens with a precondition');
+			guard = first.expression;
+			return;
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(file);
+	assert.ok(guard, `expected ${EXPORT} to declare exportAsHtml`);
+
+	const text = exportSource.slice((guard as ts.Expression).getStart(file), (guard as ts.Expression).getEnd());
+	const bails = new Function('ctx', `return Boolean(${text});`) as (ctx: unknown) => boolean;
+	// The context MarkdownViewer.svelte builds for the active tab.
+	return () => {
+		const tab = tabManager.activeTab;
+		if (!tab) return false;
+		return !bails({ rawContent: tab.rawContent, tabPath: tab.path, tabTitle: tab.title });
+	};
+})();
+
+// ----------------------------------------------------------------- fixtures
+
+function reset() {
+	tabManager.closeAll();
+	localStore.clear();
+	settings.showToc = false;
+	settings.newFileDefaultMode = true;
+}
+
+/**
+ * Ctrl+T, then type — an untitled buffer being edited, TOC closed, not split.
+ * `content` is left at whatever `addNewTab` produced precisely because the
+ * refresh condition asserted below never runs for this state.
+ */
+function untitledBufferBeingEdited(text = '# notes\n\nsomething worth exporting\n') {
+	reset();
+	tabManager.addNewTab();
+	const tab = tabManager.activeTab!;
+	tab.isEditing = true;
+	tabManager.updateTabRawContent(tab.id, text);
+	return tab;
+}
+
+// --------------------------------------------------------------- the regression
+
+test('the preview HTML cache is not refreshed while editing with the TOC closed', () => {
+	// The premise of the bug, taken from the shipping condition rather than
+	// asserted by hand. Without this, the repro below would be a test fixture
+	// choosing its own outcome.
+	const tab = untitledBufferBeingEdited();
+
+	assert.equal(tab.isEditing, true);
+	assert.equal(tab.isSplit, false);
+	assert.equal(settings.showToc, false);
+	assert.equal(
+		previewCacheRefreshes.run(),
+		false,
+		`nothing re-renders tab.content in this state. Condition: ${previewCacheRefreshes.text}`,
+	);
+	assert.equal(tab.content, '', 'so the rendered-HTML cache is still empty');
+	assert.notEqual(tab.rawContent, '', 'while the document itself is not');
+});
+
+test('an untitled buffer being edited is offered the export commands', () => {
+	untitledBufferBeingEdited();
+
+	assert.equal(exportWouldRun(), true, 'precondition: exportAsHtml would produce a file for this buffer');
+	assert.equal(
+		exportsOffered.run(),
+		true,
+		'the Home menu hid Export as HTML / Export as PDF for a document that exports fine — ' +
+			`it read the rendered-HTML cache instead of the buffer. Gate: ${exportsOffered.text}`,
+	);
+});
+
+/**
+ * Bring `tab.content` to what the running app would hold in this state.
+ *
+ * Editable panes: only the condition lifted above refreshes it. Reading mode:
+ * `renderTabPreviewFromRaw` drew the pane the user is looking at, so it is
+ * current by construction. This is what makes the matrix below a statement
+ * about the app rather than about fixtures the test wrote by hand.
+ */
+function settleRenderedCache() {
+	const tab = tabManager.activeTab;
+	if (!tab) return;
+	const editablePane = tab.isEditing || tab.isSplit;
+	if (!editablePane || previewCacheRefreshes.run()) {
+		tabManager.updateTabContent(tab.id, tab.rawContent ? `<h1>rendered</h1>` : '');
+	}
+}
+
+test('the menu is never stricter than the export it fronts', () => {
+	// The invariant behind the fix, over the states a tab can be in. Being
+	// LOOSER is allowed (a saved file with an empty buffer still lists the
+	// entries, and the export then no-ops), being STRICTER is the defect.
+	const states: Array<[string, () => void]> = [
+		['untitled, edited, TOC closed', () => void untitledBufferBeingEdited()],
+		[
+			'untitled, edited, TOC open',
+			() => {
+				untitledBufferBeingEdited();
+				settings.showToc = true;
+			},
+		],
+		[
+			'untitled, split view',
+			() => {
+				const tab = untitledBufferBeingEdited();
+				tabManager.setSplitEnabled(tab.id, true);
+			},
+		],
+		[
+			'untitled, reading mode',
+			() => {
+				const tab = untitledBufferBeingEdited();
+				tab.isEditing = false;
+			},
+		],
+		[
+			'saved file, edited, TOC closed',
+			() => {
+				reset();
+				tabManager.addTab('/notes/a.md');
+				const tab = tabManager.activeTab!;
+				tabManager.setTabRawContent(tab.id, '# a\n');
+				tab.isEditing = true;
+			},
+		],
+	];
+
+	// Collected rather than asserted one at a time, so a failure names every
+	// state the menu is wrong in instead of only the first.
+	const hidden: string[] = [];
+	for (const [name, arrange] of states) {
+		arrange();
+		settleRenderedCache();
+		if (exportWouldRun() && !exportsOffered.run()) hidden.push(name);
+	}
+
+	assert.deepEqual(hidden, [], 'the export is possible in these states and the menu hides it');
+});
+
+// ------------------------------------------------------------------ the fence
+//
+// A gate that simply always returned true would pass everything above.
+
+test('an empty untitled buffer is offered nothing to export', () => {
+	reset();
+	tabManager.addNewTab();
+	tabManager.activeTab!.isEditing = true;
+
+	assert.equal(exportWouldRun(), false, 'precondition: exportAsHtml returns null for an empty buffer');
+	assert.equal(exportsOffered.run(), false, 'so the menu must not offer it either');
+});
+
+test('a window with no tab at all offers no export', () => {
+	reset();
+
+	assert.equal(exportsOffered.run(), false);
+});
+
+test('a saved file is offered the export commands', () => {
+	reset();
+	tabManager.addTab('/notes/a.md');
+	tabManager.setTabRawContent(tabManager.activeTab!.id, '# a\n');
+
+	assert.equal(exportsOffered.run(), true);
+});
+
+test('a tab whose file has not been read yet still lists the export commands', () => {
+	// A restored tab, or one whose large-file read has not landed: it has a
+	// path and an empty buffer. The entries stay — the menu must not appear
+	// and disappear while a file loads — and the export then no-ops. Pins the
+	// `currentFile !== ''` half of the gate, which the states above do not
+	// distinguish from the buffer half.
+	reset();
+	tabManager.addTab('/notes/a.md');
+
+	assert.equal(tabManager.activeTab!.rawContent, '', 'precondition: nothing has been read');
+	assert.equal(exportsOffered.run(), true);
+});
+
+// ------------------------------------------------- addTab's Markdown argument
+//
+// The same three fields, confused in the other direction. `addTab(path,
+// content = '')` assigned its argument to `content`, `rawContent` AND
+// `originalContent` — coherent when they were one field, but it meant the
+// signature accepted Markdown into the field that is injected via {@html}.
+// Both callers in the app pass `''`, so nothing shipped broken; the ~25 test
+// callers that pass real Markdown are what says the argument is the buffer.
+
+test('addTab puts its argument in the buffer, not in the rendered-HTML field', () => {
+	reset();
+	const markdown = '# heading\n\n<script>alert(1)</script>\n';
+	tabManager.addTab('/notes/a.md', markdown);
+	const tab = tabManager.activeTab!;
+
+	assert.equal(tab.rawContent, markdown, 'the argument is the Markdown buffer');
+	assert.equal(tab.originalContent, markdown, 'and the saved baseline, so the tab opens clean');
+	assert.equal(tab.isDirty, false);
+	assert.equal(
+		tab.content,
+		'',
+		'the rendered-HTML field starts empty and is filled by the first render, as at every other ' +
+			'Tab construction site — seeding it here routes Markdown into the {@html} sink',
+	);
+});
+
+test('every Tab construction site starts the rendered-HTML field empty', () => {
+	// The invariant the fix restores. `updateTabContent` is the only writer.
+	reset();
+	// restoreState REPLACES the tab list, so it goes first.
+	tabManager.restoreState(JSON.stringify({ tabs: [{ path: '/notes/b.md', title: 'b.md' }] }));
+	tabManager.addTab('/notes/a.md', '# a\n');
+	tabManager.addNewTab();
+	tabManager.addHomeTab();
+	tabManager.insertTransferredTab({
+		path: '/notes/c.md',
+		title: 'c.md',
+		rawContent: '# c\n',
+		originalContent: '# c\n',
+		scrollTop: 0,
+		isDirty: false,
+		isEditing: false,
+		history: ['/notes/c.md'],
+		historyIndex: 0,
+		scrollPercentage: 0,
+		anchorLine: 0,
+		isSplit: false,
+		splitRatio: 0.5,
+		isScrollSynced: false,
+		hasReplacementChars: false,
+	});
+
+	assert.equal(tabManager.tabs.length, 5, 'precondition: every construction site produced a tab');
+	for (const tab of tabManager.tabs) {
+		assert.equal(tab.content, '', `${tab.path || tab.title} was constructed with a non-empty content field`);
+	}
+});

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -477,7 +477,16 @@
 						</button>
 					{/if}
 					{/if}
-					{#if currentFile !== '' || (tabManager.activeTab && tabManager.activeTab.content)}
+					<!--
+						`rawContent`, not `content`: the exports read the Markdown buffer
+						(`exportAsHtml` returns null on an empty `ctx.rawContent`), while
+						`content` is the rendered-preview HTML, refreshed only while the
+						preview is on screen. In plain edit mode with the TOC closed —
+						the default state of a new file — `content` is still empty for a
+						buffer that has never been rendered, so gating on it hid an export
+						that would have produced a file.
+					-->
+					{#if currentFile !== '' || (tabManager.activeTab && tabManager.activeTab.rawContent)}
 						<div class="home-menu-divider"></div>
 						<button
 						class="home-menu-item"

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -311,11 +311,21 @@ class TabManager {
 		}
 	}
 
-	addTab(path: string, content: string = '', pathKey?: string) {
+	/**
+	 * `rawContent` is the Markdown this tab starts with — the file's text, or
+	 * `''` for a tab whose file is read afterwards, which is what both callers
+	 * in the app do. It is NOT the rendered `content`: that starts empty here
+	 * as it does at every other construction site (`addNewTab`, `restoreState`,
+	 * `addHomeTab`, `buildTransferredTab`), and the first preview render fills
+	 * it. Seeding it from this argument put Markdown in the field that is
+	 * injected via `{@html}` — sanitized at the sink, so it showed as escaped
+	 * source rather than being a hole, but it is not what that field means.
+	 */
+	addTab(path: string, rawContent: string = '', pathKey?: string) {
 		// Opening a file that is already open activates that tab instead of
 		// building a second buffer for it — VS Code and Sublime Text both
-		// resolve an open request to the existing view. `content` is ignored in
-		// that case on purpose: the open tab may hold unsaved edits, and a
+		// resolve an open request to the existing view. `rawContent` is ignored
+		// in that case on purpose: the open tab may hold unsaved edits, and a
 		// freshly read copy of the file would erase them.
 		if (hasRealFilePath(path)) {
 			const existing = this.tabs.find((t) => isSameFilePath(t, { path, pathKey }));
@@ -332,15 +342,15 @@ class TabManager {
 				this.tabs.map((tab) => tab.title),
 				t('tabs.untitled', settings.language),
 			);
-		const fileHistory = createFileHistory(path, content);
+		const fileHistory = createFileHistory(path, rawContent);
 
 		this.tabs.push({
 			id,
 			path,
 			title: filename,
-			content,
-			rawContent: content,
-			originalContent: content,
+			content: '',
+			rawContent,
+			originalContent: rawContent,
 			scrollTop: 0,
 			isDirty: false,
 			isEditing: false,


### PR DESCRIPTION
Two reads of the wrong one of `Tab`'s three same-shaped string fields. #437 documents the distinction and reports both of these as out of scope; this is the fix. Expect a small rebase against it — it touches the field comments, this touches `addTab` and the menu.

| field | holds | read by |
|---|---|---|
| `rawContent` | the live Markdown | editor, preview, exports, `save_file_content` |
| `originalContent` | that buffer as it last came off / went onto disk | `isDirty` |
| `content` | the rendered preview **HTML** | `{@html sanitizedHtml}` |

Verified independently before relying on it: `grep -rn '\.content\b' src` returns exactly two reads of `activeTab.content` — `htmlContent` at `MarkdownViewer.svelte:239`, which is correct, and the export gate below. That grep is also the answer to "does any other menu item gate on the wrong field": no.

## 1. The export menu gated on the render cache

```svelte
{#if currentFile !== '' || (tabManager.activeTab && tabManager.activeTab.content)}
```

`exportAsHtml` gates on `ctx.rawContent` (`export.ts:376`). `content` is a cache of a render, refreshed only by the effect at `MarkdownViewer.svelte:2363`:

```js
if (tab && (tab.isSplit || (isEditing && settings.showToc)) && tab.rawContent !== undefined) {
```

So in plain edit mode with the TOC closed, nothing re-renders, and for a buffer that has never been rendered `content` is `''`. Add `currentFile === ''` and both halves of the gate are false while `rawContent` holds the document. `settings.showToc` defaults to `false` and `settings.newFileDefaultMode` defaults to `true`, so **Ctrl+T, then type** is exactly that state. Reachable since #421 let the preview work without saving first; before that an untitled tab had nothing to export either way.

### Reproduced in the running app

Vite dev server, Tauri IPC stubbed by a temporary shim (not committed), same tab and same buffer in both, only the gate expression changed between the two:

| gate | Home menu contents |
|---|---|
| `…activeTab.content` (master) | 主页 · 新建文件 · 打开文件 · 保存 · 另存为 · 窗口标签 · 将所有窗口合并到此处 · 退出 |
| `…activeTab.rawContent` (this PR) | the same, plus **导出为 HTML** and **导出为 PDF** |

Tab: `无标题 1`, dirty, `# Hello Markpad` in the editor, TOC closed, not split.

### The state matrix

`scripts/renderedHtmlField.test.ts` evaluates the shipping expressions rather than matching their text: the `{#if}` is lifted from the parsed TitleBar AST, the refresh condition from the parsed MarkdownViewer AST, and `exportAsHtml`'s early return from the TypeScript AST — all three run against the real `TabManager`. Rewrite any of them however you like and the tests follow. `content` is brought to what the running app would hold (refreshed only when the shipping condition says so) rather than being set by hand, so the repro is derived, not staged.

Five states, asking "is the export possible but hidden?":

| state | master | this PR |
|---|---|---|
| untitled, edited, TOC closed | **hidden** | offered |
| untitled, edited, TOC open | offered | offered |
| untitled, split view | offered | offered |
| untitled, reading mode | offered | offered |
| saved file, edited, TOC closed | offered | offered |

Only the first row changes. The menu is allowed to be looser than the export (a tab with a path whose file has not been read yet still lists the entries, and the export then no-ops — pinned by its own test); being stricter is the defect.

**Red on master:** 4 of 9 tests. **Mutation check** on the fixed gate:

| gate replaced with | tests failing |
|---|---|
| `…activeTab.content` (master) | 5 |
| `…activeTab.originalContent` | 4 |
| `true` | 2 |
| `false` | 4 |
| `activeTab && activeTab.rawContent` (drops the path half) | 1 |

## 2. `addTab` seeded the HTML field from a Markdown-shaped argument

`addTab(path, content = '')` assigned its argument to `content`, `rawContent` and `originalContent` alike (`tabs.svelte.ts:342`). That was coherent when the three were one field.

Caller survey, done first:

- **In the app, two callers, both pass `''`** — `documentSession.svelte.ts:254` explicitly, `MarkdownViewer.svelte:1434` by default. Nothing shipped broken.
- **In `scripts/`, ~25 callers pass real Markdown** (`tabPathIdentity`, `reopenDirtyDocument`, `foldStatePerDocument`, `externalChangeReload`) and depend on it landing in `rawContent` / `originalContent`. That is what says the argument is the buffer, not the render.
- No `windowSession` / `documentSession` / tab-transfer path constructs through it: window restore goes through `restoreState`, cross-window arrival through `insertTransferredTab` → `buildTransferredTab`.

Chosen: rename the parameter to `rawContent` **and** stop seeding `content`. Rename alone leaves the wrong assignment; dropping the seed alone leaves a call site that reads as if `content` were the thing being passed. A new shape for the two buffers is a bigger change than this defect justifies, and renaming `content` → `renderedHtml` across the codebase is deliberately not attempted here.

Nothing depends on the seeded value: `createFileHistory(path, _content)` ignores it, the only reader is `htmlContent` → `sanitizedHtml` → `{@html}`, and `addNewTab`, `restoreState`, `addHomeTab` and `buildTransferredTab` all already start `content` at `''` and let the first render fill it. This makes `addTab` the fifth, not the exception — asserted directly by `every Tab construction site starts the rendered-HTML field empty`.

**On the security framing, plainly:** `content` reaches the DOM through `MarkdownViewer.svelte:250`, `sanitizedHtml = $derived(sanitizeMarkdownHtml(htmlContent))`, and that is what `{@html}` at `:3450` injects. The sanitizer is between this field and the sink in every case, and both live callers pass `''`. This is a correctness fix — the signature permitted a value the field does not mean — not the closing of a hole.

**Mutation check** on `addTab`, whole suite:

| mutation | tests failing |
|---|---|
| `content: rawContent` (the old seed) | 2 |
| `rawContent: ''` | 1 |
| `originalContent: ''` | 4 |

## Verification

`npm test` 537/537 (528 before, +9). `npm run check` 632 files / 0 errors / 0 warnings. `npm run build` clean; the new template comment is stripped from the production bundle.

## Not covered

- **The PDF path's own rendering.** `syncPreviewForPrint` (`MarkdownViewer.svelte:1957`) re-renders before printing, which is why Export PDF is correct to be enabled in the newly-reachable state too. Not exercised here — the tests establish which branch the menu takes, not what the PDF contains.
- **Whether the entries are visible given CSS**, and the macOS native menu, which has no export items.
- **`syncPreviewForPrint`'s counterpart for HTML.** `exportAsHtml` renders from `rawContent` directly, so it needs none, but that was read rather than exercised.
- **The naming itself.** `content` still means rendered HTML and `rawContent` still means the document. That rename touches many files and belongs in its own discussion.
- Nothing in #437's added comments is made wrong by this change; the `content` line becomes more true, and its `addTab` line numbers shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
