### PR TITLE
fix(tabs): clear the whole reading position when a tab changes document

### DIFF
--- a/scripts/tabReadingPosition.test.ts
+++ b/scripts/tabReadingPosition.test.ts
@@ -1,0 +1,293 @@
+/**
+ * A tab that is pointed at a different document must forget where the reader
+ * was in the old one.
+ *
+ * `Tab` records the reading position four times, and both restore paths are
+ * fallback cascades that stop at the first entry that resolves: the preview
+ * tries `anchorLine`, then `scrollPercentage`, then `scrollTop`
+ * (`MarkdownViewer.svelte:1133-1162`), and the editor tries `editorViewState`,
+ * then `anchorLine`, then `scrollPercentage` (`components/Editor.svelte:290-311`).
+ *
+ * `navigate()` used to end with `tab.scrollTop = 0` and nothing else, which is
+ * the entry each cascade consults LAST. For any tab that had actually been
+ * scrolled, that reset was unreachable, and the next activation of the tab
+ * restored the previous document's position into the new document. `goBack` and
+ * `goForward` repoint a tab the same way and cleared nothing at all.
+ *
+ * Two things are checked here, and neither reads an implementation file as text:
+ *
+ *   - the REAL `TabManager`, driven through every route that changes which
+ *     document a tab shows and every route that changes only its path;
+ *   - the REAL `findAnchorElement` over the REAL `processMarkdownHtml` output of
+ *     two DIFFERENT documents, which is what turns "the field is stale" into a
+ *     rate: how often a line number carried over from document A resolves to
+ *     some unrelated block of document B, so the cascade stops there and the
+ *     later entries are never consulted.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { installShimDom, parseHtml, type ShimElement } from './renderProtocolDom.ts';
+
+// ---------------------------------------------------------------- environment
+
+const g = globalThis as any;
+const runeEffect = (fn: () => void) => {
+	void fn;
+};
+runeEffect.root = (fn: () => unknown) => fn();
+g.$state = (value: unknown) => value;
+g.$state.raw = (value: unknown) => value;
+g.$state.snapshot = (value: unknown) => value;
+g.$derived = (value: unknown) => value;
+g.$derived.by = (fn: () => unknown) => fn();
+g.$effect = runeEffect;
+g.window = g.window ?? {};
+g.window.__TAURI_INTERNALS__ = g.window.__TAURI_INTERNALS__ ?? {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
+};
+
+const localStore = new Map<string, string>();
+g.localStorage = g.localStorage ?? {
+	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
+	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
+	removeItem: (key: string) => void localStore.delete(key),
+	clear: () => localStore.clear(),
+};
+
+installShimDom();
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { processMarkdownHtml } = await import('../src/lib/utils/markdown.ts');
+const { findAnchorElement } = await import('../src/lib/utils/previewAnchor.ts');
+
+type Tab = (typeof tabManager.tabs)[number];
+
+function reset() {
+	tabManager.closeAll();
+	tabManager.recentlyClosed.length = 0;
+	localStore.clear();
+}
+
+/** A tab whose reader is a long way down a document, all four fields written. */
+function openScrolledTab(path: string): Tab {
+	tabManager.addTab(path, '# doc\n');
+	const tab = tabManager.tabs.find((item) => item.path === path)!;
+	tab.scrollTop = 4820;
+	tab.scrollPercentage = 0.73;
+	tab.anchorLine = 812;
+	tab.editorViewState = { cursorState: 'monaco-live-object' };
+	return tab;
+}
+
+/** Every field either restore cascade reads, in the order it reads them. */
+function readingPosition(tab: Tab) {
+	return {
+		editorViewState: tab.editorViewState,
+		anchorLine: tab.anchorLine,
+		scrollPercentage: tab.scrollPercentage,
+		scrollTop: tab.scrollTop,
+	};
+}
+
+const AT_TOP = { editorViewState: null, anchorLine: 0, scrollPercentage: 0, scrollTop: 0 };
+
+// --------------------------------------------- the routes that change document
+
+test('following a link to another file leaves the tab at the top of it', () => {
+	reset();
+	const tab = openScrolledTab('/notes/a.md');
+
+	tabManager.navigate(tab.id, '/notes/b.md');
+
+	assert.equal(tab.path, '/notes/b.md');
+	assert.deepEqual(readingPosition(tab), AT_TOP);
+});
+
+test('going back to the previous file leaves the tab at the top of it', () => {
+	reset();
+	const tab = openScrolledTab('/notes/a.md');
+	tabManager.navigate(tab.id, '/notes/b.md');
+	tab.anchorLine = 44;
+	tab.scrollPercentage = 0.2;
+	tab.scrollTop = 900;
+	tab.editorViewState = { cursorState: 'monaco-live-object' };
+
+	const back = tabManager.goBack(tab.id);
+
+	assert.equal(back, '/notes/a.md');
+	assert.equal(tab.path, '/notes/a.md');
+	assert.deepEqual(readingPosition(tab), AT_TOP);
+});
+
+test('going forward again leaves the tab at the top of that file', () => {
+	reset();
+	const tab = openScrolledTab('/notes/a.md');
+	tabManager.navigate(tab.id, '/notes/b.md');
+	tabManager.goBack(tab.id);
+	tab.anchorLine = 300;
+	tab.scrollPercentage = 0.5;
+	tab.scrollTop = 2000;
+	tab.editorViewState = { cursorState: 'monaco-live-object' };
+
+	const forward = tabManager.goForward(tab.id);
+
+	assert.equal(forward, '/notes/b.md');
+	assert.equal(tab.path, '/notes/b.md');
+	assert.deepEqual(readingPosition(tab), AT_TOP);
+});
+
+// ------------------------------------- the routes that change only the path
+//
+// The document on screen does not change in either of these, so the reader has
+// not moved and the position must survive. This is the half of the rule a
+// blanket "clear on every path write" would break.
+
+test('Save As renames the tab without moving the reader', () => {
+	reset();
+	const tab = openScrolledTab('/notes/a.md');
+	const before = readingPosition(tab);
+
+	tabManager.updateTabPath(tab.id, '/notes/copy.md');
+
+	assert.equal(tab.path, '/notes/copy.md');
+	assert.deepEqual(readingPosition(tab), before);
+});
+
+test('renaming the file on disk does not move the reader', () => {
+	reset();
+	const tab = openScrolledTab('/notes/a.md');
+	const before = readingPosition(tab);
+
+	tabManager.renameTab(tab.id, '/notes/renamed.md');
+
+	assert.equal(tab.path, '/notes/renamed.md');
+	assert.deepEqual(readingPosition(tab), before);
+});
+
+test('a link that resolves to the file already open is not a navigation', () => {
+	reset();
+	const tab = openScrolledTab('/notes/a.md');
+	const before = readingPosition(tab);
+
+	tabManager.navigate(tab.id, '/notes/a.md');
+
+	assert.deepEqual(readingPosition(tab), before);
+});
+
+/* ------------------------------------------------------------------ */
+/* what a carried-over anchor line does to the next document           */
+/* ------------------------------------------------------------------ */
+
+// comrak's shape, as recorded in renderProtocolFixtures.ts: every block carries
+// a `data-sourcepos` line range, and `processMarkdownHtml` then re-parents
+// everything after a heading into a wrapper that carries none.
+
+class DocumentBuilder {
+	private line = 1;
+	private readonly parts: string[] = [];
+	readonly lines: number[] = [];
+
+	heading(text: string, slug: string) {
+		const line = this.line;
+		this.line += 2;
+		this.lines.push(line);
+		this.parts.push(
+			`<h2 data-sourcepos="${line}:1-${line}:${text.length + 3}">` +
+				`<a href="#${slug}" aria-hidden="true" class="anchor" id="${slug}"></a>${text}</h2>`,
+		);
+	}
+
+	paragraph(text: string) {
+		const line = this.line;
+		this.line += 2;
+		this.lines.push(line);
+		this.parts.push(`<p data-sourcepos="${line}:1-${line}:${text.length}">${text}</p>`);
+	}
+
+	html() {
+		return this.parts.join('\n') + '\n';
+	}
+}
+
+/**
+ * Two different documents. `paragraphsPerSection` is what makes them different
+ * documents rather than two renders of one: the same source line lands in a
+ * different section of each.
+ */
+function buildDocument(name: string, sections: number, paragraphsPerSection: number) {
+	const doc = new DocumentBuilder();
+	for (let s = 1; s <= sections; s += 1) {
+		doc.heading(`${name} section ${s}`, `${name}-section-${s}`);
+		for (let p = 1; p <= paragraphsPerSection; p += 1) {
+			doc.paragraph(`${name} section ${s} paragraph ${p}, a sentence of prose.`);
+		}
+	}
+	return doc;
+}
+
+const DOC_A = buildDocument('alpha', 60, 6);
+const DOC_B = buildDocument('beta', 40, 11);
+
+function render(doc: DocumentBuilder, path: string): ShimElement {
+	return parseHtml(processMarkdownHtml(doc.html(), path, new Set<string>())).body;
+}
+
+const BODY_B = render(DOC_B, '/notes/b.md');
+
+function textOf(element: unknown): string {
+	return String((element as { textContent?: string }).textContent ?? '');
+}
+
+test('a line number carried over from the previous document resolves into this one', (t) => {
+	// Every source line the reader could have been parked on in document A.
+	const carried = DOC_A.lines;
+
+	let resolved = 0;
+	for (const line of carried) {
+		if (findAnchorElement(BODY_B, line)) resolved += 1;
+	}
+	const percent = Math.round((resolved / carried.length) * 1000) / 10;
+
+	t.diagnostic(`document A: ${carried.length} anchorable source lines`);
+	t.diagnostic(`document B: ${BODY_B.querySelectorAll('[data-sourcepos]').length} blocks with data-sourcepos`);
+	t.diagnostic(`carried anchors resolving inside document B: ${resolved}/${carried.length} (${percent}%)`);
+
+	// This is the mechanism, not a property of these two fixtures: while the
+	// carried line is inside the other document's range it resolves, the first
+	// cascade entry reports success, and `scrollPercentage` and `scrollTop` —
+	// the field the old `navigate()` reset — are never consulted.
+	assert.ok(
+		percent > 50,
+		`a stale anchor line is expected to resolve in a document of similar length, got ${percent}%`,
+	);
+
+	// And it resolves to the wrong text: the block at that line in B, which
+	// says `beta`, has nothing to do with the block the reader left in A.
+	const sample = DOC_A.lines[Math.floor(DOC_A.lines.length / 2)];
+	const match = findAnchorElement(BODY_B, sample)!;
+	t.diagnostic(`line ${sample} of A resolves to B's ${textOf(match.element).trim().slice(0, 48)}`);
+	assert.ok(match, `expected line ${sample} to resolve inside document B`);
+	assert.match(textOf(match.element), /beta/);
+});
+
+test('a cleared reading position resolves to nothing, so the cascade falls through to the top', () => {
+	reset();
+	const tab = openScrolledTab('/notes/a.md');
+	tabManager.navigate(tab.id, '/notes/b.md');
+
+	// Stage 1 of the preview cascade is guarded on `anchorLine > 0`, and
+	// `findAnchorElement` refuses a non-positive line outright. Asserted as a
+	// boolean: a returned match holds a live DOM node whose parent chain the
+	// assertion printer would try to serialize.
+	assert.ok(
+		findAnchorElement(BODY_B, tab.anchorLine) === null,
+		'a cleared anchorLine must not resolve to an element in the new document',
+	);
+	// Stage 2 is guarded on `scrollPercentage > 0`, so the cascade reaches
+	// stage 3 — and stage 3 is the top of the document.
+	assert.equal(tab.scrollPercentage, 0);
+	assert.equal(tab.scrollTop, 0);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -1123,6 +1123,14 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		// Depend on the ID and body existence to trigger restore
 		const id = tabManager.activeTabId;
 		const body = markdownBody;
+		// ...and on WHICH DOCUMENT that tab holds. Following a link, and
+		// back/forward, keep the tab and swap the document under it, and
+		// `clearReadingPosition` puts the tab at the top of the new one. This
+		// effect is the only thing that moves the preview to a tab's recorded
+		// position, so without this dependency that reset reaches nothing: the
+		// container keeps the pixel offset the reader had in the PREVIOUS
+		// document, and the new document opens part-way down.
+		void currentFile;
 
 		if (id && body) {
 			untrack(() => {

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -92,6 +92,10 @@ export interface Tab {
 	 * recently written is not the most precise, and one of them can be current
 	 * while its neighbours are not. None of them scrolls anything when
 	 * assigned: the restore runs on tab activation, not on write.
+	 *
+	 * Because a cascade stops at its first resolved entry, they can only be
+	 * INVALIDATED as a set — pointing the tab at another document clears all of
+	 * them, and `editorViewState`, through `clearReadingPosition`.
 	 */
 	scrollPercentage: number;
 	anchorLine: number;
@@ -785,6 +789,37 @@ class TabManager {
 		}
 	}
 
+	/**
+	 * This tab is about to show a DIFFERENT document, so everything that says
+	 * where the reader was in the old one is void. The three routes that do
+	 * that — `navigate` (following a link), `goBack` and `goForward` — all end
+	 * here, because the fields have to be cleared as a set.
+	 *
+	 * Clearing one of them is not enough and reads as if it were. Both restore
+	 * paths are fallback cascades that stop at the first entry that resolves
+	 * (see `scrollPercentage` above): the preview tries `anchorLine`, then
+	 * `scrollPercentage`, then `scrollTop`, and the editor tries
+	 * `editorViewState`, then `anchorLine`, then `scrollPercentage`. So a reset
+	 * of only the last entry is unreachable for any tab that had been scrolled,
+	 * and the tab restores the OLD document's position — `anchorLine` is a
+	 * source line, and the line the reader left in one file names an unrelated
+	 * block in the next one.
+	 *
+	 * Nothing here scrolls anything; a restore runs on tab activation and on
+	 * editor mount, which is why the symptom of getting this wrong shows up on
+	 * a later tab switch rather than at the moment of the navigation.
+	 *
+	 * Only a change of DOCUMENT clears them. Save As and rename
+	 * (`updateTabPath`, `renameTab`) change the tab's path while the text on
+	 * screen stays put, and the reader has not moved.
+	 */
+	private clearReadingPosition(tab: Tab) {
+		tab.editorViewState = null;
+		tab.anchorLine = 0;
+		tab.scrollPercentage = 0;
+		tab.scrollTop = 0;
+	}
+
 	navigate(id: string, path: string, pathKey?: string) {
 		const tab = this.tabs.find(t => t.id === id);
 		if (tab) {
@@ -810,7 +845,7 @@ class TabManager {
 			tab.pathKey = pathKey;
 			tab.title = path.split(/[/\\]/).pop() || 'Untitled';
 			tab.isDirty = false;
-			tab.scrollTop = 0;
+			this.clearReadingPosition(tab);
 		}
 	}
 
@@ -842,6 +877,7 @@ class TabManager {
 			tab.pathKey = undefined;
 			tab.title = path.split(/[/\\]/).pop() || 'Untitled';
 			tab.isDirty = false;
+			this.clearReadingPosition(tab);
 			return path;
 		}
 		return null;
@@ -860,6 +896,7 @@ class TabManager {
 			tab.pathKey = undefined;
 			tab.title = path.split(/[/\\]/).pop() || 'Untitled';
 			tab.isDirty = false;
+			this.clearReadingPosition(tab);
 			return path;
 		}
 		return null;


### PR DESCRIPTION
#443 documented that `scrollTop` / `scrollPercentage` / `anchorLine` are a fallback cascade and reported, without fixing it, that `navigate()` resets only the last entry. This is that fix, plus the two things the investigation turned up: `goBack`/`goForward` have the same shape and reset nothing, and the reset does not reach the preview at the moment of the navigation either.

`npm test` 573/573, `npm run check` 638 files / 0 errors, `npm run build` clean, all on `1707b39`. No Rust touched.

## Mechanism

Three routes point an existing tab at a **different document**: `navigate()` (following a Markdown link), `goBack()` and `goForward()`. Both restore paths are cascades that stop at the first entry that resolves:

| | 1st | 2nd | 3rd |
|---|---|---|---|
| preview (`MarkdownViewer.svelte:1133-1162`) | `anchorLine` | `scrollPercentage` | `scrollTop` |
| editor (`components/Editor.svelte:290-311`) | `editorViewState` | `anchorLine` | `scrollPercentage` |

`scrollTop` is the entry each one consults **last**, and it was the only thing `navigate()` reset (`tabs.svelte.ts:813`). For any tab that had actually been scrolled, `anchorLine > 0`, so stage 1 answers and the reset is unreachable. `goBack`/`goForward` reset nothing at all.

`anchorLine` is a **source line**. The line the reader left in one file names an unrelated block in the next one, and it resolves: over `processMarkdownHtml` output of two different 400-line documents, **420/420 (100%)** of the anchor lines reachable in document A resolve to some element in document B (`scripts/tabReadingPosition.test.ts`, run against the real `findAnchorElement`). Nothing reports a failure — the cascade stops at stage 1 and the later entries are never consulted.

## The reset was written when it was the only field

`navigate()` is `b00eb24` (2026-01-28). At that commit `scrollTop` was the only position field, **and the restore effect was reactive to it**:

```js
$effect(() => {
	const tab = tabManager.activeTab;
	if (tab && markdownBody) markdownBody.scrollTop = tab.scrollTop;
});
```

So `tab.scrollTop = 0` did scroll the preview to the top, immediately. `scrollPercentage` and `anchorLine` arrived three days later in `edfb555` ("roughly match viewer-editor scroll location") without touching `navigate()`, and the effect was later narrowed to `activeTabId` + `markdownBody` with its body `untrack`ed. The decision was right when it was made; two fields and one effect rewrite went past it.

## Measured in the running frontend

Driven through the real Svelte frontend against a stubbed Tauri bridge (two synthetic documents, `render_markdown` emitting comrak's `data-sourcepos` shape). `a.md` is 60 sections × 6 paragraphs, `b.md` is 40 × 11. Numbers are the preview container's `scrollTop` and the block sitting at the anchor offset.

| step | before | after |
|---|---|---|
| reader scrolls `a.md` | 7000px, line 361 `alpha section 26 paragraph 4` | same |
| **follows the link to `b.md`** | **7000px, `beta section 16 paragraph 9`** | **0px, top of `b.md`** |
| switches to another tab and back | **6623px, `beta section 15 paragraph 11`** — the old `anchorLine` of 361 resolved in the new document | 0px |
| reader scrolls `b.md` to 11000px | line 597 | same |
| **Back** to `a.md` | **11000px, `alpha section 41 paragraph 1`** | **0px** |
| **Forward** to `b.md` | 11000px | 0px |

Throughout the "before" column the tab's own `scrollTop` reads `0` — the reset landed on the field, and nothing ever asked it.

## The fix

**One place that owns "this tab now shows a different document."** A private `clearReadingPosition(tab)` clears `editorViewState`, `anchorLine`, `scrollPercentage`, `scrollTop`, called from `navigate`, `goBack` and `goForward`. All four, because the cascades stop at their first resolved entry — clearing only some of them reproduces the same defect one stage up, which is what clearing only `scrollTop` was.

**`editorViewState` is in the set** because it is the editor's stage 1, the direct analogue of `anchorLine`. `collapsedHeaders` is deliberately not: it is fold state, not a position. See "Not covered".

**The preview restore effect gains a dependency on which document the active tab holds** (`void currentFile`). It is the only thing that moves the preview to a tab's recorded position, so without it the store can record "top of the new document" and nothing acts on it — the container simply keeps the pixel offset from the previous document, which is the 7000px row above. This restores what `b00eb24`'s effect did reactively, at the one event that needs it.

**Save As and rename keep the position.** They change the tab's path while the text on screen stays put, so they do not call `clearReadingPosition`. The effect does re-run for them, and re-applies the position the tab already has: measured at 8000px, Save As and rename both land at 7998px with `anchorLine` unchanged at 435 — the anchor round trip's own 2px, not a jump. Closing an unrelated tab is the same.

## Tests

`scripts/tabReadingPosition.test.ts`, 8 tests, driving the real `TabManager`, the real `processMarkdownHtml` and the real `findAnchorElement`. No file is read as text.

| test | what can go wrong |
|---|---|
| following a link to another file leaves the tab at the top of it | the cascade entry above `scrollTop` survives the navigation |
| going back to the previous file leaves the tab at the top of it | `goBack` resets nothing |
| going forward again leaves the tab at the top of that file | `goForward` resets nothing |
| Save As renames the tab without moving the reader | a blanket "clear on every path write" |
| renaming the file on disk does not move the reader | same |
| a link that resolves to the file already open is not a navigation | the `tab.path === path` early return |
| a line number carried over from the previous document resolves into this one | the measurement above — states *why* clearing `scrollTop` alone is unreachable |
| a cleared reading position resolves to nothing, so the cascade falls through | the guards that make stage 3 reachable again |

Red on `6b58cd5`: 4 fail / 4 pass. The four that pass on master are the guards — they must stay green on both sides or they are not guarding anything.

## Mutation check

Each mutation applied alone to `6b58cd5` + this test file:

| mutation | result |
|---|---|
| baseline | 8 pass |
| drop `editorViewState = null` | 3 fail |
| drop `anchorLine = 0` | 4 fail |
| drop `scrollPercentage = 0` | 4 fail |
| drop `scrollTop = 0` | 4 fail |
| call removed from `navigate` | 2 fail |
| call removed from `goBack` | 1 fail |
| call removed from `goForward` | 1 fail |
| **also** called from `updateTabPath` (over-reach) | 1 fail |
| **also** called from `renameTab` (over-reach) | 1 fail |

Both directions, including over-reach.

## Not covered

**The effect dependency has no executable test.** It lives inside an `$effect` in a 4341-line `.svelte` file, which `node --test` cannot import — the coverage gap #442 is about. Its evidence is the measured table above, not a test. A source-text assertion would only detect that a line was edited, which is what #433 deleted a test for.

**`collapsedHeaders` has the same shape and is not fixed here.** `loadMarkdown` renders the incoming document with `foldsForTab(activeId)` (`documentSession.svelte.ts:396`), which still holds the *previous* document's fold keys, and a fold key is a heading slug — every file with an `## Introduction` shares the key `introduction`. So following a link can open the new document with a section already shut. That is the exact failure #425's own comment describes, reached through navigation rather than through a window-wide set. It is fold state rather than a reading position, it hides text rather than moving the viewport, and it needs its own evidence, so it belongs in its own PR.

**A hash link to another file still does not land on its anchor.** `openRelativeMarkdownTarget` calls `scrollToAnchorWhenReady` after the load and I could not get it to resolve in the harness — but that is true on master too, where the deep link left the preview at the previous document's 6000px. This change moves the failure from "the old document's offset" to "the top of the right document"; the anchor jump itself is untouched and unexplained. The ordering is not a race: `loadMarkdown` awaits `tick()` before returning, so the effect has flushed before the anchor scroll starts.

**No `cargo test`.** No Rust in the diff.

**Severity.** Losing a scroll position is an annoyance, not data loss. What makes it worth a PR is that it is silent in both directions — nothing reports that the anchor failed to mean anything, and the deferred half has no visible connection to the link click that caused it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
