### PR TITLE
refactor(lib): stop exporting 23 symbols that never leave their module

### DIFF
--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -52,7 +52,7 @@ export type LanguageCode =
 	| 'id' // Indonesian
 	| 'tr'; // Turkish
 
-export const SUPPORTED_LANGUAGES: { code: LanguageCode; name: string; nativeName: string }[] = [
+const SUPPORTED_LANGUAGES: { code: LanguageCode; name: string; nativeName: string }[] = [
 	{ code: 'cs', name: 'Czech', nativeName: 'Čeština' },
 	{ code: 'da', name: 'Danish', nativeName: 'Dansk' },
 	{ code: 'nl', name: 'Dutch', nativeName: 'Nederlands' },
@@ -81,9 +81,9 @@ export const SUPPORTED_LANGUAGES: { code: LanguageCode; name: string; nativeName
 	{ code: 'zh-TW', name: 'Chinese (Traditional)', nativeName: '繁體中文' },
 ];
 
-export const SUPPORTED_LANGUAGE_CODES: readonly LanguageCode[] = SUPPORTED_LANGUAGES.map((entry) => entry.code);
+const SUPPORTED_LANGUAGE_CODES: readonly LanguageCode[] = SUPPORTED_LANGUAGES.map((entry) => entry.code);
 
-export function isSupportedLanguage(value: unknown): value is LanguageCode {
+function isSupportedLanguage(value: unknown): value is LanguageCode {
 	return typeof value === 'string' && (SUPPORTED_LANGUAGE_CODES as readonly string[]).includes(value);
 }
 
@@ -305,7 +305,7 @@ export function writeStoredSetting(key: string, value: string | null): boolean {
 }
 
 /** Applies everything currently in localStorage onto `target`. */
-export function loadPersistedSettings<T>(target: T, entries: readonly PersistedSetting<T>[]): void {
+function loadPersistedSettings<T>(target: T, entries: readonly PersistedSetting<T>[]): void {
 	if (typeof localStorage === 'undefined') return;
 	for (const entry of entries) {
 		entry.load(target, localStorage.getItem(entry.key));
@@ -326,7 +326,7 @@ export function loadPersistedSettings<T>(target: T, entries: readonly PersistedS
  * *other* same-origin document, so each window folds its siblings' changes into
  * its own state instead of drifting until the next restart.
  */
-export function installPersistedSettings<T>(target: T, entries: readonly PersistedSetting<T>[]): void {
+function installPersistedSettings<T>(target: T, entries: readonly PersistedSetting<T>[]): void {
 	for (const entry of entries) {
 		$effect(() => {
 			writeStoredSetting(entry.key, entry.read(target));

--- a/src/lib/stores/update.svelte.ts
+++ b/src/lib/stores/update.svelte.ts
@@ -2,7 +2,7 @@ import { check, type Update } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 import { getVersion } from '@tauri-apps/api/app';
 
-export type UpdatePhase =
+type UpdatePhase =
 	| 'idle'
 	| 'checking'
 	| 'up-to-date'
@@ -10,7 +10,7 @@ export type UpdatePhase =
 	| 'downloading'
 	| 'error';
 
-export type ErrorSource = 'check' | 'download' | 'install';
+type ErrorSource = 'check' | 'download' | 'install';
 
 // Match only messages that genuinely indicate the updater plugin lacks an
 // endpoint / pubkey configuration. We deliberately do NOT match the bare

--- a/src/lib/utils/editorToolbar.ts
+++ b/src/lib/utils/editorToolbar.ts
@@ -1,4 +1,4 @@
-export type EditorToolbarGroup = 'inline' | 'block' | 'list' | 'insert';
+type EditorToolbarGroup = 'inline' | 'block' | 'list' | 'insert';
 
 export type EditorToolbarTool = {
 	id: string;
@@ -13,7 +13,7 @@ export type EditorToolbarMove = {
 	toIndex: number;
 };
 
-export const EDITOR_TOOLBAR_TOOLS: EditorToolbarTool[] = [
+const EDITOR_TOOLBAR_TOOLS: EditorToolbarTool[] = [
 	{ id: 'fmt-bold', label: 'B', name: 'Bold', shortcut: (modifier) => `${modifier}+B`, group: 'inline' },
 	{ id: 'fmt-italic', label: 'I', name: 'Italic', shortcut: (modifier) => `${modifier}+I`, group: 'inline' },
 	{ id: 'fmt-underline', label: 'U', name: 'Underline', shortcut: (modifier) => `${modifier}+U`, group: 'inline' },

--- a/src/lib/utils/exportFonts.ts
+++ b/src/lib/utils/exportFonts.ts
@@ -53,7 +53,7 @@ function selectorClasses(selector: string): string[] {
 		.filter((name) => name !== 'katex');
 }
 
-export interface KatexFamilyRule {
+interface KatexFamilyRule {
 	/** Class tokens that must all be present for the rule to apply. */
 	classes: string[];
 	families: string[];
@@ -64,7 +64,7 @@ export interface KatexFamilyRule {
  * family, read out of the stylesheet rather than hard-coded, so a KaTeX upgrade
  * that renames a class or adds a family is picked up without edits here.
  */
-export function parseKatexFamilyRules(css: string): KatexFamilyRule[] {
+function parseKatexFamilyRules(css: string): KatexFamilyRule[] {
 	const rules: KatexFamilyRule[] = [];
 	for (const match of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
 		const selector = match[1].trim();
@@ -81,7 +81,7 @@ export function parseKatexFamilyRules(css: string): KatexFamilyRule[] {
 }
 
 /** Every class token used anywhere under `root`, including `root` itself. */
-export function collectClassNames(root: Element): Set<string> {
+function collectClassNames(root: Element): Set<string> {
 	const names = new Set<string>();
 	// Walked rather than selected: `querySelectorAll('*')` is the one call that
 	// would tie this to a full selector engine, and the walk is no slower.
@@ -221,7 +221,7 @@ export function katexFontUrlsToEmbed(css: string, usedFamilies: Set<string>): st
 }
 
 /** `btoa` in chunks: a 30 KB font blows the argument limit of `apply`. */
-export function bytesToBase64(bytes: Uint8Array): string {
+function bytesToBase64(bytes: Uint8Array): string {
 	let binary = '';
 	const chunk = 0x8000;
 	for (let index = 0; index < bytes.length; index += chunk) {

--- a/src/lib/utils/frontMatter.ts
+++ b/src/lib/utils/frontMatter.ts
@@ -1,6 +1,6 @@
 import { parseDocument } from 'yaml';
 
-export type FrontMatterValueKind = 'string' | 'number' | 'boolean' | 'list' | 'object' | 'null';
+type FrontMatterValueKind = 'string' | 'number' | 'boolean' | 'list' | 'object' | 'null';
 
 export type FrontMatterField = {
 	key: string;
@@ -198,7 +198,7 @@ export function updateFrontMatterField(content: string, key: string, value: unkn
 	return `---${parsed.lineEnding}${serialized}${parsed.lineEnding}---${parsed.lineEnding}${parsed.lineEnding}${parsed.body}`;
 }
 
-export function parseFrontMatterTagInput(value: string): string[] {
+function parseFrontMatterTagInput(value: string): string[] {
 	return value
 		.split(',')
 		.map((item) => item.trim())

--- a/src/lib/utils/markdownLinks.ts
+++ b/src/lib/utils/markdownLinks.ts
@@ -15,7 +15,7 @@ export function hasMarkdownLinkExtension(path: string): boolean {
 	return /\.(md|markdown|mdown|mkd|txt)$/i.test(path);
 }
 
-export function isAbsoluteMarkdownPath(path: string): boolean {
+function isAbsoluteMarkdownPath(path: string): boolean {
 	return path.startsWith('/') || path.startsWith('\\') || /^[a-z]:/i.test(path);
 }
 

--- a/src/lib/utils/mermaidPrint.ts
+++ b/src/lib/utils/mermaidPrint.ts
@@ -22,7 +22,7 @@ const SOURCE_ATTR = 'data-mermaid-source';
 
 export const MERMAID_PRINT_THEME = 'neutral';
 
-export interface MermaidRenderer {
+interface MermaidRenderer {
 	initialize(config: { startOnLoad: boolean; theme: string }): void;
 	render(id: string, source: string): Promise<{ svg: string }>;
 }

--- a/src/lib/utils/openExportedFile.ts
+++ b/src/lib/utils/openExportedFile.ts
@@ -1,7 +1,7 @@
 export type ExportedFileFormat = 'HTML' | 'PDF';
 export type OpenExportedFileResult = 'opened' | 'declined' | 'failed';
 
-export type OpenExportedFileLabels = {
+type OpenExportedFileLabels = {
 	title?: string;
 	message?: string;
 };

--- a/src/lib/utils/pasteContext.ts
+++ b/src/lib/utils/pasteContext.ts
@@ -26,7 +26,7 @@ export const MARKDOWN_LANGUAGE_ID = 'markdown';
  * A plain letter is used on purpose: it carries no markdown meaning, so it
  * cannot open or close a construct that would change the caret's own token.
  */
-export const PASTE_PROBE_CHARACTER = 'x';
+const PASTE_PROBE_CHARACTER = 'x';
 
 export type PasteContextToken = {
 	readonly offset: number;
@@ -34,7 +34,7 @@ export type PasteContextToken = {
 	readonly language: string;
 };
 
-export type PasteContextTokenizer = (text: string) => readonly (readonly PasteContextToken[])[];
+type PasteContextTokenizer = (text: string) => readonly (readonly PasteContextToken[])[];
 
 /**
  * Token types Monaco's markdown grammar emits for code. The `.md` suffix is
@@ -79,7 +79,7 @@ export function findTokenAtOffset(
 	return found;
 }
 
-export function isCodeAtOffset(tokens: readonly PasteContextToken[], offset: number): boolean {
+function isCodeAtOffset(tokens: readonly PasteContextToken[], offset: number): boolean {
 	const token = findTokenAtOffset(tokens, offset);
 	return token ? isCodeToken(token) : false;
 }

--- a/src/lib/utils/tabFileActions.ts
+++ b/src/lib/utils/tabFileActions.ts
@@ -1,6 +1,6 @@
 import { isHomePath } from './homeTab.js';
 
-export type TabFileActionId = 'copy-path' | 'open-location';
+type TabFileActionId = 'copy-path' | 'open-location';
 
 export type TabFileAction = {
 	id: TabFileActionId;

--- a/src/lib/utils/titlebarToolbar.ts
+++ b/src/lib/utils/titlebarToolbar.ts
@@ -20,7 +20,7 @@ export type ConfiguredTitlebarToolbarIds = {
 	menuIds: string[];
 };
 
-export const TITLEBAR_TOOLBAR_ACTIONS: TitlebarToolbarAction[] = [
+const TITLEBAR_TOOLBAR_ACTIONS: TitlebarToolbarAction[] = [
 	{ id: 'back', labelKey: 'menu.back', fallbackName: 'Back', sample: '<', defaultPlacement: 'bar' },
 	{ id: 'forward', labelKey: 'menu.forward', fallbackName: 'Forward', sample: '>', defaultPlacement: 'bar' },
 	{ id: 'reload', labelKey: 'tooltip.reloadFromDisk', fallbackName: 'Reload from Disk', sample: 'R', defaultPlacement: 'bar' },


### PR DESCRIPTION
**This fixes no bug.** Nothing here changes behaviour, output, or performance. 23 declarations lose the `export` keyword and keep everything else. The benefit is that a reader opening one of these modules sees an interface that reflects what the module actually promises, instead of one where two thirds of the surface is noise.

`npm test` 565/565 (unchanged from `6b58cd5`), `npm run check` 637 files / 0 errors, `npm run build` clean. No Rust touched.

## The starting list was right about references and wrong about what follows

The candidates came from a scan for `export`ed symbols in `src/lib/**/*.ts` with no consumer outside their defining file — 49 of them, after setting aside 29 that only `scripts/` consumes. Re-checked here across `src/`, `scripts/`, `src-tauri/`, and the root config files: **all 49 do have zero external references.** That part held.

What did not hold is the conclusion. The scan excluded the defining file from its own search, so "no external reference" was being read as "dead". Printing every in-file occurrence of all 49 settles it:

**Every one of the 49 is used inside its own file.** Not one is an orphan. So the delete bucket is empty, and the whole question is `export`-removal versus keep.

| classification | count |
|---|---|
| used inside its own file → `export` removed, declaration kept | **23** |
| used nowhere at all → declaration deleted | **0** |
| kept exported, with reason | **26** |

## The line

A type **keeps** `export` when it is *directly* the parameter type or the return type of an exported function, or the declared type of an exported constant. That is the module's stated interface: a caller who builds the argument in a separate statement (`const ctx: PdfExportContext = {…}`) or holds the result in a typed field has to be able to name it, and no importer existing yet is not evidence that none should.

A type **loses** `export` when it is only reachable *inside* such a type — a field of an options bag — or appears only in value positions internal to the module. Structural typing and inference cover those; a caller never has to write the name. A function loses `export` when every call to it is in its own file.

That rule decides all 49 without a tie-break, and re-exporting any of them later is a one-word change.

## `export` removed (23)

| symbol | file | why it is internal |
|---|---|---|
| `SUPPORTED_LANGUAGES` | `stores/settings.svelte.ts` | value position only — feeds `SUPPORTED_LANGUAGE_CODES` |
| `SUPPORTED_LANGUAGE_CODES` | `stores/settings.svelte.ts` | value position only — feeds `isSupportedLanguage` |
| `isSupportedLanguage` | `stores/settings.svelte.ts` | one call, `:751`, validating the persisted `language` key |
| `loadPersistedSettings` | `stores/settings.svelte.ts` | two calls, both in this file (`:343`, `:423`) |
| `installPersistedSettings` | `stores/settings.svelte.ts` | one call, `:435` |
| `UpdatePhase` | `stores/update.svelte.ts` | type of a field on a non-exported class; `UpdateDialog.svelte` compares `updateStore.phase` to string literals and never names the type |
| `ErrorSource` | `stores/update.svelte.ts` | same |
| `EditorToolbarGroup` | `utils/editorToolbar.ts` | field of `EditorToolbarTool` |
| `EDITOR_TOOLBAR_TOOLS` | `utils/editorToolbar.ts` | value position only — callers go through `getEditorToolbarTools()` and `DEFAULT_EDITOR_TOOLBAR_ORDER` |
| `KatexFamilyRule` | `utils/exportFonts.ts` | return type of `parseKatexFamilyRules`, which is itself internal |
| `parseKatexFamilyRules` | `utils/exportFonts.ts` | one call, `:109`, inside `collectUsedKatexFamilies` |
| `collectClassNames` | `utils/exportFonts.ts` | one call, `:106`, same |
| `bytesToBase64` | `utils/exportFonts.ts` | one call, `:247`, inside `fetchFontDataUrls` |
| `FrontMatterValueKind` | `utils/frontMatter.ts` | field of `FrontMatterField` |
| `parseFrontMatterTagInput` | `utils/frontMatter.ts` | two calls, both in this file |
| `isAbsoluteMarkdownPath` | `utils/markdownLinks.ts` | one call, `:54` |
| `MermaidRenderer` | `utils/mermaidPrint.ts` | field of `PrintDiagramContext` (which stays exported) |
| `OpenExportedFileLabels` | `utils/openExportedFile.ts` | optional field of `OpenExportedFileDeps` (which stays exported) |
| `PASTE_PROBE_CHARACTER` | `utils/pasteContext.ts` | value position only, `:122` |
| `PasteContextTokenizer` | `utils/pasteContext.ts` | field of `PasteCaretContext` (which stays exported) |
| `isCodeAtOffset` | `utils/pasteContext.ts` | one call, `:156` |
| `TabFileActionId` | `utils/tabFileActions.ts` | field of `TabFileAction` (which stays exported) |
| `TITLEBAR_TOOLBAR_ACTIONS` | `utils/titlebarToolbar.ts` | value position only — callers go through `getTitlebarToolbarActions()` and the two `DEFAULT_TITLEBAR_TOOLBAR_*` constants |

## Kept exported (26)

24 of them are the vocabulary of a module's public interface — the shape a caller has to name to build an argument or hold a result:

| symbol | the exported signature it appears in |
|---|---|
| `ExternalChangeOutcome` | return of `resolveExternalChange`, which `createDocumentSession` hands back (`documentSession.svelte.ts:630`) |
| `PersistedSetting` | param of two helpers and return of `createSettingsPersistence()` |
| `EditorToolbarMove` | param of `applyEditorToolbarMove`, return of `getEditorToolbar{Reorder,Adjacent}Move` |
| `ExportHtmlResult` | return of `exportAsHtml` |
| `PdfExportContext` | param of `exportAsPdf` |
| `ExportDocumentInput` | param of `buildExportDocument` |
| `KatexFontFace` | return of `findKatexFontFaces` |
| `PrintDiagramContext` | param of `renderDiagramsForPrint` |
| `ExportedFileFormat` | param of `askToOpenExportedFile` |
| `OpenExportedFileResult` | return of `askToOpenExportedFile` |
| `OpenExportedFileDeps` | param of `askToOpenExportedFile` |
| `PasteCaretContext` | param of `shouldLinkifyPastedUrl` |
| `PathIdentity` | params of `isSameFilePath` |
| `LineRange` | return of `parseSourceposLineRange` |
| `AnchorNode` | param of `findAnchorElement` |
| `AnchorMatch` | return of `findAnchorElement` |
| `RenderRichContentOptions` | param of `renderRichContent` |
| `TabFileAction` | return of `getTabFileActions` |
| `FileHistoryState` | params and returns across six exported functions |
| `FileHistoryNavigationState` | params of `replaceCurrentHistoryEntry`, `navigateFileHistory` |
| `FileHistoryNavigationResult` | return of `goBackInHistory`, `goForwardInHistory` |
| `TitlebarToolbarAction` | return of `getTitlebarToolbarActions` |
| `TitlebarToolbarMove` | param of `applyTitlebarToolbarMove`, return of `getTitlebarToolbar{Reorder,Adjacent}Move` |
| `ConfiguredTitlebarToolbarIds` | return of `getConfiguredTitlebarToolbarIds` |
| `DefaultFonts` | declared type of the exported `DEFAULT_FONTS`, which `Settings.svelte` reads |

`PersistedSetting` is the clearest of these. `scripts/settingsPersistence.test.ts:100` needs that type and cannot import it, so it writes `ReturnType<typeof createSettingsPersistence>[number]` instead. The export is doing work even with no `import` naming it.

The 26th is `TOC_WIDTH_RANGE`, kept for a different reason — see below.

## Two things found while classifying

**`settings.svelte.ts` carries a second, stale copy of the language catalogue.** The group of 8 the scan flagged in that file is not one feature's leftovers; it is two unrelated things, and only the language half is interesting. `SUPPORTED_LANGUAGES` (`:55`) duplicates `getSupportedLanguages()` in `utils/i18n.ts:33` — same 26 entries, same `code`/`name`/`nativeName` shape — and `settings.svelte.ts:27` duplicates `i18n.ts:1`'s `LanguageCode` union. The live one is `i18n.ts`: `Settings.svelte:1166-1168` renders the language `<select>` from it.

The two copies have already drifted. For `pt`, `i18n.ts` says `Portuguese` / `Português`; `settings.svelte.ts` says `Portuguese (European)` / `Português (Europeu)`. Nothing catches that, because the settings copy is only consumed for its `code` column — `.map((entry) => entry.code)` on the next line. Its `name` and `nativeName` are never read by anything.

So the chain is live but only one column deep: `SUPPORTED_LANGUAGES` → `SUPPORTED_LANGUAGE_CODES` → `isSupportedLanguage` → validating the persisted `language` key at `:751`. Un-exporting is correct and is all this PR does. Deleting the duplicate — or deriving the codes from `i18n.ts` — is a real change with a real reason and belongs in its own PR.

**`TOC_WIDTH_RANGE` is unreferenced because its consumer re-typed the numbers.** It is one of five sibling `NumericSettingRange` constants; the other four are imported and consumed by `Settings.svelte`. `NumericSettingRange`'s own doc comment (`settings.svelte.ts:262-266`) states the contract: *"Single source of truth: the settings UI renders `min`/`max`/`step` from it and every write path clamps against the same object."*

The TOC width control is the drag handle in `MarkdownViewer.svelte`, not a settings slider, and it does not import the range. It declares its own:

```js
const TOC_MIN_WIDTH = 180;   // MarkdownViewer.svelte:267
const TOC_MAX_WIDTH = 420;   // MarkdownViewer.svelte:268
```

Identical to `TOC_WIDTH_RANGE`'s `min`/`max` (`:209`), and used for the clamp at `:430`, the keyboard jumps at `:444`/`:447`, and `aria-valuemin`/`aria-valuemax` at `:3468`/`:3469`. The store's own `setTocWidth` clamps against `TOC_WIDTH_RANGE` as well, so the numbers agree today by coincidence of them being typed twice.

`TOC_WIDTH_RANGE` therefore keeps its `export`. Its unreferenced-ness is a defect in the caller, not surplus surface, and un-exporting it would cement the duplication and make the obvious fix start by re-adding the keyword. Not fixed here — importing the range into `MarkdownViewer.svelte` changes what a wrong number would do, which is more than a visibility PR should carry.

## Not done

- **No lint rule or test guards against the surface growing back.** Nothing stops the next `export` with no importer. A `scripts/` check in the shape of `singleImplementationConvention.test.ts` could assert it, but that is a source-text assertion with its own design questions and does not belong in the same change as the removals it would police.
- **The 29 symbols referenced only from `scripts/`** are untouched, as intended. Removing `export` there would delete executable tests, which is the wrong trade in this repo.
- **`.svelte` files were not scanned for their own unreferenced exports** — only `src/lib/**/*.ts` was in scope.
- **`SUPPORTED_LANGUAGES`'s unread `name`/`nativeName` columns are left in place.** Deleting data from a declaration is a different action from narrowing its visibility, and the whole constant is a duplicate that wants resolving as one decision.
- **Verification is the compiler, not a behaviour run.** `npm run check` covers `src/` and `scripts/` (637 files, 0 errors) and would name any broken reference; `npm test` is unchanged at 565 because none of these 23 were reachable from a test. The app was not launched — for a change that only removes a keyword from a declaration, there is nothing at runtime for it to observe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
