### PR TITLE
fix(ci): unpin WebKitGTK so the AppImage bundles a Mesa-compatible version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,12 +88,12 @@ jobs:
           librsvg2-dev \
           patchelf \
           rpm \
-          libwebkit2gtk-4.1-0=2.44.0-2 \
-          libwebkit2gtk-4.1-dev=2.44.0-2 \
-          libjavascriptcoregtk-4.1-0=2.44.0-2 \
-          libjavascriptcoregtk-4.1-dev=2.44.0-2 \
-          gir1.2-javascriptcoregtk-4.1=2.44.0-2 \
-          gir1.2-webkit2-4.1=2.44.0-2
+          libwebkit2gtk-4.1-0 \
+          libwebkit2gtk-4.1-dev \
+          libjavascriptcoregtk-4.1-0 \
+          libjavascriptcoregtk-4.1-dev \
+          gir1.2-javascriptcoregtk-4.1 \
+          gir1.2-webkit2-4.1
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf rpm xdg-utils \
           libxcb1-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
 


### PR DESCRIPTION
## Symptom
The Linux AppImage exits immediately on Intel/Mesa systems with:

    Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...

No window ever appears. Reported in #182 (CachyOS, Intel Arc, Mesa); reproduced
on the current v2.7.0 release (Arch, Intel, Mesa 26.1.6, Wayland).

## Root cause
The release job in `.github/workflows/build.yml` pins the WebKitGTK stack:

    libwebkit2gtk-4.1-0=2.44.0-2
    libwebkit2gtk-4.1-dev=2.44.0-2
    ...

so `tauri build` bundles WebKitGTK 2.44.0 into the AppImage, and 2.44.0 fails EGL
initialization against modern Mesa. The abort comes from the bundled
`libwebkit2gtk-4.1.so.0` itself: forcing the app onto a current system WebKit
(2.52.x) makes it disappear. The usual env workarounds
(`WEBKIT_DISABLE_DMABUF_RENDERER=1`, `WEBKIT_DISABLE_COMPOSITING_MODE=1`,
`LIBGL_ALWAYS_SOFTWARE=1`) do not help.

## Fix
Drop the `=2.44.0-2` version pins so the ubuntu-24.04 runner installs the current
patched WebKitGTK from noble-updates (2.52.3-0ubuntu0.24.04.1 at time of writing),
which `tauri build` then bundles. All six packages are binaries of the one
`webkit2gtk` source published in lockstep, so they resolve to a single version.

If you'd rather keep an explicit pin, `=2.52.3-0ubuntu0.24.04.1` works equally;
I unpinned so it won't go stale again.

## Verification
Rebuilt v2.7.0 with `npm run tauri build -- --bundles appimage`:
- Before (bundled 2.44.0): `EGL_BAD_PARAMETER`, process exits, no window.
- After (bundled 2.52.x): launches and renders the full UI.

Environment: Arch Linux, Intel, Mesa 26.1.6, Wayland. Confirmed with the real
repackaged AppImage, not just in theory.

## Note
The deeper fragility is that the AppImage bundles WebKitGTK at all; an old bundled
WebKit against a newer host Mesa is inherently brittle. This CI change is the clean
app-side fix; the underlying behavior lives upstream in tauri-bundler.
