### PR TITLE
test(guards): re-anchor nine assertions that could not fail

### DIFF
--- a/scripts/editorContextMenuI18n.test.ts
+++ b/scripts/editorContextMenuI18n.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { getSupportedLanguages, t, type LanguageCode } from '../src/lib/utils/i18n.js';
+import { getSupportedLanguages, t, translations, type LanguageCode, type Translation } from '../src/lib/utils/i18n.js';
 
 // WHAT THIS FILE COVERS, AND WHAT IT DOES NOT
 //
@@ -22,6 +22,33 @@ const supported = getSupportedLanguages().map((l) => l.code);
 
 function count(source: string, pattern: RegExp): number {
 	return source.match(pattern)?.length ?? 0;
+}
+
+/**
+ * Does `lang`'s own dictionary define `key`, without the English fallback?
+ *
+ * `t()` falls back to English, so `assert.notEqual(t(key, lang), key)` can only
+ * fail when ENGLISH lacks the key — which each caller below already asserts one
+ * line earlier. The 26-language loop around it restated that 26 times and could
+ * not see the regression it was written for: deleting the German
+ * `menu.inlineCode` entry left the whole suite green while the German context
+ * menu rendered the English label.
+ *
+ * These labels are held to a stricter bar than the dictionary at large.
+ * i18nCoverage.test.ts reports per-locale gaps rather than failing on them,
+ * because 19 locales are missing >100 keys and nobody should have to translate
+ * a new English string 25 times before landing it. That trade does not apply
+ * here: this is a fixed list of a dozen context-menu entries, all 26 languages
+ * define all of them today, and adding an eleventh action means adding a row to
+ * FORMATTING_ACTIONS by hand — so the cost is visible where it is incurred.
+ */
+function defines(lang: LanguageCode, key: string): boolean {
+	let node: string | Translation | undefined = translations[lang];
+	for (const part of key.split('.')) {
+		if (typeof node !== 'object' || node === null || !(part in node)) return false;
+		node = node[part];
+	}
+	return typeof node === 'string';
 }
 
 // The markdown formatting entries that used to be English string literals.
@@ -60,13 +87,16 @@ test('every context-menu label is translated, none is an English literal', () =>
 	);
 });
 
-test('the formatting labels exist in English and resolve in every language', () => {
+test('the formatting labels exist in English and are translated in every language', () => {
 	for (const [, key, englishLabel] of FORMATTING_ACTIONS) {
 		assert.equal(t(key, 'en'), englishLabel, `${key} is defined for English`);
 		for (const lang of supported) {
-			const label = t(key, lang as LanguageCode);
-			assert.notEqual(label, key, `${key} resolves for ${lang} instead of echoing the key`);
-			assert.ok(label.length > 0, `${key} is non-empty for ${lang}`);
+			// `defines`, not `t(...) !== key` — see the note on the helper.
+			assert.ok(
+				defines(lang as LanguageCode, key),
+				`${key} is translated for ${lang}; it currently falls back to the English label`,
+			);
+			assert.ok(t(key, lang as LanguageCode).length > 0, `${key} is non-empty for ${lang}`);
 		}
 	}
 });
@@ -92,7 +122,11 @@ test('toggle-occurrences-highlight has its own label, not Show Whitespace', () =
 	for (const lang of supported) {
 		const occurrences = t('settings.occurrencesHighlight', lang as LanguageCode);
 		const whitespace = t('settings.showWhitespace', lang as LanguageCode);
-		assert.notEqual(occurrences, 'settings.occurrencesHighlight', `defined for ${lang}`);
+		// Same substitution as above: `occurrences !== 'settings.occurrencesHighlight'`
+		// only ever failed if English lacked the key, which the assertions at the
+		// top of this test already cover.
+		assert.ok(defines(lang as LanguageCode, 'settings.occurrencesHighlight'), `translated for ${lang}`);
+		assert.ok(defines(lang as LanguageCode, 'settings.showWhitespace'), `translated for ${lang}`);
 		assert.notEqual(
 			occurrences,
 			whitespace,
@@ -156,13 +190,13 @@ test('actions are re-registered when the UI language changes', () => {
 	);
 	assert.match(editor, /onDestroy\(disposeLocalizedActions\)/, 'teardown releases them too');
 
-	// The old design read a `uiLanguage` snapshot captured inside onMount.
+	// The old design read a `uiLanguage` snapshot captured inside onMount. The
+	// narrower "no label is still bound to the snapshot" count that used to
+	// follow this line is gone: it counted occurrences of a pattern containing
+	// `uiLanguage`, so the line above has to pass for it to be reached and,
+	// once it has, the count is zero by construction. There is no state of the
+	// component in which it, and not the line above, is the failure.
 	assert.doesNotMatch(editor, /uiLanguage/, 'no captured language snapshot remains');
-	assert.equal(
-		count(editor, /label: t\('[^']+', uiLanguage\)/g),
-		0,
-		'no label is still bound to the snapshot',
-	);
 });
 
 test('no action id is registered more than once', () => {

--- a/scripts/previewSanitize.test.ts
+++ b/scripts/previewSanitize.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import { MARKDOWN_SANITIZE_CONFIG, ALLOWED_MARKDOWN_URI_REGEXP } from '../src/lib/utils/sanitize.js';
-import { SANITIZER_FILES, callSiteOffsets, enclosingFunctionName, filesMatching, readSourceFiles } from './sourceTree.js';
+import { SANITIZER_FILES, callSiteOffsets, enclosingFunctionName, filesMatching, readSourceFiles, sliceBetween } from './sourceTree.js';
 
 // The preview is the path the `<style>` clause in the shared policy was written
 // for, and it was the one path not using it. `tab.content` (the rendered,
@@ -28,9 +28,18 @@ import { SANITIZER_FILES, callSiteOffsets, enclosingFunctionName, filesMatching,
 // halves are permitted by the shipped CSP — `style-src 'self' 'unsafe-inline' …`
 // and `img-src 'self' asset: https: …` (src-tauri/tauri.conf.json).
 //
+// The payload was, verbatim:
+//
+//   <style>.titlebar{display:none} body{background-image:url("https://attacker.example/beacon")}</style>
+//
+// It used to be a `POC_STYLE` constant with an `assert.match(POC_STYLE,
+// /^<style>/)` under it. That assertion read as part of the chain below but had
+// no end in `src/`: both sides were this file, one line apart, so no change to
+// the application could ever fail it. The payload is documentation, so it is
+// documentation now.
+//
 // What is checkable here is the wiring that decides which config the preview
 // gets, and that is what these tests pin.
-const POC_STYLE = '<style>.titlebar{display:none} body{background-image:url("https://attacker.example/beacon")}</style>';
 
 const SOURCES = readSourceFiles('src');
 const viewerSource = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
@@ -62,12 +71,37 @@ test('the preview sanitizes through the shared policy, not a local config', () =
 		'the viewer must import the shared sanitizer',
 	);
 
-	// The sink itself: every bare `{@html ident}` in the viewer injects the
-	// sanitizer's output and nothing else. Stated over *all* of them rather than
-	// over one known-good spelling, so adding a second injection point of the raw
-	// document is a failure instead of an unnoticed addition.
-	const injected = [...new Set([...viewerSource.matchAll(/\{@html\s+([A-Za-z_$][\w$]*)\s*\}/g)].map((m) => m[1]))];
-	assert.deepEqual(injected, [sanitizedSinkName()], 'the preview sink must inject the shared sanitizer output');
+	// The sinks: every `{@html …}` in the viewer, whatever the expression looks
+	// like. Stated over *all* of them rather than over one known-good spelling,
+	// so adding an injection point of the raw document is a failure instead of
+	// an unnoticed addition.
+	//
+	// The capture used to be `([A-Za-z_$][\w$]*)`, bare identifiers only, which
+	// made the claim unfalsifiable in exactly the direction it is about. The
+	// list it compared was `[sanitizedSinkName()]` by construction: the second
+	// sink already in the file, `{@html tooltip.html}`, was invisible to it, and
+	// a planted `{@html unsafe.rawHtml}` beside the sanitized one — the raw
+	// rendered document, injected — left the whole suite green.
+	//
+	// So the set is an allowlist now, and `tooltip.html` is on it with a reason
+	// rather than by accident: the footnote tooltip is a clone of a subtree of
+	// `markdownBody`, i.e. of the DOM the sanitized sink already injected. It is
+	// not a second policy, it is the same bytes read back out of the document —
+	// which is what the next two assertions pin.
+	const injected = [...new Set([...viewerSource.matchAll(/\{@html\s+([^}]+?)\s*\}/g)].map((m) => m[1]))].sort();
+	assert.deepEqual(
+		injected,
+		[sanitizedSinkName(), 'tooltip.html'].sort(),
+		'unexpected {@html} sink — what the preview injects is the shared sanitizer output',
+	);
+
+	// Why the footnote sink is allowed, pinned as a direction rather than as a
+	// spelling: the tooltip body is read out of the rendered document, never
+	// built from a string the sanitizer has not seen.
+	const footnote = sliceBetween(viewerSource, "anchor.hasAttribute('data-footnote-ref')", 'isFootnote: true');
+	assert.match(footnote, /markdownBody\?\.querySelector/, 'the footnote body is found in the rendered document');
+	assert.match(footnote, /\.innerHTML/, 'and taken from the DOM the shared sanitizer already filtered');
+	assert.doesNotMatch(footnote, /rawContent/, 'never from the unrendered buffer');
 
 	// The regression itself — a DOMPurify call with a config assembled at the
 	// call site — is caught for the whole tree by the call-site allowlist below;
@@ -88,8 +122,11 @@ test('the shared policy the preview now gets is the one that forbids author styl
 	assert.match(sanitizeSource, /return DOMPurify\.sanitize\(html, MARKDOWN_SANITIZE_CONFIG\)/);
 	assert.deepEqual(Object.keys(MARKDOWN_SANITIZE_CONFIG).sort(), ['ALLOWED_URI_REGEXP', 'FORBID_TAGS']);
 	assert.deepEqual(MARKDOWN_SANITIZE_CONFIG.FORBID_TAGS, ['style']);
+	// Identity, not equality: the regression this file exists for is a *copy* of
+	// the URI pattern, and a copy that happens to be spelled the same today is
+	// the thing that drifts tomorrow. Measured — rebuilding the config's regexp
+	// from the exported one's source and flags fails here.
 	assert.equal(MARKDOWN_SANITIZE_CONFIG.ALLOWED_URI_REGEXP, ALLOWED_MARKDOWN_URI_REGEXP);
-	assert.match(POC_STYLE, /^<style>/);
 });
 
 // Every `DOMPurify.sanitize` in `src/` is a decision about what a piece of

--- a/scripts/recentFilesMultiWindow.test.ts
+++ b/scripts/recentFilesMultiWindow.test.ts
@@ -60,8 +60,6 @@ Object.defineProperty(globalThis, 'window', {
 Object.defineProperty(globalThis, 'navigator', { value: { language: 'en-US' }, configurable: true });
 
 const {
-	RECENT_FILES_KEY,
-	RECENT_FILES_LIMIT,
 	dropRecentFile,
 	isRecentFilesStorageEvent,
 	parseRecentFiles,
@@ -71,13 +69,32 @@ const {
 	updateStoredRecentFiles,
 } = await import('../src/lib/utils/recentFiles.js');
 
+/*
+ * The key and the cap, written out rather than imported.
+ *
+ * They used to be `RECENT_FILES_KEY` and `RECENT_FILES_LIMIT`, exported from
+ * `recentFiles.ts` for this file and for nothing else, and every assertion
+ * compared the module's value with itself. Measured: `'recent-files'` renamed
+ * to `'markpad-recent'` — green, and a rename orphans every existing user's
+ * list, because that literal appears nowhere else to contradict it. `9` changed
+ * to `3` — green, because the boundedness test seeded `LIMIT + 5` and then
+ * asserted the result was `LIMIT` long.
+ *
+ * Both are on-disk format. A localStorage key and the length of a list the user
+ * can see are things a reader should be able to look up in the test, and things
+ * that must not change without someone deciding to change them, so they are
+ * stated here and the exports are gone.
+ */
+const KEY = 'recent-files';
+const LIMIT = 9;
+
 function seed(files: string[]) {
 	backing.clear();
 	writes.length = 0;
-	backing.set(RECENT_FILES_KEY, JSON.stringify(files));
+	backing.set(KEY, JSON.stringify(files));
 }
 
-const stored = () => parseRecentFiles(backing.get(RECENT_FILES_KEY) ?? null);
+const stored = () => parseRecentFiles(backing.get(KEY) ?? null);
 
 /**
  * A window: its own in-memory copy of the list, exactly as the component holds
@@ -153,10 +170,31 @@ test('renaming onto a path already in the list leaves one entry', () => {
 });
 
 test('the list stays bounded no matter how the entries arrived', () => {
-	const many = Array.from({ length: RECENT_FILES_LIMIT + 5 }, (_, index) => `/f${index}.md`);
+	const many = Array.from({ length: LIMIT + 5 }, (_, index) => `/f${index}.md`);
 	seed(many);
 	makeWindow([]).open('/new.md');
-	assert.equal(stored().length, RECENT_FILES_LIMIT);
+	assert.equal(stored().length, LIMIT);
+	assert.equal(stored()[0], '/new.md');
+});
+
+test('each of the two caps is load-bearing on its own', () => {
+	// An open goes through both of them — `promoteRecentFile` caps, and
+	// `updateStoredRecentFiles` caps again — so the test above stays green when
+	// either one is deleted, and only fails when both are. Each layer is driven
+	// alone here: the pure function directly, and the helper with a mutation
+	// that does not cap.
+	//
+	// Both layers earn their keep. `promoteRecentFile` is exported and is the
+	// one that defines what "recent" means; the cap in `updateStoredRecentFiles`
+	// is what bounds the stored list whatever a caller hands it, including the
+	// merge of a sibling window's longer list.
+	const many = Array.from({ length: LIMIT + 5 }, (_, index) => `/f${index}.md`);
+
+	assert.equal(promoteRecentFile(many, '/new.md').length, LIMIT, 'promoteRecentFile caps what it returns');
+
+	seed(many);
+	updateStoredRecentFiles((current) => ['/new.md', ...current]);
+	assert.equal(stored().length, LIMIT, 'and the stored list is capped even when the mutation is not');
 	assert.equal(stored()[0], '/new.md');
 });
 
@@ -173,25 +211,25 @@ test('a write that changes nothing does not wake the other windows', () => {
 
 test('a corrupt entry is survivable', () => {
 	backing.clear();
-	backing.set(RECENT_FILES_KEY, '{not json');
+	backing.set(KEY, '{not json');
 	assert.deepEqual(readStoredRecentFiles(), []);
-	backing.set(RECENT_FILES_KEY, '{"a":1}');
+	backing.set(KEY, '{"a":1}');
 	assert.deepEqual(readStoredRecentFiles(), []);
-	backing.set(RECENT_FILES_KEY, '["/a.md", 7, null]');
+	backing.set(KEY, '["/a.md", 7, null]');
 	assert.deepEqual(readStoredRecentFiles(), ['/a.md']);
 	// And a corrupt entry must not stop the next open from being recorded.
-	backing.set(RECENT_FILES_KEY, 'garbage');
+	backing.set(KEY, 'garbage');
 	makeWindow([]).open('/b.md');
 	assert.deepEqual(stored(), ['/b.md']);
 });
 
 test('only this key, and a wholesale clear, count as a remote change', () => {
-	assert.equal(isRecentFilesStorageEvent({ key: RECENT_FILES_KEY, storageArea: null }), true);
+	assert.equal(isRecentFilesStorageEvent({ key: KEY, storageArea: null }), true);
 	// `key: null` is localStorage being cleared.
 	assert.equal(isRecentFilesStorageEvent({ key: null, storageArea: null }), true);
 	assert.equal(isRecentFilesStorageEvent({ key: 'theme', storageArea: null }), false);
 	assert.equal(
-		isRecentFilesStorageEvent({ key: RECENT_FILES_KEY, storageArea: {} as Storage }),
+		isRecentFilesStorageEvent({ key: KEY, storageArea: {} as Storage }),
 		false,
 		'sessionStorage is a different store',
 	);

--- a/scripts/sourceTree.test.ts
+++ b/scripts/sourceTree.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { callbackBodies, enclosingFunctionName, offsetOf, sliceBetween, sliceFrom } from './sourceTree.js';
+import { callbackBodies, enclosingFunctionName, functionSource, offsetOf, sliceBetween, sliceFrom } from './sourceTree.js';
 
 // scripts/sourceTree.ts is the plumbing four convention tests state their claims
 // through, so a hole in it is a hole in all of them at once, and it is invisible
@@ -92,6 +92,45 @@ test('a callback body is its own body, whatever the closing brace looks like', (
 	]);
 	assert.deepEqual(callbackBodies(source, '$effect.pre'), ['{\n\t\tpre();\n\t}']);
 	assert.deepEqual(callbackBodies(source, 'onMount'), []);
+});
+
+test('a function is extracted as a function, not as "up to the next declaration"', () => {
+	// The hole this closes: an anchor pair that names the *neighbour* stops
+	// bounding the subject as soon as anything is declared between them, and a
+	// neighbour carrying the same guard then satisfies the assertion. Here the
+	// two functions are deliberately near-identical, which is the case in
+	// MarkdownViewer.svelte (`canTransfer`/`canDetach`,
+	// `handleDetach`/`moveTabToWindow`) that went undetected.
+	const source = [
+		'<script lang="ts">',
+		'\tasync function subject(id: string) {',
+		'\t\treturn guard(id);',
+		'\t}',
+		'',
+		'\tasync function neighbour(id: string) {',
+		'\t\treturn guard(id);',
+		'\t}',
+		'',
+		'\tconst options = {',
+		'\t\tpredicate: (id: string) => guard(id),',
+		'\t};',
+		'</script>',
+	].join('\n');
+
+	assert.equal(functionSource(source, 'subject'), 'async function subject(id: string) {\n\t\treturn guard(id);\n\t}');
+	assert.equal(functionSource(source, 'predicate'), '(id: string) => guard(id)');
+
+	// The neighbour is not part of the subject, which is the whole point.
+	assert.doesNotMatch(functionSource(source, 'subject'), /neighbour/);
+
+	// A renamed or duplicated subject is a failure with a name, not a wider slice.
+	assert.throws(() => functionSource(source, 'gone'), /exactly one function named "gone", found 0/);
+	// Two functions of the same name is the case a "first match wins" helper
+	// would silently pick one of — a wrapper and the method it delegates to, say.
+	assert.throws(
+		() => functionSource(source.replace('predicate:', 'subject:'), 'subject'),
+		/exactly one function named "subject", found 2/,
+	);
 });
 
 test('the parsers read .ts files as well as components', () => {

--- a/scripts/sourceTree.ts
+++ b/scripts/sourceTree.ts
@@ -271,6 +271,34 @@ export function enclosingFunctionName(text: string, index: number): string | nul
 }
 
 /**
+ * The source of the one function bound to `name`, whatever the spelling —
+ * `function name() {}`, `const name = () => {}`, `{ name: (…) => {} }`, a class
+ * method.
+ *
+ * For the checks that state something about *one function*, where the anchor
+ * pair `sliceBetween(text, 'async function subject', 'async function
+ * whatever-comes-next')` names the neighbour rather than the subject: the slice
+ * is then only as tight as the declaration order happens to make it, and it
+ * widens silently as the file grows. Both uses in truncatedBufferGuard.test.ts
+ * had already grown past their subject — the transfer slice ran from
+ * `canTransfer` through `canDetach`, the detach slice from `handleDetach`
+ * through `moveTabToWindow` — and each swallowed function carries a
+ * character-identical copy of the guard under test. Measured: the guard deleted
+ * from the subject, the neighbour's copy satisfying the `assert.match`, the
+ * whole suite green.
+ *
+ * A function extracted as a function cannot drift that way. `assert.equal` on
+ * the count rather than "the first one" is deliberate: a rename or a second
+ * definition of the same name fails here, loudly, instead of quietly changing
+ * what the caller is asserting about.
+ */
+export function functionSource(text: string, name: string): string {
+	const found = functionScopes(text).filter((scope) => scope.name === name);
+	assert.equal(found.length, 1, `expected exactly one function named ${JSON.stringify(name)}, found ${found.length}`);
+	return text.slice(found[0].start, found[0].end);
+}
+
+/**
  * The source text of each function argument passed to `callee(…)`, braces
  * included.
  *

--- a/scripts/truncatedBufferGuard.test.ts
+++ b/scripts/truncatedBufferGuard.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { sliceBetween, sliceFrom } from './sourceTree.js';
+import { functionSource, sliceBetween, sliceFrom } from './sourceTree.js';
 
 // A markdown file larger than 50KB is opened twice: `open_markdown_preview`
 // returns the first 50KB so something renders immediately, and a background
@@ -416,10 +416,33 @@ test('entering split view completes a partial buffer instead of trusting it', ()
 test('a partial buffer cannot be handed to another window', () => {
 	// The destination rebuilds the tab from the payload alone and has no way
 	// to know the text is incomplete, so its auto-save would truncate the file.
-	const canTransfer = sliceBetween(viewer, 'canTransfer: (tabId)', 'transferPayload:');
-	assert.match(canTransfer, /isTruncated/);
-	const detach = sliceBetween(viewer, 'async function handleDetach', 'async function carryActiveTabToNextWindow');
-	assert.match(detach, /ensureFullContent/);
+	//
+	// Each subject is extracted by its own name. The previous form sliced
+	// `'canTransfer: (tabId)'` → `'transferPayload:'`, which ran past
+	// `canDetach`, and `'async function handleDetach'` → `'async function
+	// carryActiveTabToNextWindow'`, which ran past `moveTabToWindow`. Both
+	// swallowed neighbours end in a character-identical copy of the guard being
+	// asserted, so the `assert.match` was satisfied either way: deleting
+	// `&& !tab.isTruncated` from `canTransfer`, and separately deleting the whole
+	// four-line `ensureFullContent` guard from `handleDetach`, each left the
+	// suite green — on the transfer-then-auto-save path this file is named for.
+	//
+	// The two neighbours were therefore never asserted about, only stood in
+	// front of. Both are the same guard on the same path, so both are named.
+	for (const predicate of ['canTransfer', 'canDetach']) {
+		assert.match(
+			functionSource(viewer, predicate),
+			/!tab\.isTruncated/,
+			`${predicate} must refuse a tab whose buffer is still the preview slice`,
+		);
+	}
+	for (const mover of ['handleDetach', 'moveTabToWindow']) {
+		assert.match(
+			functionSource(viewer, mover),
+			/if \(!\(await documentSession\.ensureFullContent\(tabId\)\)\) \{[\s\S]*?return false;/,
+			`${mover} must complete the buffer before the payload is built, and stop when it cannot`,
+		);
+	}
 });
 
 test('front matter edits in preview mode complete the buffer first', () => {

--- a/scripts/viewModeWithoutSaving.test.ts
+++ b/scripts/viewModeWithoutSaving.test.ts
@@ -425,9 +425,20 @@ test('closing the window still reviews unsaved tabs', () => {
 	// `appExit` and the window close handler are untouched by this change; the
 	// confirmation there is load-bearing because the buffer dies with the
 	// window. Source-level, because they are wired to Tauri window events.
-	const exit = sliceBetween(viewer, 'async function appExit()', 'async function toggleEdit');
+	//
+	// `pluck` rather than an anchor pair: the previous end anchor was
+	// `'async function toggleEdit'`, which is 969 lines below a 16-line
+	// function, so both assertions below were satisfied by anything anywhere in
+	// that span. Measured — the review moved verbatim into a helper 20 lines
+	// down that nobody calls, `appExit` reduced to `appWindow.close()`, whole
+	// suite green.
+	const exit = pluck('appExit');
 	assert.match(exit, /tabManager\.tabs\.some\(\(t\) => t\.isDirty \|\| \(t\.path === '' && t\.rawContent\.trim\(\) !== ''\)\)/);
 	assert.match(exit, /modal\.areYouSureYouWantToExit/);
+	// And the answer has to be acted on. Asking and then closing anyway loses
+	// the same buffer the dialog exists to protect; the identifier is left
+	// unpinned because which local holds the answer is not the contract.
+	assert.match(exit, /if \(\w+ !== 'discard'\) return;/, "an answer other than 'discard' stops the exit");
 
 	const closeHandler = sliceBetween(viewer, 'appWindow.onCloseRequested', 'onDragDropEvent');
 	assert.match(closeHandler, /await canCloseTab\(dirty\.id\)/);

--- a/scripts/windowOrganization.test.ts
+++ b/scripts/windowOrganization.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { sliceBetween } from './sourceTree.js';
+
 const runtime = readFileSync('src-tauri/src/window_runtime.rs', 'utf8');
 const session = readFileSync('src/lib/sessions/windowSession.svelte.ts', 'utf8');
 const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
@@ -9,12 +11,24 @@ const tab = readFileSync('src/lib/components/Tab.svelte', 'utf8');
 const titleBar = readFileSync('src/lib/components/TitleBar.svelte', 'utf8');
 
 test('the runtime registers live viewer windows in stable creation order', () => {
-	assert.match(runtime, /window_registry/);
 	assert.match(runtime, /window_counter/);
 	assert.match(runtime, /pub fn set_window_meta/);
 	assert.match(runtime, /pub fn list_viewer_windows/);
 	assert.match(runtime, /list\.sort_by_key\(\|entry\| entry\.meta\.number\)/);
-	assert.match(runtime, /window_registry[\s\S]*?remove\(window\.label\(\)\)/);
+
+	// Deregistration, read inside the arm that has to do it. The previous form
+	// was `/window_registry[\s\S]*?remove\(window\.label\(\)\)/` over the whole
+	// file: `window_registry` is the struct field at the top, `remove(window
+	// .label())` is the *watcher* cleanup ~430 lines down, and nothing required
+	// the two to be one statement. Measured — deleting the registry removal from
+	// the `Destroyed` arm left the suite green, and every closed window stayed in
+	// `list_viewer_windows` as a transfer target that no longer exists.
+	const destroyed = sliceBetween(runtime, 'tauri::WindowEvent::Destroyed => {', '\n        }');
+	assert.match(
+		destroyed,
+		/window_registry\)\.remove\(window\.label\(\)\)/,
+		'a destroyed window must be deregistered, or it is still offered as a move target',
+	);
 });
 
 test('moving to an existing window uses the acknowledged transfer protocol', () => {

--- a/src/lib/utils/recentFiles.ts
+++ b/src/lib/utils/recentFiles.ts
@@ -1,7 +1,12 @@
 import { writeStoredSetting } from '../stores/settings.svelte.js';
 
-export const RECENT_FILES_KEY = 'recent-files';
-export const RECENT_FILES_LIMIT = 9;
+// Module-private on purpose. Both used to be exported, and the only importer
+// was recentFilesMultiWindow.test.ts, which compared each one with itself —
+// so renaming the key or changing the cap could not fail anything. The test
+// writes both values out now; an export that exists to be asserted against
+// itself is not a contract with anyone.
+const RECENT_FILES_KEY = 'recent-files';
+const RECENT_FILES_LIMIT = 9;
 
 /**
  * The recent-file list, as stored. Anything that is not an array of strings is


### PR DESCRIPTION
A survey instrumented all 82 test files (22,477 assertion invocations logged) and then applied 35 source mutations, one full suite run each. It found 33 assertion sites that cannot fail. **Nine of them sit on real guards, and those nine are this PR.** The rest are handled separately.

**These tests are recent, and the series that is fixing them is the series that wrote them.** 16 of the 18 affected test files did not exist at the last release. None of this is inherited.

## The failure mode, and why #440 did not cover it

#440 fixed anchors that were **missing** — `source.slice(source.indexOf(absent))` slices from `-1`, so the subject degenerated to the last character of the file and no `doesNotMatch` could fail against it. That is a hole in the *helper*, and `sliceFrom` / `sliceBetween` / `offsetOf` now assert their anchors exist.

This is the opposite end. Both anchors are present; they are **too far apart**. The slice runs past the function under test into a neighbour, and something in the neighbour satisfies the match. The helper cannot see it, because nothing is missing.

```
sliceBetween(viewer, 'async function handleDetach', 'async function carryActiveTabToNextWindow')

  async function handleDetach(tabId) {
      if (!(await documentSession.ensureFullContent(tabId))) {   ← subject
          ...
  async function moveTabToWindow(tabId, targetLabel, ...) {
      if (!(await documentSession.ensureFullContent(tabId))) {   ← still inside the slice
```

Delete the first one. `assert.match(detach, /ensureFullContent/)` passes on the second.

## The six that reproduced

Every mutation below was applied to `master` before any fix, one full `npm test` per mutation. All six reproduced.

### 1. Both partial-buffer transfer guards — `truncatedBufferGuard.test.ts`

The file exists for one claim: a buffer holding only the first 50KB of a large file is never written back over that file. Two of its three source-level assertions did not hold it.

`sliceBetween(viewer, 'canTransfer: (tabId)', 'transferPayload:')` runs from `MarkdownViewer.svelte:504` past `canDetach` at `:508`. Both predicates end in `&& !tab.isTruncated`, so `assert.match(canTransfer, /isTruncated/)` is satisfied by the neighbour. Same shape for the detach slice above.

Both mutations are the transfer-a-truncated-buffer-then-auto-save-truncates-the-file path.

**Fixed by** `functionSource(viewer, name)` — see below — one call per predicate and per mover. The two neighbours that were doing the covering, `canDetach` and `moveTabToWindow`, were never asserted about at all; they are now, and the guard asserted on the movers is the whole four-line block rather than the bare identifier.

### 2. The exit review can be deleted outright — `viewModeWithoutSaving.test.ts`

`sliceBetween(viewer, 'async function appExit()', 'async function toggleEdit')` spans **969 lines**. `appExit` is 16.

Moving the unsaved-tab confirmation verbatim into a helper 20 lines below that nobody calls, and reducing `appExit` to `appWindow.close()`, is green.

**Fixed by** the file's own `pluck('appExit')`, a comment- and string-aware brace counter that was already there for the transpiled harness. One assertion added: the answer has to be *acted on*, not merely asked for. Asking and then closing anyway loses the same buffer the dialog exists to protect, and `/if \(\w+ !== 'discard'\) return;/` leaves the identifier unpinned because which local holds the answer is not the contract.

### 3. The `{@html}` sink list saw only bare identifiers — `previewSanitize.test.ts`

```js
[...viewerSource.matchAll(/\{@html\s+([A-Za-z_$][\w$]*)\s*\}/g)]
```

`{@html tooltip.html}` — already live at `MarkdownViewer.svelte:3543` — is invisible to that capture, so the list it compared was `['sanitizedHtml']` **by construction**. The assertion's stated purpose is that "adding a second injection point of the raw document is a failure instead of an unnoticed addition", and that is the one thing it could not do.

**Fixed by** capturing the whole expression and comparing against an allowlist. `tooltip.html` is on it with a reason rather than by accident: the footnote tooltip is a clone of a subtree of `markdownBody`, i.e. of the DOM the sanitized sink already injected — the same bytes read back out of the document, not a second policy. Two assertions pin that direction (found via `markdownBody?.querySelector`, taken from `.innerHTML`, never from `rawContent`), so a future `tooltip.html` fed from the raw buffer is red.

### 4. Closed windows are never deregistered — `windowOrganization.test.ts`

```js
assert.match(runtime, /window_registry[\s\S]*?remove\(window\.label\(\)\)/);
```

`window_registry` is the struct field at `window_runtime.rs:26`. `remove(window.label())` is the **watcher** cleanup at `:453`. Nothing required them to be the same statement, and the registry removal in the `Destroyed` arm at `:484` is deletable without a test noticing — after which every closed window stays in `list_viewer_windows` as a move target that no longer exists.

**Fixed by** slicing the `Destroyed` arm and reading the removal inside it. The bare `assert.match(runtime, /window_registry/)` above it is dropped as subsumed.

### 5. The recent-files key and cap were compared with themselves — `recentFilesMultiWindow.test.ts`

`RECENT_FILES_KEY` and `RECENT_FILES_LIMIT` were exported from `recentFiles.ts` **only** for this test, and every assertion compared the module's value with itself.

Renaming the key is green — and a rename silently orphans every existing user's list, because the literal appears nowhere else to contradict it. Changing the cap from 9 to 3 is green, because the boundedness test seeded `LIMIT + 5` and then asserted the result was `LIMIT` long.

**Fixed by** writing both values out in the test. Both are on-disk format: a localStorage key and the length of a list the user can see are things a reader should be able to look up, and things that must not change without someone deciding to. **The exports go with them** — this is the only source change in the PR, and it is the shape that started the survey: an export that exists to be asserted against itself is not a contract with anyone.

The *boundedness* claim was alive but only half-alive: the source caps the list twice, in `promoteRecentFile` and again in `updateStoredRecentFiles`, and an open goes through both — so removing either alone was green and only removing both was red. Tightened: one new test drives each layer on its own.

### 6. `t()` falls back to English — `editorContextMenuI18n.test.ts`

```js
assert.notEqual(t(key, lang), key, `${key} resolves for ${lang}`);
```

`t()` returns the English string when a language lacks the key, so this can only fail when *English* lacks it — which the line above already proved. The 26-language loop restated line 65 twenty-six times.

Deleting the German `menu.inlineCode` entry is green. German renders the English label, which is the user-visible regression.

**Fixed by** reading `translations[lang]` directly, without the fallback. These twelve labels are deliberately held to a stricter bar than the dictionary at large — `i18nCoverage.test.ts` reports per-locale gaps rather than failing on them, because 19 locales are missing >100 keys and nobody should have to translate a new English string 25 times before landing it. That trade does not apply to a fixed list of a dozen context-menu entries that all 26 languages already define, where an eleventh action means adding a row to `FORMATTING_ACTIONS` by hand.

## The three that no mutation can reach

Deleting is the right answer for two of them. The third turned out not to be in that class.

| site | why no mutation applies | done |
|---|---|---|
| `previewSanitize.test.ts:92` | `assert.match(POC_STYLE, /^<style>/)` — `POC_STYLE` is a template literal declared 59 lines above, in this file. Both sides are the test. | **Deleted.** The payload was documentation pretending to be an assertion; it is a comment now, verbatim. |
| `editorContextMenuI18n.test.ts:161` | counts occurrences of a pattern *containing* `uiLanguage`, one line after `assert.doesNotMatch(editor, /uiLanguage/)`. The line above must pass to reach it, and once it has the count is zero by construction. | **Deleted.** No state of the component makes it, and not the line above, the failure. |
| `previewSanitize.test.ts:91` | reported as the same class — `MARKDOWN_SANITIZE_CONFIG.ALLOWED_URI_REGEXP` against the constant it is assigned from one line earlier, measured as the same object reference. | **Kept.** It is reachable: rebuilding the config's regexp from the exported one's `.source` and `.flags` fails it. That is a *copy* of the URI pattern, which is precisely the regression this file exists for, so identity is the right comparison and the import stays. The identical assertion is duplicated at `exportSanitize.test.ts:68`. |

## `functionSource`

Sites 1 and 2 are the same defect: an anchor pair that names the **neighbour** rather than the subject. `sourceTree.ts` gained AST helpers in #440 for exactly this reason, so the fix is a third one rather than another hand-rolled anchor pair:

```ts
export function functionSource(text: string, name: string): string {
	const found = functionScopes(text).filter((scope) => scope.name === name);
	assert.equal(found.length, 1, `expected exactly one function named ${JSON.stringify(name)}, found ${found.length}`);
	return text.slice(found[0].start, found[0].end);
}
```

It reads a function bound to `name` in any of the spellings `src/` uses — `function f() {}`, `const f = () => {}`, `{ f: () => {} }`, class methods — and `assert.equal` on the count rather than "the first one" means a rename or a second definition fails here, loudly, instead of quietly changing what the caller is asserting about. Pinned in `sourceTree.test.ts` against string literals, so refactoring the app cannot make that test fail and changing the helper is the only thing that can.

## Mutation table

Green measured against `master` before the fix; red measured after, on the rebased branch. Each mutation applied to `src/` or `src-tauri/`, the suite run, the source restored.

| # | mutation | before | after | failure message |
|---|---|---|---|---|
| 1a | `canTransfer`: drop `&& !tab.isTruncated` | GREEN 584 | RED | `canTransfer must refuse a tab whose buffer is still the preview slice` |
| 1b | `handleDetach`: delete the four-line `ensureFullContent` guard | GREEN 584 | RED | `handleDetach must complete the buffer before the payload is built, and stop when it cannot` |
| 1c | `canDetach`: drop `&& !tab.isTruncated` *(new coverage)* | GREEN 584 | RED | `canDetach must refuse a tab whose buffer is still the preview slice` |
| 1d | `moveTabToWindow`: delete the four-line guard *(new coverage)* | GREEN 584 | RED | `moveTabToWindow must complete the buffer before the payload is built, and stop when it cannot` |
| 2a | `appExit`: exit review moved verbatim into an uncalled helper | GREEN 584 | RED | `The input did not match /tabManager\.tabs\.some\(\(t\) => t\.isDirty …` |
| 2b | `appExit`: ask, then close regardless of the answer *(new coverage)* | GREEN 584 | RED | `an answer other than 'discard' stops the exit` |
| 3a | add `{@html unsafe.rawHtml}` beside the sanitized sink | GREEN 584 | RED | `unexpected {@html} sink — what the preview injects is the shared sanitizer output` |
| 3b | footnote tooltip HTML taken from the raw buffer *(new coverage)* | GREEN 584 | RED | `and taken from the DOM the shared sanitizer already filtered` |
| 4 | `window_runtime.rs`: drop the registry removal from the `Destroyed` arm | GREEN 584 | RED | `a destroyed window must be deregistered, or it is still offered as a move target` |
| 5a | `RECENT_FILES_KEY`: `'recent-files'` → `'markpad-recent'` | GREEN 584 | RED (6 tests) | `Expected values to be strictly deep-equal` |
| 5b | `RECENT_FILES_LIMIT`: `9` → `3` | GREEN 584 | RED (2 tests) | `promoteRecentFile caps what it returns` |
| 5c | drop the cap in `promoteRecentFile` only | GREEN 584 | RED | `promoteRecentFile caps what it returns` |
| 5d | drop the cap in `updateStoredRecentFiles` only | GREEN 584 | RED | `and the stored list is capped even when the mutation is not` |
| 5e | drop **both** caps *(already caught before this PR)* | RED | RED | `the list stays bounded no matter how the entries arrived` |
| 6 | `i18n.ts`: delete the German `menu.inlineCode` entry | GREEN 584 | RED | `menu.inlineCode is translated for de; it currently falls back to the English label` |
| A1 | `previewSanitize.test.ts:92` | — | — | no mutation applies; the subject is a literal in the test file. **Deleted.** |
| A2 | `sanitize.ts`: config rebuilds the URI regexp from `.source` + `.flags` | GREEN 584 | RED | `Values have same structure but are not reference-equal` — the site was reachable, so it is **kept** |
| A3 | `editorContextMenuI18n.test.ts:161` | — | — | no mutation applies; strictly subsumed by `:160`. **Deleted.** |

One correction to the survey's own report: the mutation for site 2 as literally worded — delete the review block from `appExit` and close immediately — is **red**, caught by `windowStateRestore.test.ts:107`, which slices `appExit` with the tight `'\n\t}'` end anchor. The dead-assertion claim holds for the harder variant in the table, where the block stays inside the 969-line span.

## What did not change

No `src/` or `src-tauri/` behaviour. The only source edit is `export const` → `const` on the two recent-files constants (case 5), which is the one exception the audit allows and only because the assertion that needed them is gone.

No existing assertion was weakened. Two were dropped as strictly subsumed by a stronger one alongside them (`windowOrganization`'s bare `/window_registry/`, `editorContextMenuI18n`'s `uiLanguage` count) and two were dropped as unfalsifiable. Everything else is the same claim on a tighter subject, plus six guards that had never been asserted about at all.

## Verification

`npm test` 594/594, `npm run check` 0 errors 0 warnings, `npm run build`, `cargo test` 150/150 — all measured after rebasing onto `5be7c18` (#448), not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
