### PR TITLE
fix(preview): never anchor the scroll restore to a boxless <br>

### DIFF
--- a/scripts/previewAnchorRestore.test.ts
+++ b/scripts/previewAnchorRestore.test.ts
@@ -81,6 +81,29 @@ class DocumentBuilder {
 		this.line = end + 1;
 	}
 
+	/**
+	 * A paragraph the author soft-wrapped over several source lines.
+	 * `convert_markdown` sets `render.hardbreaks`, so comrak ends every line but
+	 * the last with `<br data-sourcepos="…" />` — the exact shape recorded in
+	 * `renderProtocolFixtures.ts`. Every one of those `br`s is a `[data-sourcepos]`
+	 * element that `findAnchorElement` can descend into and that reports
+	 * `offsetTop === 0, offsetHeight === 0` to the restore.
+	 */
+	wrappedParagraph(lines: string[]) {
+		const start = this.line;
+		const end = start + lines.length - 1;
+		const html = lines
+			.map((text, index) =>
+				index === lines.length - 1
+					? text
+					: `${text}<br data-sourcepos="${start + index}:${text.length + 1}-${start + index}:${text.length + 1}" />\n`,
+			)
+			.join('');
+		this.blocks.push({ startLine: start, endLine: end });
+		this.parts.push(`<p data-sourcepos="${start}:1-${end}:${lines[lines.length - 1].length}">${html}</p>`);
+		this.line = end + 1;
+	}
+
 	code(lines: string[]) {
 		const start = this.line;
 		const end = start + lines.length + 1;
@@ -289,6 +312,77 @@ test('a collapsed fold resolves to the collapsed wrapper, not to its hidden cont
 	const element = match.element as ShimElement;
 	assert.ok(element.classList.contains('foldable-content-wrapper'));
 	assert.ok(element.classList.contains('is-collapsed'));
+});
+
+/**
+ * A document with no headings at all: `processMarkdownHtml` creates no fold
+ * wrappers, so every rendered block stays a top-level child. Issue #153's
+ * follow-up report is about exactly this shape.
+ */
+function buildTextOnlyDocument(paragraphs: number) {
+	const doc = new DocumentBuilder();
+	for (let i = 1; i <= paragraphs; i += 1) {
+		doc.wrappedParagraph([
+			`Paragraph ${i} first line of prose the author soft-wrapped.`,
+			`Paragraph ${i} second line, still the same markdown block.`,
+			`Paragraph ${i} third and final line of the block.`,
+		]);
+		doc.blank();
+	}
+	return doc;
+}
+
+/**
+ * The resolver may only return an element that can tell the restore where it
+ * is. `getAnchorScrollTop` is handed `offsetTop` and `offsetHeight`, and a `br`
+ * reports `0` for both in every browser — so resolving to one is not a near
+ * miss, it is `scrollTop = 0`: the reader is thrown to the top of the document.
+ *
+ * Measured in Chrome over this pipeline's own output: an anchor resolved to a
+ * `br` restored to 0 from scroll offsets of 219, 328, 438, 547, 657 and 766 px.
+ * The shim has no layout, so this is asserted structurally instead — that is
+ * also why the rates above could read 100% while the round trip was broken.
+ */
+test('a soft-wrapped paragraph resolves to the paragraph, never to its <br>', () => {
+	const doc = new DocumentBuilder();
+	doc.wrappedParagraph(['first line', 'second line', 'third line']);
+	const body = parseHtml(processMarkdownHtml(doc.html(), FILE_PATH, new Set())).body;
+
+	assert.ok(body.querySelectorAll('br[data-sourcepos]').length > 0, 'fixture must contain annotated hard breaks');
+
+	for (const line of [1, 2, 3]) {
+		const match = findAnchorElement(body, line);
+		assert.ok(match, `line ${line} must resolve`);
+		assert.equal((match.element as ShimElement).tagName, 'P', `line ${line} resolved to a boxless element`);
+		assert.deepEqual({ startLine: match.startLine, endLine: match.endLine }, { startLine: 1, endLine: 3 });
+	}
+});
+
+test('heading-less document: every anchor line resolves to an element with a box', (t) => {
+	const doc = buildTextOnlyDocument(150);
+	const result = measure(doc, 300);
+
+	t.diagnostic(`text-only: ${doc.lineCount} source lines, ${result.annotatedElements} elements with data-sourcepos`);
+	t.diagnostic(`text-only: ${result.topLevelChildren} top-level children, ` +
+		`${result.topLevelWithSourcepos} of them with data-sourcepos`);
+	t.diagnostic(`text-only: findAnchorElement ${result.fixed.hits}/${result.fixed.total} (${result.fixed.percent}%)`);
+
+	assert.equal(result.fixed.hits, result.fixed.total);
+
+	// Every source line the renderer attributed to a block, not just the sample:
+	// the failure is per-line, and two of every three lines of a soft-wrapped
+	// paragraph are `br` lines.
+	let boxless = 0;
+	let total = 0;
+	for (const block of doc.blocks) {
+		for (let line = block.startLine; line <= block.endLine; line += 1) {
+			total += 1;
+			const match = findAnchorElement(result.body, line);
+			if (match && ['BR', 'WBR'].includes((match.element as ShimElement).tagName)) boxless += 1;
+		}
+	}
+	t.diagnostic(`text-only: ${boxless}/${total} anchor lines resolved to a boxless element`);
+	assert.equal(boxless, 0, `${boxless}/${total} anchor lines resolved to an element with no box`);
 });
 
 test('an anchor line past the end of the document does not resolve', () => {

--- a/src/lib/utils/previewAnchor.ts
+++ b/src/lib/utils/previewAnchor.ts
@@ -36,6 +36,7 @@ export type LineRange = {
  */
 export type AnchorNode = {
 	readonly nodeType: number;
+	readonly tagName?: string;
 	readonly childNodes: Iterable<AnchorNode>;
 	getAttribute?(name: string): string | null;
 	readonly classList?: { contains(token: string): boolean };
@@ -46,6 +47,19 @@ export type AnchorMatch = LineRange & {
 };
 
 const ELEMENT_NODE = 1;
+
+/**
+ * Elements comrak stamps with a `data-sourcepos` that generate no CSS box the
+ * `offsetTop` / `offsetHeight` API can report. `render.hardbreaks` is on, so
+ * every soft-wrapped line of prose ends in one of these, and resolving an
+ * anchor to one hands the restore `offsetTop = 0, offsetHeight = 0` — which
+ * scrolls the preview to the top of the document instead of to the line.
+ */
+const BOXLESS_TAGS = new Set(['BR', 'WBR']);
+
+function isAnchorable(node: AnchorNode): boolean {
+	return !BOXLESS_TAGS.has(node.tagName ?? '');
+}
 
 /**
  * Distance from the top of the viewport at which the anchor line is pinned.
@@ -68,7 +82,7 @@ export function parseSourceposLineRange(sourcepos: string | null | undefined): L
 function elementChildren(node: AnchorNode): AnchorNode[] {
 	const out: AnchorNode[] = [];
 	for (const child of node.childNodes) {
-		if (child.nodeType === ELEMENT_NODE) out.push(child);
+		if (child.nodeType === ELEMENT_NODE && isAnchorable(child)) out.push(child);
 	}
 	return out;
 }


### PR DESCRIPTION
Reported by @luanfernandes in an edit to #153: a text-only document always returns
to the top when he switches tabs and comes back, while another file restores fine.
He called it "partially fixed", which turns out to be exactly right — and the
variable is not the one either of us assumed.

## Mechanism

`convert_markdown` sets `options.render.hardbreaks = true` (`lib.rs:1671`), so
comrak ends every soft-wrapped source line inside a paragraph with a `<br>` — and
stamps it with `data-sourcepos` like any other node:

```html
<p data-sourcepos="1:1-3:45">This is a plain note with no headings at all.<br data-sourcepos="1:46-1:46" />
It wraps across several source lines the way a<br data-sourcepos="2:47-2:47" />
person actually types prose into a text file.</p>
```

`search()` in `previewAnchor.ts` descends into anything carrying a source range, so
for a line that ends in a soft wrap it returns the `<br>` as "the narrowest block
containing this line". A `<br>` has no principal box:

```
first br[data-sourcepos]: offsetTop=0 offsetHeight=0 offsetParent=ARTICLE
```

and the restore is `getAnchorScrollTop(0, 0, …, 60)` = `max(0, 0 + 0·ratio − 60)` =
**0**. The preview scrolls to the top. Measured round trip on v2.7.0 — capture at
offset S, switch tab, restore:

```
S=219 line=10 -> BR[10-10] offsetTop=0 h=0 restored=0 drift=-219
S=547 line=26 -> BR[26-26] offsetTop=0 h=0 restored=0 drift=-547
ROUND TRIP: n=40 worstDrift=-4378 restoredToTop=32/40
```

Capture and persistence are clean. `getPreviewScrollAnchor` never picks a `<br>` —
`querySelectorAll` is document order and the enclosing `<p>` hits `distance === 0`
first. `tab.anchorLine` survives the tab switch and is never `0` here, so the `> 0`
gate is not involved. `offsetParent` is `ARTICLE.markdown-body` for every matched
element in both document shapes, so that constant cancels as the module's header
says it does.

## The real variable is hard-wrapping, not headings

| document | `br[data-sourcepos]` | restored to top | worst drift |
|---|---|---|---|
| text-only, soft-wrapped | 160 | **32/40** | −4378 px |
| text-only, one line per paragraph | 0 | 0/40 | −101 px |
| headings + subheadings, soft-wrapped | 168 | **20/40** | −7139 px |
| headings + subheadings, one line per paragraph | 0 | 0/40 | −93 px |

Headings dilute it — a heading, a list item and a code fence are single-line blocks
whose anchor lands on something with a box — but a structured document written in
wrapped prose still fails half the time. The reporter's "file with headings" is
almost certainly one long line per paragraph.

## Why the suite could not catch it

Worth stating plainly, because the number looks good:

**`previewAnchorRestore.test.ts` scores `findAnchorElement 300/300 (100%)` on both
fixtures, and always did.** Resolution genuinely succeeds. The element it resolves
to simply cannot say where it is. There is no tolerated miss rate here — this is a
regression hiding behind a perfect metric.

Two gaps let it through. `scripts/renderProtocolDom.ts` models no layout at all —
`grep -rn offsetTop scripts/` returns nothing, so `getAnchorScrollTop` had only ever
been exercised with hand-written numbers. And `DocumentBuilder` never emits a
`<br data-sourcepos>`, so the failing shape was not in the corpus, even though the
recorded real output in `renderProtocolFixtures.ts` contains it.

## The fix

`BOXLESS_TAGS = new Set(['BR', 'WBR'])`, an `isAnchorable()` predicate, one clause in
`elementChildren`, one optional `tagName` on `AnchorNode`. Skipping the `<br>` lets
`search` fall through to the `carried` match — the enclosing `<p>` — which is what
the interpolation in `getAnchorScrollTop` was built for in the first place.

```
after: text-only 0/40 to top, worst drift 15 px
       headings  0/40 to top, worst drift −42 px
```

The test adds a `wrappedParagraph()` builder emitting the recorded hardbreak shape,
and asserts the structural invariant per line rather than by sampling: **the resolver
may only return an element that generates a box.** Reverting the fix with the tests
kept gives `300/450 anchor lines resolved to a boxless element`, 2 red, and all 8
pre-existing tests still green.

## Verification

    npm test        679 / 679
    npm run check   0 errors
    cargo test      unaffected
    npm audit       0 vulnerabilities

**Measured in headless Chrome, not in the app.** The preview's box was reproduced
from `src/styles.css` plus the component-scoped rules, driving the real
`getPreviewScrollAnchor` and `previewAnchor.ts` over real comrak → real
`processMarkdownHtml` output. Only Blink was measured; a `<br>` having no principal
box follows from CSSOM and I would expect the same in WKWebView and WebView2, but I
did not verify either.
