### PR TITLE
fix(tabs): forget a document's folds when the tab is pointed at another one

### DIFF
--- a/scripts/foldStatePerDocument.test.ts
+++ b/scripts/foldStatePerDocument.test.ts
@@ -10,6 +10,12 @@
  * to contain that heading opened with the section already shut and nothing on
  * screen to explain it.
  *
+ * Per tab is not the same as per document. A tab can be repointed at another
+ * file without a tab switch — following a link, and back/forward — and the set
+ * used to travel with it, so the same collision reappeared one route over. The
+ * second half of this file drives those three routes, and the routes that
+ * change only the path and must leave the folds alone.
+ *
  * These tests run the REAL `toggleFold` and `handleLinkClick` out of
  * MarkdownViewer.svelte, the REAL `visibleItems` out of Toc.svelte and the REAL
  * `processMarkdownHtml`, against the REAL TabManager. Nothing here asserts on
@@ -63,6 +69,7 @@ const { processMarkdownHtml } = await import('../src/lib/utils/markdown.ts');
 
 const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
 const toc = readFileSync(new URL('../src/lib/components/Toc.svelte', import.meta.url), 'utf8');
+const session = readFileSync(new URL('../src/lib/sessions/documentSession.svelte.ts', import.meta.url), 'utf8');
 
 // ------------------------------------------------------------ source plucking
 
@@ -256,6 +263,25 @@ function buildTocFilter() {
 
 const tocVisibleItems = buildTocFilter();
 
+/**
+ * The real `foldsForTab` out of documentSession — the set the LOAD path hands
+ * the renderer, looked up at render time.
+ *
+ * The viewer's `collapsedHeaders` derived (above) is what the outline and the
+ * live preview DOM read; this is what decides which sections the incoming
+ * HTML is built with `is-collapsed` already on. They are different readers of
+ * the same field and both are exercised below, because a fold leak shows up in
+ * each of them separately.
+ */
+const foldsForTab = (() => {
+	const js = ts.transpileModule(pluckFunction(session, 'foldsForTab'), {
+		compilerOptions: { target: ts.ScriptTarget.ES2022 },
+	}).outputText;
+	return new Function('tabManager', `"use strict";\n${js}\nreturn foldsForTab;`)(tabManager) as (
+		tabId: string,
+	) => Set<string>;
+})();
+
 const TOC_ITEMS = [
 	{ id: FOLD_KEY, text: 'Introduction', level: 2, isBlock: false, hasChildren: true },
 	{ id: 'details', text: 'Details', level: 3, isBlock: false, hasChildren: false },
@@ -406,4 +432,157 @@ test('closing a tab takes its fold state with it', () => {
 	tabManager.closeTab(a);
 	tabManager.addTab('/notes/a.md', DOC_A);
 	assert.equal(app.foldsOnScreen().has(FOLD_KEY), false, 'reopening the file starts fresh');
+});
+
+// ------------------------------------------- the routes that swap the document
+//
+// A tab does not only change document when the user switches to another tab.
+// Three routes keep the tab and point it at a DIFFERENT file: `navigate`
+// (following a Markdown link), `goBack` and `goForward`. `loadMarkdown` then
+// renders the incoming file with `foldsForTab(activeId)` on the very next line
+// (`documentSession.svelte.ts`), so the fold keys of the document the reader
+// just LEFT decide which sections of the new one arrive shut.
+//
+// Nothing is deferred here: the HTML that first appears already carries
+// `is-collapsed`, and the outline hides the same section's children on the same
+// render. #425 gave the set a per-tab home, which fixed the tab-switch route;
+// this is the same key collision reached through the navigation route. #447
+// clears the reading position at these three sites for the same reason and
+// scoped folds out of it — a position moves the viewport, a fold hides text.
+
+/** Fold a heading in a.md, then follow a link to b.md, which shares the heading. */
+function foldInAThenFollowLinkTo(path: string) {
+	reset();
+	const app = buildViewer();
+
+	tabManager.addTab('/notes/a.md', DOC_A);
+	const id = tabManager.activeTabId!;
+	app.showDocument(render(DOC_A, '/notes/a.md', app.foldsOnScreen()));
+	app.toggleFold(FOLD_KEY);
+	assert.equal(app.foldsOnScreen().has(FOLD_KEY), true, 'precondition: a.md has the section folded');
+
+	tabManager.navigate(id, path);
+	return { app, id };
+}
+
+test('following a link renders the new document with its own fold state', () => {
+	const { app, id } = foldInAThenFollowLinkTo('/notes/b.md');
+
+	const onScreen = render(DOC_B, '/notes/b.md', foldsForTab(id));
+	assert.equal(
+		isSectionCollapsed(onScreen),
+		false,
+		'the document the link led to must render with its own fold state, which is none',
+	);
+	assert.match(onScreen.textContent, /Beta body\./);
+	assert.equal(app.foldsOnScreen().has(FOLD_KEY), false);
+});
+
+test("the table of contents shows the linked document's children", () => {
+	// The outline reads the same field through the viewer's derived, so it hides
+	// the section's children in a document the user never folded anything in.
+	const { app } = foldInAThenFollowLinkTo('/notes/b.md');
+
+	assert.deepEqual(
+		tocVisibleItems(TOC_ITEMS, app.foldsOnScreen()).map((item) => item.id),
+		[FOLD_KEY, 'details'],
+		'the outline must list the linked document’s own headings',
+	);
+});
+
+/**
+ * Land on `path` with the section folded in the document currently on screen —
+ * and nothing folded before that, so the assertion cannot be satisfied by
+ * `toggleFold` merely undoing a fold that was carried in.
+ */
+function foldHereThen(app: Viewer, id: string, html: string, path: string) {
+	app.showDocument(render(html, path, foldsForTab(id)));
+	app.toggleFold(FOLD_KEY);
+	assert.equal(app.foldsOnScreen().has(FOLD_KEY), true, `precondition: ${path} has the section folded`);
+}
+
+test('going back renders the previous document with its own fold state', () => {
+	reset();
+	const app = buildViewer();
+	tabManager.addTab('/notes/a.md', DOC_A);
+	const id = tabManager.activeTabId!;
+	tabManager.navigate(id, '/notes/b.md');
+	foldHereThen(app, id, DOC_B, '/notes/b.md');
+
+	assert.equal(tabManager.goBack(id), '/notes/a.md');
+	assert.equal(isSectionCollapsed(render(DOC_A, '/notes/a.md', foldsForTab(id))), false);
+});
+
+test('going forward renders that document with its own fold state', () => {
+	reset();
+	const app = buildViewer();
+	tabManager.addTab('/notes/a.md', DOC_A);
+	const id = tabManager.activeTabId!;
+	tabManager.navigate(id, '/notes/b.md');
+	tabManager.goBack(id);
+	foldHereThen(app, id, DOC_A, '/notes/a.md');
+
+	assert.equal(tabManager.goForward(id), '/notes/b.md');
+	assert.equal(isSectionCollapsed(render(DOC_B, '/notes/b.md', foldsForTab(id))), false);
+});
+
+test('the tab gets a new set rather than the old one emptied', () => {
+	// `Tab.collapsedHeaders` is replaced, never mutated: the viewer's derived
+	// holds the Set itself, and Svelte cannot see a `.clear()` of a Set it is
+	// already holding — the outline would keep hiding the section.
+	reset();
+	tabManager.addTab('/notes/a.md', DOC_A);
+	const id = tabManager.activeTabId!;
+	const before = foldsForTab(id);
+
+	tabManager.navigate(id, '/notes/b.md');
+
+	assert.notEqual(foldsForTab(id), before, 'the navigation must install a different Set');
+});
+
+// ------------------------------------ the routes that change only the path
+//
+// The text on screen does not change in any of these, so the folds the reader
+// put there still describe it. This is the half of the rule a blanket "clear on
+// every path write" would break — the same guard #447 keeps for the position.
+
+test('Save As keeps the folds, because the document on screen has not changed', () => {
+	reset();
+	const app = buildViewer();
+	tabManager.addTab('/notes/a.md', DOC_A);
+	const id = tabManager.activeTabId!;
+	app.showDocument(render(DOC_A, '/notes/a.md', app.foldsOnScreen()));
+	app.toggleFold(FOLD_KEY);
+
+	tabManager.updateTabPath(id, '/notes/copy.md');
+
+	assert.equal(tabManager.tabs.find((tab) => tab.id === id)!.path, '/notes/copy.md');
+	assert.equal(isSectionCollapsed(render(DOC_A, '/notes/copy.md', foldsForTab(id))), true);
+});
+
+test('renaming the file on disk keeps the folds', () => {
+	reset();
+	const app = buildViewer();
+	tabManager.addTab('/notes/a.md', DOC_A);
+	const id = tabManager.activeTabId!;
+	app.showDocument(render(DOC_A, '/notes/a.md', app.foldsOnScreen()));
+	app.toggleFold(FOLD_KEY);
+
+	tabManager.renameTab(id, '/notes/renamed.md');
+
+	assert.equal(tabManager.tabs.find((tab) => tab.id === id)!.path, '/notes/renamed.md');
+	assert.equal(isSectionCollapsed(render(DOC_A, '/notes/renamed.md', foldsForTab(id))), true);
+});
+
+test('a link that resolves to the file already open is not a navigation', () => {
+	reset();
+	const app = buildViewer();
+	tabManager.addTab('/notes/a.md', DOC_A);
+	const id = tabManager.activeTabId!;
+	app.showDocument(render(DOC_A, '/notes/a.md', app.foldsOnScreen()));
+	app.toggleFold(FOLD_KEY);
+
+	tabManager.navigate(id, '/notes/a.md');
+
+	assert.equal(isSectionCollapsed(render(DOC_A, '/notes/a.md', foldsForTab(id))), true);
 });

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -118,6 +118,11 @@ export interface Tab {
 	 *
 	 * A tab field also covers untitled buffers, which have no path to key by.
 	 *
+	 * Per tab is not the same as per document, because a tab can be repointed at
+	 * another file without a tab switch — following a link, and back/forward.
+	 * Those routes clear this set, together with the reading position above; see
+	 * `forgetPreviousDocument`.
+	 *
 	 * Replace the set to change it — never mutate in place. The preview render
 	 * reads this value, and Svelte cannot see a mutation of a Set it is already
 	 * holding.
@@ -790,10 +795,36 @@ class TabManager {
 	}
 
 	/**
-	 * This tab is about to show a DIFFERENT document, so everything that says
-	 * where the reader was in the old one is void. The three routes that do
-	 * that — `navigate` (following a link), `goBack` and `goForward` — all end
-	 * here, because the fields have to be cleared as a set.
+	 * This tab now shows a DIFFERENT document, so everything the TAB records
+	 * about the one it was showing is void. The three routes that repoint a tab
+	 * — `navigate` (following a link), `goBack` and `goForward` — call this and
+	 * nothing else, so a fourth route has one question to answer ("does this
+	 * change which document the tab holds?") rather than one per field group.
+	 *
+	 * The two helpers stay separate because they are separate concerns with
+	 * separate reasons: a stale reading position moves the viewport, a stale
+	 * fold hides text, and each needs its own explanation. What they share is
+	 * this trigger — both doc comments below used to open by restating it, which
+	 * is what an unnamed shared concept looks like. This is its name.
+	 *
+	 * Not the buffer: `rawContent`, `originalContent` and `content` are
+	 * overwritten by the load that follows, not cleared here. This is only the
+	 * state that describes a document without being it.
+	 *
+	 * Only a change of DOCUMENT gets here. Save As and rename (`updateTabPath`,
+	 * `renameTab`) change the tab's path while the text on screen stays put: the
+	 * reader has not moved, and the folds they put in that text still describe
+	 * it. Tests guard both directions.
+	 */
+	private forgetPreviousDocument(tab: Tab) {
+		this.clearReadingPosition(tab);
+		this.clearCollapsedHeaders(tab);
+	}
+
+	/**
+	 * Everything that says where the reader was in the document this tab has
+	 * just left. Called only from `forgetPreviousDocument`; the fields have to
+	 * be cleared as a set.
 	 *
 	 * Clearing one of them is not enough and reads as if it were. Both restore
 	 * paths are fallback cascades that stop at the first entry that resolves
@@ -809,15 +840,35 @@ class TabManager {
 	 * editor mount, which is why the symptom of getting this wrong shows up on
 	 * a later tab switch rather than at the moment of the navigation.
 	 *
-	 * Only a change of DOCUMENT clears them. Save As and rename
-	 * (`updateTabPath`, `renameTab`) change the tab's path while the text on
-	 * screen stays put, and the reader has not moved.
+	 * Which routes reach here, and which deliberately do not, is stated once in
+	 * `forgetPreviousDocument` rather than in each helper.
 	 */
 	private clearReadingPosition(tab: Tab) {
 		tab.editorViewState = null;
 		tab.anchorLine = 0;
 		tab.scrollPercentage = 0;
 		tab.scrollTop = 0;
+	}
+
+	/**
+	 * The folded-heading set of the document this tab has just left. Called only
+	 * from `forgetPreviousDocument`.
+	 *
+	 * A fold key is a heading slug (see `Tab.collapsedHeaders`), which is only
+	 * unique WITHIN a document, so carrying the set across means the incoming
+	 * document is rendered with any section whose slug happens to match already
+	 * shut. `loadMarkdown` reads the set on the line after the `navigate` call,
+	 * so nothing is deferred: the HTML that first appears already carries
+	 * `is-collapsed`, and the outline hides the same section's children on the
+	 * same render, with nothing on screen to explain either. That is #425's
+	 * failure reached through the navigation route instead of a window-wide set.
+	 *
+	 * Replaces the set rather than emptying it, as every other writer does — the
+	 * viewer holds it through a `$derived`, and Svelte cannot see a `.clear()`
+	 * of a Set it is already holding.
+	 */
+	private clearCollapsedHeaders(tab: Tab) {
+		tab.collapsedHeaders = new Set<string>();
 	}
 
 	navigate(id: string, path: string, pathKey?: string) {
@@ -845,7 +896,7 @@ class TabManager {
 			tab.pathKey = pathKey;
 			tab.title = path.split(/[/\\]/).pop() || 'Untitled';
 			tab.isDirty = false;
-			this.clearReadingPosition(tab);
+			this.forgetPreviousDocument(tab);
 		}
 	}
 
@@ -877,7 +928,7 @@ class TabManager {
 			tab.pathKey = undefined;
 			tab.title = path.split(/[/\\]/).pop() || 'Untitled';
 			tab.isDirty = false;
-			this.clearReadingPosition(tab);
+			this.forgetPreviousDocument(tab);
 			return path;
 		}
 		return null;
@@ -896,7 +947,7 @@ class TabManager {
 			tab.pathKey = undefined;
 			tab.title = path.split(/[/\\]/).pop() || 'Untitled';
 			tab.isDirty = false;
-			this.clearReadingPosition(tab);
+			this.forgetPreviousDocument(tab);
 			return path;
 		}
 		return null;


### PR DESCRIPTION
Fold `## Introduction`, click a link to another file that also has an `## Introduction`, and it opens with that section already shut — in a document you have never folded anything in.

This is the third instance of one shape. **#425** found it between documents in different tabs and moved `collapsedHeaders` from the window onto the `Tab`. **#447** found it in the scroll cascade, where `navigate` / `goBack` / `goForward` repoint a tab at a different document and carried the reader's position over; its "Not covered" section names this one and scopes it out. A tab is not a document, and the routes that change which document a tab holds are where the difference shows.

Rebased onto `df80968` (#447). `npm test` 592/592, `npm run check` 638 files / 0 errors, `npm run build` clean, all measured on the rebased branch. No Rust touched.

## Mechanism

Three routes keep a tab and point it at a **different** file: `navigate()` (following a Markdown link), `goBack()` and `goForward()`. None of them touched `collapsedHeaders`, and `loadMarkdown` renders the incoming document with the tab's set on the line straight after:

```js
if (pendingNavigateTabId) tabManager.navigate(pendingNavigateTabId, filePath, pathKey);
const processed = await options.renderMarkdown(content, filePath, foldsForTab(activeId));
```

`foldsForTab` returns `tab.collapsedHeaders` — which at that instant still holds the keys of the document being left.

**Nothing is deferred.** Unlike #447, this needs no restore effect: `processMarkdownHtml` writes `is-collapsed` onto the heading and its wrapper while it builds the HTML, so the very first frame of the new document has the section shut. The outline reads the same field through the viewer's `$derived`, so it hides that section's children on the same render.

**The key collides because it is a slug.** `h.id || h.textContent?.trim()` is unique within a document and nowhere else. Measured over the 202 real Markdown files in this checkout with ≥3 headings (the repo's own, plus its dependencies' READMEs and changelogs):

| | |
|---|---|
| ordered document pairs where ≥1 heading slug of A names a heading in B | **27.9%** (55520 / 199347 sampled) |
| individual carried keys landing on a heading in B | 3.4% (114074 / 3401213) |
| documents containing `license` | 31.7% |
| documents containing `installation` | 29.7% |
| documents containing `usage` | 27.7% |

So a reader who folds `## Installation` in one README and follows a link has roughly a 1-in-3 chance of the next one arriving with its Installation section hidden.

## Measured in the running frontend

Driven through the real Svelte frontend in a browser against a stubbed Tauri bridge (`render_markdown` emitting comrak's shape, two in-memory documents that share `## Introduction` with a `### Detail` under it). The number is the fold wrapper's measured height — 0px is a genuinely hidden section, not just a class. Both columns re-measured after the rebase, against `df80968` and against this branch.

| step | before (`df80968`) | after |
|---|---|---|
| fold `## Introduction` in `a.md` | 0px, collapsed | same |
| **follow the link to `b.md`** | **0px — `b.md` opens with the section shut** | **137px, open** |
| click `b.md`'s chevron once | **137px — the click reads as an *unfold*** of a section the reader never folded | 0px, folds it |
| **Back to `a.md`** | **137px — the fold the reader *did* make in `a.md` is gone**, spent on `b.md` | 137px, open |
| Forward to `b.md` | 0px | 137px, open |

A second run, folding only in `b.md` and then pressing Back, lands on `a.md` at **0px** — the same leak in the other direction, this time with the folded tab's own document nowhere on screen.

Both symptoms in the "before" column come from one `Set`: because the two documents share the key, a toggle in either one moves the fold for both, so the leak does not only hide text the reader did not hide — it also loses folds they did make. #447 changed nothing here; the two tables measured before and after that merge are identical.

## The fix, and the shape

A private `clearCollapsedHeaders(tab)` that **replaces** the set. The interesting decision is where it is called from.

The mechanical rebase onto #447 gave each of `navigate` / `goBack` / `goForward` **two** calls — `clearReadingPosition` and `clearCollapsedHeaders`. That is the shape #447 set out to remove: three routes that must each remember two things, and a fourth route later that must remember both. This repo has been bitten by it twice recently (#436: two of five explicit saves remembered to cancel the auto-save timer; #439: six sites cleared one flag while two cleared the other).

So the three routes now call **one** `forgetPreviousDocument(tab)`, and that calls both helpers:

```ts
private forgetPreviousDocument(tab: Tab) {
	this.clearReadingPosition(tab);
	this.clearCollapsedHeaders(tab);
}
```

**The helpers are not merged.** A stale reading position moves the viewport; a stale fold hides text. They invalidate for different reasons, they fail differently, and each earns its own doc comment. What they share is the *trigger*, and the tell that the trigger was an unnamed concept is that both helpers' comments opened by restating it in slightly different words. `forgetPreviousDocument` is that name, and it is now the single place stating which routes reach it and which deliberately do not.

**Replaces rather than empties.** `Tab.collapsedHeaders` is documented as replace-only: the viewer holds the Set through a `$derived`, and Svelte cannot see a `.clear()` of a Set it is already holding — the outline would keep hiding the section. Tested.

**Save As and rename must not get there.** `updateTabPath` and `renameTab` change the tab's path while the text on screen stays put, so the reader has not moved and the folds they put in that text still describe it. Every path-changing site in `TabManager` was checked; those two are the only others.

**Cross-window transfer is unchanged.** `tabTransfer.ts` already excludes `collapsedHeaders` deliberately (#425) — the destination re-renders from source with everything open, which is already the cleared state.

## Is that now the whole set?

With folds added, `forgetPreviousDocument` clears `editorViewState`, `anchorLine`, `scrollPercentage`, `scrollTop`, `collapsedHeaders`. Every other `Tab` field was classified:

| category | fields |
|---|---|
| cleared at the trigger | the five above |
| written by the routes themselves | `path`, `pathKey`, `title`, `isDirty`, `history`, `historyIndex` |
| overwritten by the load that follows, never stale | `content`, `rawContent`, `originalContent`, `isTruncated` (`setTabRawContent`), `hasReplacementChars` (`setTabDecodedLossy`, called on both load branches and documented as clearing) |
| per tab / per user, not per document | `isEditing`, `isSplit`, `splitRatio`, `isScrollSynced` |

No sixth field of the same shape. One near-miss, checked and left alone: `_lastRenderedRawContent`, an ad-hoc property compared against `rawContent` to skip a redundant render. It does hold the previous document's text after a navigate, but a stale value can only skip a render when the two documents are byte-identical — in which case the render would be identical anyway.

## Tests

Eight tests added to `scripts/foldStatePerDocument.test.ts` — the file that owns this rule — driving the real `TabManager`, the real `processMarkdownHtml`, the real `toggleFold` out of `MarkdownViewer.svelte`, the real `visibleItems` out of `Toc.svelte`, and now the real `foldsForTab` plucked out of `documentSession.svelte.ts`, which is the reader that decides what the incoming HTML arrives with. No file is asserted on as text.

| test | what can go wrong |
|---|---|
| following a link renders the new document with its own fold state | the set travels through `navigate` |
| the table of contents shows the linked document's children | the outline reads the same field and hides them |
| going back renders the previous document with its own fold state | `goBack` clears nothing |
| going forward renders that document with its own fold state | `goForward` clears nothing |
| the tab gets a new set rather than the old one emptied | an in-place `.clear()` the `$derived` cannot see |
| Save As keeps the folds, because the document on screen has not changed | a blanket "clear on every path write" |
| renaming the file on disk keeps the folds | same |
| a link that resolves to the file already open is not a navigation | the `tab.path === path` early return |

Red on `df80968`: **5 fail / 10 pass**, with #447's own `tabReadingPosition.test.ts` at 8/8 on the same source. The three of mine that pass on master are the guards — they must be green on both sides or they are not guarding anything.

One draft of the back/forward tests passed on master for the wrong reason: the setup folded in `a.md` first, so `toggleFold` in `b.md` found the carried key and *removed* it, leaving an empty set that satisfied the assertion. They now fold only in the document on screen and assert the precondition.

## Mutation check

Each mutation applied alone on top of the fix, on `df80968`, run against both suites — including the two new ways a single entry point can break, which is dropping a call from *inside* it:

| mutation | fold tests | #447's tests |
|---|---|---|
| baseline | 15 pass | 8 pass |
| `clearReadingPosition` dropped **inside** `forgetPreviousDocument` | 15 pass | **4 fail** |
| `clearCollapsedHeaders` dropped **inside** `forgetPreviousDocument` | **5 fail** | 8 pass |
| entry point call removed from `navigate` | **3 fail** | **2 fail** |
| entry point call removed from `goBack` | **1 fail** | **1 fail** |
| entry point call removed from `goForward` | **1 fail** | **1 fail** |
| fold set emptied in place instead of replaced | **1 fail** | 8 pass |
| entry point **also** called from `updateTabPath` (over-reach) | **1 fail** | **1 fail** |
| entry point **also** called from `renameTab` (over-reach) | **1 fail** | **1 fail** |

The first two rows are the point of the table: each helper is covered by exactly one suite, so the entry point cannot quietly lose either half. The rest fail in both, which is what a shared entry point should do.

## Not covered

**Forward no longer restores a fold made before you went Back.** In the table above, `Forward to b.md` used to land at 0px because the key was still in the tab's set; it now opens flush. That is the same call the fix makes everywhere else — the tab's set describes the document it is leaving, not the one being restored — and it matches #447, which clears the reading position on back/forward too. Per-document fold *history* would need folds keyed by document, which #425 argued against for persistence for the same reason: a fold key describes a heading in a particular revision of a file.

**The outline was not measured in the browser.** The overlay renders at zero height in the headless viewport, so the live ToC could not be read. Its evidence is the real `visibleItems` in the test, plus #425 having established it reads the same field. The preview measurements above are real.

**Stale keys still accumulate** in a tab that stays on one document while its headings are renamed — pre-existing, listed in #425's own "Not covered", untouched here.

**No `cargo test`.** No Rust in the diff.

**Severity.** A hidden section is quieter than a lost scroll position: the text is simply not there, the chevron looks the same as any other collapsed heading, and the first click on it opens a section instead of closing one — which is the moment the reader learns their fold in the previous document is also gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
