### PR TITLE
fix(editor): let a list toggle replace the list marker already on the line

### DIFF
--- a/scripts/editorToolbar.test.ts
+++ b/scripts/editorToolbar.test.ts
@@ -3,12 +3,15 @@ import { test } from 'node:test';
 
 import {
 	DEFAULT_EDITOR_TOOLBAR_ORDER,
+	LINE_MARKER_TOOL_IDS,
 	getEditorToolbarAdjacentMove,
 	getEditorToolbarReorderMove,
 	getEditorToolbarTools,
 	getVisibleEditorToolbarTools,
 	normalizeEditorToolbarHidden,
 	normalizeEditorToolbarOrder,
+	toggleLineMarker,
+	type LineMarkerToolId,
 } from '../src/lib/utils/editorToolbar.js';
 
 /**
@@ -100,4 +103,117 @@ test('toolbar reorder helpers resolve drag and keyboard moves', () => {
 	assert.deepEqual(getEditorToolbarAdjacentMove(order, 'fmt-italic', 'down'), { fromIndex: 1, toIndex: 2 });
 	assert.equal(getEditorToolbarReorderMove(order, 'fmt-bold', 'fmt-bold'), null);
 	assert.equal(getEditorToolbarAdjacentMove(order, 'fmt-bold', 'up'), null);
+});
+
+test('every tool with a line marker is a tool the toolbar renders', () => {
+	assert.deepEqual(LINE_MARKER_TOOL_IDS, [
+		'fmt-quote',
+		'fmt-bullet-list',
+		'fmt-numbered-list',
+		'fmt-checklist',
+		'fmt-heading-1',
+		'fmt-heading-2',
+		'fmt-heading-3',
+	]);
+
+	for (const id of LINE_MARKER_TOOL_IDS) {
+		assert.ok(
+			DEFAULT_EDITOR_TOOLBAR_ORDER.includes(id),
+			`${id} has a line marker but is not a toolbar tool`,
+		);
+	}
+});
+
+/**
+ * One row per (tool, starting line) pair, written as the exact text the
+ * transform has to produce. Issue #451 was a *string* — bullet on `1. foo`
+ * yielded `- 1. foo` — so nothing short of running the transform and comparing
+ * output can fail on it; an assertion about how `Editor.svelte` reads would
+ * have stayed green through the whole bug.
+ *
+ * The three list markers compete for one slot, so each of them replaces the
+ * other two (and the task box travels with the checklist marker, or the line
+ * keeps an orphan `[ ]` no tool recognises). Quote is deliberately not in that
+ * set: `> - foo` is a quoted list item, which is what a user asking for a quote
+ * around a list item wants.
+ */
+const LINE_MARKER_MATRIX: Array<[LineMarkerToolId, string, string]> = [
+	// Bullet list.
+	['fmt-bullet-list', 'foo', '- foo'],
+	['fmt-bullet-list', '- foo', 'foo'],
+	['fmt-bullet-list', '1. foo', '- foo'],
+	['fmt-bullet-list', '- [ ] foo', '- foo'],
+	['fmt-bullet-list', '- [x] foo', '- foo'],
+	['fmt-bullet-list', '> foo', '- > foo'],
+
+	// Numbered list.
+	['fmt-numbered-list', 'foo', '1. foo'],
+	['fmt-numbered-list', '- foo', '1. foo'],
+	['fmt-numbered-list', '1. foo', 'foo'],
+	['fmt-numbered-list', '- [ ] foo', '1. foo'],
+	['fmt-numbered-list', '1. [ ] foo', '1. foo'],
+	['fmt-numbered-list', '> foo', '1. > foo'],
+
+	// Checklist.
+	['fmt-checklist', 'foo', '- [ ] foo'],
+	['fmt-checklist', '- foo', '- [ ] foo'],
+	['fmt-checklist', '1. foo', '- [ ] foo'],
+	['fmt-checklist', '- [ ] foo', 'foo'],
+	['fmt-checklist', '- [x] foo', 'foo'],
+	['fmt-checklist', '> foo', '- [ ] > foo'],
+
+	// Quote wraps, it does not displace: a quoted list item is the point.
+	['fmt-quote', 'foo', '> foo'],
+	['fmt-quote', '- foo', '> - foo'],
+	['fmt-quote', '1. foo', '> 1. foo'],
+	['fmt-quote', '- [ ] foo', '> - [ ] foo'],
+	['fmt-quote', '> foo', 'foo'],
+
+	// Headings replace headings, and nothing else — `# - foo` is a heading whose
+	// text begins with a dash, and un-toggling gives the list item back.
+	['fmt-heading-2', 'foo', '## foo'],
+	['fmt-heading-2', '# foo', '## foo'],
+	['fmt-heading-2', '## foo', 'foo'],
+	['fmt-heading-1', '### foo', '# foo'],
+	['fmt-heading-1', '- foo', '# - foo'],
+];
+
+for (const [id, from, to] of LINE_MARKER_MATRIX) {
+	test(`${id} turns ${JSON.stringify(from)} into ${JSON.stringify(to)}`, () => {
+		assert.deepEqual(toggleLineMarker(id, [from]), [to]);
+	});
+}
+
+test('a selection that mixes marker types converges on the toggled one', () => {
+	assert.deepEqual(
+		toggleLineMarker('fmt-bullet-list', ['- alpha', '1. beta', '- [ ] gamma', 'delta']),
+		['- alpha', '- beta', '- gamma', '- delta'],
+	);
+
+	// Removal needs *every* content line to already carry this tool's marker, so
+	// a half-marked selection is completed rather than stripped.
+	assert.deepEqual(
+		toggleLineMarker('fmt-checklist', ['- [ ] alpha', '- beta']),
+		['- [ ] alpha', '- [ ] beta'],
+	);
+
+	assert.deepEqual(toggleLineMarker('fmt-bullet-list', ['- alpha', '- beta']), ['alpha', 'beta']);
+});
+
+test('numbering counts content lines and leaves blank lines alone', () => {
+	assert.deepEqual(
+		toggleLineMarker('fmt-numbered-list', ['- alpha', '', 'beta', '1. gamma']),
+		['1. alpha', '', '2. beta', '3. gamma'],
+	);
+
+	assert.deepEqual(toggleLineMarker('fmt-bullet-list', ['', '   ']), ['', '   ']);
+});
+
+test('quote nests around an already quoted line instead of replacing it', () => {
+	assert.deepEqual(toggleLineMarker('fmt-quote', ['> alpha', 'beta']), ['> > alpha', '> beta']);
+	assert.deepEqual(toggleLineMarker('fmt-quote', ['> alpha', '> beta']), ['alpha', 'beta']);
+});
+
+test('a bracketed link at the head of a list item is not read as a task box', () => {
+	assert.deepEqual(toggleLineMarker('fmt-numbered-list', ['- [label](url)']), ['1. [label](url)']);
 });

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -5,6 +5,7 @@
 	import { t, type LanguageCode } from '../utils/i18n.js';
 	import { managedImageFromCopy, type ManagedImage } from '../utils/managedImages.js';
 	import { MARKDOWN_LANGUAGE_ID, shouldLinkifyPastedUrl } from '../utils/pasteContext.js';
+	import { toggleLineMarker, type LineMarkerToolId } from '../utils/editorToolbar.js';
 	import {
 		getScrollSyncPositionFromPixels,
 		getScrollTopForSyncPosition,
@@ -724,43 +725,11 @@
 		]);
 	};
 
-	const toggleLinePrefix = (source: string, prefix: string, pattern: RegExp) => {
-		transformSelectedLines(source, (lines) => {
-			const contentLines = lines.filter((line) => line.trim().length > 0);
-			const shouldRemove = contentLines.length > 0 && contentLines.every((line) => pattern.test(line));
-			return lines.map((line) => {
-				if (!line.trim()) return line;
-				if (shouldRemove) return line.replace(pattern, "");
-				return `${prefix}${line}`;
-			});
-		});
-	};
-
-	const toggleHeading = (level: number) => {
-		const heading = "#".repeat(level);
-		transformSelectedLines(`fmt-heading-${level}`, (lines) => {
-			const pattern = new RegExp(`^${heading}\\s+`);
-			const contentLines = lines.filter((line) => line.trim().length > 0);
-			const shouldRemove = contentLines.length > 0 && contentLines.every((line) => pattern.test(line));
-			return lines.map((line) => {
-				if (!line.trim()) return line;
-				const withoutHeading = line.replace(/^#{1,6}\s+/, "");
-				return shouldRemove ? withoutHeading : `${heading} ${withoutHeading}`;
-			});
-		});
-	};
-
-	const toggleNumberedList = () => {
-		transformSelectedLines("fmt-numbered-list", (lines) => {
-			const contentLines = lines.filter((line) => line.trim().length > 0);
-			const shouldRemove = contentLines.length > 0 && contentLines.every((line) => /^\d+\.\s+/.test(line));
-			let itemIndex = 1;
-			return lines.map((line) => {
-				if (!line.trim()) return line;
-				if (shouldRemove) return line.replace(/^\d+\.\s+/, "");
-				return `${itemIndex++}. ${line.replace(/^(?:[-*+]|\d+\.)\s+/, "")}`;
-			});
-		});
+	// Which marker each of these tools owns, and what it replaces, lives in
+	// `utils/editorToolbar.ts` — one table, keyed by the same ids the toolbar
+	// renders, so a list toggle cannot forget to displace a competing marker.
+	const toggleLineMarkerTool = (id: LineMarkerToolId) => {
+		transformSelectedLines(id, (lines) => toggleLineMarker(id, lines));
 	};
 
 	const wrapAsCodeBlock = () => {
@@ -991,43 +960,43 @@
 			editor.addAction({
 				id: "fmt-quote",
 				label: t('menu.quote', lang),
-				run: () => toggleLinePrefix("fmt-quote", "> ", /^>\s+/),
+				run: () => toggleLineMarkerTool("fmt-quote"),
 			}),
 
 			editor.addAction({
 				id: "fmt-heading-1",
 				label: t('menu.heading1', lang),
-				run: () => toggleHeading(1),
+				run: () => toggleLineMarkerTool("fmt-heading-1"),
 			}),
 
 			editor.addAction({
 				id: "fmt-heading-2",
 				label: t('menu.heading2', lang),
-				run: () => toggleHeading(2),
+				run: () => toggleLineMarkerTool("fmt-heading-2"),
 			}),
 
 			editor.addAction({
 				id: "fmt-heading-3",
 				label: t('menu.heading3', lang),
-				run: () => toggleHeading(3),
+				run: () => toggleLineMarkerTool("fmt-heading-3"),
 			}),
 
 			editor.addAction({
 				id: "fmt-bullet-list",
 				label: t('menu.bulletList', lang),
-				run: () => toggleLinePrefix("fmt-bullet-list", "- ", /^[-*+]\s+/),
+				run: () => toggleLineMarkerTool("fmt-bullet-list"),
 			}),
 
 			editor.addAction({
 				id: "fmt-numbered-list",
 				label: t('menu.numberedList', lang),
-				run: () => toggleNumberedList(),
+				run: () => toggleLineMarkerTool("fmt-numbered-list"),
 			}),
 
 			editor.addAction({
 				id: "fmt-checklist",
 				label: t('menu.checklist', lang),
-				run: () => toggleLinePrefix("fmt-checklist", "- [ ] ", /^[-*+]\s+\[[ xX]\]\s+/),
+				run: () => toggleLineMarkerTool("fmt-checklist"),
 			}),
 
 			editor.addAction({

--- a/src/lib/utils/editorToolbar.ts
+++ b/src/lib/utils/editorToolbar.ts
@@ -32,6 +32,87 @@ const EDITOR_TOOLBAR_TOOLS: EditorToolbarTool[] = [
 
 export const DEFAULT_EDITOR_TOOLBAR_ORDER = EDITOR_TOOLBAR_TOOLS.map((tool) => tool.id);
 
+const TASK_BOX = String.raw`\[[ xX]\]\s+`;
+
+/**
+ * A bullet, an ordered number and a task box all claim the same slot at the
+ * head of a line, so applying one of them has to take away whichever one is
+ * already there — that is what `1. foo` -> `- 1. foo` got wrong.
+ *
+ * The box is part of the marker, not part of the text: stripping only `- ` off
+ * `- [ ] foo` would leave the orphan `[ ] foo`, which no toggle recognises any
+ * more. The ordered-plus-box form is matched too, so the `1. [ ] foo` that the
+ * old numbered-list toggle used to produce normalises on the next toggle
+ * instead of round-tripping to an orphan box.
+ */
+const ANY_LIST_MARKER = new RegExp(String.raw`^(?:[-*+]|\d+\.)\s+(?:${TASK_BOX})?`);
+
+const ANY_HEADING = /^#{1,6}\s+/;
+
+type LineMarker = {
+	/** Matches the marker this tool owns; deciding when a toggle un-toggles. */
+	readonly own: RegExp;
+	/** The marker text. The argument counts content lines, for `1.`, `2.`, … */
+	readonly render: (itemIndex: number) => string;
+	/**
+	 * The markers this tool replaces when it applies its own. Quote has none on
+	 * purpose: `> - foo` is a quoted list item, a nesting people write by hand
+	 * and ask a toolbar for, not a line wearing two competing markers.
+	 */
+	readonly competing: RegExp | null;
+};
+
+const LINE_MARKERS = {
+	'fmt-quote': { own: /^>\s+/, render: () => '> ', competing: null },
+	// The list toggles exclude a following task box from `own` so that they add
+	// their marker to a checklist item instead of un-toggling it and leaving the
+	// box behind.
+	'fmt-bullet-list': {
+		own: new RegExp(String.raw`^[-*+]\s+(?!${TASK_BOX})`),
+		render: () => '- ',
+		competing: ANY_LIST_MARKER,
+	},
+	'fmt-numbered-list': {
+		own: new RegExp(String.raw`^\d+\.\s+(?!${TASK_BOX})`),
+		render: (itemIndex: number) => `${itemIndex}. `,
+		competing: ANY_LIST_MARKER,
+	},
+	'fmt-checklist': {
+		own: new RegExp(String.raw`^[-*+]\s+${TASK_BOX}`),
+		render: () => '- [ ] ',
+		competing: ANY_LIST_MARKER,
+	},
+	'fmt-heading-1': { own: /^#\s+/, render: () => '# ', competing: ANY_HEADING },
+	'fmt-heading-2': { own: /^##\s+/, render: () => '## ', competing: ANY_HEADING },
+	'fmt-heading-3': { own: /^###\s+/, render: () => '### ', competing: ANY_HEADING },
+} satisfies Record<string, LineMarker>;
+
+export type LineMarkerToolId = keyof typeof LINE_MARKERS;
+
+export const LINE_MARKER_TOOL_IDS = Object.keys(LINE_MARKERS) as LineMarkerToolId[];
+
+/**
+ * Applies (or removes) one toolbar line marker across the selected lines.
+ *
+ * Removal wins only when every content line already carries this tool's own
+ * marker; otherwise the marker is applied to all of them, which is what makes a
+ * mixed selection converge on one list type instead of stacking markers.
+ * Blank lines are left exactly as they are and are not numbered.
+ */
+export function toggleLineMarker(id: LineMarkerToolId, lines: readonly string[]): string[] {
+	const marker = LINE_MARKERS[id];
+	const contentLines = lines.filter((line) => line.trim().length > 0);
+	const shouldRemove = contentLines.length > 0 && contentLines.every((line) => marker.own.test(line));
+
+	let itemIndex = 1;
+	return lines.map((line) => {
+		if (!line.trim()) return line;
+		if (shouldRemove) return line.replace(marker.own, '');
+		const body = marker.competing ? line.replace(marker.competing, '') : line;
+		return `${marker.render(itemIndex++)}${body}`;
+	});
+}
+
 const knownToolbarIds = new Set(DEFAULT_EDITOR_TOOLBAR_ORDER);
 
 export function normalizeEditorToolbarOrder(order: readonly string[] | null | undefined): string[] {


### PR DESCRIPTION
Marking a numbered item as a bullet left the number behind: `1. foo`
became `- 1. foo` (#451). All three list toggles put their prefix on the
line, and only the numbered one took anything off first — its
`line.replace(/^(?:[-*+]|\d+\.)\s+/, "")` is why the reverse direction,
bullet to numbered, looked correct.

A bullet, an ordered number and a task box claim the same slot at the
head of a line, so the reported case is one of a family. The two
unreported siblings that shipped with it: checklist on `1. foo` gave
`- [ ] 1. foo`, and checklist on `- foo` gave `- [ ] - foo`. Two more
sit on the removal side, where the bullet toggle's `/^[-*+]\s+/` also
matches a checklist item — bullet on `- [ ] foo` un-toggled it down to
the orphan `[ ] foo`, and the numbered toggle stripped the dash but not
the box, producing `1. [ ] foo`, a state whose own un-toggle then yields
`[ ] foo` as well. A mixed selection hit the same wall: bullet over
`- a` and `1. b` gave `- - a` and `- 1. b`.

`shouldRemove` itself is right — removal should need every content line
to carry this tool's own marker — and once applying displaces
competitors, a mixed selection converges on one list type rather than
stacking markers. It only needed the bullet and numbered patterns to
stop claiming a checklist line as their own.

Quote is deliberately left as it was. `> - foo` is a quoted list item
and `> 1. foo` a quoted numbered one; both are legitimate Markdown, and
that nesting is exactly what pressing quote on a list item is for. So
the rule encoded here is not "strip whatever was there" but "a list
marker displaces a competing list marker; a block-level wrapper does
not".

Rather than repeat a strip regex at each call site, the three
near-identical toggles in `Editor.svelte` (`toggleLinePrefix`,
`toggleHeading`, `toggleNumberedList`) collapse into one table in
`utils/editorToolbar.ts`, keyed by the toolbar ids the actions already
register: every entry says which marker it owns, how it renders, and
what it competes with (`null` for quote; headings against headings).
That is also what makes the transform reachable from `scripts/` —
`Editor.svelte` cannot be imported by the test runner, so a matrix of
28 input/output pairs would otherwise have been unwritable. The
extraction is deliberately minimal: only the line-marker toggling moved,
and the heading rows reproduce the old behaviour exactly, `# - foo`
included — a heading is not a list toggle, so it displaces nothing but
headings.

Seven matrix rows and the mixed-selection case fail against the code
they replace.

Trade-off: turning a checklist item into a bullet or a numbered item now
drops the box, checked state included, instead of stranding it. The
three list types are alternatives in one slot, so keeping `[x]` would
mean minting a fourth form that the checklist toggle does not recognise.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>


---

## Transitions

| input | bullet | numbered | checklist |
|---|---|---|---|
| `1. foo` | `- foo` *(was `- 1. foo`)* — #451 | — | `- [ ] foo` *(was `- [ ] 1. foo`)* |
| `- foo` | `foo` | `1. foo` | `- [ ] foo` *(was `- [ ] - foo`)* |
| `- [ ] foo` | `- foo` *(was `[ ] foo`)* | `1. foo` *(was `1. [ ] foo`)* | `foo` |
| `- [x] foo` | `- foo` *(was `[x] foo`)* | `1. foo` | `foo` |
| `> foo`, `# foo` | unchanged | unchanged | unchanged |

## Verification

    npm test        631 / 631   (598 before; +33)
    npm run check   638 files, 0 errors, 0 warnings
    cargo test      154 / 154
    npm audit       0 vulnerabilities

Reverting the fix and keeping the tests turns **8 red** — the seven matrix rows
above plus mixed selection — and leaves all five quote rows and all five heading
rows green, which is the evidence that neither was touched.

Also exercised by hand in a local macOS build: `- [ ] foo` → `- foo` → `foo` →
`- foo` → `foo` across four clicks of the bullet button.

## Not covered

None of the toggles has ever handled leading indentation (`  - nested`), a
space-less marker (`>tight`), or `1)` as an ordered delimiter. That is detection
breadth rather than marker competition, and widening it would change quote and
heading behaviour too — left alone deliberately.
