### PR TITLE
test(scroll-sync): cover the split-view mapping by running it

### DIFF
--- a/scripts/scrollSync.test.ts
+++ b/scripts/scrollSync.test.ts
@@ -1,0 +1,203 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+	getScrollSyncPositionFromPixels,
+	getScrollTopForSyncPosition,
+	type ScrollSyncPosition,
+} from '../src/lib/utils/scrollSync.js';
+
+// These tests import and run the mapping. The previous scroll-sync tests read
+// Editor.svelte as text, so the defect that set the sync threshold to a value
+// which disabled sync outright left all 23 of their assertions green (#433).
+// Every assertion below is on a returned number, so an arithmetic change that
+// stops the panes tracking each other fails here.
+
+type Pane = { scrollMax: number; frontMatterEnd: number };
+
+// The same document in the two panes. Front matter is ordinary text in the
+// editor and a fixed-height panel in the preview, so it takes 20% of the
+// editor's scroll range and 10% of the preview's. Those proportions differing
+// is the entire reason the mapping carries a section rather than one ratio.
+const EDITOR: Pane = { scrollMax: 1000, frontMatterEnd: 200 };
+const PREVIEW: Pane = { scrollMax: 600, frontMatterEnd: 60 };
+
+function positionIn(pane: Pane, scrollTop: number): ScrollSyncPosition {
+	return getScrollSyncPositionFromPixels(scrollTop, pane.scrollMax, pane.frontMatterEnd);
+}
+
+function scrollTopIn(pane: Pane, position: ScrollSyncPosition): number {
+	return getScrollTopForSyncPosition(position, pane.scrollMax, pane.frontMatterEnd);
+}
+
+// What split view actually does on every scroll event: read a position out of
+// the pane the user moved, and turn it into pixels for the other pane.
+function across(from: Pane, to: Pane, scrollTop: number): number {
+	return scrollTopIn(to, positionIn(from, scrollTop));
+}
+
+function assertClose(actual: number, expected: number, what: string) {
+	assert.ok(
+		Math.abs(actual - expected) < 1e-9,
+		`${what}: expected ${expected}, got ${actual}`,
+	);
+}
+
+test('the front-matter boundary in one pane lands on the boundary in the other', () => {
+	// The measurement the whole design exists for. A single global
+	// scrollTop/scrollMax ratio would put the editor's boundary at
+	// (200 / 1000) * 600 = 120px in the preview — twice past the end of the
+	// preview's own front matter, i.e. already scrolled into the body.
+	const naiveGlobalRatio = (EDITOR.frontMatterEnd / EDITOR.scrollMax) * PREVIEW.scrollMax;
+	assert.equal(naiveGlobalRatio, 120);
+
+	assert.equal(across(EDITOR, PREVIEW, 200), 60, 'editor boundary must land on the preview boundary');
+	assert.equal(across(PREVIEW, EDITOR, 60), 200, 'preview boundary must land on the editor boundary');
+});
+
+test('front matter maps onto front matter by its own share of the section', () => {
+	assert.deepEqual(positionIn(EDITOR, 100), { section: 'frontmatter', ratio: 0.5 });
+	assert.equal(across(EDITOR, PREVIEW, 100), 30);
+	assert.equal(across(EDITOR, PREVIEW, 50), 15);
+	assert.equal(across(PREVIEW, EDITOR, 30), 100);
+});
+
+test('body maps onto body by its share of the body range, not of the whole pane', () => {
+	// Half way down the editor's body is (600 - 200) / (1000 - 200).
+	assert.deepEqual(positionIn(EDITOR, 600), { section: 'body', ratio: 0.5 });
+	// ...which is 60 + (600 - 60) * 0.5 in the preview, not 600/1000 * 600 = 360.
+	assert.equal(across(EDITOR, PREVIEW, 600), 330);
+	assert.equal(across(PREVIEW, EDITOR, 330), 600);
+});
+
+test('top and bottom are fixed points of the mapping', () => {
+	assert.equal(across(EDITOR, PREVIEW, 0), 0);
+	assert.equal(across(EDITOR, PREVIEW, EDITOR.scrollMax), PREVIEW.scrollMax);
+	assert.equal(across(PREVIEW, EDITOR, 0), 0);
+	assert.equal(across(PREVIEW, EDITOR, PREVIEW.scrollMax), EDITOR.scrollMax);
+});
+
+test('scrolling one pane down always moves the other pane down', () => {
+	// The shape of the defect that went undetected last time: sync that reports
+	// a constant, so the other pane never follows. An inverted ratio fails here
+	// too — this is the only property that covers the whole range at once.
+	const sweep = [0, 1, 50, 100, 150, 199, 200, 201, 400, 600, 800, 999, 1000];
+	const mapped = sweep.map((scrollTop) => across(EDITOR, PREVIEW, scrollTop));
+
+	for (let i = 1; i < sweep.length; i += 1) {
+		assert.ok(
+			mapped[i] > mapped[i - 1],
+			`editor ${sweep[i - 1]} -> ${sweep[i]} must move the preview forward, got ${mapped[i - 1]} -> ${mapped[i]}`,
+		);
+	}
+});
+
+test('a position round-trips through pixels in the pane it came from', () => {
+	for (const pane of [EDITOR, PREVIEW]) {
+		const sweep = [0, 1, pane.frontMatterEnd - 1, pane.frontMatterEnd, pane.frontMatterEnd + 1, pane.scrollMax / 2, pane.scrollMax - 1, pane.scrollMax];
+
+		for (const scrollTop of sweep) {
+			const back = scrollTopIn(pane, positionIn(pane, scrollTop));
+			assertClose(back, scrollTop, `scrollTop ${scrollTop} in pane max=${pane.scrollMax} fm=${pane.frontMatterEnd}`);
+
+			// ...and the position recovered from those pixels is the same position.
+			assert.deepEqual(positionIn(pane, back), positionIn(pane, scrollTop));
+		}
+	}
+});
+
+test('the boundary pixel belongs to the body, not to the front matter', () => {
+	// Both labels put the same pixel on screen (frontmatter at ratio 1 and body
+	// at ratio 0 both resolve to frontMatterEnd in every pane), so this can only
+	// be asserted on the label. It is what makes the `<` in the section test an
+	// invariant rather than an arbitrary choice: scrolling one pixel further
+	// must not jump back to a ratio of 1.
+	assert.deepEqual(positionIn(EDITOR, 199), { section: 'frontmatter', ratio: 0.995 });
+	assert.equal(positionIn(EDITOR, 200).section, 'body');
+	assert.equal(positionIn(EDITOR, 200).ratio, 0);
+	assert.equal(positionIn(EDITOR, 201).section, 'body');
+
+	assert.equal(scrollTopIn(EDITOR, { section: 'frontmatter', ratio: 1 }), EDITOR.frontMatterEnd);
+	assert.equal(scrollTopIn(EDITOR, { section: 'body', ratio: 0 }), EDITOR.frontMatterEnd);
+});
+
+test('a document with no front matter is one body range', () => {
+	const plain: Pane = { scrollMax: 800, frontMatterEnd: 0 };
+
+	assert.deepEqual(positionIn(plain, 0), { section: 'body', ratio: 0 });
+	assert.deepEqual(positionIn(plain, 200), { section: 'body', ratio: 0.25 });
+	assert.deepEqual(positionIn(plain, 800), { section: 'body', ratio: 1 });
+	assert.equal(scrollTopIn(plain, { section: 'body', ratio: 0.25 }), 200);
+
+	// A front-matter position arriving from a pane that has one scrolls this
+	// pane to the top, because its front matter occupies no pixels.
+	assert.equal(scrollTopIn(plain, { section: 'frontmatter', ratio: 1 }), 0);
+	assert.equal(across(EDITOR, plain, 100), 0);
+});
+
+test('a document shorter than the viewport has no scroll range and no division by zero', () => {
+	const short: Pane = { scrollMax: 0, frontMatterEnd: 0 };
+
+	assert.deepEqual(positionIn(short, 0), { section: 'body', ratio: 0 });
+	assert.deepEqual(positionIn(short, 500), { section: 'body', ratio: 0 });
+	assert.equal(scrollTopIn(short, { section: 'body', ratio: 1 }), 0);
+	assert.equal(scrollTopIn(short, { section: 'frontmatter', ratio: 1 }), 0);
+
+	// scrollMax 0 with a measured front matter height: the height clamps away
+	// with the range, rather than dividing by a range that is not there.
+	const shortWithFrontMatter: Pane = { scrollMax: 0, frontMatterEnd: 120 };
+	assert.deepEqual(positionIn(shortWithFrontMatter, 60), { section: 'body', ratio: 0 });
+	assert.equal(scrollTopIn(shortWithFrontMatter, { section: 'frontmatter', ratio: 0.5 }), 0);
+});
+
+test('front matter taller than the scroll range leaves no body range', () => {
+	// Reachable: a long YAML block in a short document. frontMatterEnd clamps to
+	// scrollMax, so the body range is exactly zero.
+	const allFrontMatter: Pane = { scrollMax: 100, frontMatterEnd: 400 };
+
+	assert.deepEqual(positionIn(allFrontMatter, 50), { section: 'frontmatter', ratio: 0.5 });
+	assert.deepEqual(positionIn(allFrontMatter, 100), { section: 'body', ratio: 0 });
+	assert.equal(scrollTopIn(allFrontMatter, { section: 'frontmatter', ratio: 0.5 }), 50);
+
+	// A zero-width body must not swallow the bottom of the pane: a body position
+	// arriving from the other pane still lands at the end of the scroll range.
+	assert.equal(scrollTopIn(allFrontMatter, { section: 'body', ratio: 0 }), 100);
+	assert.equal(scrollTopIn(allFrontMatter, { section: 'body', ratio: 1 }), 100);
+	assert.equal(across(EDITOR, allFrontMatter, 1000), 100);
+});
+
+test('out-of-range pixels clamp instead of escaping the pane', () => {
+	assert.deepEqual(positionIn(EDITOR, -500), { section: 'frontmatter', ratio: 0 });
+	assert.deepEqual(positionIn(EDITOR, 5000), { section: 'body', ratio: 1 });
+	assert.equal(across(EDITOR, PREVIEW, -500), 0);
+	assert.equal(across(EDITOR, PREVIEW, 5000), PREVIEW.scrollMax);
+
+	// A negative scrollMax or frontMatterEnd is floored at 0 rather than
+	// inverting the arithmetic.
+	assert.deepEqual(getScrollSyncPositionFromPixels(100, -1000, 200), { section: 'body', ratio: 0 });
+	assert.deepEqual(getScrollSyncPositionFromPixels(100, 1000, -200), { section: 'body', ratio: 0.1 });
+	assert.equal(getScrollTopForSyncPosition({ section: 'body', ratio: 1 }, -1000, 200), 0);
+	assert.equal(getScrollTopForSyncPosition({ section: 'body', ratio: 1 }, 1000, -200), 1000);
+});
+
+test('a non-finite measurement or ratio never reaches setScrollTop', () => {
+	// Monaco and the DOM both return measurements that can be NaN mid-layout,
+	// and the position travels across a component boundary before it is used.
+	assert.deepEqual(positionIn(EDITOR, Number.NaN), { section: 'body', ratio: 0 });
+	assert.deepEqual(positionIn(EDITOR, Number.POSITIVE_INFINITY), { section: 'body', ratio: 1 });
+
+	for (const ratio of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, -1, 2]) {
+		for (const section of ['frontmatter', 'body'] as const) {
+			const scrollTop = scrollTopIn(PREVIEW, { section, ratio });
+			assert.ok(
+				Number.isFinite(scrollTop) && scrollTop >= 0 && scrollTop <= PREVIEW.scrollMax,
+				`ratio ${ratio} in ${section} produced ${scrollTop}`,
+			);
+		}
+	}
+
+	// Out-of-range finite ratios clamp to the ends of their section; non-finite
+	// ones are rejected outright and read as 0, not as the nearest end.
+	assert.equal(scrollTopIn(PREVIEW, { section: 'body', ratio: 2 }), PREVIEW.scrollMax);
+	assert.equal(scrollTopIn(PREVIEW, { section: 'body', ratio: Number.POSITIVE_INFINITY }), PREVIEW.frontMatterEnd);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -80,6 +80,11 @@ import {
 import { tabManager, type Tab } from './stores/tabs.svelte.js';
 import { snapshotTab } from './utils/tabTransfer.js';
 import { adjustPreviewMaxWidth, getPreviewContentWidth, getStoredPreviewFullWidth } from './utils/previewWidth.js';
+import {
+	getScrollSyncPositionFromPixels,
+	getScrollTopForSyncPosition,
+	type ScrollSyncPosition,
+} from './utils/scrollSync.js';
 import { settings } from './stores/settings.svelte.js';
 import { t } from './utils/i18n.js';
 import { createWindowSession } from './sessions/windowSession.svelte.js';
@@ -122,11 +127,6 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		blue: 'rgba(67, 138, 243, 0.4)',
 		cyan: 'rgba(43, 185, 178, 0.4)',
 		green: 'rgba(77, 177, 88, 0.4)',
-	};
-
-	type ScrollSyncPosition = {
-		section: 'frontmatter' | 'body';
-		ratio: number;
 	};
 
 	let editorPane = $state<{ 
@@ -1173,45 +1173,8 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		}
 	});
 
-	function clampScrollRatio(value: number) {
-		if (!Number.isFinite(value)) return 0;
-		return Math.max(0, Math.min(1, value));
-	}
-
 	function getPreviewScrollMax(target: HTMLElement) {
 		return Math.max(0, target.scrollHeight - target.clientHeight);
-	}
-
-	function getScrollSyncPositionFromPixels(scrollTop: number, scrollMax: number, frontMatterEnd: number): ScrollSyncPosition {
-		const safeMax = Math.max(0, scrollMax);
-		const safeFrontMatterEnd = Math.max(0, Math.min(safeMax, frontMatterEnd));
-		const safeScrollTop = Math.max(0, Math.min(safeMax, scrollTop));
-
-		if (safeFrontMatterEnd > 0 && safeScrollTop < safeFrontMatterEnd) {
-			return {
-				section: 'frontmatter',
-				ratio: clampScrollRatio(safeScrollTop / safeFrontMatterEnd),
-			};
-		}
-
-		const bodyRange = Math.max(0, safeMax - safeFrontMatterEnd);
-		return {
-			section: 'body',
-			ratio: bodyRange > 0 ? clampScrollRatio((safeScrollTop - safeFrontMatterEnd) / bodyRange) : 0,
-		};
-	}
-
-	function getScrollTopForSyncPosition(position: ScrollSyncPosition, scrollMax: number, frontMatterEnd: number) {
-		const safeMax = Math.max(0, scrollMax);
-		const safeFrontMatterEnd = Math.max(0, Math.min(safeMax, frontMatterEnd));
-		const ratio = clampScrollRatio(position.ratio);
-
-		if (position.section === 'frontmatter') {
-			return safeFrontMatterEnd * ratio;
-		}
-
-		const bodyRange = Math.max(0, safeMax - safeFrontMatterEnd);
-		return safeFrontMatterEnd + bodyRange * ratio;
 	}
 
 	function getPreviewFrontMatterScrollEnd(target: HTMLElement) {

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -5,6 +5,11 @@
 	import { t, type LanguageCode } from '../utils/i18n.js';
 	import { managedImageFromCopy, type ManagedImage } from '../utils/managedImages.js';
 	import { MARKDOWN_LANGUAGE_ID, shouldLinkifyPastedUrl } from '../utils/pasteContext.js';
+	import {
+		getScrollSyncPositionFromPixels,
+		getScrollTopForSyncPosition,
+		type ScrollSyncPosition,
+	} from '../utils/scrollSync.js';
 
 	// Monaco is ~86% of the startup JavaScript (a 4.4 MB chunk, ~360ms of
 	// parse+eval, paid once per window because every window is its own webview)
@@ -27,11 +32,6 @@
 	import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
 	import { openUrl } from "@tauri-apps/plugin-opener";
 	import { invoke } from "@tauri-apps/api/core";
-
-	type ScrollSyncPosition = {
-		section: 'frontmatter' | 'body';
-		ratio: number;
-	};
 
 	let {
 		value = $bindable(),
@@ -1179,43 +1179,6 @@
 	});
 
 	onDestroy(disposeLocalizedActions);
-
-	function clampScrollRatio(value: number) {
-		if (!Number.isFinite(value)) return 0;
-		return Math.max(0, Math.min(1, value));
-	}
-
-	function getScrollSyncPositionFromPixels(scrollTop: number, scrollMax: number, frontMatterEnd: number): ScrollSyncPosition {
-		const safeMax = Math.max(0, scrollMax);
-		const safeFrontMatterEnd = Math.max(0, Math.min(safeMax, frontMatterEnd));
-		const safeScrollTop = Math.max(0, Math.min(safeMax, scrollTop));
-
-		if (safeFrontMatterEnd > 0 && safeScrollTop < safeFrontMatterEnd) {
-			return {
-				section: 'frontmatter',
-				ratio: clampScrollRatio(safeScrollTop / safeFrontMatterEnd),
-			};
-		}
-
-		const bodyRange = Math.max(0, safeMax - safeFrontMatterEnd);
-		return {
-			section: 'body',
-			ratio: bodyRange > 0 ? clampScrollRatio((safeScrollTop - safeFrontMatterEnd) / bodyRange) : 0,
-		};
-	}
-
-	function getScrollTopForSyncPosition(position: ScrollSyncPosition, scrollMax: number, frontMatterEnd: number) {
-		const safeMax = Math.max(0, scrollMax);
-		const safeFrontMatterEnd = Math.max(0, Math.min(safeMax, frontMatterEnd));
-		const ratio = clampScrollRatio(position.ratio);
-
-		if (position.section === 'frontmatter') {
-			return safeFrontMatterEnd * ratio;
-		}
-
-		const bodyRange = Math.max(0, safeMax - safeFrontMatterEnd);
-		return safeFrontMatterEnd + bodyRange * ratio;
-	}
 
 	function getFrontMatterBodyStartLine(content: string) {
 		const lines = content.split(/\r\n|\n|\r/);

--- a/src/lib/utils/scrollSync.ts
+++ b/src/lib/utils/scrollSync.ts
@@ -1,0 +1,61 @@
+// Split-view scroll sync maps a position in one pane onto pixels in the other.
+//
+// The two panes are not proportional to each other. Front matter renders as a
+// fixed-height panel in the preview and as ordinary text lines in the editor, so
+// the same document gives the two panes different total scroll ranges *and* a
+// different share of that range spent on front matter. A single global
+// scrollTop/scrollMax ratio therefore drifts: at the moment the editor finishes
+// scrolling past its front matter, the naive ratio has already carried the
+// preview well into the body.
+//
+// The fix is to split the range in two at `frontMatterEnd` and carry a
+// (section, ratio) pair between the panes instead of a raw ratio. Front matter
+// maps onto front matter and body onto body, whatever each pane's proportions
+// are, and the boundary maps onto the boundary exactly.
+//
+// Both functions are pure arithmetic. They lived, byte for byte, in both
+// Editor.svelte and MarkdownViewer.svelte; neither copy could be imported by a
+// test, because `node --test` cannot load a `.svelte` file. Here they are
+// covered for real by scripts/scrollSync.test.ts.
+
+export type ScrollSyncPosition = {
+	section: 'frontmatter' | 'body';
+	ratio: number;
+};
+
+function clampScrollRatio(value: number) {
+	if (!Number.isFinite(value)) return 0;
+	return Math.max(0, Math.min(1, value));
+}
+
+export function getScrollSyncPositionFromPixels(scrollTop: number, scrollMax: number, frontMatterEnd: number): ScrollSyncPosition {
+	const safeMax = Math.max(0, scrollMax);
+	const safeFrontMatterEnd = Math.max(0, Math.min(safeMax, frontMatterEnd));
+	const safeScrollTop = Math.max(0, Math.min(safeMax, scrollTop));
+
+	if (safeFrontMatterEnd > 0 && safeScrollTop < safeFrontMatterEnd) {
+		return {
+			section: 'frontmatter',
+			ratio: clampScrollRatio(safeScrollTop / safeFrontMatterEnd),
+		};
+	}
+
+	const bodyRange = Math.max(0, safeMax - safeFrontMatterEnd);
+	return {
+		section: 'body',
+		ratio: bodyRange > 0 ? clampScrollRatio((safeScrollTop - safeFrontMatterEnd) / bodyRange) : 0,
+	};
+}
+
+export function getScrollTopForSyncPosition(position: ScrollSyncPosition, scrollMax: number, frontMatterEnd: number) {
+	const safeMax = Math.max(0, scrollMax);
+	const safeFrontMatterEnd = Math.max(0, Math.min(safeMax, frontMatterEnd));
+	const ratio = clampScrollRatio(position.ratio);
+
+	if (position.section === 'frontmatter') {
+		return safeFrontMatterEnd * ratio;
+	}
+
+	const bodyRange = Math.max(0, safeMax - safeFrontMatterEnd);
+	return safeFrontMatterEnd + bodyRange * ratio;
+}


### PR DESCRIPTION
Scroll sync is the miss from the coverage audit that is easiest to close, because the part of it that can be wrong is arithmetic.

The injected defect set the sync threshold to a value that disabled sync entirely. `previewScrollSync.test.ts` (23 assertions) and `scrollSyncInput.test.ts` stayed green through it. Both read a `.svelte` file as text, so what they detect is that a particular line was edited — the first was deleted in #433 for exactly that. The behaviour is currently untested.

That is not a property of those two files. `node --test` cannot import `.svelte`, so **14,581 lines across 21 components have no executable coverage at all**, and the only thing a test can do to logic inside one is grep it. The fix that works is the one that produced `documentSession` and `windowSession`: move the logic out. This is one function pair's worth of that.

## What moved, and the check that it moved unchanged

`getScrollSyncPositionFromPixels` and `getScrollTopForSyncPosition` read nothing but their arguments — no DOM, no Monaco, no component state, no closure over anything but the private `clampScrollRatio` beside them. They are pure arithmetic and leave the component with no wrapper and no seam.

They were also **duplicated**. Both functions and `clampScrollRatio` existed byte for byte in `Editor.svelte` (editor side) and `MarkdownViewer.svelte` (preview side) — two private copies of one formula, each invisible to the other and to the compiler. Nothing imports a private function, so the two could have drifted silently; a fix applied to one pane's copy would have left the other pane mapping by the old formula, and split view would have desynchronised in one direction only. That is the bug class `singleImplementationConvention.test.ts` exists for, and it could not see this one because a private identifier is not a legal marker there.

Both call sites now import `src/lib/utils/scrollSync.ts`. The diff on both components is a deletion plus an import; `Editor.svelte`'s `editorReady` effect from #423 is untouched.

The move is byte-identical, not asserted to be. Taking the two pre-change blocks out of `git show HEAD:`, removing the module's `export ` keywords and re-indenting it by one tab:

```
Editor.svelte            md5=31ab31100fc37e77e4a08d0c18470e70  identical_to_module=True
MarkdownViewer.svelte    md5=31ab31100fc37e77e4a08d0c18470e70  identical_to_module=True
utils/scrollSync.ts      md5=31ab31100fc37e77e4a08d0c18470e70
```

## What the mapping is for

The two panes are not proportional to each other. Front matter is ordinary text lines in the editor and a fixed-height panel in the preview, so the same document gives them different total scroll ranges *and* a different share of that range spent on front matter. The tests use 1000px total / 200px front matter for the editor and 600px / 60px for the preview — 20% against 10%.

A single `scrollTop / scrollMax` ratio drifts under that. At the moment the editor finishes scrolling past its front matter, `(200 / 1000) * 600 = 120px` in the preview is already 60px into the body. Splitting the range at `frontMatterEnd` and carrying a `(section, ratio)` pair instead maps front matter onto front matter, body onto body, and the boundary onto the boundary — 60, exactly.

That number is the first assertion in the file, with the naive 120 computed alongside it so the test says why 60 is the answer.

## Tests

`scripts/scrollSync.test.ts`, 12 tests, all of them calling the functions. No `readFileSync`, no regex over source.

| test | what can go wrong |
|---|---|
| the front-matter boundary in one pane lands on the boundary in the other | the drift above; the mapping stops being section-aware |
| front matter maps onto front matter by its own share of the section | front-matter positions land by global ratio |
| body maps onto body by its share of the body range, not of the whole pane | `frontMatterEnd` dropped from the body arithmetic |
| top and bottom are fixed points of the mapping | the ends stop agreeing |
| scrolling one pane down always moves the other pane down | a constant return — the shape of the defect that was missed |
| a position round-trips through pixels in the pane it came from | the mapping is not invertible where it must be |
| the boundary pixel belongs to the body, not to the front matter | `<` / `<=` at the section split |
| a document with no front matter is one body range | `frontMatterEnd` of 0 |
| a document shorter than the viewport has no scroll range and no division by zero | `scrollMax` of 0 |
| front matter taller than the scroll range leaves no body range | `frontMatterEnd >= scrollMax`, zero body range |
| out-of-range pixels clamp instead of escaping the pane | negative and past-the-end inputs |
| a non-finite measurement or ratio never reaches setScrollTop | NaN out of a mid-layout measurement |

Two of those are worth stating in full, because they are not restatements of the implementation.

**The round trip is exact, including where the mapping looks degenerate.** For a `scrollTop` on either side of the boundary, `position → pixels` returns the same pixel and `pixels → position` returns the same position. It holds even when the body range is zero (`frontMatterEnd >= scrollMax`), because a body ratio of 0 resolves to `frontMatterEnd`, which in that pane *is* the bottom of the scroll range.

**The boundary label can only be asserted as a label.** At `scrollTop === frontMatterEnd`, `frontmatter` at ratio 1 and `body` at ratio 0 resolve to the same pixel in *every* pane, so flipping `<` to `<=` is invisible in the target scrollTop. Asserting `section === 'body'` there is not pedantry about the return shape: it is what stops a one-pixel scroll from jumping back to a ratio of 1.

## Mutation check

Each defect injected into `src/lib/utils/scrollSync.ts` on top of this change, the suite run, the file restored. 12 tests in the suite.

| injected defect | result | first red test |
|---|---|---|
| sync disabled: position is always the top | RED (10) | front matter maps onto front matter by its own share of the section |
| sync disabled: target scrollTop is always 0 | RED (11) | the front-matter boundary in one pane lands on the boundary in the other |
| identity: ratio taken over the whole pane, `frontMatterEnd` dropped | RED (5) | the front-matter boundary in one pane lands on the boundary in the other |
| `frontMatterEnd` dropped from the reverse mapping | RED (7) | the front-matter boundary in one pane lands on the boundary in the other |
| inverted ratio (forward) | RED (6) | front matter maps onto front matter by its own share of the section |
| inverted ratio (reverse, body) | RED (8) | the front-matter boundary in one pane lands on the boundary in the other |
| section never reported as front matter | RED (7) | front matter maps onto front matter by its own share of the section |
| off-by-one at the boundary: `<` becomes `<=` | RED (2) | the boundary pixel belongs to the body, not to the front matter |
| boundary clamp dropped: `frontMatterEnd` not capped at `scrollMax` | RED (3) | a document shorter than the viewport has no scroll range and no division by zero |
| `scrollTop` not clamped to the scroll range | RED (1) | a non-finite measurement or ratio never reaches setScrollTop |
| zero-range guard dropped: division by a zero body range | RED (4) | a document shorter than the viewport has no scroll range and no division by zero |
| non-finite ratio guard dropped | RED (1) | a non-finite measurement or ratio never reaches setScrollTop |
| ratio not clamped in the reverse mapping | RED (1) | a non-finite measurement or ratio never reaches setScrollTop |

13 injected, 13 caught. The first two rows are the two ways to write "sync does nothing", which is the defect the deleted tests could not fail.

Messages name the measurement, not the line:

```
editor boundary must land on the preview boundary
editor 199 -> 200 must move the preview forward, got 59.7 -> 59.7
ratio NaN in frontmatter produced NaN
```

The first pass had a fourteenth entry that came back green. It was a bad patch, not a gap — the injected early return sat behind `if (false && …)` and never executed. Rewritten to actually fire, it is row 1.

**`npm test` 540 → 552 passing, `npm run check` 633 files / 0 errors, `npm run build` clean.**

# Not covered

- **`revealFoldsAround` / `foldToggleFor` in `FindBar.svelte`** — the same extraction, and the closest of the three. `foldToggleFor(container, root)` is already parameterised on the DOM it touches; `revealFoldsAround` closes only over `markdownBody` and a module constant, so passing the root in makes it pure over a DOM interface. The behaviour worth pinning is an ordering claim — outermost fold opened first, so a nested one is on screen when its own toggle fires — and `foldMeasurementBatching.test.ts`'s recording stand-in already records exactly that kind of ordered event stream. Needs a stand-in for `classList`/`closest`/`matches`/`dispatchEvent` and a `CSS.escape` shim, so a larger fixture than this PR's, but the same shape.
- **`exportAsPdf` in `export.ts`** — importable already, so no extraction; the blocker is different in kind. It calls `invoke` and the dialog plugin's `save` as module-level imports, so a test needs the `window.__TAURI_INTERNALS__` stub that `checkedReadMigration.test.ts` and `reopenDirtyDocument.test.ts` already use, plus a seam for `save`. The claims are small and real: non-Windows invokes `print_pdf` and never opens a dialog, Windows opens one, and a cancelled dialog must invoke nothing. `macosPdfExport.test.ts` covers the command-name half by grep and nothing covers the branch.
- **`reloadFromDisk`'s dirty-state guard in `MarkdownViewer.svelte`** — not the same clean extraction: it has no arithmetic core, and what matters is the sequencing (`canCloseTab` resolves the buffer, *then* `loadMarkdown` runs with `discardUnsavedBuffer: true` to cover typing during the await). A predicate lifted out of it would not carry that. The realistic route is the `documentSession` one — `canCloseTab` and `loadMarkdown` are both already in `documentSession.svelte.ts`, which several test files drive for real against a stubbed backend, so moving the reload beside them makes it testable without a new technique. That is a behaviour-moving change with its own risk, not a mechanical lift, and belongs in its own PR.
- **No guard against the duplication coming back.** `singleImplementationConvention.test.ts` could take a row pinning `getScrollSyncPositionFromPixels` to `scrollSync.ts`, and now that the name is exported it would be a legal marker. Not added here: it is a source-text assertion, this PR's claim is that executable tests are what catch defects, and the two should not be argued in the same change.
- **No live split-view run.** The mapping is verified against the real functions; the measurement functions that feed it (`getEditorContentScrollMax`, `getEditorFrontMatterScrollEnd`, `getPreviewFrontMatterScrollEnd`) still live in components, still read Monaco and the DOM, and are still uncovered. A wrong `frontMatterEnd` would produce a correct mapping of a wrong number, and nothing here would notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
