### PR TITLE
test(scripts): normalize line endings on read instead of per assertion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,33 @@
+# Line endings.
+#
+# Without this file, a Windows clone with the default `core.autocrlf=true`
+# checks the whole tree out CRLF. Every test in `scripts/` that reads `src/` as
+# text then matches patterns against bytes the repository does not contain —
+# fifteen files had to be hand-patched that way while cutting v2.7.0 (#452).
+#
+# This is the belt. `scripts/sourceTree.ts`'s `readSource` is the braces, and it
+# is the half that actually holds: `.gitattributes` does not touch a tree that is
+# already checked out (that needs `git add --renormalize .`), and it cannot stop
+# an editor from writing CRLF into a file it saves.
+#
+# Every tracked file in this repo is LF today, so this changes no stored bytes
+# and no working tree on Linux or macOS. What it changes is the *next* Windows
+# clone.
+* text=auto eol=lf
+
+# Consumed by Windows-only toolchains, which is where a lone LF is a real risk
+# rather than a theoretical one. These are pinned to CRLF so the bytes NSIS and
+# Chocolatey see are the bytes they see today on a `core.autocrlf=true` runner —
+# this file is not the place to also change the installer build.
+*.nsi   text eol=crlf
+*.nsh   text eol=crlf
+*.ps1   text eol=crlf
+*.bat   text eol=crlf
+*.cmd   text eol=crlf
+
+# Never touched, never diffed as text.
+*.png   binary
+*.gif   binary
+*.svg   text eol=lf
+*.ico   binary
+*.icns  binary

--- a/scripts/checkedReadMigration.test.ts
+++ b/scripts/checkedReadMigration.test.ts
@@ -1,8 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { offsetOf, readSourceFiles, sliceBetween } from './sourceTree.js';
+import { offsetOf, readSource, readSourceFiles, sliceBetween } from './sourceTree.js';
 
 // Runes and the Tauri bridge, shimmed the way truncatedBufferGuard.test.ts
 // shims them: the stores are runes modules, and Node's test runner gives every
@@ -152,7 +151,7 @@ test('the completed buffer is refused or accepted according to that verdict', as
 
 // --- the two component call sites -------------------------------------------
 
-const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
 test('the unchecked read command is gone, and nothing calls it', () => {
 	// This was a three-file allowlist — the files #379 migrated. That is the
@@ -168,7 +167,7 @@ test('the unchecked read command is gone, and nothing calls it', () => {
 		.map(({ path }) => path);
 	assert.deepEqual(offenders, [], 'read_file_content no longer exists; read_file_content_checked is the read');
 
-	const rust = readFileSync('src-tauri/src/lib.rs', 'utf8');
+	const rust = readSource('src-tauri/src/lib.rs');
 	assert.doesNotMatch(rust, /\basync fn read_file_content\(/, 'the unchecked command must stay deleted');
 	assert.doesNotMatch(rust, /^\s*read_file_content,\s*$/m, 'and must not be registered again');
 });
@@ -200,7 +199,7 @@ test('the session can tell a refusal from a failure', () => {
 	// both halves for real; this only pins that the tab is consulted at all,
 	// since a predicate that answers from memory alone is the defect.
 	const body = sliceBetween(
-		readFileSync('src/lib/sessions/documentSession.svelte.ts', 'utf8'),
+		readSource('src/lib/sessions/documentSession.svelte.ts'),
 		'function isLossySaveRefused(',
 		'function updateLoading',
 	);
@@ -228,7 +227,7 @@ test('a tab that can only be refused stops re-arming the timer', () => {
 	// only drops afterwards — and "Save As" to a new file clears
 	// `hasReplacementChars`, which restores it.
 	assert.match(
-		readFileSync('src/lib/sessions/documentSession.svelte.ts', 'utf8'),
+		readSource('src/lib/sessions/documentSession.svelte.ts'),
 		/lossySaveWarnedTabs\.delete\(tab\.id\)/,
 	);
 });

--- a/scripts/documentLoadFailure.test.ts
+++ b/scripts/documentLoadFailure.test.ts
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const session = readFileSync('src/lib/sessions/documentSession.svelte.ts', 'utf8');
+import { readSource } from './sourceTree.js';
+
+const session = readSource('src/lib/sessions/documentSession.svelte.ts');
 
 test('a transient missing-file read error preserves the open tab', () => {
 	assert.doesNotMatch(session, /tabManager\.closeTab/);

--- a/scripts/documentWatcherSession.test.ts
+++ b/scripts/documentWatcherSession.test.ts
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { sliceFrom } from './sourceTree.js';
+import { readSource, sliceFrom } from './sourceTree.js';
 
-const session = readFileSync('src/lib/sessions/documentSession.svelte.ts', 'utf8');
+const session = readSource('src/lib/sessions/documentSession.svelte.ts');
 
 test('self writes suppress watcher reloads only during their grace period', () => {
 	const handler = sliceFrom(session, 'function shouldReloadExternalChange');

--- a/scripts/editorContextMenuI18n.test.ts
+++ b/scripts/editorContextMenuI18n.test.ts
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import { getSupportedLanguages, t, translations, type LanguageCode, type Translation } from '../src/lib/utils/i18n.js';
+import { readSource } from './sourceTree.js';
 
 // WHAT THIS FILE COVERS, AND WHAT IT DOES NOT
 //
@@ -16,7 +16,7 @@ import { getSupportedLanguages, t, translations, type LanguageCode, type Transla
 // Monaco behaves that way when the effect re-runs — verifying that needs a
 // running editor.
 
-const editor = readFileSync('src/lib/components/Editor.svelte', 'utf8');
+const editor = readSource('src/lib/components/Editor.svelte');
 
 const supported = getSupportedLanguages().map((l) => l.code);
 

--- a/scripts/editorOptionWiring.test.ts
+++ b/scripts/editorOptionWiring.test.ts
@@ -1,8 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { sliceBetween } from './sourceTree.js';
+import { readSource, sliceBetween } from './sourceTree.js';
 
 // Editor.svelte translates the settings store into Monaco options and
 // keybindings. Every regression locked here came from that translation layer
@@ -10,8 +9,8 @@ import { sliceBetween } from './sourceTree.js';
 // modifier that macOS never delivers, one key bound twice, and a native
 // behaviour dropped by the action that replaced it.
 
-const editor = readFileSync('src/lib/components/Editor.svelte', 'utf8');
-const settingsStore = readFileSync('src/lib/stores/settings.svelte.ts', 'utf8');
+const editor = readSource('src/lib/components/Editor.svelte');
+const settingsStore = readSource('src/lib/stores/settings.svelte.ts');
 
 function count(source: string, pattern: RegExp): number {
 	return source.match(pattern)?.length ?? 0;

--- a/scripts/editorPdfExport.test.ts
+++ b/scripts/editorPdfExport.test.ts
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import { compile } from 'svelte/compiler';
 
-import { offsetOf, sliceBetween, sliceFrom } from './sourceTree.js';
+import { offsetOf, readSource, sliceBetween, sliceFrom } from './sourceTree.js';
 
 /*
  * Export PDF from plain edit mode produced a blank page, for two independent
@@ -33,8 +32,8 @@ import { offsetOf, sliceBetween, sliceFrom } from './sourceTree.js';
  *    the note on those tests for what that does and does not establish.
  */
 
-const styles = readFileSync('src/styles.css', 'utf8');
-const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+const styles = readSource('src/styles.css');
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
 const componentCss = (() => {
 	const compiled = compile(viewer, { filename: 'MarkdownViewer.svelte', css: 'external' });

--- a/scripts/explicitSaveCancelsAutoSave.test.ts
+++ b/scripts/explicitSaveCancelsAutoSave.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { readFileSync } from 'node:fs';
+
+import { readSource } from './sourceTree.js';
 
 // An explicit save and the 1.5s auto-save debounce can both be aimed at one
 // tab. The debounce is armed on the last keystroke and disarmed by the
@@ -166,7 +167,7 @@ test('no call site takes the cancel duty back from saveContent', async () => {
 	// forget it again. A cancel immediately before a `saveContent` is the
 	// shape that says someone stopped trusting the function to do it.
 	for (const path of ['src/lib/MarkdownViewer.svelte', 'src/lib/sessions/documentSession.svelte.ts']) {
-		const body = readFileSync(path, 'utf8');
+		const body = readSource(path);
 		assert.doesNotMatch(
 			body,
 			/cancelPendingAutoSave\([^)]*\);\s*(?:\/\/[^\n]*\n\s*)*(?:const \w+ = )?(?:await |return )*saveContent\(/,
@@ -177,7 +178,7 @@ test('no call site takes the cancel duty back from saveContent', async () => {
 	// And the duty is discharged before the write, not after — the source-level
 	// mirror of the ordering test above, so a refactor that reorders the two
 	// inside `saveContent` is caught even if the stub harness stops seeing it.
-	const session = readFileSync('src/lib/sessions/documentSession.svelte.ts', 'utf8');
+	const session = readSource('src/lib/sessions/documentSession.svelte.ts');
 	const saveContentBody = session.slice(session.indexOf('async function saveContent('));
 	const cancel = saveContentBody.indexOf('options.cancelPendingAutoSave(');
 	const write = saveContentBody.indexOf("invoke('save_file_content'");

--- a/scripts/exportFoldParity.test.ts
+++ b/scripts/exportFoldParity.test.ts
@@ -1,11 +1,11 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import { buildExportDocument } from '../src/lib/utils/export.js';
+import { readSource } from './sourceTree.js';
 
-const styles = readFileSync('src/styles.css', 'utf8');
-const exportSource = readFileSync('src/lib/utils/export.ts', 'utf8');
+const styles = readSource('src/styles.css');
+const exportSource = readSource('src/lib/utils/export.ts');
 
 // Both export routes have to agree on what is in the file. The HTML route
 // decides in TypeScript (it renders every fold open); the print/PDF route

--- a/scripts/exportSanitize.test.ts
+++ b/scripts/exportSanitize.test.ts
@@ -1,5 +1,4 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import {
@@ -8,9 +7,10 @@ import {
 	MARKDOWN_SANITIZE_CONFIG,
 } from '../src/lib/utils/sanitize.js';
 import { hasMarkdownLinkExtension } from '../src/lib/utils/markdownLinks.js';
+import { readSource } from './sourceTree.js';
 
-const exportSource = readFileSync('src/lib/utils/export.ts', 'utf8');
-const sanitizeSource = readFileSync('src/lib/utils/sanitize.ts', 'utf8');
+const exportSource = readSource('src/lib/utils/export.ts');
+const sanitizeSource = readSource('src/lib/utils/sanitize.ts');
 
 // The report's proof of concept. A document containing this line renders as
 // nothing in the preview (the viewer sanitizes), so the user sees no sign of

--- a/scripts/exportedThemeFidelity.test.ts
+++ b/scripts/exportedThemeFidelity.test.ts
@@ -1,11 +1,11 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import { buildExportDocument, exportThemeAttribute } from '../src/lib/utils/export.js';
+import { readSource } from './sourceTree.js';
 
-const styles = readFileSync('src/styles.css', 'utf8');
-const exportSource = readFileSync('src/lib/utils/export.ts', 'utf8');
+const styles = readSource('src/styles.css');
+const exportSource = readSource('src/lib/utils/export.ts');
 
 /** The opening `<html …>` tag of a built export. */
 function htmlTag(document: string): string {

--- a/scripts/externalChangeReload.test.ts
+++ b/scripts/externalChangeReload.test.ts
@@ -1,8 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { sliceBetween } from './sourceTree.js';
+import { readSource, sliceBetween } from './sourceTree.js';
 
 // Live Mode watches the open file and reloads it when something else writes
 // it — git checkout, a cloud sync, a second Markpad window. The reload path
@@ -33,7 +32,7 @@ g.window.__TAURI_INTERNALS__ = {
 const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
 
-const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
+const viewer = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
 
 function makeSession() {
 	return createDocumentSession({

--- a/scripts/fileAssociations.test.ts
+++ b/scripts/fileAssociations.test.ts
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const config = JSON.parse(readFileSync('src-tauri/tauri.conf.json', 'utf8')) as {
+import { readSource } from './sourceTree.js';
+
+const config = JSON.parse(readSource('src-tauri/tauri.conf.json')) as {
 	bundle: { fileAssociations: Array<{ ext: string[] }> };
 };
 

--- a/scripts/foldKeys.test.ts
+++ b/scripts/foldKeys.test.ts
@@ -1,8 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { sliceFrom } from './sourceTree.js';
+import { readSource, sliceFrom } from './sourceTree.js';
 
 // Fold state is keyed by `h.id || textContent`. comrak emits the
 // deduplicated heading id on an empty inner <a class="anchor">, not on the
@@ -11,7 +10,7 @@ import { sliceFrom } from './sourceTree.js';
 // id-based fold keys never match the preview's text-based ones.
 
 test('processMarkdownHtml promotes the anchor id onto the heading element', () => {
-	const source = readFileSync('src/lib/utils/markdown.ts', 'utf8');
+	const source = readSource('src/lib/utils/markdown.ts');
 
 	const headingLoop = sliceFrom(source, 'querySelectorAll("h1, h2, h3, h4, h5, h6")');
 	assert.match(headingLoop, /querySelector\("a\.anchor"\)/, 'heading loop looks up the comrak anchor');
@@ -20,12 +19,12 @@ test('processMarkdownHtml promotes the anchor id onto the heading element', () =
 });
 
 test('fold restore keys by heading id before falling back to text', () => {
-	const source = readFileSync('src/lib/utils/markdown.ts', 'utf8');
+	const source = readSource('src/lib/utils/markdown.ts');
 	assert.match(source, /const \w+ = \w+\.id \|\| \w+\.textContent/, 'restore key prefers the (now populated) heading id');
 });
 
 test('viewer fold handlers key by heading id before falling back to text', () => {
-	const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+	const viewer = readSource('src/lib/MarkdownViewer.svelte');
 	assert.match(viewer, /foldableHeader\.id \|\| foldableHeader\.textContent/, 'preview chevron keys by heading id first');
 	assert.match(viewer, /\[id="\$\{CSS\.escape\(key\)\}"\]\.foldable-header/, 'toggleFold resolves the heading by id');
 });

--- a/scripts/foldLayout.test.ts
+++ b/scripts/foldLayout.test.ts
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { readSource } from './sourceTree.js';
+
 test('fold layout observes rendered content and publishes its measured height', () => {
-	const source = readFileSync('src/lib/utils/foldLayout.ts', 'utf8');
+	const source = readSource('src/lib/utils/foldLayout.ts');
 
 	assert.match(source, /new ResizeObserver/);
 	assert.match(source, /--fold-content-height/);
@@ -11,7 +12,7 @@ test('fold layout observes rendered content and publishes its measured height', 
 });
 
 test('fold wrapper animates an explicit measured height instead of a fractional grid track', () => {
-	const styles = readFileSync('src/styles.css', 'utf8');
+	const styles = readSource('src/styles.css');
 	const expandedRule = styles.match(/\.foldable-content-wrapper\s*\{([^}]*)\}/)?.[1] || '';
 
 	assert.match(expandedRule, /height:\s*var\(--fold-content-height/);
@@ -27,8 +28,8 @@ test('fold wrapper animates an explicit measured height instead of a fractional 
 // lands on a target that is still moving — a defect that only shows up as "find
 // sometimes scrolls to the wrong place".
 test('the find-bar fold re-aim delay outlasts the CSS fold transition', () => {
-	const findBar = readFileSync('src/lib/components/FindBar.svelte', 'utf8');
-	const styles = readFileSync('src/styles.css', 'utf8');
+	const findBar = readSource('src/lib/components/FindBar.svelte');
+	const styles = readSource('src/styles.css');
 
 	const declared = findBar.match(/const FOLD_TRANSITION_MS = (\d+);/);
 	assert.ok(declared, 'FindBar.svelte must declare the delay it waits for the fold to settle');
@@ -44,14 +45,14 @@ test('the find-bar fold re-aim delay outlasts the CSS fold transition', () => {
 });
 
 test('preview lifecycle starts and cleans up fold observation', () => {
-	const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+	const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
 	assert.match(viewer, /observeFoldLayout\((?:markdownBody|body)\)/);
 	assert.match(viewer, /stopObservingFoldLayout\?\.\(\)/);
 });
 
 test('fold measurement pauses while the preview pane is hidden by edit mode', () => {
-	const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+	const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
 	assert.match(viewer, /if \(!html \|\| !body \|\| \(isEditing && !isSplit\)\) return;/);
 });

--- a/scripts/foldStatePerDocument.test.ts
+++ b/scripts/foldStatePerDocument.test.ts
@@ -28,12 +28,11 @@
  */
 
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 import ts from 'typescript';
 
 import { installShimDom, parseHtml, type ShimElement } from './renderProtocolDom.ts';
-import { offsetOf } from './sourceTree.js';
+import { offsetOf, readSource } from './sourceTree.js';
 
 // ---------------------------------------------------------------- environment
 
@@ -67,9 +66,9 @@ installShimDom();
 const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 const { processMarkdownHtml } = await import('../src/lib/utils/markdown.ts');
 
-const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
-const toc = readFileSync(new URL('../src/lib/components/Toc.svelte', import.meta.url), 'utf8');
-const session = readFileSync(new URL('../src/lib/sessions/documentSession.svelte.ts', import.meta.url), 'utf8');
+const viewer = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
+const toc = readSource(new URL('../src/lib/components/Toc.svelte', import.meta.url));
+const session = readSource(new URL('../src/lib/sessions/documentSession.svelte.ts', import.meta.url));
 
 // ------------------------------------------------------------ source plucking
 
@@ -124,7 +123,7 @@ function pluckFunction(source: string, name: string, required = true): string {
 type Declaration = { declare: string; refresh: string };
 
 function pluckDeclaration(source: string, name: string, required = true): Declaration | null {
-	const match = new RegExp(`\\r?\\n\\t(let|const) ${name} = ([^\\r\\n]*);\\r?\\n`).exec(source);
+	const match = new RegExp(`\\n\\t(let|const) ${name} = ([^\\n]*);\\n`).exec(source);
 	if (!match) {
 		assert.ok(!required, `expected the component to declare ${name} on one line`);
 		return null;

--- a/scripts/homeTabRender.test.ts
+++ b/scripts/homeTabRender.test.ts
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import { parse } from 'svelte/compiler';
+
+import { readSource } from './sourceTree.js';
 
 /*
  * Issue #392, second half (reported by @PathGao): "the Home tab it opens
@@ -76,7 +77,7 @@ const { getSupportedLanguages, t } = await import('../src/lib/utils/i18n.js');
 // ------------------------------------------------------- the gate, as written
 
 const VIEWER = 'src/lib/MarkdownViewer.svelte';
-const source = readFileSync(VIEWER, 'utf8');
+const source = readSource(VIEWER);
 
 type Node = Record<string, any>;
 

--- a/scripts/i18nCoverage.test.ts
+++ b/scripts/i18nCoverage.test.ts
@@ -1,6 +1,4 @@
 import assert from 'node:assert/strict';
-import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { join } from 'node:path';
 import test from 'node:test';
 
 import {
@@ -10,6 +8,7 @@ import {
 	type LanguageCode,
 	type Translation,
 } from '../src/lib/utils/i18n.js';
+import { readSource, walkSourceFiles } from './sourceTree.js';
 
 // WHAT THIS FILE COVERS, AND WHY IT EXISTS
 //
@@ -60,15 +59,6 @@ const dictionaries = new Map<LanguageCode, Map<string, string>>(
 const english = dictionaries.get('en')!;
 
 // ------------------------------------------------------------------- source
-
-function sourceFiles(dir: string, out: string[] = []): string[] {
-	for (const entry of readdirSync(dir)) {
-		const path = join(dir, entry);
-		if (statSync(path).isDirectory()) sourceFiles(path, out);
-		else if (path.endsWith('.svelte') || path.endsWith('.ts')) out.push(path.replace(/\\/g, '/'));
-	}
-	return out;
-}
 
 // Prose in a doc comment can mention `t('foo')`. Drop whole comment lines
 // rather than trying to parse comments out of the middle of code — this only
@@ -147,9 +137,9 @@ const dynamicPrefixes = new Map<string, Set<string>>();
 /** `t(someVariable, lang)` — the key is computed elsewhere. */
 const indirectCalls = new Set<string>();
 
-for (const file of sourceFiles(SOURCE_ROOT)) {
+for (const file of walkSourceFiles(SOURCE_ROOT)) {
 	if (file === DICTIONARY) continue;
-	const src = stripCommentLines(readFileSync(file, 'utf8'));
+	const src = stripCommentLines(readSource(file));
 
 	// `t(` but not `format(`, `.at(`, `assert(` …
 	for (const match of src.matchAll(/(?<![\w$.])t\(/g)) {
@@ -313,7 +303,7 @@ test('every template-literal key family is declared and resolvable', () => {
 	);
 
 	for (const [prefix, { file, member, why }] of Object.entries(DYNAMIC_FAMILIES)) {
-		const source = readFileSync(file, 'utf8');
+		const source = readSource(file);
 		// A member may legitimately appear at several call sites (`tk('close')`),
 		// so this is a set, not a list.
 		const members = new Set([...source.matchAll(member)].map((m) => m[1]));
@@ -333,7 +323,7 @@ test('t() never echoes a key back for a reachable string', () => {
 	// rather than through the tables.
 	const reachable = new Set(staticKeys.map((r) => r.key));
 	for (const [prefix, { file, member }] of Object.entries(DYNAMIC_FAMILIES)) {
-		const source = readFileSync(file, 'utf8');
+		const source = readSource(file);
 		for (const m of source.matchAll(member)) reachable.add(`${prefix}${m[1]}`);
 	}
 	for (const key of reachable) {
@@ -362,7 +352,7 @@ test('the tag-colour names reach the UI in every language', () => {
 
 test('the window-tag editor’s Save button is translated', () => {
 	// The button that shipped reading "common.save".
-	const titleBar = readFileSync('src/lib/components/TitleBar.svelte', 'utf8');
+	const titleBar = readSource('src/lib/components/TitleBar.svelte');
 	const match = titleBar.match(/onclick=\{applyTag\}>\{t\('([^']+)', currentLanguage\)\}/);
 	assert.ok(match, 'the tag editor still labels its confirm button through t()');
 	assert.ok(english.has(match[1]), `${match[1]} is defined in English`);

--- a/scripts/issue261EditorPdf.test.ts
+++ b/scripts/issue261EditorPdf.test.ts
@@ -1,15 +1,13 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { offsetOf, sliceBetween, sliceFrom } from './sourceTree.js';
+import { offsetOf, readSource, sliceBetween, sliceFrom } from './sourceTree.js';
 
-const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
-const styles = readFileSync('src/styles.css', 'utf8');
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
+const styles = readSource('src/styles.css');
 
 test('editor context menu is not intercepted by the document menu', () => {
-	const endMarker = viewer.includes('\r\n') ? '\r\n\tfunction handleMouseOver' : '\n\tfunction handleMouseOver';
-	const handler = sliceBetween(viewer, 'function handleContextMenu(e: MouseEvent)', endMarker);
+	const handler = sliceBetween(viewer, 'function handleContextMenu(e: MouseEvent)', '\n\tfunction handleMouseOver');
 	const editorReturn = offsetOf(handler, 'if (isInsideEditor) return;');
 	const preventDefault = offsetOf(handler, 'e.preventDefault();');
 
@@ -46,8 +44,7 @@ test('print layout lets the viewer pane escape the interactive split flex ratio'
 });
 
 test('floating toc toggle keeps a visible translucent surface outside edit mode', () => {
-	const endMarker = viewer.includes('\r\n') ? '\r\n\t.toc-toggle-floating.expanded {' : '\n\t.toc-toggle-floating.expanded {';
-	const selector = sliceBetween(viewer, '\t.toc-toggle-floating {', endMarker);
+	const selector = sliceBetween(viewer, '\t.toc-toggle-floating {', '\n\t.toc-toggle-floating.expanded {');
 
 	assert.match(selector, /background-color:\s*color-mix\(in srgb, var\(--color-canvas-default\) 82%, transparent\);/);
 	assert.match(selector, /border:\s*1px solid var\(--color-border-default\);/);

--- a/scripts/issue281MinimalMacosMenu.test.ts
+++ b/scripts/issue281MinimalMacosMenu.test.ts
@@ -1,18 +1,17 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { sliceBetween } from './sourceTree.js';
+import { readSource, sliceBetween } from './sourceTree.js';
 
-const tauriLib = readFileSync('src-tauri/src/lib.rs', 'utf8');
-const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+const tauriLib = readSource('src-tauri/src/lib.rs');
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
 test('macOS native menu keeps only application-level actions', () => {
-	const startMarker = tauriLib.includes('\r\n')
-		? '#[cfg(target_os = "macos")]\r\n            {\r\n                use tauri::menu'
-		: '#[cfg(target_os = "macos")]\n            {\n                use tauri::menu';
-	const endMarker = tauriLib.includes('\r\n') ? '\r\n            let config_dir' : '\n            let config_dir';
-	const menuSetup = sliceBetween(tauriLib, startMarker, endMarker);
+	const menuSetup = sliceBetween(
+		tauriLib,
+		'#[cfg(target_os = "macos")]\n            {\n                use tauri::menu',
+		'\n            let config_dir',
+	);
 
 	assert.match(menuSetup, /MenuItemBuilder::with_id\("menu-app-settings", "Settings…"\)\s*\.accelerator\("CmdOrCtrl\+,"\)/);
 	assert.match(menuSetup, /MenuItemBuilder::with_id\("check-updates", "Check for Updates…"\)/);

--- a/scripts/largeFileLoadRevision.test.ts
+++ b/scripts/largeFileLoadRevision.test.ts
@@ -1,9 +1,11 @@
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import test from 'node:test';
 
+import { readSource } from './sourceTree.js';
+
 const sessionPath = new URL('../src/lib/sessions/documentSession.svelte.ts', import.meta.url);
-const session = existsSync(sessionPath) ? readFileSync(sessionPath, 'utf8') : '';
+const session = existsSync(sessionPath) ? readSource(sessionPath) : '';
 
 test('large-file completion requires the current clean load revision and unchanged view mode', () => {
 	assert.match(session, /const loadRevisionByTab = new Map<string, number>\(\);/);

--- a/scripts/liveModeWatchedPath.test.ts
+++ b/scripts/liveModeWatchedPath.test.ts
@@ -1,11 +1,10 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { callbackBodies, filesMatching, readSourceFiles, sliceBetween } from './sourceTree.js';
+import { callbackBodies, filesMatching, readSource, readSourceFiles, sliceBetween } from './sourceTree.js';
 
-const runtime = readFileSync('src-tauri/src/window_runtime.rs', 'utf8');
-const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+const runtime = readSource('src-tauri/src/window_runtime.rs');
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
 test('Live Mode routes a watcher notification to its watched path', () => {
 	assert.match(runtime, /emit_to\(event_label\.as_str\(\), "file-changed", watched_path\.clone\(\)\)/);
@@ -17,12 +16,12 @@ test('Live Mode routes a watcher notification to its watched path', () => {
 	// externalChangeReload.test.ts for the routing behaviour.
 	assert.match(viewer, /if \(!liveMode\) return;/);
 	assert.match(viewer, /documentSession\.resolveExternalChange\(changedPath\)/);
-	const session = readFileSync('src/lib/sessions/documentSession.svelte.ts', 'utf8');
+	const session = readSource('src/lib/sessions/documentSession.svelte.ts');
 	assert.match(session, /tabManager\.tabs\.find\(\(tab\) => tab\.path === changedPath\)/);
 });
 
 test('Live Mode follows the active file instead of retaining a previous tab watcher', () => {
-	assert.match(viewer, /if \(liveMode && currentFile\) \{\r?\n\t\t\tinvoke\('watch_file', \{ path: currentFile \}\)/);
+	assert.match(viewer, /if \(liveMode && currentFile\) \{\n\t\t\tinvoke\('watch_file', \{ path: currentFile \}\)/);
 
 	// The defect #296 fixed was `documentSession` re-issuing `watch_file` on
 	// every load, so the watcher followed whichever document loaded last rather

--- a/scripts/localFileLinks.test.ts
+++ b/scripts/localFileLinks.test.ts
@@ -1,9 +1,8 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import { resolveLocalFileLinkPath } from '../src/lib/utils/localFileLinks.js';
-import { offsetOf, sliceBetween } from './sourceTree.js';
+import { offsetOf, readSource, sliceBetween } from './sourceTree.js';
 
 /*
  * `[data](./data.csv)` did nothing on macOS and Linux, and opened a dead page
@@ -90,7 +89,7 @@ test('a markdown link still resolves to a path, so branch order is what keeps it
 
 // --- wiring ------------------------------------------------------------------
 
-const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
 const handler = sliceBetween(viewer, 'async function handleDocumentClick', 'let zoomLevel');
 
 test('markdown targets are still claimed before the local-file branch', () => {
@@ -118,7 +117,7 @@ test('the capability still grants the command this depends on', () => {
 	// `askToOpenExportedFile` (#399, fixed in #403). Asserted here so the grant
 	// cannot quietly disappear; the scope's shape is deliberately not asserted,
 	// so narrowing it later is not a test failure.
-	const capability = readFileSync('src-tauri/capabilities/default.json', 'utf8');
+	const capability = readSource('src-tauri/capabilities/default.json');
 	assert.match(capability, /opener:allow-open-path/);
 });
 

--- a/scripts/lossyDecodeSaveGuard.test.ts
+++ b/scripts/lossyDecodeSaveGuard.test.ts
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import type { Tab } from '../src/lib/stores/tabs.svelte.js';
 import { buildTransferredTab, snapshotTab, validateTransferPayload } from '../src/lib/utils/tabTransfer.js';
-import { offsetOf, sliceBetween } from './sourceTree.js';
+import { offsetOf, readSource, sliceBetween } from './sourceTree.js';
 
 // Every read path decodes leniently (#371): a file in a legacy encoding
 // (GBK, Big5, Shift-JIS, EUC-KR, CP1251 ...) opens as U+FFFD mojibake instead
@@ -20,10 +19,10 @@ import { offsetOf, sliceBetween } from './sourceTree.js';
 // stays open: the new file is genuinely UTF-8, so writing it is correct, and
 // it is the user's only way out.
 
-const session = readFileSync('src/lib/sessions/documentSession.svelte.ts', 'utf8');
-const windowSession = readFileSync('src/lib/sessions/windowSession.svelte.ts', 'utf8');
-const tabs = readFileSync('src/lib/stores/tabs.svelte.ts', 'utf8');
-const rust = readFileSync('src-tauri/src/lib.rs', 'utf8');
+const session = readSource('src/lib/sessions/documentSession.svelte.ts');
+const windowSession = readSource('src/lib/sessions/windowSession.svelte.ts');
+const tabs = readSource('src/lib/stores/tabs.svelte.ts');
+const rust = readSource('src-tauri/src/lib.rs');
 
 const loadMarkdown = () => sliceBetween(session, 'async function loadMarkdown', 'async function saveContent');
 const saveContent = () => sliceBetween(session, 'async function saveContent(', 'async function saveContentAs');
@@ -142,7 +141,7 @@ test('saveContent is the choke point auto-save and the close dialogs share', () 
 	// flow in canCloseTab; both call saveContent, so guarding it covers them
 	// without touching either.
 	assert.match(session, /const success = await saveContent\(tabId\);/);
-	const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+	const viewer = readSource('src/lib/MarkdownViewer.svelte');
 	assert.match(viewer, /saveContent\(s\.id\)\.then\(/);
 });
 
@@ -174,7 +173,7 @@ test('the refusal tells the user what to do and is not repeated per keystroke', 
 	const body = guard();
 	assert.match(body, /toast\.lossySaveBlocked/);
 	assert.match(body, /lossySaveWarnedTabs\.has\(tab\.id\)/);
-	const i18n = readFileSync('src/lib/utils/i18n.ts', 'utf8');
+	const i18n = readSource('src/lib/utils/i18n.ts');
 	assert.match(i18n, /lossySaveBlocked: 'Not saved: this file is not UTF-8/);
 	assert.match(i18n, /use "Save As" to write a copy/);
 });

--- a/scripts/macosOpenDocumentPaths.test.ts
+++ b/scripts/macosOpenDocumentPaths.test.ts
@@ -1,10 +1,11 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const runtime = readFileSync('src-tauri/src/window_runtime.rs', 'utf8');
-const tauriLib = readFileSync('src-tauri/src/lib.rs', 'utf8');
-const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+import { readSource } from './sourceTree.js';
+
+const runtime = readSource('src-tauri/src/window_runtime.rs');
+const tauriLib = readSource('src-tauri/src/lib.rs');
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
 test('macOS open-document events preserve every delivered file path', () => {
 	assert.match(runtime, /startup_files: Mutex<Vec<String>>/);

--- a/scripts/macosPdfExport.test.ts
+++ b/scripts/macosPdfExport.test.ts
@@ -1,11 +1,10 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { sliceBetween } from './sourceTree.js';
+import { readSource, sliceBetween } from './sourceTree.js';
 
 test('all Markpad webviews may invoke Tauri native printing', () => {
-	const capability = JSON.parse(readFileSync('src-tauri/capabilities/default.json', 'utf8')) as {
+	const capability = JSON.parse(readSource('src-tauri/capabilities/default.json')) as {
 		windows: string[];
 		permissions: string[];
 	};
@@ -25,8 +24,8 @@ test('all Markpad webviews may invoke Tauri native printing', () => {
 // when one moves and the other does not. The failure is silent at build time
 // and total at runtime: "Export PDF" does nothing at all.
 test('both PDF commands the exporter invokes are registered with Tauri', () => {
-	const exporter = readFileSync('src/lib/utils/export.ts', 'utf8');
-	const tauriLib = readFileSync('src-tauri/src/lib.rs', 'utf8');
+	const exporter = readSource('src/lib/utils/export.ts');
+	const tauriLib = readSource('src-tauri/src/lib.rs');
 
 	const registered = new Set(
 		sliceBetween(tauriLib, 'tauri::generate_handler![', ']')
@@ -43,7 +42,7 @@ test('both PDF commands the exporter invokes are registered with Tauri', () => {
 		assert.ok(registered.has(command), `export.ts invokes '${command}', which lib.rs must register`);
 		assert.match(
 			tauriLib,
-			new RegExp(`#\\[tauri::command\\]\\r?\\n(?:async )?fn ${command}\\(`),
+			new RegExp(`#\\[tauri::command\\]\\n(?:async )?fn ${command}\\(`),
 			`${command} must be defined as a Tauri command`,
 		);
 	}

--- a/scripts/mathDelimiterContract.test.ts
+++ b/scripts/mathDelimiterContract.test.ts
@@ -38,8 +38,6 @@
 
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 
 import {
 	installShimDom,
@@ -50,6 +48,7 @@ import {
 	type ShimNode,
 	type ShimText,
 } from './renderProtocolDom.ts';
+import { readSource } from './sourceTree.js';
 
 installShimDom();
 (globalThis as any).window = globalThis;
@@ -67,7 +66,7 @@ type ContractCase = {
 };
 
 const corpus: { cases: ContractCase[] } = JSON.parse(
-	readFileSync(fileURLToPath(new URL('./mathDelimiterCorpus.json', import.meta.url)), 'utf8'),
+	readSource(new URL('./mathDelimiterCorpus.json', import.meta.url)),
 );
 
 const FILE_PATH = '/documents/notes.md';

--- a/scripts/menuModalGuards.test.ts
+++ b/scripts/menuModalGuards.test.ts
@@ -1,15 +1,16 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
-const titleBar = readFileSync(new URL('../src/lib/components/TitleBar.svelte', import.meta.url), 'utf8');
-const modal = readFileSync(new URL('../src/lib/components/Modal.svelte', import.meta.url), 'utf8');
+import { readSource } from './sourceTree.js';
+
+const viewer = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
+const titleBar = readSource(new URL('../src/lib/components/TitleBar.svelte', import.meta.url));
+const modal = readSource(new URL('../src/lib/components/Modal.svelte', import.meta.url));
 
 test('document context menus do not open while a modal is active', () => {
 	assert.match(
 		viewer,
-		/function handleContextMenu\(e: MouseEvent\) \{\r?\n\t\tif \(modalState\.show\) return;/,
+		/function handleContextMenu\(e: MouseEvent\) \{\n\t\tif \(modalState\.show\) return;/,
 	);
 });
 

--- a/scripts/mermaidPrintTheme.test.ts
+++ b/scripts/mermaidPrintTheme.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
+
+import { readSource } from './sourceTree.js';
 
 import {
 	findRestorableDiagrams,
@@ -10,8 +11,8 @@ import {
 	resolveMermaidTheme,
 } from '../src/lib/utils/mermaidPrint.js';
 
-const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
-const richContent = readFileSync(new URL('../src/lib/utils/richContent.ts', import.meta.url), 'utf8');
+const viewer = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
+const richContent = readSource(new URL('../src/lib/utils/richContent.ts', import.meta.url));
 
 /**
  * Minimal stand-ins for the DOM pieces the helper touches. Enough to drive

--- a/scripts/monacoStartupGraph.test.ts
+++ b/scripts/monacoStartupGraph.test.ts
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { dirname, relative, resolve } from 'node:path';
 import test from 'node:test';
 
-import { callbackBodies } from './sourceTree.js';
+import { callbackBodies, readSource, walkSourceFiles } from './sourceTree.js';
 
 // Monaco is ~86% of Markpad's startup JavaScript (measured: a 4.4 MB chunk out
 // of 4.7 MB on first paint, ~360ms of parse+eval, paid once per window because
@@ -37,8 +37,15 @@ const STATIC_IMPORT = /(?:^|[\s;}])(?:import|export)\s+(?!type\s)(?:[^'"();]*?\s
 /** `import type ... from 'x'` / `export type ... from 'x'` — erased at compile time. */
 const TYPE_IMPORT = /\b(?:import|export)\s+type\s[^'"();]*?from\s*['"][^'"]+['"]/g;
 
-function readSource(file: string): string {
-	const raw = readFileSync(file, 'utf8');
+/**
+ * The part of `file` that can carry an import, read through `readSource`.
+ *
+ * A filter on top of the shared reader rather than a reader of its own — it was
+ * spelled `readSource` here first, with its own `readFileSync` inside, which is
+ * how this file ended up with a private copy of the line-ending decision.
+ */
+function importableSource(file: string): string {
+	const raw = readSource(file);
 	if (!file.endsWith('.svelte')) return raw;
 	// Only the <script> blocks can import; the markup and <style> cannot.
 	return [...raw.matchAll(/<script[^>]*>([\s\S]*?)<\/script>/g)].map((m) => m[1]).join('\n');
@@ -90,7 +97,7 @@ function walkStaticGraph(entry: string): Map<string, string[]> {
 		const file = queue.pop()!;
 		if (reached.has(file)) continue;
 
-		const specifiers = staticSpecifiers(readSource(file));
+		const specifiers = staticSpecifiers(importableSource(file));
 		reached.set(file, specifiers);
 
 		for (const specifier of specifiers) {
@@ -166,7 +173,7 @@ test('Monaco is not reachable by static import from the app entry', () => {
 });
 
 test('Editor.svelte loads Monaco with a dynamic import', () => {
-	const editor = readFileSync('src/lib/components/Editor.svelte', 'utf8');
+	const editor = readSource('src/lib/components/Editor.svelte');
 
 	assert.match(
 		editor,
@@ -190,7 +197,7 @@ test('every effect that drives the editor waits for editorReady', () => {
 	// `editor` is a plain `let`, assigned after an await. An effect gated on it
 	// alone runs once against nothing and is never re-triggered, which silently
 	// drops scroll sync, the zoom-aware font size, the theme and Vim mode.
-	const editor = readFileSync('src/lib/components/Editor.svelte', 'utf8');
+	const editor = readSource('src/lib/components/Editor.svelte');
 
 	// The bodies come from the parsed component, not from
 	// `/\$effect\(\(\) => \{([\s\S]*?)\n\t\}\);/`. That pattern needed a
@@ -224,22 +231,14 @@ test('no source file outside Editor.svelte reintroduces a static Monaco import',
 	// only pulled in through a dynamic import elsewhere): grep the whole tree.
 	const offenders: string[] = [];
 
-	const visit = (dir: string) => {
-		for (const entry of readdirSync(dir, { withFileTypes: true })) {
-			const path = `${dir}/${entry.name}`;
-			if (entry.isDirectory()) {
-				visit(path);
-			} else if (/\.(svelte|ts|js)$/.test(entry.name)) {
-				for (const specifier of staticSpecifiers(readSource(path))) {
-					if (specifier.endsWith('?worker')) continue;
-					if (FORBIDDEN.some((pkg) => specifier === pkg || specifier.startsWith(`${pkg}/`))) {
-						offenders.push(`${path} -> ${specifier}`);
-					}
-				}
+	for (const path of walkSourceFiles('src')) {
+		for (const specifier of staticSpecifiers(importableSource(path))) {
+			if (specifier.endsWith('?worker')) continue;
+			if (FORBIDDEN.some((pkg) => specifier === pkg || specifier.startsWith(`${pkg}/`))) {
+				offenders.push(`${path} -> ${specifier}`);
 			}
 		}
-	};
+	}
 
-	visit('src');
 	assert.deepEqual(offenders, []);
 });

--- a/scripts/pasteUrlContext.test.ts
+++ b/scripts/pasteUrlContext.test.ts
@@ -1,10 +1,11 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import { compile } from 'monaco-editor/esm/vs/editor/standalone/common/monarch/monarchCompile.js';
 import { MonarchTokenizer } from 'monaco-editor/esm/vs/editor/standalone/common/monarch/monarchLexer.js';
 import { language as markdownLanguage } from 'monaco-editor/esm/vs/basic-languages/markdown/markdown.js';
+
+import { readSource } from './sourceTree.js';
 
 import {
 	buildPasteProbe,
@@ -214,7 +215,7 @@ test('the caret lands in the token that starts at or before it', () => {
 test('the paste path consults the context guard before building a link', () => {
 	// Source-text only: this proves Editor.svelte reads this way, not that it
 	// behaves this way at runtime.
-	const editor = readFileSync('src/lib/components/Editor.svelte', 'utf8');
+	const editor = readSource('src/lib/components/Editor.svelte');
 
 	assert.match(
 		editor,

--- a/scripts/previewAnchorRestore.test.ts
+++ b/scripts/previewAnchorRestore.test.ts
@@ -26,6 +26,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { installShimDom, parseHtml, NODE_ELEMENT, type ShimElement } from './renderProtocolDom.ts';
+import { readSource } from './sourceTree.js';
 
 installShimDom();
 
@@ -321,8 +322,7 @@ test('source position ranges parse the way comrak writes them', () => {
  * top-level-only scan the rates above were measured against does not come back.
  */
 test('the viewer restores through the measured resolver', async () => {
-	const { readFileSync } = await import('node:fs');
-	const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+	const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
 	// Read out of the one import statement rather than matched across the whole
 	// file: `import \{[\s\S]*findAnchorElement[\s\S]*\} from '…previewAnchor.js'`

--- a/scripts/previewSanitize.test.ts
+++ b/scripts/previewSanitize.test.ts
@@ -1,9 +1,8 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import { MARKDOWN_SANITIZE_CONFIG, ALLOWED_MARKDOWN_URI_REGEXP } from '../src/lib/utils/sanitize.js';
-import { SANITIZER_FILES, callSiteOffsets, enclosingFunctionName, filesMatching, readSourceFiles, sliceBetween } from './sourceTree.js';
+import { SANITIZER_FILES, callSiteOffsets, enclosingFunctionName, filesMatching, readSource, readSourceFiles, sliceBetween } from './sourceTree.js';
 
 // The preview is the path the `<style>` clause in the shared policy was written
 // for, and it was the one path not using it. `tab.content` (the rendered,
@@ -42,9 +41,9 @@ import { SANITIZER_FILES, callSiteOffsets, enclosingFunctionName, filesMatching,
 // gets, and that is what these tests pin.
 
 const SOURCES = readSourceFiles('src');
-const viewerSource = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
-const sanitizeSource = readFileSync('src/lib/utils/sanitize.ts', 'utf8');
-const richContentSource = readFileSync('src/lib/utils/richContent.ts', 'utf8');
+const viewerSource = readSource('src/lib/MarkdownViewer.svelte');
+const sanitizeSource = readSource('src/lib/utils/sanitize.ts');
+const richContentSource = readSource('src/lib/utils/richContent.ts');
 
 /**
  * The identifier the preview injects with `{@html}`, proved to be the shared

--- a/scripts/previewWidth.test.ts
+++ b/scripts/previewWidth.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
+
+import { readSource } from './sourceTree.js';
 
 import {
 	adjustPreviewMaxWidth,
@@ -12,9 +13,9 @@ import {
 	normalizePreviewMaxWidth,
 } from '../src/lib/utils/previewWidth.js';
 
-const settingsSource = readFileSync(new URL('../src/lib/stores/settings.svelte.ts', import.meta.url), 'utf8');
-const viewerSource = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
-const settingsComponentSource = readFileSync(new URL('../src/lib/components/Settings.svelte', import.meta.url), 'utf8');
+const settingsSource = readSource(new URL('../src/lib/stores/settings.svelte.ts', import.meta.url));
+const viewerSource = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
+const settingsComponentSource = readSource(new URL('../src/lib/components/Settings.svelte', import.meta.url));
 
 test('preview width defaults and clamps persisted numeric values', () => {
 	assert.equal(DEFAULT_PREVIEW_MAX_WIDTH, 880);

--- a/scripts/printFindHighlight.test.ts
+++ b/scripts/printFindHighlight.test.ts
@@ -1,11 +1,10 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { offsetOf, sliceBetween, sliceFrom } from './sourceTree.js';
+import { offsetOf, readSource, sliceBetween, sliceFrom } from './sourceTree.js';
 
-const styles = readFileSync('src/styles.css', 'utf8');
-const findBar = readFileSync('src/lib/components/FindBar.svelte', 'utf8');
+const styles = readSource('src/styles.css');
+const findBar = readSource('src/lib/components/FindBar.svelte');
 
 /** The `@media print` block only — not everything that follows it in the file. */
 function extractPrintBlock(source: string): string {

--- a/scripts/printOversizedMedia.test.ts
+++ b/scripts/printOversizedMedia.test.ts
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { offsetOf } from './sourceTree.js';
+import { offsetOf, readSource } from './sourceTree.js';
 
-const styles = readFileSync('src/styles.css', 'utf8');
+const styles = readSource('src/styles.css');
 
 /** The `@media print` block only — not everything that follows it in the file. */
 function extractPrintBlock(source: string): string {
@@ -96,6 +95,6 @@ test('the media caps do not undo the existing print handling', () => {
 	// to the next page instead of cropping them.
 	assert.match(
 		printBlock,
-		/\.markdown-body img,\s*\r?\n\s*\.markdown-body \.mermaid-diagram,[\s\S]*?break-inside:\s*avoid;/,
+		/\.markdown-body img,\s*\n\s*\.markdown-body \.mermaid-diagram,[\s\S]*?break-inside:\s*avoid;/,
 	);
 });

--- a/scripts/recentFilesMultiWindow.test.ts
+++ b/scripts/recentFilesMultiWindow.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
+
+import { readSource } from './sourceTree.js';
 
 /*
  * The recent-file list was written back as `JSON.stringify(recentFiles)` from
@@ -237,7 +238,7 @@ test('only this key, and a wholesale clear, count as a remote change', () => {
 
 // --- wiring ------------------------------------------------------------------
 
-const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
 test('every mutation goes through the read-modify-write helper', () => {
 	assert.match(viewer, /recentFiles = updateStoredRecentFiles\(\((\w+)\) => promoteRecentFile\(\1, path\)\)/);

--- a/scripts/releaseWorkflow.test.ts
+++ b/scripts/releaseWorkflow.test.ts
@@ -1,11 +1,12 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const workflow = readFileSync('.github/workflows/build.yml', 'utf8');
-const snapcraft = readFileSync('snapcraft.yaml', 'utf8');
-const cargoToml = readFileSync('src-tauri/Cargo.toml', 'utf8');
-const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as {
+import { readSource } from './sourceTree.js';
+
+const workflow = readSource('.github/workflows/build.yml');
+const snapcraft = readSource('snapcraft.yaml');
+const cargoToml = readSource('src-tauri/Cargo.toml');
+const packageJson = JSON.parse(readSource('package.json')) as {
 	scripts: Record<string, string>;
 	version: string;
 };

--- a/scripts/renderPipelineConvention.test.ts
+++ b/scripts/renderPipelineConvention.test.ts
@@ -1,8 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { callSiteOffsets, enclosingFunctionName } from './sourceTree.js';
+import { callSiteOffsets, enclosingFunctionName, readSource } from './sourceTree.js';
 
 // Every preview render must go through renderMarkdownPreview, which strips
 // YAML front matter before invoking the Rust renderer. Calling the raw
@@ -22,7 +21,7 @@ const VIEWER = 'src/lib/MarkdownViewer.svelte';
 const WRAPPER = 'renderMarkdownPreview';
 
 test('every raw render_markdown call in the viewer sits inside renderMarkdownPreview', () => {
-	const viewer = readFileSync(VIEWER, 'utf8');
+	const viewer = readSource(VIEWER);
 	const offsets = callSiteOffsets(viewer, 'invoke').filter((offset) =>
 		/^invoke\(\s*'render_markdown'/.test(viewer.slice(offset)),
 	);

--- a/scripts/renderedHtmlField.test.ts
+++ b/scripts/renderedHtmlField.test.ts
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import { parse } from 'svelte/compiler';
 import ts from 'typescript';
+
+import { readSource } from './sourceTree.js';
 
 /*
  * The Home menu decided whether to offer "Export as HTML" / "Export as PDF" by
@@ -135,7 +136,7 @@ function compileGate(source: string, expression: Node, available: Record<string,
 // ------------------------------------------- 1. the export gate, as written
 
 const TITLE_BAR = 'src/lib/components/TitleBar.svelte';
-const titleBarSource = readFileSync(TITLE_BAR, 'utf8');
+const titleBarSource = readSource(TITLE_BAR);
 
 const exportMenuGate = (() => {
 	const ast = parse(titleBarSource, { modern: true, filename: TITLE_BAR });
@@ -174,7 +175,7 @@ const exportsOffered = compileGate(
 // ------------------------------- 2. the condition that refreshes tab.content
 
 const VIEWER = 'src/lib/MarkdownViewer.svelte';
-const viewerSource = readFileSync(VIEWER, 'utf8');
+const viewerSource = readSource(VIEWER);
 
 const previewCacheRefreshes = (() => {
 	const ast = parse(viewerSource, { modern: true, filename: VIEWER });
@@ -208,7 +209,7 @@ const previewCacheRefreshes = (() => {
 // ------------------------------------- 3. exportAsHtml's own precondition
 
 const EXPORT = 'src/lib/utils/export.ts';
-const exportSource = readFileSync(EXPORT, 'utf8');
+const exportSource = readSource(EXPORT);
 
 /** `if (!ctx.rawContent) return null;` — evaluated, not matched. */
 const exportWouldRun = (() => {

--- a/scripts/reopenDirtyDocument.test.ts
+++ b/scripts/reopenDirtyDocument.test.ts
@@ -1,8 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { sliceBetween } from './sourceTree.js';
+import { readSource, sliceBetween } from './sourceTree.js';
 
 // Opening a file that is ALREADY open in a tab with unsaved edits must not
 // re-read it from disk. `setTabRawContent` replaces rawContent AND
@@ -60,7 +59,7 @@ g.window.__TAURI_INTERNALS__ = {
 const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
 
-const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
+const viewer = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
 
 function makeSession() {
 	return createDocumentSession({

--- a/scripts/saveFromReadingMode.test.ts
+++ b/scripts/saveFromReadingMode.test.ts
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { offsetOf, sliceBetween } from './sourceTree.js';
+import { offsetOf, readSource, sliceBetween } from './sourceTree.js';
 
-const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
+const viewer = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
 
 function keydownSaveBranch(): string {
 	return sliceBetween(viewer, "if (cmdOrCtrl && key === 's') {", "if (cmdOrCtrl && e.shiftKey && key === 't')");

--- a/scripts/saveImageAsAssetUrl.test.ts
+++ b/scripts/saveImageAsAssetUrl.test.ts
@@ -1,9 +1,8 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import { normalizeAssetPath } from '../src/lib/utils/exportHtml.js';
-import { offsetOf, sliceBetween } from './sourceTree.js';
+import { offsetOf, readSource, sliceBetween } from './sourceTree.js';
 
 /*
  * "Save image as" could never save a remote image, and on Windows it could not
@@ -28,7 +27,7 @@ import { offsetOf, sliceBetween } from './sourceTree.js';
  * site — plus the two properties the reuse buys, run against the real function.
  */
 
-const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
 const body = sliceBetween(viewer, 'async function saveImageAs', 'async function saveDiagramAs');
 
 test('a Windows asset URL names the same file as the asset: form', () => {
@@ -84,6 +83,6 @@ test('the CSP that makes the remote case impossible is still the one described',
 	// If `connect-src` is ever widened, the comment above stops being true and
 	// a JS download becomes possible again. Fail here rather than leave a
 	// stale explanation in the source.
-	const conf = readFileSync('src-tauri/tauri.conf.json', 'utf8');
+	const conf = readSource('src-tauri/tauri.conf.json');
 	assert.match(conf, /"connect-src":\s*"'self'"/);
 });

--- a/scripts/scrollSyncInput.test.ts
+++ b/scripts/scrollSyncInput.test.ts
@@ -1,8 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { callbackBodies } from './sourceTree.js';
+import { callbackBodies, readSource } from './sourceTree.js';
 
 // The effect is identified by what it does — it is the one that reads
 // `onscrollsync` — not by where its text starts and stops.
@@ -16,7 +15,7 @@ import { callbackBodies } from './sourceTree.js';
 // anchor never got that guard, and it depends on the *next* effect being
 // tab-indented and spelled `$effect(() => {`; write it any other way and this
 // file silently starts asserting about the rest of the component.
-const editor = readFileSync('src/lib/components/Editor.svelte', 'utf8');
+const editor = readSource('src/lib/components/Editor.svelte');
 const syncEffects = callbackBodies(editor, '$effect').filter((body) => body.includes('onscrollsync'));
 assert.equal(syncEffects.length, 1, `expected exactly one $effect reading onscrollsync (got ${syncEffects.length})`);
 const syncEffect = syncEffects[0];

--- a/scripts/settingsPersistence.test.ts
+++ b/scripts/settingsPersistence.test.ts
@@ -1,8 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { callbackBodies, sliceBetween } from './sourceTree.js';
+import { callbackBodies, readSource, sliceBetween } from './sourceTree.js';
 // Plain TypeScript, no runes: safe to import statically, unlike the store below.
 import { getSupportedLanguages, translations } from '../src/lib/utils/i18n.js';
 
@@ -102,8 +101,8 @@ const {
 
 type PersistedEntry = ReturnType<typeof createSettingsPersistence>[number];
 
-const storeSource = readFileSync(new URL('../src/lib/stores/settings.svelte.ts', import.meta.url), 'utf8');
-const componentSource = readFileSync(new URL('../src/lib/components/Settings.svelte', import.meta.url), 'utf8');
+const storeSource = readSource(new URL('../src/lib/stores/settings.svelte.ts', import.meta.url));
+const componentSource = readSource(new URL('../src/lib/components/Settings.svelte', import.meta.url));
 
 function resetStorage(seed: Record<string, string> = {}) {
 	storageBacking.clear();
@@ -530,8 +529,8 @@ test('the open effect neither reads the app version nor re-enters itself', () =>
 
 	// `loaded` and `previousActiveElement` are read and written by this effect,
 	// so they must not be reactive.
-	assert.match(componentSource, /\r?\n\tlet loaded = false;/);
-	assert.match(componentSource, /\r?\n\tlet previousActiveElement: HTMLElement \| null = null;/);
+	assert.match(componentSource, /\n\tlet loaded = false;/);
+	assert.match(componentSource, /\n\tlet previousActiveElement: HTMLElement \| null = null;/);
 });
 
 /*

--- a/scripts/singleImplementationConvention.test.ts
+++ b/scripts/singleImplementationConvention.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { SANITIZER_FILES, filesMatching, readSourceFiles } from './sourceTree.js';
+import { SANITIZER_FILES, type SourceFile, filesMatching, readSourceFiles } from './sourceTree.js';
 
 // A fixed behavior must have exactly one implementation.
 //
@@ -35,6 +35,8 @@ type Rule = {
 	why: string;
 	marker: RegExp;
 	allowed: string[];
+	// The tree to scan, repo-relative. `src` unless the rule is about the suite.
+	dir?: string;
 	// Optional: every allowed file that matches `marker` must also match this.
 	requires?: { pattern: RegExp; message: string };
 };
@@ -175,17 +177,44 @@ const RULES: Rule[] = [
 		marker: /aria-valuemin=/g,
 		allowed: ['src/lib/MarkdownViewer.svelte'],
 		requires: {
-			pattern: /aria-valuemin=\{TOC_WIDTH_RANGE\.min\}\s*\r?\n\s*aria-valuemax=\{TOC_WIDTH_RANGE\.max\}/,
+			pattern: /aria-valuemin=\{TOC_WIDTH_RANGE\.min\}\s*\n\s*aria-valuemax=\{TOC_WIDTH_RANGE\.max\}/,
 			message: 'the resize separator must advertise TOC_WIDTH_RANGE.min/.max, not numbers of its own',
 		},
 	},
+	{
+		name: 'this suite reads a file through one function',
+		why: "A test that reads source with its own readFileSync gets the bytes Git checked out, and on Windows `core.autocrlf` makes those CRLF. Every `\\n` in a pattern then matches nothing and every anchor containing one is 'not found' — fifteen files were red on the maintainer's Windows checkout while cutting v2.7.0 and were hand-patched assertion by assertion (#452). `readSource` in sourceTree.ts decides the line ending once, on read, so the assertions stay written against `\\n` and a new test cannot re-open the hole by accident. Read the file with `readSource(path)` from './sourceTree.js' — it takes a cwd-relative string or a `new URL(…, import.meta.url)` — and write the assertion against `\\n`.",
+		// The call, not the import: `import { readFileSync }` on its own reads
+		// nothing, and a file may legitimately keep the import for another member.
+		marker: /readFileSync\s*\(/g,
+		allowed: ['scripts/sourceTree.ts'],
+		dir: 'scripts',
+	},
+	{
+		name: 'this suite walks a directory through one function',
+		why: "The other half of the same story. A private directory walk misses the `\\\\`→`/` normalization `walkSourceFiles` does, so on Windows every path it reports is spelled with backslashes and every allowlist compared against it is a list of strings that cannot match. i18nCoverage.test.ts carried exactly that copy and needed the identical hand-patch in #452; monacoStartupGraph.test.ts carried a second one that happened to be spelled with a template literal and so escaped by luck rather than by design. Use `walkSourceFiles(dir)` for the paths or `readSourceFiles(dir)` for paths plus text, both from './sourceTree.js'.",
+		marker: /readdirSync\s*\(/g,
+		allowed: ['scripts/sourceTree.ts'],
+		dir: 'scripts',
+	},
 ];
 
-const SOURCES = readSourceFiles('src');
+// One walk per tree, shared by the rules that name it. `scripts` is a tree here
+// too: the last two rules are about the suite reading `src`, not about `src`.
+const TREES = new Map<string, SourceFile[]>();
+
+function sourcesIn(dir: string): SourceFile[] {
+	const cached = TREES.get(dir);
+	if (cached) return cached;
+	const sources = readSourceFiles(dir);
+	TREES.set(dir, sources);
+	return sources;
+}
 
 for (const rule of RULES) {
 	test(`single implementation: ${rule.name}`, () => {
-		const matched = filesMatching(SOURCES, rule.marker);
+		const sources = sourcesIn(rule.dir ?? 'src');
+		const matched = filesMatching(sources, rule.marker);
 
 		const unexpected = matched.filter((path) => !rule.allowed.includes(path));
 		assert.deepEqual(
@@ -196,7 +225,7 @@ for (const rule of RULES) {
 
 		if (rule.requires) {
 			for (const path of matched) {
-				const text = SOURCES.find((source) => source.path === path)!.text;
+				const text = sources.find((source) => source.path === path)!.text;
 				assert.match(text, rule.requires.pattern, `${path}: ${rule.requires.message}`);
 			}
 		}
@@ -209,8 +238,8 @@ test('every rule keeps at least one live implementation', () => {
 	for (const rule of RULES) {
 		if (rule.allowed.length === 0) continue;
 		assert.ok(
-			filesMatching(SOURCES, rule.marker).length > 0,
-			`rule "${rule.name}" matches nothing in src — update its marker or drop the rule`,
+			filesMatching(sourcesIn(rule.dir ?? 'src'), rule.marker).length > 0,
+			`rule "${rule.name}" matches nothing in ${rule.dir ?? 'src'} — update its marker or drop the rule`,
 		);
 	}
 });

--- a/scripts/sourceTree.ts
+++ b/scripts/sourceTree.ts
@@ -14,8 +14,51 @@ import { parse } from 'svelte/compiler';
 // Three copies of `walk()` used to live in singleImplementationConvention,
 // renderPipelineConvention and previewSanitize; the DOMPurify allowlist was
 // maintained twice. One copy each, here.
+//
+// The same argument is why `readSource` exists rather than a `readFileSync` per
+// call site: reading a file as text is a decision about line endings and path
+// separators, and a decision made 135 times is a decision made differently.
+// `singleImplementationConvention.test.ts` holds both to one copy.
 
 export type SourceFile = { path: string; text: string };
+
+/**
+ * A repo file as text, with CRLF collapsed to LF.
+ *
+ * Every assertion below that matches source against a pattern containing `\n`,
+ * and every anchor handed to `sliceFrom` / `sliceBetween` that spells a line
+ * break, is a claim about bytes Git checked out. On Windows `core.autocrlf`
+ * defaults to true, so the whole working tree arrives CRLF, none of those
+ * patterns match, and `sliceBetween` throws `expected to find "…"` for an anchor
+ * that is sitting right there in the file.
+ *
+ * Not hypothetical: fifteen test files were red on the maintainer's Windows
+ * checkout while cutting v2.7.0, and were hand-patched one assertion at a time
+ * in #452 — `[^\r\n]` here, `source.includes('\r\n') ? … : …` there. Those
+ * patches are correct and they do not scale. 60 files in this suite read a repo
+ * file as text across 135 call sites, every new one re-rolls the same dice on a
+ * Unix machine, and the loss is only discovered by a maintainer running the
+ * suite on Windows.
+ *
+ * So the line ending is decided once, here, and every assertion downstream is
+ * written against `\n` — the form the files have in the repository.
+ *
+ * This does not make CRLF untestable, because no test that cares about CRLF
+ * reads it off the disk. `frontMatter.test.ts`, `frontMatterProseBlock.test.ts`
+ * and `pasteUrlContext.test.ts` all assert on the parser's handling of a CRLF
+ * *document*, and each spells the document as a literal in the test — which is
+ * the right way round: a fixture whose bytes matter should not be at the mercy
+ * of what Git decided to check out.
+ *
+ * `path` is `string | URL` because both spellings are already in use: a
+ * cwd-relative string (`npm test` runs from the repo root) and
+ * `new URL('../src/…', import.meta.url)`, which resolves against the test file
+ * rather than the cwd. `readFileSync` takes either, so no call site has to
+ * change shape to get normalized.
+ */
+export function readSource(path: string | URL): string {
+	return readFileSync(path, 'utf8').replace(/\r\n/g, '\n');
+}
 
 /**
  * `source` from the first occurrence of `start` onwards.
@@ -80,7 +123,7 @@ export function walkSourceFiles(dir: string): string[] {
 }
 
 export function readSourceFiles(dir: string): SourceFile[] {
-	return walkSourceFiles(dir).map((path) => ({ path, text: readFileSync(path, 'utf8') }));
+	return walkSourceFiles(dir).map((path) => ({ path, text: readSource(path) }));
 }
 
 /** src-relative paths of the files that contain `marker`, sorted. */

--- a/scripts/tabTransfer.test.ts
+++ b/scripts/tabTransfer.test.ts
@@ -1,8 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { sliceBetween } from './sourceTree.js';
+import { readSource, sliceBetween } from './sourceTree.js';
 
 import type { Tab } from '../src/lib/stores/tabs.svelte.js';
 import {
@@ -209,7 +208,7 @@ test('file-backed arrivals keep their title', () => {
 // in node), so — like windowStateRestore.test.ts — the thin store wrapper is
 // checked statically; all decision logic above is exercised directly.
 test('insertTransferredTab is a thin wrapper: build, push, activate, return the id', () => {
-	const tabs = readFileSync('src/lib/stores/tabs.svelte.ts', 'utf8');
+	const tabs = readSource('src/lib/stores/tabs.svelte.ts');
 	const fn = sliceBetween(tabs, 'insertTransferredTab(', 'closeTab(');
 
 	assert.match(fn, /buildTransferredTab\(/);
@@ -223,15 +222,15 @@ test('insertTransferredTab is a thin wrapper: build, push, activate, return the 
 });
 
 test('serializeState still persists window shape only (untouched by transfer)', () => {
-	const tabs = readFileSync('src/lib/stores/tabs.svelte.ts', 'utf8');
+	const tabs = readSource('src/lib/stores/tabs.svelte.ts');
 	const fn = sliceBetween(tabs, 'serializeState()', 'restoreState(');
 	assert.doesNotMatch(fn, /rawContent/);
 	assert.doesNotMatch(fn, /TransferableTab/);
 });
 
 test('source removal waits for destination completion', () => {
-	const broker = readFileSync('src-tauri/src/tab_transfer.rs', 'utf8');
-	const session = readFileSync('src/lib/sessions/windowSession.svelte.ts', 'utf8');
+	const broker = readSource('src-tauri/src/tab_transfer.rs');
+	const session = readSource('src/lib/sessions/windowSession.svelte.ts');
 
 	assert.match(broker, /pub fn complete_detached_tab/);
 	const claim = sliceBetween(broker, 'pub fn claim_detached_tab', 'pub fn complete_detached_tab');

--- a/scripts/tabTransferHandoff.test.ts
+++ b/scripts/tabTransferHandoff.test.ts
@@ -1,12 +1,11 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { sliceBetween, sliceFrom } from './sourceTree.js';
+import { readSource, sliceBetween, sliceFrom } from './sourceTree.js';
 
-const session = readFileSync(new URL('../src/lib/sessions/windowSession.svelte.ts', import.meta.url), 'utf8');
-const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
-const broker = readFileSync(new URL('../src-tauri/src/tab_transfer.rs', import.meta.url), 'utf8');
+const session = readSource(new URL('../src/lib/sessions/windowSession.svelte.ts', import.meta.url));
+const viewer = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
+const broker = readSource(new URL('../src-tauri/src/tab_transfer.rs', import.meta.url));
 
 // A tab transfer is only ever allowed to end in one of two states: the source
 // still has the tab, or the destination does. Every defect below produced the
@@ -44,8 +43,8 @@ test('a failed render undoes the inserted tab', () => {
 	// The tab must exist before it can be rendered, so the destination owns a
 	// document the source still shows until the render succeeds.
 	const accept = sliceBetween(viewer, 'acceptTransferredTab: async (snapshot)', 'onError: (message, error)');
-	assert.match(accept, /\} catch \(error\) \{\s*\r?\n\s*tabManager\.closeTab\(id\);\s*\r?\n\s*throw error;/);
-	assert.match(accept, /if \(isDisposed\) \{\s*\r?\n\s*tabManager\.closeTab\(id\);/);
+	assert.match(accept, /\} catch \(error\) \{\s*\n\s*tabManager\.closeTab\(id\);\s*\n\s*throw error;/);
+	assert.match(accept, /if \(isDisposed\) \{\s*\n\s*tabManager\.closeTab\(id\);/);
 });
 
 test('a second transfer of the same tab is refused while one is in flight', () => {
@@ -53,7 +52,7 @@ test('a second transfer of the same tab is refused while one is in flight', () =
 	// resolves; two payloads for one tab means two windows each build it.
 	assert.match(session, /const transfersInFlight = new Set<string>\(\);/);
 	assert.match(session, /if \(transfersInFlight\.has\(tabId\)\) return false;/);
-	assert.match(session, /\} finally \{\s*\r?\n\s*transfersInFlight\.delete\(tabId\);/);
+	assert.match(session, /\} finally \{\s*\n\s*transfersInFlight\.delete\(tabId\);/);
 });
 
 test('the broker binds every operation to the window that may perform it', () => {

--- a/scripts/themeCssValidation.test.ts
+++ b/scripts/themeCssValidation.test.ts
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
 import { isHexColor, isSafeCssColor, sanitizeThemeColors } from '../src/lib/utils/theme.js';
+import { readSource } from './sourceTree.js';
 
 // P1-C-3: an imported VS Code theme's colour values are interpolated into a
 // global <style> block that is replayed on every launch (the theme name is
@@ -85,7 +85,7 @@ test('[P1-C-3] sanitizeThemeColors survives a hostile theme.json shape', () => {
 });
 
 test('[P1-C-3] the injected style tag is built only from validated values', () => {
-	const source = readFileSync('src/lib/utils/theme.ts', 'utf8');
+	const source = readSource('src/lib/utils/theme.ts');
 
 	assert.match(source, /const colors = sanitizeThemeColors\(theme\.colors\)/);
 	assert.match(

--- a/scripts/truncatedBufferGuard.test.ts
+++ b/scripts/truncatedBufferGuard.test.ts
@@ -1,8 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { functionSource, sliceBetween, sliceFrom } from './sourceTree.js';
+import { functionSource, readSource, sliceBetween, sliceFrom } from './sourceTree.js';
 
 // A markdown file larger than 50KB is opened twice: `open_markdown_preview`
 // returns the first 50KB so something renders immediately, and a background
@@ -47,7 +46,7 @@ g.window.__TAURI_INTERNALS__ = {
 const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
 
-const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
+const viewer = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
 
 const errors: string[] = [];
 /** What the close dialog answers next. Set per test. */

--- a/scripts/untitledTitle.test.ts
+++ b/scripts/untitledTitle.test.ts
@@ -1,8 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { sliceBetween } from './sourceTree.js';
+import { readSource, sliceBetween } from './sourceTree.js';
 
 import { nextUntitledTitle } from '../src/lib/utils/untitledTitle.js';
 
@@ -39,7 +38,7 @@ test('works with localized bases', () => {
 });
 
 test('new tabs are created with numbered untitled titles', () => {
-	const tabs = readFileSync('src/lib/stores/tabs.svelte.ts', 'utf8');
+	const tabs = readSource('src/lib/stores/tabs.svelte.ts');
 	assert.match(tabs, /nextUntitledTitle\(/);
 	// both creation paths go through the helper
 	const addNewTab = sliceBetween(tabs, 'addNewTab()', 'addHomeTab()');

--- a/scripts/viewModeWithoutSaving.test.ts
+++ b/scripts/viewModeWithoutSaving.test.ts
@@ -1,8 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { offsetOf, sliceBetween, sliceFrom } from './sourceTree.js';
+import { offsetOf, readSource, sliceBetween, sliceFrom } from './sourceTree.js';
 import ts from 'typescript';
 
 // Issue #168, second report by @dayeggpi: "allow user to switch to rendered
@@ -48,7 +47,7 @@ const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 const { settings } = await import('../src/lib/stores/settings.svelte.js');
 const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
 
-const viewer = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
+const viewer = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
 
 // ------------------------------------------------------------ source plucking
 

--- a/scripts/wikilinkFileTargets.test.ts
+++ b/scripts/wikilinkFileTargets.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
+
+import { readSource } from './sourceTree.js';
 
 import {
 	getMarkdownLinkTarget,
@@ -25,8 +26,8 @@ import {
 // only prove the href is recognized as a local markdown target and decodes
 // back to the path and anchor the document asked for.
 
-const rustSource = readFileSync(new URL('../src-tauri/src/lib.rs', import.meta.url), 'utf8');
-const viewerSource = readFileSync(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url), 'utf8');
+const rustSource = readSource(new URL('../src-tauri/src/lib.rs', import.meta.url));
+const viewerSource = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
 
 // href values as produced by process_wikilinks() in src-tauri/src/lib.rs.
 // Only the heading-bearing forms appear: a wikilink with no `#` is

--- a/scripts/windowClosePerTab.test.ts
+++ b/scripts/windowClosePerTab.test.ts
@@ -1,12 +1,12 @@
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import test from 'node:test';
 
-import { offsetOf, sliceBetween, sliceFrom } from './sourceTree.js';
+import { offsetOf, readSource, sliceBetween, sliceFrom } from './sourceTree.js';
 
-const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
 const documentSessionPath = 'src/lib/sessions/documentSession.svelte.ts';
-const documentSession = existsSync(documentSessionPath) ? readFileSync(documentSessionPath, 'utf8') : '';
+const documentSession = existsSync(documentSessionPath) ? readSource(documentSessionPath) : '';
 
 // Window close (issue #189): instead of one aggregate "you have N unsaved
 // files" modal, the red close button walks the dirty tabs one at a time —

--- a/scripts/windowOrganization.test.ts
+++ b/scripts/windowOrganization.test.ts
@@ -1,14 +1,13 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { sliceBetween } from './sourceTree.js';
+import { readSource, sliceBetween } from './sourceTree.js';
 
-const runtime = readFileSync('src-tauri/src/window_runtime.rs', 'utf8');
-const session = readFileSync('src/lib/sessions/windowSession.svelte.ts', 'utf8');
-const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
-const tab = readFileSync('src/lib/components/Tab.svelte', 'utf8');
-const titleBar = readFileSync('src/lib/components/TitleBar.svelte', 'utf8');
+const runtime = readSource('src-tauri/src/window_runtime.rs');
+const session = readSource('src/lib/sessions/windowSession.svelte.ts');
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
+const tab = readSource('src/lib/components/Tab.svelte');
+const titleBar = readSource('src/lib/components/TitleBar.svelte');
 
 test('the runtime registers live viewer windows in stable creation order', () => {
 	assert.match(runtime, /window_counter/);
@@ -23,8 +22,7 @@ test('the runtime registers live viewer windows in stable creation order', () =>
 	// the two to be one statement. Measured — deleting the registry removal from
 	// the `Destroyed` arm left the suite green, and every closed window stayed in
 	// `list_viewer_windows` as a transfer target that no longer exists.
-	const destroyedMarker = runtime.includes('\r\n') ? '\r\n        }' : '\n        }';
-	const destroyed = sliceBetween(runtime, 'tauri::WindowEvent::Destroyed => {', destroyedMarker);
+	const destroyed = sliceBetween(runtime, 'tauri::WindowEvent::Destroyed => {', '\n        }');
 	assert.match(
 		destroyed,
 		/window_registry\)\.remove\(window\.label\(\)\)/,
@@ -50,10 +48,10 @@ test('moving to an existing window uses the acknowledged transfer protocol', () 
 // `async` is invisible until "Move to New Window" freezes a Windows user's app
 // hard enough to need a force-kill. Issue #356.
 test('create_transfer_window is async so window creation cannot deadlock the main thread', () => {
-	const lib = readFileSync('src-tauri/src/lib.rs', 'utf8');
+	const lib = readSource('src-tauri/src/lib.rs');
 
-	assert.match(lib, /#\[tauri::command\]\r?\nasync fn create_transfer_window\(/);
-	assert.doesNotMatch(lib, /#\[tauri::command\]\r?\nfn create_transfer_window\(/);
+	assert.match(lib, /#\[tauri::command\]\nasync fn create_transfer_window\(/);
+	assert.doesNotMatch(lib, /#\[tauri::command\]\nfn create_transfer_window\(/);
 });
 
 test('window organization exposes move, merge, and carry actions', () => {

--- a/scripts/windowStartupHandle.test.ts
+++ b/scripts/windowStartupHandle.test.ts
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const backend = readFileSync('src-tauri/src/lib.rs', 'utf8');
+import { readSource } from './sourceTree.js';
+
+const backend = readSource('src-tauri/src/lib.rs');
 
 test('startup reuses the window handle returned by the builder', () => {
 	assert.match(backend, /let window = window_builder\.build\(\)\?;/);

--- a/scripts/windowStateRestore.test.ts
+++ b/scripts/windowStateRestore.test.ts
@@ -1,13 +1,12 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { offsetOf, sliceBetween } from './sourceTree.js';
+import { offsetOf, readSource, sliceBetween } from './sourceTree.js';
 
-const tabs = readFileSync('src/lib/stores/tabs.svelte.ts', 'utf8');
-const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
-const session = readFileSync('src/lib/sessions/windowSession.svelte.ts', 'utf8');
-const documentSession = readFileSync('src/lib/sessions/documentSession.svelte.ts', 'utf8');
+const tabs = readSource('src/lib/stores/tabs.svelte.ts');
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
+const session = readSource('src/lib/sessions/windowSession.svelte.ts');
+const documentSession = readSource('src/lib/sessions/documentSession.svelte.ts');
 
 // Session restore persists WINDOW state only: which files are open, the
 // active tab, and per-tab UI (edit mode, split, scroll). Document content
@@ -55,7 +54,7 @@ test('startup restore reads content from disk, not from the snapshot', () => {
 	assert.match(restore, /tabManager\.markTabContentUnavailable\(tab\.id\);/);
 	// dropping is reserved for an entry that is not a file at all — a legacy
 	// 'HOME' sentinel (homeSentinelSnapshot.test.ts)
-	assert.match(restore, /if \(!hasRealFilePath\(tab\.path\)\) \{\s*\r?\n\s*options\.dropRestoredTab\(tab\.id\);/);
+	assert.match(restore, /if \(!hasRealFilePath\(tab\.path\)\) \{\s*\n\s*options\.dropRestoredTab\(tab\.id\);/);
 	assert.match(viewer, /await windowSession\.restore\(\);/);
 });
 
@@ -94,19 +93,17 @@ test('v2 snapshots are invisible to legacy builds (Rust file, localStorage keys 
 	assert.match(session, /invoke\('load_window_state'\)/);
 	assert.match(
 		session,
-		/localStorage\.getItem\(options\.windowStateKey\) \?\?\r?\n?\s*localStorage\.getItem\(options\.legacyStateKey\)/,
+		/localStorage\.getItem\(options\.windowStateKey\) \?\?\n?\s*localStorage\.getItem\(options\.legacyStateKey\)/,
 	);
 	// The shared helper clears the Rust snapshot and both localStorage keys.
 	// Only explicit exit uses it: a restore that goes wrong must never delete
 	// the record of which documents were open (interruptedSessionRestore.test.ts).
-	const endMarker = session.includes('\r\n') ? '\r\n\t}\r\n\r\n\tfunction readProgress' : '\n\t}\n\n\tfunction readProgress';
-	const discardScope = sliceBetween(session, 'async function discardPersistedState', endMarker);
+	const discardScope = sliceBetween(session, 'async function discardPersistedState', '\n\t}\n\n\tfunction readProgress');
 	assert.match(discardScope, /clear_window_state/);
 	assert.match(discardScope, /removeItem\(options\.windowStateKey\)/);
 	assert.match(discardScope, /removeItem\(options\.legacyStateKey\)/);
 	// Explicit exit delegates to the same cleanup path.
-	const exitEndMarker = viewer.includes('\r\n') ? '\r\n\t}' : '\n\t}';
-	const exitScope = sliceBetween(viewer, 'async function appExit', exitEndMarker);
+	const exitScope = sliceBetween(viewer, 'async function appExit', '\n\t}');
 	assert.match(exitScope, /await discardPersistedWindowState\(\)/);
 });
 

--- a/scripts/windowTags.test.ts
+++ b/scripts/windowTags.test.ts
@@ -1,14 +1,13 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { offsetOf } from './sourceTree.js';
+import { offsetOf, readSource } from './sourceTree.js';
 
-const tabs = readFileSync('src/lib/stores/tabs.svelte.ts', 'utf8');
-const runtime = readFileSync('src-tauri/src/window_runtime.rs', 'utf8');
-const viewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
-const titleBar = readFileSync('src/lib/components/TitleBar.svelte', 'utf8');
-const home = readFileSync('src/lib/components/HomePage.svelte', 'utf8');
+const tabs = readSource('src/lib/stores/tabs.svelte.ts');
+const runtime = readSource('src-tauri/src/window_runtime.rs');
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
+const titleBar = readSource('src/lib/components/TitleBar.svelte');
+const home = readSource('src/lib/components/HomePage.svelte');
 
 test('window tags persist with the v2 window snapshot', () => {
 	assert.match(tabs, /windowTag = \$state/);

--- a/scripts/windowTitleCapability.test.ts
+++ b/scripts/windowTitleCapability.test.ts
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { readSource } from './sourceTree.js';
+
 test('all Markpad windows may update their native title', () => {
-	const capability = JSON.parse(readFileSync('src-tauri/capabilities/default.json', 'utf8')) as {
+	const capability = JSON.parse(readSource('src-tauri/capabilities/default.json')) as {
 		permissions: string[];
 	};
 

--- a/scripts/workflowSecurityAudit.test.ts
+++ b/scripts/workflowSecurityAudit.test.ts
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const workflow = readFileSync('.github/workflows/test.yml', 'utf8');
+import { readSource } from './sourceTree.js';
+
+const workflow = readSource('.github/workflows/test.yml');
 
 test('pull-request checks reject vulnerabilities anywhere in the resolved lockfile', () => {
 	assert.match(workflow, /name: audit complete dependency lockfile[\s\S]*run: npm audit(?:\s|$)/);

--- a/scripts/youtubeExternalFallback.test.ts
+++ b/scripts/youtubeExternalFallback.test.ts
@@ -1,12 +1,11 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { offsetOf, sliceBetween } from './sourceTree.js';
+import { offsetOf, readSource, sliceBetween } from './sourceTree.js';
 
-const markdown = readFileSync('src/lib/utils/markdown.ts', 'utf8');
-const markdownViewer = readFileSync('src/lib/MarkdownViewer.svelte', 'utf8');
-const tauriConfig = readFileSync('src-tauri/tauri.conf.json', 'utf8');
+const markdown = readSource('src/lib/utils/markdown.ts');
+const markdownViewer = readSource('src/lib/MarkdownViewer.svelte');
+const tauriConfig = readSource('src-tauri/tauri.conf.json');
 
 test('YouTube links render as browser-opening thumbnail anchors', () => {
 	assert.match(markdown, /function replaceWithYoutubeLink\(element: Element, videoId: string, href: string\)/);
@@ -37,6 +36,6 @@ test('linked YouTube thumbnails are not intercepted by image zoom', () => {
 	assert.ok(anchorGuard < imageZoom, 'the anchor branch claims the click before image zoom sees it');
 	assert.match(
 		linkHandler,
-		/if \(a\) \{[\s\S]*?if \(relativeMarkdownTarget\) \{[\s\S]*?return;[\s\S]*?\}\r?\n\s*return;\r?\n\s*\}\r?\n\r?\n\s*\/\/ media zoom handling/,
+		/if \(a\) \{[\s\S]*?if \(relativeMarkdownTarget\) \{[\s\S]*?return;[\s\S]*?\}\n\s*return;\n\s*\}\n\n\s*\/\/ media zoom handling/,
 	);
 });


### PR DESCRIPTION
`846b84b2` in #452 fixed this suite on Windows by hand, one assertion at a time,
in the middle of cutting a release. That should not have been your job — the
tests are mine, and the reason fifteen of them broke is that fifty of them each
made the same decision separately. This moves the decision to one place and adds
the guard that keeps it there.

**This is test-only.** No `src/`, no `src-tauri/`, no product behaviour; the only
non-`scripts/` file is a new `.gitattributes`. Merge it before or after v2.7.0 —
whichever suits the release you have in flight. There is no rush and nothing here
that a user can see.

## Root cause

Two halves, both the same shape: a decision that belongs on the read, made at
every call site instead.

**Line endings.** The repo has no `.gitattributes`, so a Windows clone with the
default `core.autocrlf=true` checks the entire tree out CRLF. Every test that
reads `src/` as text then matches it against a pattern containing a literal `\n`,
or slices it with an anchor containing one, and none of those match the bytes on
disk. `sliceBetween` reports it as `expected to find "…"` for an anchor that is
sitting right there in the file.

**Path separators.** `walkSourceFiles()` in `sourceTree.ts` has always done
`.replace(/\\/g, '/')`. `i18nCoverage.test.ts` and `monacoStartupGraph.test.ts`
each carried their own private copy of the walk, so neither inherited it — which
is precisely what `sourceTree.ts`'s header comment says the module exists to
prevent ("Three copies of `walk()` used to live in …. One copy each, here.").

## What this does

**1. `readSource(path)` in `sourceTree.ts`.**

```ts
export function readSource(path: string | URL): string {
	return readFileSync(path, 'utf8').replace(/\r\n/g, '\n');
}
```

`string | URL` because both spellings were already in use — a cwd-relative string
and `new URL('../src/…', import.meta.url)` — so no call site had to change shape
to get normalized. Documented at the length the neighbouring helpers are, naming
#452, so the next reader cannot mistake it for indirection for its own sake.

**2. 60 files, 135 call sites routed through it** — and the `\r?` workarounds
*removed* where they become redundant. That is the point: the assertion goes back
to reading as `\n`, which is the form the files have in the repository, and the
normalization happens once.

Deliberately left alone: the CRLF fixtures in `frontMatter.test.ts`,
`frontMatterProseBlock.test.ts` and `pasteUrlContext.test.ts`. Those assert on the
parser's handling of a CRLF *document*, and each spells the document as a literal
in the test — which is the right way round. A fixture whose bytes are the point
must not depend on what Git checked out.

**3. Both private walkers folded into `walkSourceFiles`.** Filters checked first:
`i18nCoverage`'s was `.svelte || .ts` against `walkSourceFiles`'s
`.ts|.svelte|.js` — the same set today, since `src/` has no `.js`, and the wider
one is the one that should win (a `.js` file calling `t()` is a file whose keys
must resolve). `monacoStartupGraph`'s was `/\.(svelte|ts|js)$/`, identical. Neither
needed `walkSourceFiles` widened with an argument.

One of your fifteen patches is **not** subsumed and stays: the
`.replace(/\\/g, '/')` on `relative(process.cwd(), f)` in `monacoStartupGraph`.
That normalizes the output of the import-graph walk, which resolves absolute paths
and never goes through `walkSourceFiles` — a real separator fix, not a symptom of
the duplication.

**4. The guard**, as two rows in `singleImplementationConvention.test.ts`'s `RULES`
rather than a new mechanism — that file already is where a convention like this is
written down. The only thing it could not express was a rule about the suite
itself, because `SOURCES` was fixed to `src`; rules now take an optional `dir` and
the tree walk is memoized per directory. Everything existing is unchanged.

| marker | allowed in |
|---|---|
| `readFileSync(` | `scripts/sourceTree.ts` |
| `readdirSync(` | `scripts/sourceTree.ts` |

Both markers are the *call*, not the import — `import { readFileSync }` on its own
reads nothing. Both messages name the replacement and how to call it. The existing
`every rule keeps at least one live implementation` test covers the new rows, so a
marker that stops matching `sourceTree.ts` is reported rather than silently
guarding nothing.

**5. `.gitattributes`** — `* text=auto eol=lf`, with `.nsi/.nsh/.ps1/.bat/.cmd`
pinned to CRLF. Those are read by NSIS and Chocolatey on Windows and are pinned so
the bytes those toolchains see stay identical to what a `core.autocrlf=true` runner
hands them today; this is not the PR to also change the installer build. Every
tracked file in the repo is LF right now (verified — `git add --renormalize .`
stages nothing outside this branch's own edits), so no stored bytes change and no
Linux or macOS working tree changes. What changes is the next Windows clone.

**Why both.** `.gitattributes` is the belt and it is the weaker half on purpose: it
does not touch a tree that is already checked out — that needs
`git add --renormalize .` — and it cannot stop an editor from writing CRLF into a
file it saves. `readSource` is the braces, and it is the half that actually holds.

## Falsification

**The guard catches existing drift.** Run before either cleanup, against `master`:

| rule | files flagged on first run |
|---|---|
| `readFileSync(` outside `sourceTree.ts` | **59** |
| `readdirSync(` outside `sourceTree.ts` | **2** (`i18nCoverage`, `monacoStartupGraph`) |

**The fix fixes the Windows case.** Measured on macOS by converting every tracked
text file to CRLF end to end — `src/`, `src-tauri/`, `scripts/`, the workflows,
`snapcraft.yaml`, `Cargo.toml`, the JSON — and running the suite, then restoring.

| tree | CRLF result |
|---|---|
| `master` as it stands | 596/596 pass — your patch works |
| `master` with `846b84b2` reverse-applied | **21 tests fail across 8 files** |
| this branch | **598/598 pass**, with the workarounds deleted rather than kept |
| this branch, `readSource` reduced to a plain read | **21 tests fail across 8 files** — the same set |

The last two rows are the pair that matters: one line of normalization does
character-for-character the work that 33 hand-edited characters across 15 files
were doing, and rolling back only that line reproduces the failure exactly.

The 8 files that genuinely reddened are `foldStatePerDocument`,
`issue281MinimalMacosMenu`, `liveModeWatchedPath`, `macosPdfExport`,
`menuModalGuards`, `windowOrganization`, `windowStateRestore`,
`youtubeExternalFallback`. Of the other seven you patched, two were the
path-separator half — which a macOS run cannot reproduce at all, since it is
backslashes and not `\r` — and five were precautionary: their patterns already
tolerated the extra `\r` because a neighbouring `\s*` absorbed it. Those five are
reverted here as no-ops, not as behaviour changes.

## Verification

```
npm test              598/598 pass, 0 fail          (596 before; +2 are the new rules)
npm run check         638 files, 0 errors, 0 warnings
cargo test            150/150 pass
```

`.github/workflows/test.yml` runs `npm ci`, `npm audit`, `npm run check`, `npm test`
and `cargo test`; all of them are above except `npm audit`, which this branch cannot
affect — no dependency changed and `package-lock.json` is untouched.

Each of the three commits was also checked out and run on its own — 596, 596, 598,
zero failures — so the 62-file diff is reviewable commit by commit rather than only
at the tip.

Not touched, on purpose: `src-tauri/` in any form, including
`src-tauri/src/tab_transfer.rs`.
