### PR TITLE
fix(editor): stop Monaco outlining fullwidth CJK punctuation

### DIFF
--- a/scripts/editorOptionWiring.test.ts
+++ b/scripts/editorOptionWiring.test.ts
@@ -1,6 +1,17 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import {
+	EditorOptions,
+	inUntrustedWorkspace,
+	type UnicodeHighlightOptions,
+} from 'monaco-editor/esm/vs/editor/common/config/editorOptions.js';
+import {
+	UnicodeTextModelHighlighter,
+	type UnicodeHighlightResult,
+} from 'monaco-editor/esm/vs/editor/common/services/unicodeTextModelHighlighter.js';
+import ts from 'typescript';
+
 import { readSource, sliceBetween } from './sourceTree.js';
 
 // Editor.svelte translates the settings store into Monaco options and
@@ -161,4 +172,166 @@ test('Show Whitespace renders every whitespace run, not just trailing', () => {
 		2,
 		'creation and updateOptions agree on "all"',
 	);
+});
+
+// ----------------------------------------------------------------- executed
+//
+// Everything above matches Editor.svelte as text, because a keybinding and a
+// settings-driven enum cannot be exercised without a DOM. `unicodeHighlight`
+// can do better, and the weak form would be particularly bad here: asserting
+// that the string "ambiguousCharacters" occurs in the file says nothing about
+// which characters Monaco ends up outlining, which is the entire contract.
+//
+// So the option literal is lifted out of the real `monaco.editor.create` call,
+// evaluated, and pushed through the same two pieces of Monaco the running
+// editor uses — `EditorOptions.unicodeHighlight.applyUpdate` to merge it over
+// the shipped defaults, and `UnicodeTextModelHighlighter` to decide what gets a
+// box. A regression has to survive Monaco's own code to reach the assertions.
+
+/** The options object Editor.svelte hands to `monaco.editor.create`, evaluated. */
+function createdEditorOptions(): Record<string, unknown> {
+	const script = sliceBetween(editor, '<script lang="ts">', '</script>');
+	const source = ts.createSourceFile('Editor.ts', script, ts.ScriptTarget.Latest, true);
+
+	const literals: ts.Expression[] = [];
+	const visit = (node: ts.Node): void => {
+		if (ts.isCallExpression(node) && node.expression.getText(source) === 'monaco.editor.create') {
+			assert.equal(node.arguments.length, 2, 'monaco.editor.create(container, options)');
+			literals.push(node.arguments[1]);
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(source);
+
+	// Also the check that this file is looking at the only editor in the app: a
+	// second `create` call would need the same option and would not be covered
+	// by anything below.
+	assert.equal(literals.length, 1, 'exactly one Monaco editor is constructed in Editor.svelte');
+
+	const js = ts.transpileModule(`(${literals[0].getText(source)})`, {
+		compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ESNext },
+	}).outputText;
+
+	// The literal closes over four locals. None of them can reach
+	// `unicodeHighlight`, which is a constant, so they are stubbed rather than
+	// reconstructed — the settings proxy answers undefined for every key, which
+	// is enough to let the object build.
+	return new Function('settings', 'value', 'language', 'getTheme', `return ${js};`)(
+		new Proxy({}, { get: () => undefined }),
+		'',
+		'markdown',
+		() => 'app-theme-dark',
+	) as Record<string, unknown>;
+}
+
+/**
+ * Monaco's shipped defaults with the component's option merged over them.
+ *
+ * `?? {}` models the real absence case rather than guarding: a component that
+ * passes no `unicodeHighlight` gets Monaco's defaults, which is the state this
+ * whole section exists to move away from. Without it, deleting the option from
+ * Editor.svelte fails the tests below with a TypeError raised inside Monaco
+ * instead of the assertion naming the characters that came back.
+ */
+function effectiveUnicodeHighlight(passed: unknown): UnicodeHighlightOptions {
+	const option = EditorOptions.unicodeHighlight;
+	return option.applyUpdate(option.defaultValue, passed ?? {}).newValue;
+}
+
+/**
+ * What Monaco would outline in `lines`, given an effective option set.
+ *
+ * Mirrors `resolveOptions()` in unicodeHighlighter.ts, which is not exported.
+ * `trusted` is true because that is what standalone Monaco reports —
+ * `StandaloneWorkspaceTrustManagementService.isWorkspaceTrusted()` returns true
+ * unconditionally. That is why `nonBasicASCII`, whose default is the
+ * `inUntrustedWorkspace` sentinel, is already off and needs no setting in
+ * Editor.svelte: it resolves through `!trusted`.
+ */
+function outlined(lines: string[], effective: UnicodeHighlightOptions): UnicodeHighlightResult {
+	const trusted = true;
+	const through = (value: boolean | 'inUntrustedWorkspace') =>
+		value === inUntrustedWorkspace ? !trusted : value;
+	return UnicodeTextModelHighlighter.computeUnicodeHighlights(
+		{ getLineCount: () => lines.length, getLineContent: (n: number) => lines[n - 1] },
+		{
+			nonBasicASCII: through(effective.nonBasicASCII),
+			ambiguousCharacters: effective.ambiguousCharacters,
+			invisibleCharacters: effective.invisibleCharacters,
+			includeComments: through(effective.includeComments),
+			includeStrings: through(effective.includeStrings),
+			allowedCodePoints: Object.keys(effective.allowedCharacters).map((c) => c.codePointAt(0)),
+			// The real value is derived from the OS locale and Monaco's UI
+			// language. It is pinned here because it makes no difference: the
+			// fullwidth forms are confusable in every locale Monaco ships, zh-CN
+			// and ja-JP included, which is why the reporters saw boxes on
+			// CJK systems in the first place.
+			allowedLocales: ['en'],
+		},
+	);
+}
+
+// Prose a CJK author actually types. The boxes need a basic-ASCII character in
+// the same word as the fullwidth punctuation — `shouldHighlightNonBasicASCII`
+// suppresses the highlight when the surrounding word is entirely non-ASCII —
+// so a Latin technical term or a Markdown emphasis marker is what triggers it.
+const CJK_PROSE = [
+	'使用 Monaco，然后保存。',
+	'安装依赖（npm ci），再运行测试。',
+	'这是 Markdown，不是 HTML。',
+	'打开 Settings：Editor，字体大小。',
+	'**粗体**，*斜体*，`代码`。',
+	'标题（English Title）说明',
+	'你好，世界。（测试）！？',
+];
+
+test('the editor turns off ambiguous-character highlighting and nothing else', () => {
+	// Reports #186 and #94 are both Monaco outlining fullwidth punctuation.
+	// Narrowness is the assertion: `unicodeHighlight: false` or a third
+	// sub-option would also make the boxes go away, and would take the
+	// invisible-character warning with it.
+	const options = createdEditorOptions();
+	assert.deepEqual(
+		options.unicodeHighlight,
+		{ ambiguousCharacters: false },
+		'exactly one sub-option is overridden',
+	);
+});
+
+test('no box is drawn on fullwidth CJK punctuation', () => {
+	const effective = effectiveUnicodeHighlight(createdEditorOptions().unicodeHighlight);
+	const found = outlined(CJK_PROSE, effective);
+	assert.equal(
+		found.ranges.length,
+		0,
+		`nothing outlined in CJK prose, got ${JSON.stringify(
+			found.ranges.map((r) => CJK_PROSE[r.startLineNumber - 1].slice(r.startColumn - 1, r.endColumn - 1)),
+		)}`,
+	);
+	assert.equal(found.ambiguousCharacterCount, 0);
+});
+
+test('the fixtures still reproduce the bug once the option is taken away', () => {
+	// Without this the test above could pass because Monaco stopped treating
+	// the fullwidth forms as confusable — an upgrade would quietly leave it
+	// asserting nothing. It fails loudly instead, on the fixtures rather than
+	// on the fix.
+	const withDefaults = effectiveUnicodeHighlight({ ambiguousCharacters: true });
+	const found = outlined(CJK_PROSE, withDefaults);
+	assert.ok(
+		found.ambiguousCharacterCount >= 6,
+		`Monaco's defaults still box CJK punctuation, got ${found.ambiguousCharacterCount}`,
+	);
+});
+
+test('the invisible-character warning survives the fix', () => {
+	// A stray NBSP or zero-width space is a real hazard in Markdown — an NBSP
+	// after `-` stops a list from parsing — and unlike the punctuation it is
+	// never something the author typed on purpose. Turning the whole feature
+	// off would have taken it with it.
+	const effective = effectiveUnicodeHighlight(createdEditorOptions().unicodeHighlight);
+	assert.equal(effective.invisibleCharacters, true, 'left at the Monaco default');
+
+	const found = outlined(['a b', 'x​z'], effective);
+	assert.equal(found.invisibleCharacterCount, 2, 'NBSP and zero-width space are still flagged');
 });

--- a/scripts/monacoInternals.d.ts
+++ b/scripts/monacoInternals.d.ts
@@ -1,0 +1,88 @@
+// Types for the two Monaco internals `editorOptionWiring.test.ts` drives
+// directly.
+//
+// Monaco ships declarations for its public API surface (`monaco-editor`) only.
+// The option registry and the Unicode highlighter are plain ESM modules that
+// resolve at runtime — Editor.svelte already deep-imports `monaco-editor/esm/…`
+// for its five workers — but they carry no `.d.ts`, so `npm run check` reads
+// them as implicit `any`.
+//
+// They are declared here rather than left as `any` because the test asserts on
+// what comes back out of them: `ambiguousCharacterCount` silently becoming
+// `undefined` after a Monaco upgrade would turn `assert.equal(count, 0)` into a
+// test that passes while checking nothing. Narrow declarations make that a type
+// error instead. A module that moves outright fails loudly at import time.
+//
+// Only the members the test calls are declared. This is not an attempt to type
+// Monaco's internals in general.
+
+declare module 'monaco-editor/esm/vs/editor/common/config/editorOptions.js' {
+	/** Sentinel default for the options gated on workspace trust. */
+	export const inUntrustedWorkspace: 'inUntrustedWorkspace';
+
+	export interface UnicodeHighlightOptions {
+		nonBasicASCII: boolean | 'inUntrustedWorkspace';
+		invisibleCharacters: boolean;
+		ambiguousCharacters: boolean;
+		includeComments: boolean | 'inUntrustedWorkspace';
+		includeStrings: boolean | 'inUntrustedWorkspace';
+		allowedCharacters: Record<string, boolean>;
+		allowedLocales: Record<string, boolean>;
+	}
+
+	export const EditorOptions: {
+		unicodeHighlight: {
+			readonly defaultValue: UnicodeHighlightOptions;
+			/** Merges a partial option object over `value`, as `editor.create` does. */
+			applyUpdate(
+				value: UnicodeHighlightOptions,
+				update: unknown,
+			): { newValue: UnicodeHighlightOptions };
+		};
+	};
+}
+
+declare module 'monaco-editor/esm/vs/editor/common/services/unicodeTextModelHighlighter.js' {
+	export interface UnicodeHighlightRange {
+		startLineNumber: number;
+		startColumn: number;
+		endLineNumber: number;
+		endColumn: number;
+	}
+
+	export interface UnicodeHighlightResult {
+		ranges: UnicodeHighlightRange[];
+		ambiguousCharacterCount: number;
+		invisibleCharacterCount: number;
+		nonBasicAsciiCharacterCount: number;
+		hasMore: boolean;
+	}
+
+	/** The minimum of `ITextModel` the highlighter reads. */
+	export interface HighlightableModel {
+		getLineCount(): number;
+		getLineContent(lineNumber: number): string;
+	}
+
+	/**
+	 * Resolved form of `UnicodeHighlightOptions`: the workspace-trust sentinels
+	 * are already collapsed to booleans, and the two allow-maps are flattened to
+	 * lists by the caller.
+	 */
+	export interface ResolvedUnicodeHighlightOptions {
+		nonBasicASCII: boolean;
+		ambiguousCharacters: boolean;
+		invisibleCharacters: boolean;
+		includeComments: boolean;
+		includeStrings: boolean;
+		allowedCodePoints: (number | undefined)[];
+		allowedLocales: string[];
+	}
+
+	export const UnicodeTextModelHighlighter: {
+		computeUnicodeHighlights(
+			model: HighlightableModel,
+			options: ResolvedUnicodeHighlightOptions,
+		): UnicodeHighlightResult;
+	};
+}

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -273,6 +273,27 @@
 			fontFamily: settings.editorFont,
 			wordBasedSuggestions: "off",
 			quickSuggestions: false,
+			// Monaco's Unicode highlighter is built for source code, where a
+			// character that looks like ASCII but is not is an attack vector. In
+			// prose it fires on the punctuation CJK authors type all day: `，`
+			// `！` `？` `（` `）` `；` `：` are all confusables of an ASCII
+			// counterpart, so Monaco outlines each one (#186, #94).
+			//
+			// It only fires when the confusable shares a word with basic ASCII —
+			// shouldHighlightNonBasicASCII() suppresses the box when the
+			// surrounding word is entirely non-ASCII — which is why pure CJK
+			// looks fine and `使用 Monaco，然后保存。` or `安装依赖（npm ci）` does
+			// not. Latin technical terms inside CJK prose are the normal case,
+			// and `**粗体**，` triggers it with no Latin word at all.
+			//
+			// invisibleCharacters stays at its default: a stray zero-width space
+			// or NBSP is a real hazard in Markdown (an NBSP after `-` stops a
+			// list from parsing) and it never fires on something typed on
+			// purpose. nonBasicASCII needs no setting — it defaults to
+			// `inUntrustedWorkspace` and standalone Monaco's workspace-trust
+			// service returns true unconditionally, so it is already off; were it
+			// on, every ideograph would be boxed rather than the punctuation.
+			unicodeHighlight: { ambiguousCharacters: false },
 			renderWhitespace: settings.showWhitespace ? "all" : "none",
 			padding: { top: 20 },
 			scrollbar: {


### PR DESCRIPTION
Closes #186. Closes #94. First half of #393; the `z`-family half (#104) is left
alone, per your "can get to the other Monaco defaults at a later date" on #393.
You queued this one — "if we can fix the punctuation highlights we can queue it"
— the day before v2.7.0, and it did not make the release.

`monaco.editor.create` has never passed `unicodeHighlight`; there is no
occurrence anywhere in the repo, so Monaco's defaults have been in charge for
the editor's whole life. `ambiguousCharacters` defaults to true, and `，` `！`
`？` `（` `）` `；` `：` are each a confusable of an ASCII counterpart, so each
gets a box. That default is right for source code, where a character that looks
like ASCII but is not is an attack vector, and wrong for a Markdown editor whose
users write prose.

### Why it looks intermittent

The highlight is suppressed when the word around the character is entirely
non-ASCII — `shouldHighlightNonBasicASCII` in
`common/services/unicodeTextModelHighlighter.js` returns early on "no basic
ASCII, and something obviously non-ASCII present". So pure CJK is clean and the
boxes appear only once basic ASCII shares a word with the punctuation:

| line | boxed by default |
|---|---|
| `你好，世界。（测试）！？` | nothing |
| `使用 Monaco，然后保存。` | `，` |
| `安装依赖（npm ci），再运行测试。` | `（` `）` `，` |
| `打开 Settings：Editor，字体大小。` | `：` `，` |
| ``**粗体**，*斜体*，`代码`。`` | `，` `，` |

The last row is the one that makes this unavoidable: no Latin word is needed,
because a Markdown emphasis marker is itself basic ASCII. Mixing Latin technical
terms into CJK prose is the normal case, not an edge one.

### Scope

One sub-option, `ambiguousCharacters: false`. The rest are deliberate:

**`invisibleCharacters` stays at its default.** A stray zero-width space or NBSP
is a real hazard in Markdown — an NBSP after `-` stops the list from parsing —
and unlike the punctuation it is never something the author typed on purpose. It
is the part of this feature that earns its place in a prose editor, and
`unicodeHighlight: false` would have taken it with the boxes.

**`nonBasicASCII` needs no setting.** It defaults to the `inUntrustedWorkspace`
sentinel, which resolves through `!trusted`, and standalone Monaco's
`StandaloneWorkspaceTrustManagementService.isWorkspaceTrusted()` returns true
unconditionally — so it is already off. Were it on, every ideograph would be
boxed rather than the punctuation, which is not what either reporter described.
Pinning it would be a no-op today and would freeze a default you are entitled to
change later.

**`allowedCharacters` was the narrower alternative and is worse.** It needs an
enumerated list of every fullwidth form across Chinese, Japanese and Korean
input, and boxes whatever the list forgets.

### Unconditional, not gated on language

Monaco already ships the mechanism a language gate would use — `allowedLocales`,
seeded from the OS locale — and it does not help. `使用 Monaco，然后保存。` boxes
identically under `en`, `zh-CN`, `zh-Hans`, `ja-JP` and `ko-KR`, which is why the
reporters saw boxes on CJK systems in the first place. Beyond that, a content or
UI-language gate would make the same file render differently depending on state,
and would flip mid-typing as the first CJK character arrived.

The editor is the only Monaco instance in the app — the preview is a Rust
`render_markdown` HTML pipeline and there is no diff editor — so there is nowhere
else to apply this. `editor.updateOptions` merges and does not pass
`unicodeHighlight`, so setting it once at creation holds.

### Tests

Four tests in `editorOptionWiring.test.ts`. They execute the option object
rather than matching the source for a string, which matters here: asserting that
`"ambiguousCharacters"` appears in `Editor.svelte` says nothing about which
characters Monaco ends up outlining, and that is the whole contract. The literal
is lifted out of the real `monaco.editor.create` call with the TypeScript parser,
evaluated, merged over Monaco's shipped defaults through
`EditorOptions.unicodeHighlight.applyUpdate`, and run through
`UnicodeTextModelHighlighter` — the function that decides what gets a box. A
regression has to survive Monaco's own code to reach the assertions.

One of the four asserts the fixtures *still reproduce the bug* once the option is
taken away, so a Monaco upgrade that changed the confusable set fails loudly
instead of leaving the other three quietly asserting nothing.

Reverting only the option, keeping the tests:

```
✖ the editor turns off ambiguous-character highlighting and nothing else
  AssertionError: exactly one sub-option is overridden
  + actual - expected
  + undefined
  - { ambiguousCharacters: false }

✖ no box is drawn on fullwidth CJK punctuation
  AssertionError: nothing outlined in CJK prose, got
    ["，","（","）","，","，","：","，","，","，","（","）"]
  11 !== 0

ℹ pass 9   ℹ fail 2
```

Replacing it with a blanket `{ ambiguousCharacters: false, invisibleCharacters:
false, nonBasicASCII: false }` instead reddens the other direction — "the
invisible-character warning survives the fix" and the narrowness assertion — so
the pair pins the fix from both sides.

`scripts/monacoInternals.d.ts` is the one judgement call I would flag. Monaco
ships declarations for its public API only, so driving the option registry and
the highlighter from a test needs types for two internal module paths.
Declaring them narrowly rather than as `any` means a shape change is a type
error and a moved module is a loud import failure; the alternative was to give
up on executing Monaco's real logic and go back to a source-text assertion.

### Verification

`npm audit`, `npm run check` (0 errors, 644 files), `npm test` (681 pass), and
`cargo test` all green.

Visually: I rendered Monaco 0.55.1 with this exact option object against the
document above, with and without the fix. Default gives 11 `unicode-highlight`
decorations; with the fix, 1 — the zero-width space, still flagged, which is the
point of keeping `invisibleCharacters`. To be precise about what that was: real
Monaco in a browser with the same options, not the packaged Tauri app, which
does not run outside its webview (`__TAURI_INTERNALS__` is undefined).

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
