### PR TITLE
test(save): cover the branch where the partial-buffer guard refuses

### DIFF
--- a/scripts/truncatedBufferGuard.test.ts
+++ b/scripts/truncatedBufferGuard.test.ts
@@ -50,6 +50,8 @@ const { createDocumentSession } = await import('../src/lib/sessions/documentSess
 const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
 
 const errors: string[] = [];
+/** What the close dialog answers next. Set per test. */
+let closeAnswer: 'save' | 'discard' | 'cancel' = 'discard';
 
 function makeSession() {
 	return createDocumentSession({
@@ -67,7 +69,7 @@ function makeSession() {
 		onError: (message) => errors.push(message),
 		selfWriteGraceMs: 400,
 		cancelPendingAutoSave: () => {},
-		askClose: async () => 'discard' as const,
+		askClose: async () => closeAnswer,
 		onCloseSaveNewerEdits: () => {},
 		onCloseAutoSaveFailed: () => {},
 	});
@@ -77,6 +79,7 @@ function reset() {
 	tabManager.closeAll();
 	invokeCalls = [];
 	errors.length = 0;
+	closeAnswer = 'discard';
 }
 
 /** Open a >50KB file and leave the background full read pending forever. */
@@ -235,6 +238,163 @@ test('toggling a task checkbox completes the buffer before writing it', async ()
 		(write!.args.content as string).includes('- [ ] last'),
 		'the part of the file past the preview window survives',
 	);
+});
+
+// --- the refusal itself: what each writer does when the buffer stays partial ---
+//
+// Everything above proves the guard lets a COMPLETED buffer through. The
+// branch it exists for — `ensureFullContent` answering false — had no test
+// driving a writer into it, and an audit that deleted the verdict check from
+// `toggleTaskCheckbox` outright left the whole suite green.
+//
+// `ensureFullContent` answers false in exactly three states, and each is
+// exercised below:
+//
+//   1. the tab is gone — a transfer or detach whose tab closed mid-flight,
+//   2. the partial buffer already carries edits: replacing it would trade the
+//      user's typing for the file's tail, so it is left alone,
+//   3. the re-read itself failed — the only one of the three that reports.
+//
+// The two writers that do not consult it, `saveContent` and `saveContentAs`,
+// carry the same refusal as their own `isTruncated` backstop, so they are
+// driven into it here too.
+//
+// A buffer that is still partial afterwards is unusable in both directions: it
+// cannot be written (that truncates the file) and it can no longer be completed
+// (state 2 is permanent once the buffer is dirty). So every test asserts the
+// same pair — nothing reached `save_file_content`, and the buffer was left
+// exactly as it was found.
+
+/** Did anything at all get written to disk in this test? */
+const wroteToDisk = () => invokeCalls.some((call) => call.cmd === 'save_file_content');
+
+const TASKS = `- [ ] first\n\n${'y'.repeat(PREVIEW_BYTES)}\n\n- [ ] last\n`;
+const TASKS_PARTIAL = TASKS.slice(0, PREVIEW_BYTES);
+
+/** Open the >50KB task list and leave it holding only its preview slice. */
+async function openPartialTasks() {
+	handleInvoke = (cmd) => {
+		if (cmd === 'open_markdown_preview') return ['<p>preview</p>', TASKS_PARTIAL, false, false];
+		if (cmd === 'read_file_content_checked') return new Promise(() => {});
+		throw new Error(`unexpected invoke: ${cmd}`);
+	};
+	const session = makeSession();
+	await session.loadMarkdown('/docs/tasks.md');
+	const tab = tabManager.activeTab!;
+	assert.equal(tab.rawContent, TASKS_PARTIAL, 'precondition: the buffer is the partial read');
+	return { session, tab };
+}
+
+/**
+ * From here on the file's tail cannot be read — an unplugged drive, a network
+ * volume that went away, a file another process replaced. Writes are allowed
+ * through so that a guard which stops refusing is caught by the write it lets
+ * happen, not by an "unexpected invoke" from the stub.
+ */
+function makeTailUnreadable() {
+	handleInvoke = (cmd) => {
+		if (cmd === 'read_file_content_checked') return Promise.reject(new Error('Os { code: 5, kind: Uncategorized }'));
+		if (cmd === 'save_file_content') return null;
+		if (cmd === 'canonicalize_path') return '/docs/copy.md';
+		if (cmd === 'plugin:dialog|save') return '/docs/copy.md';
+		throw new Error(`unexpected invoke: ${cmd}`);
+	};
+}
+
+test('a re-read that fails leaves the buffer partial, still flagged, and reported', async () => {
+	reset();
+	const { session, tab } = await openPartial();
+	makeTailUnreadable();
+
+	assert.equal(await session.ensureFullContent(tab.id), false, 'a buffer that is still partial must be reported as such');
+	assert.equal(tab.rawContent, PARTIAL, 'a failed read must not leave a half-filled buffer behind');
+	assert.equal(tab.isTruncated, true, 'and the flag must survive, or every writer downstream stops refusing');
+	assert.equal(tab.isDirty, false, 'nothing was edited, so nothing may be marked unsaved');
+	assert.deepEqual(errors, ['Error loading the rest of the file'], 'the user is told why the document cannot be edited');
+});
+
+test('completing the buffer of a tab that is gone is refused, not assumed', async () => {
+	// `handleDetach` and `moveTabToWindow` pass an id, and the tab behind it can
+	// be closed while the call is in flight. "No such tab" is not "nothing to
+	// do": answering true would hand the transfer a buffer nobody owns.
+	reset();
+	const { session, tab } = await openPartial();
+	const id = tab.id;
+	tabManager.closeTab(id);
+	const before = invokeCalls.length;
+
+	assert.equal(await session.ensureFullContent(id), false, 'there is no buffer to vouch for');
+	assert.equal(invokeCalls.length, before, 'and nothing is read for it either');
+});
+
+test('a task checkbox is not toggled into a buffer that could not be completed', async () => {
+	// The audit's injected defect: `toggleTaskCheckbox` calling
+	// `ensureFullContent` and ignoring what it says. Reading mode shows the
+	// preview slice with its checkboxes already clickable, so this is reachable
+	// with one click on a large file whose tail never arrived.
+	reset();
+	const { session, tab } = await openPartialTasks();
+	makeTailUnreadable();
+
+	assert.equal(await session.toggleTaskCheckbox(1, true), false, 'the toggle must report failure so the checkbox springs back');
+	assert.equal(wroteToDisk(), false, 'a partial buffer must never reach save_file_content');
+	assert.equal(tab.rawContent, TASKS_PARTIAL, 'and the buffer must not be edited either');
+	assert.equal(tab.isDirty, false, 'a dirty partial buffer can never be completed again — that is the trap');
+	assert.ok(errors.length > 0, 'the refusal is reported, not silent');
+});
+
+test('a task checkbox is not toggled into a partial buffer that already carries edits', async () => {
+	// The other refusal state, and the one that is silent by design: the tail is
+	// readable, but taking it would overwrite what the user typed. The toggle's
+	// `false` is the whole signal — the caller in MarkdownViewer puts the
+	// checkbox back with it.
+	reset();
+	const { session, tab } = await openPartialTasks();
+	const edited = `${TASKS_PARTIAL}\n- [ ] typed by hand\n`;
+	tabManager.updateTabRawContent(tab.id, edited);
+	handleInvoke = (cmd) => {
+		if (cmd === 'read_file_content_checked') return [TASKS, false];
+		if (cmd === 'save_file_content') return null;
+		throw new Error(`unexpected invoke: ${cmd}`);
+	};
+
+	assert.equal(await session.toggleTaskCheckbox(1, true), false, 'the toggle must report failure so the checkbox springs back');
+	assert.equal(wroteToDisk(), false, 'the preview slice must not be written over the document');
+	assert.equal(tab.rawContent, edited, 'and the edits it carries must not be traded for the file’s tail');
+});
+
+test('Save As refuses to copy a partially loaded document', async () => {
+	// The copy would be silently short, and it is a NEW file — nothing about it
+	// says it is missing everything past 50KB. The guard sits before the dialog,
+	// so the user is not asked where to put a document that is not going to be
+	// written.
+	reset();
+	const { session } = await openPartial();
+	makeTailUnreadable();
+
+	assert.equal(await session.saveContentAs(), false, 'Save As must report failure rather than write a short copy');
+	assert.equal(wroteToDisk(), false, 'an incomplete copy must never be written');
+	assert.equal(
+		invokeCalls.some((call) => call.cmd.endsWith('dialog|save')),
+		false,
+		'and the Save As dialog is not opened for a write that cannot happen',
+	);
+	assert.deepEqual(errors, ['Refusing to save a partially loaded document']);
+});
+
+test('answering “Save” to the close dialog cannot flush a partial buffer', async () => {
+	// The close path is the one place a refused save is not merely reported:
+	// `canCloseTab` returning true here closes the tab, and the buffer — the only
+	// copy of those edits — goes with it. A save that was refused is not a save.
+	reset();
+	const { session, tab } = await openPartial();
+	tabManager.updateTabRawContent(tab.id, `${PARTIAL}edited`);
+	makeTailUnreadable();
+	closeAnswer = 'save';
+
+	assert.equal(await session.canCloseTab(tab.id), false, 'a tab whose save was refused must stay open');
+	assert.equal(wroteToDisk(), false);
+	assert.ok(errors.length > 0, 'the user is told why the tab will not close');
 });
 
 // --- wiring that cannot be executed outside a Svelte runtime ---


### PR DESCRIPTION
`scripts/truncatedBufferGuard.test.ts` exists for one claim: a buffer that holds only the first 50KB of a large file is never written back over that file. Every test in it drove the guard's **success** path — open a partial buffer, complete it, watch the whole document reach disk.

Deleting the verdict check from `toggleTaskCheckbox`, so it edits and saves whatever `ensureFullContent` leaves behind:

```diff
-		if (!(await ensureFullContent(tab.id))) return false;
+		await ensureFullContent(tab.id);
```

**565 tests, 565 passing.** The file whose entire purpose is that guard had no test for the guard refusing.

## What `false` actually means

`ensureFullContent` re-reads the file behind a partial buffer and returns whether the buffer is whole afterwards. Three states produce `false`, and they are not variations of one thing:

| state | reports? | how it is reached |
|---|---|---|
| the tab is gone | no | `handleDetach` / `moveTabToWindow` hold an id; the tab can close while the call is in flight |
| the buffer already carries edits | no | replacing it would trade the user's typing for the file's tail, so it is left alone |
| the re-read failed | `onError` | an unplugged drive, a network volume that went away, a file replaced under us |

The second state is a trap and not merely a refusal: once a partial buffer is dirty it can never be completed again, so a writer that edits it first has permanently disarmed the recovery path. That is why the tests assert the buffer is left byte-identical, not merely that no write happened.

**Every call site checks the result.** All six — `toggleTaskCheckbox` in `documentSession`, and `handleFrontMatterEdit`, `handleFrontMatterListChange`, `toggleSplitView`, `handleDetach`, `moveTabToWindow` in `MarkdownViewer.svelte` — stop on `false`; the five in the component also raise `toast.partialDocument`. No live bug, a coverage gap.

`saveContent` and `saveContentAs` do not consult it. They carry the same refusal as their own `isTruncated` backstop, which is the last line of defence if an entry point is ever missed, so they are driven into it here too.

## Tests

Six added to `truncatedBufferGuard.test.ts`, all calling into the real `documentSession` and the real `TabManager` over the stubbed Tauri bridge that file already sets up. No new source-text assertions — the existing three at the bottom of the file, for wiring `node --test` cannot import from a `.svelte` file, are untouched.

| test | what it pins |
|---|---|
| a re-read that fails leaves the buffer partial, still flagged, and reported | the failing branch returns `false`, does not half-fill the buffer, keeps `isTruncated`, and says so once |
| completing the buffer of a tab that is gone is refused, not assumed | "no such tab" is not "nothing to do" — and nothing is read for it |
| a task checkbox is not toggled into a buffer that could not be completed | the audit's defect: the toggle reports failure, writes nothing, and leaves the buffer clean |
| a task checkbox is not toggled into a partial buffer that already carries edits | the silent state — the `false` return is the whole signal, and the typing survives |
| Save As refuses to copy a partially loaded document | a short copy is a NEW file that nothing marks as short; the dialog does not even open |
| answering "Save" to the close dialog cannot flush a partial buffer | the one path where a refused save loses data: `canCloseTab` must stay `false` and the tab must stay open |

The close-dialog test needed the harness's `askClose` to be settable; it still answers `discard` by default, so no existing test changed behaviour.

Both recent changes to this file are load-bearing here and neither is fought. **#438** serialises saves per tab: the truncated refusal returns before `writeExclusively`, so it never enters the queue and a later save on the same tab still writes — `completing a partial buffer … unblocks saving`, already in the file, is what covers that ordering. **#439** made `isLossySaveRefused` ask the tab as well as the memory: a partial-buffer refusal never touches `lossySaveWarnedTabs` and never reads as a lossy refusal, so the auto-save timer stays free to report a real failure on the same tab.

## Mutation check

Each defect injected into `src/lib/sessions/documentSession.svelte.ts`, `scripts/truncatedBufferGuard.test.ts` run, the source restored. 17 tests in the file.

| injected defect | result | first red test |
|---|---|---|
| `toggleTaskCheckbox` ignores the verdict *(the audit's defect)* | RED (2) | a task checkbox is not toggled into a buffer that could not be completed |
| `saveContentAs` drops its `isTruncated` guard | RED (1) | Save As refuses to copy a partially loaded document |
| `saveContent` drops its `isTruncated` guard | RED (2) | saving refuses to write a partial buffer over the file |
| `ensureFullContent` treats a failed re-read as success | RED (2) | a re-read that fails leaves the buffer partial, still flagged, and reported |
| `ensureFullContent` reports the failed re-read to nobody | RED (2) | a re-read that fails leaves the buffer partial, still flagged, and reported |
| `ensureFullContent` completes a dirty partial buffer anyway | RED (2) | a partial buffer that already carries edits is never silently discarded |
| `ensureFullContent` answers `true` for a tab that is gone | RED (1) | completing the buffer of a tab that is gone is refused, not assumed |
| `canCloseTab` closes on a refused save | RED (1) | answering "Save" to the close dialog cannot flush a partial buffer |

8 injected, 8 caught. Rows 3 and 6 are caught first by tests that were already there — those two are not vacuous, they were simply the only refusals anything reached.

Messages name the behaviour, not the line:

```
the toggle must report failure so the checkbox springs back
a partial buffer must never reach save_file_content
and the edits it carries must not be traded for the file's tail
a tab whose save was refused must stay open
the user is told why the document cannot be edited
```

**`npm test` 565 → 571 passing, `npm run check` 637 files / 0 errors, `npm run build` clean.**

# Not covered

- **The five refusal sites in `MarkdownViewer.svelte`** — `handleFrontMatterEdit`, `handleFrontMatterListChange`, `toggleSplitView`, `handleDetach`, `moveTabToWindow`. Each checks the verdict and raises `toast.partialDocument`, and each is still asserted only as source text, because `node --test` cannot import a `.svelte` file (#442's finding: 21 components, no executable coverage). The grep tests prove `ensureFullContent` is *mentioned* in those bodies, not that the early return fires. Closing this is the same extraction #442 did for the scroll-sync math, and it is a bigger lift here: these handlers touch the DOM and component state, so it is a behaviour-moving change rather than a mechanical one.
- **The dirty-partial refusal is silent to the user.** States 1 and 2 report nothing; only the failed re-read raises a toast. In practice the caller compensates — the checkbox springs back, the front-matter handlers toast on `false` themselves — so the user does see *something*. It is still a gap between "the user was told" and "the UI happened to react", and it is why the checkbox tests assert the return value rather than a message.
- **`markTabContentUnavailable`'s tab.** `isTruncated` also means "the file could not be read at all", set by the failed-load path with an empty buffer. Every writer refuses it for the same reason, and nothing here distinguishes the two producers of the flag; `documentLoadFailure.test.ts` owns that side.
- **No concurrency between a refusal and a live write.** #438's queue is exercised by `oneWritePerTabInFlight.test.ts`, and the refusals here are all reached with nothing in flight. A refusal arriving while a save for the same tab is draining is a state neither file drives.
- **Nothing pins the backstop to `saveContent`/`saveContentAs` specifically.** If someone moves the `isTruncated` check into `writeExclusively`, these tests still pass — they assert the refusal, not where it lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
