### PR TITLE
fix(installer): give the NSIS hooks the macro names the bundler checks for

### DIFF
--- a/scripts/nsisInstallerHooks.test.ts
+++ b/scripts/nsisInstallerHooks.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readSource } from './sourceTree.js';
+
+// `bundle.windows.nsis.installerHooks` is a file the NSIS bundler `!include`s
+// into its own installer script, and the four call sites in that script are all
+// guarded by `!ifmacrodef`:
+//
+//   !ifmacrodef NSIS_HOOK_POSTINSTALL
+//     !insertmacro NSIS_HOOK_POSTINSTALL
+//   !endif
+//
+// `!ifmacrodef` is a compile-time conditional, so a hook whose macro name is
+// spelled any other way is skipped with no error and no warning. The installer
+// still builds, still installs, and simply never runs the hook — which is how
+// `hooks.nsi` sat inert from 2026-01-12 to 2026-08-05 defining
+// `NSIS_HOOK_POST_INSTALL` (an underscore the bundler does not use).
+//
+// Nothing else in the build can catch that: the bundler does not validate the
+// file, and NSIS itself is only reachable on a Windows runner. So the spelling
+// is pinned here.
+//
+// Source: crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi in
+// tauri-apps/tauri, unchanged in this set since tauri-cli-v2.0.0. This repo
+// pins @tauri-apps/cli 2.9.6 in package-lock.json.
+const BUNDLER_HOOK_MACROS = [
+	'NSIS_HOOK_PREINSTALL',
+	'NSIS_HOOK_POSTINSTALL',
+	'NSIS_HOOK_PREUNINSTALL',
+	'NSIS_HOOK_POSTUNINSTALL'
+];
+
+const config = JSON.parse(readSource('src-tauri/tauri.conf.json')) as {
+	bundle: { windows?: { nsis?: { installMode?: string; installerHooks?: string } } };
+};
+
+const installerHooks = config.bundle.windows?.nsis?.installerHooks;
+
+test('a configured installer hook file exists', () => {
+	if (installerHooks === undefined) return;
+	// The path is resolved relative to the config file, not to the repo root.
+	assert.doesNotThrow(
+		() => readSource(`src-tauri/${installerHooks}`),
+		`bundle.windows.nsis.installerHooks points at src-tauri/${installerHooks}, which is not in the repo`
+	);
+});
+
+test('installer hook macros are spelled the way the bundler checks for them', () => {
+	if (installerHooks === undefined) return;
+	const hooks = readSource(`src-tauri/${installerHooks}`);
+	const defined = [...hooks.matchAll(/^[ \t]*!macro[ \t]+(\S+)/gm)].map((match) => match[1]);
+
+	// Only the entry points are pinned; a hook file is free to define private
+	// helper macros under any name it likes.
+	const entryPoints = defined.filter((name) => /^NSIS_HOOK/i.test(name));
+
+	for (const name of entryPoints) {
+		assert.ok(
+			BUNDLER_HOOK_MACROS.includes(name),
+			`${installerHooks} defines !macro ${name}, which no !ifmacrodef in the bundler template matches, ` +
+				`so it is never inserted. Expected one of: ${BUNDLER_HOOK_MACROS.join(', ')}`
+		);
+	}
+
+	// A hook file that defines no entry point at all is the same dead weight by
+	// a different route: the config names it, the bundler includes it, nothing
+	// in it ever runs.
+	assert.notEqual(
+		entryPoints.length,
+		0,
+		`${installerHooks} defines no NSIS_HOOK_* macro, so including it has no effect. ` +
+			'Drop bundle.windows.nsis.installerHooks instead.'
+	);
+});
+
+test('installer hooks write through the install-mode hive, not a hardcoded one', () => {
+	if (installerHooks === undefined) return;
+	const hooks = readSource(`src-tauri/${installerHooks}`);
+	const installMode = config.bundle.windows?.nsis?.installMode ?? 'currentUser';
+	if (installMode === 'currentUser') return;
+
+	// With installMode "both" the user picks per-user or all-users at install
+	// time, and the bundler template writes every registry key through SHCTX so
+	// it follows that choice. A hook that names a hive outright disagrees with
+	// the rest of the installer: an all-users install would leave per-user keys
+	// that the all-users uninstall cannot see.
+	const hardcoded = [
+		...hooks.matchAll(
+			/^[ \t]*(?:Write|Delete|Read)Reg\w*[ \t]+(HKCU|HKLM|HKCR|HKEY_CURRENT_USER|HKEY_LOCAL_MACHINE|HKEY_CLASSES_ROOT)\b/gm
+		)
+	].map((match) => match[1]);
+
+	assert.deepEqual(
+		hardcoded,
+		[],
+		`installMode is ${JSON.stringify(installMode)}, so ${installerHooks} must address the registry ` +
+			'through SHCTX (or SHELL_CONTEXT) like the bundler template does, not through ' +
+			`${[...new Set(hardcoded)].join('/')}.`
+	);
+});

--- a/src-tauri/hooks.nsi
+++ b/src-tauri/hooks.nsi
@@ -1,37 +1,26 @@
-!macro MARKPAD_REGISTER_OPEN_WITH EXTENSION
-  WriteRegStr HKCU "Software\Classes\.${EXTENSION}\shell\Open with Markpad" "" "Open with Markpad"
-  WriteRegStr HKCU "Software\Classes\.${EXTENSION}\shell\Open with Markpad" "Icon" "$INSTDIR\Markpad.exe"
-  WriteRegStr HKCU "Software\Classes\.${EXTENSION}\shell\Open with Markpad\command" "" "$\"$INSTDIR\Markpad.exe$\" $\"%1$\""
+; NSIS installer hooks, included by the bundler template
+; (crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi) and inserted from
+; `!ifmacrodef NSIS_HOOK_POSTINSTALL` / `!ifmacrodef NSIS_HOOK_POSTUNINSTALL`.
+; There is no underscore between POST and INSTALL, and `!ifmacrodef` is a
+; compile-time conditional, so any other spelling is skipped in silence.
+;
+; Everything a hook does here has to be something the template does not already
+; do. The template creates the desktop shortcut from the finish-page checkbox
+; (and automatically for silent and passive installs), registers `.md` and
+; `.markdown` from `bundle.fileAssociations` via APP_ASSOCIATE, and writes every
+; key through SHCTX so it follows `installMode`. Duplicating any of that from
+; here overrides a choice the user was already given.
 
-  WriteRegStr HKCU "Software\Classes\SystemFileAssociations\.${EXTENSION}\shell\Open with Markpad" "" "Open with Markpad"
-  WriteRegStr HKCU "Software\Classes\SystemFileAssociations\.${EXTENSION}\shell\Open with Markpad" "Icon" "$INSTDIR\Markpad.exe"
-  WriteRegStr HKCU "Software\Classes\SystemFileAssociations\.${EXTENSION}\shell\Open with Markpad\command" "" "$\"$INSTDIR\Markpad.exe$\" $\"%1$\""
-
-  WriteRegStr HKCU "Software\Classes\.${EXTENSION}\OpenWithList\Markpad.exe" "" ""
-!macroend
-
-!macro MARKPAD_UNREGISTER_OPEN_WITH EXTENSION
-  DeleteRegKey HKCU "Software\Classes\.${EXTENSION}\shell\Open with Markpad"
-  DeleteRegKey HKCU "Software\Classes\SystemFileAssociations\.${EXTENSION}\shell\Open with Markpad"
-  DeleteRegKey HKCU "Software\Classes\.${EXTENSION}\OpenWithList\Markpad.exe"
-!macroend
-
-!macro NSIS_HOOK_POST_INSTALL
-  CreateShortcut "$DESKTOP\Markpad.lnk" "$INSTDIR\Markpad.exe" "" "$INSTDIR\Markpad.exe" 0
-
-  WriteRegStr HKCU "Software\Classes\Applications\Markpad.exe\shell\open\command" "" "$\"$INSTDIR\Markpad.exe$\" $\"%1$\""
-  !insertmacro MARKPAD_REGISTER_OPEN_WITH "md"
-  !insertmacro MARKPAD_REGISTER_OPEN_WITH "markdown"
-
+!macro NSIS_HOOK_POSTINSTALL
+  ; The template registers the file associations through FileAssociation.nsh but
+  ; never inserts that header's own UPDATEFILEASSOC, so Explorer can go on
+  ; serving the previous handler and icon for `.md` until the next logon.
+  ; Broadcasting SHCNE_ASSOCCHANGED (0x08000000) with SHCNF_IDLIST (0) and two
+  ; null items is the documented way to tell it to re-read them.
   System::Call 'shell32::SHChangeNotify(i 0x08000000, i 0, p 0, p 0)'
 !macroend
 
-!macro NSIS_HOOK_POST_UNINSTALL
-  Delete "$DESKTOP\Markpad.lnk"
-
-  DeleteRegKey HKCU "Software\Classes\Applications\Markpad.exe"
-  !insertmacro MARKPAD_UNREGISTER_OPEN_WITH "md"
-  !insertmacro MARKPAD_UNREGISTER_OPEN_WITH "markdown"
-
+!macro NSIS_HOOK_POSTUNINSTALL
+  ; And again once APP_UNASSOCIATE has handed `.md` back.
   System::Call 'shell32::SHChangeNotify(i 0x08000000, i 0, p 0, p 0)'
 !macroend


### PR DESCRIPTION
`tauri.conf.json` points `bundle.windows.nsis.installerHooks` at `hooks.nsi`, which
defines `NSIS_HOOK_POST_INSTALL` and `NSIS_HOOK_POST_UNINSTALL`. The bundler
guards its call sites with **`NSIS_HOOK_POSTINSTALL`** and
**`NSIS_HOOK_POSTUNINSTALL`** — no underscore:

```
installer.nsi @ tauri-cli-v2.9.6   (the version package-lock.json pins)
  617:  !ifmacrodef NSIS_HOOK_PREINSTALL
  709:  !ifmacrodef NSIS_HOOK_POSTINSTALL
  754:  !ifmacrodef NSIS_HOOK_PREUNINSTALL
  862:  !ifmacrodef NSIS_HOOK_POSTUNINSTALL
```

Same at `tauri-cli-v2.0.0` and on `dev` — the underscored spelling has never
existed. `!ifmacrodef` is a compile-time conditional, so the mismatch produces no
error and no warning. **The file has never run**, from `b89fc17` (2026-01-12) to
today. Nothing tested it.

## Why the macros were not simply renamed

Renaming alone would have activated three behaviours that conflict with the
template. Each was checked against 2.9.6 rather than assumed:

| `hooks.nsi` did | template | |
|---|---|---|
| create `$DESKTOP\Markpad.lnk` unconditionally | finish-page checkbox (`:386`), auto only for silent/passive (`:702`), and `CreateOrUpdateDesktopShortcut` returns early on `$UpdateMode` (`:945`) | **removed** |
| write `Applications\Markpad.exe\shell\open\command` | not covered | **removed** — see below |
| write `Open with Markpad` under `.md\shell`, `SystemFileAssociations\.md\shell` and `OpenWithList` | `APP_ASSOCIATE` (`:642`) writes the verb under the ProgID only | **removed** — see below |
| `SHChangeNotify(SHCNE_ASSOCCHANGED)` | not covered; `FileAssociation.nsh` ships `UPDATEFILEASSOC` for it and `installer.nsi` includes the header but never inserts the macro | **kept** |

Every write in the file was hardcoded `HKCU` while the template writes through
`SHCTX`, which follows `installMode: "both"` — so an all-users install would have
put per-user keys in an elevated user's hive.

The shortcut row is the concrete one: `tauri-plugin-updater` 2.10.1 passes
`/UPDATE`, which is precisely why the template skips shortcut creation during an
update. The hook would have recreated a desktop shortcut the user had deleted, on
every auto-update.

Removing rows that never ran changes nothing at runtime; keeping one is the
behaviour change. `SHChangeNotify` is the only keeper — no registry writes, so the
hive question does not arise, idempotent, and it restores the intended use of a
header the template already includes.

## A fix that never shipped

`a5fda8e` — *"Fix markdown preview wrapping and open-with registration"*,
2026-04-30 — added the `Applications\` and `OpenWithList` registrations to fix a
real report. It went into a file that does not execute, so **that fix has never
reached a user, and the open-with gap is probably still open.** Reviving it means
converting the hardcoded `HKCU` to `SHCTX` and deconflicting a second
`Open with Markpad` label against the template's own — Windows-only validation, so
it wants its own PR rather than a rider on this one. Flagging rather than dropping.

## The guard

`scripts/nsisInstallerHooks.test.ts`: the configured hook file exists; every
`NSIS_HOOK*` macro it defines is one of the four the bundler checks; and while
`installMode` is not `currentUser`, no hook names a registry hive outright. Against
the file as it stood:

```
✖ installer hook macros are spelled the way the bundler checks for them
  hooks.nsi defines !macro NSIS_HOOK_POST_INSTALL, which no !ifmacrodef in the
  bundler template matches, so it is never inserted.
  Expected one of: NSIS_HOOK_PREINSTALL, NSIS_HOOK_POSTINSTALL,
  NSIS_HOOK_PREUNINSTALL, NSIS_HOOK_POSTUNINSTALL

✖ installer hooks write through the install-mode hive, not a hardcoded one
  + [ 'HKCU' × 12 ]   - []
```

The failure mode here was silence; a name check is the only thing that turns it
into a signal. If `installerHooks` is ever dropped entirely the tests no-op, so the
guard does not stand in the way of retiring the file later.

## Two things found while checking, neither fixed here

**`<ProgID>_backup` self-clobbers, in the template.** `FileAssociation.nsh:70-71`
writes `.md`'s current handler into `Markdown File_backup` unconditionally; on a
reinstall that value is already `Markdown File`, so the backup overwrites itself,
and `APP_UNASSOCIATE` then restores `.md` to a ProgID it deletes in the next line.
The restore is unconditional too, so uninstalling stomps a `.md` association a
different editor took over afterwards. This is #255/#256 again, in the NSIS path.
A `NSIS_HOOK_PREINSTALL` alone cannot fix it — it runs before `APP_ASSOCIATE` — so
it needs a PRE/POST pair, and arguably belongs upstream in `FileAssociation.nsh`.

**The two install paths use different ProgIDs.** NSIS writes `Markdown File`;
`setup.rs` writes `Markpad.File` with its own `PreviousAssociations` subkey. They
can clobber each other's `.md` default. Relevant to #395.

## Verification

    npm test        643 / 643
    npm run check   0 errors
    cargo test      154 / 154
    npm audit       0 vulnerabilities

**Not verifiable without Windows**, and stated as inference rather than
measurement: that the shell actually refreshes on the `SHChangeNotify` call; that
NSIS compiles the file (there is no NSIS on macOS — the guard is a name check, not
a compile); that `NSIS_HOOK_POSTINSTALL` now genuinely fires; and whether the
removed `Applications\`/`OpenWithList` writes were producing value the template
misses. Worth a look on a real machine before the next release.
