### PR TITLE
fix(export): let the exported HTML follow the preview's max width

### DIFF
--- a/scripts/exportContentWidth.test.ts
+++ b/scripts/exportContentWidth.test.ts
@@ -1,0 +1,381 @@
+/**
+ * #467: "Is there a way how to change the width of exported HTML?" — there was
+ * not. The exporter wrote `max-width: 900px` into every file it produced, which
+ * is neither the user's Preview → Max width (#346–#349, renamed in #456) nor
+ * even the app's own default of 880.
+ *
+ * Everything below resolves the stylesheet the export actually emits, rather
+ * than matching on the source of the template that emits it. A test that
+ * grepped `export.ts` for a width would stay green with the value going
+ * nowhere: the declaration only means something once it is inside the `<style>`
+ * block of a built document, attached to a selector the exported `<article
+ * class="markdown-body">` matches, and last in the cascade. The last two tests
+ * run the real `exportAsHtml` end to end and read the bytes it hands to
+ * `save_file_content`, on the harness `exportRichContent.test.ts` established.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+	DEFAULT_PREVIEW_MAX_WIDTH,
+	getPreviewContentWidth,
+	MAX_PREVIEW_MAX_WIDTH,
+	MIN_PREVIEW_MAX_WIDTH,
+} from '../src/lib/utils/previewWidth.js';
+import { installShimDom } from './renderProtocolDom.ts';
+import { functionSource, readSource } from './sourceTree.js';
+
+// The shim has to be in place before `export.ts` is evaluated, so the module is
+// imported dynamically here exactly as it is in `exportRichContent.test.ts`.
+installShimDom();
+(globalThis as any).window = globalThis;
+(globalThis as any).location = { href: 'http://tauri.localhost/' };
+
+const DOMPurify = (await import('dompurify')).default as any;
+// Without a real DOM the filter is a no-op object; what it does and where it
+// sits in the pipeline is `exportSanitize.test.ts`'s subject, not this file's.
+DOMPurify.sanitize = (html: string) => html;
+
+const { buildExportDocument, exportAsHtml, exportContentMaxWidth } = await import('../src/lib/utils/export.ts');
+
+const appStyles = readSource(new URL('../src/styles.css', import.meta.url));
+const viewerSource = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
+
+type Rule = { selectors: string[]; declarations: string; media: 'screen' | 'print' };
+type Declaration = { value: string; important: boolean };
+
+function stripComments(css: string): string {
+	return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+/**
+ * Flattens a stylesheet into rules, remembering whether each one is inside a
+ * print block. Brace-aware rather than regex-per-rule, because the sheet under
+ * test is the app's real one: `@media`, `@supports` and `@font-face` all nest.
+ */
+function parseRules(css: string, media: Rule['media'] = 'screen'): Rule[] {
+	const rules: Rule[] = [];
+	let index = 0;
+
+	while (index < css.length) {
+		const open = css.indexOf('{', index);
+		if (open === -1) break;
+		const prelude = css.slice(index, open).trim();
+
+		let depth = 0;
+		let close = open;
+		for (; close < css.length; close += 1) {
+			if (css[close] === '{') depth += 1;
+			else if (css[close] === '}') {
+				depth -= 1;
+				if (depth === 0) break;
+			}
+		}
+		if (close >= css.length) break;
+
+		const body = css.slice(open + 1, close);
+		if (prelude.startsWith('@')) {
+			if (/^@(?:media|supports|layer|container)\b/.test(prelude)) {
+				rules.push(...parseRules(body, /\bprint\b/.test(prelude) ? 'print' : media));
+			}
+		} else if (prelude) {
+			rules.push({ selectors: prelude.split(',').map((s) => s.trim()), declarations: body, media });
+		}
+
+		index = close + 1;
+	}
+
+	return rules;
+}
+
+/** The `<style>` block of a built export, comments removed. */
+function exportedStylesheet(document_: string): string {
+	const match = document_.match(/<style>([\s\S]*?)<\/style>/);
+	assert.ok(match, 'the export must carry a stylesheet');
+	return stripComments(match[1]);
+}
+
+/** Every `property` declared for a bare `.markdown-body`, in cascade order. */
+function declarationsFor(css: string, property: string, media: Rule['media']): Declaration[] {
+	const found: Declaration[] = [];
+	for (const rule of parseRules(css)) {
+		if (rule.media !== media || !rule.selectors.includes('.markdown-body')) continue;
+		for (const piece of rule.declarations.split(';')) {
+			const colon = piece.indexOf(':');
+			if (colon === -1) continue;
+			if (piece.slice(0, colon).trim().toLowerCase() !== property) continue;
+			let value = piece.slice(colon + 1).trim();
+			const important = /!important$/i.test(value);
+			if (important) value = value.replace(/!important$/i, '').trim();
+			found.push({ value, important });
+		}
+	}
+	return found;
+}
+
+/**
+ * What an exported `<article class="markdown-body">` is actually capped at.
+ *
+ * All the candidates have identical specificity (one class, no `!important`
+ * among them today), so the winner is the last one in the sheet — which is what
+ * makes this worth resolving rather than reading off the template: the export's
+ * own rules are appended *after* the app's copied stylesheet, and a future
+ * `.markdown-body { max-width: … }` added anywhere below would take the file
+ * back off the setting without touching `export.ts` at all.
+ */
+function exportedMaxWidth(contentWidth: number | null, styles = ''): string {
+	const document_ = buildExportDocument({
+		theme: 'light',
+		title: 'Notes',
+		styles,
+		articleHtml: '<p>body</p>',
+		contentWidth,
+	});
+	const declared = declarationsFor(exportedStylesheet(document_), 'max-width', 'screen');
+	assert.ok(declared.length >= 1, 'the export must cap .markdown-body');
+	const important = declared.filter((d) => d.important);
+	return (important.length ? important : declared).at(-1)!.value;
+}
+
+test('the exported file is capped at the width the preview was reading at', () => {
+	// The whole of #467, stated as the four corners of the setting plus the
+	// default. Each one is a real document built by the real template.
+	for (const width of [MIN_PREVIEW_MAX_WIDTH, 720, DEFAULT_PREVIEW_MAX_WIDTH, 1240, MAX_PREVIEW_MAX_WIDTH]) {
+		assert.equal(exportedMaxWidth(width), `${width}px`, `an export made at ${width} must cap at ${width}`);
+	}
+
+	// And the number it used to ship regardless is gone from the artefact.
+	const document_ = buildExportDocument({
+		theme: 'light',
+		title: 'Notes',
+		styles: '',
+		articleHtml: '<p>body</p>',
+		contentWidth: DEFAULT_PREVIEW_MAX_WIDTH,
+	});
+	assert.doesNotMatch(document_, /max-width:\s*900px/);
+});
+
+test('changing the setting changes the file that comes out', () => {
+	// The claim the reporter cares about is not "some width is emitted" but
+	// "moving the setting moves the export", so two exports of the same document
+	// at two widths have to differ, and differ only there.
+	const narrow = exportedMaxWidth(getPreviewContentWidth(700, false));
+	const wide = exportedMaxWidth(getPreviewContentWidth(1400, false));
+	assert.equal(narrow, '700px');
+	assert.equal(wide, '1400px');
+	assert.notEqual(narrow, wide);
+
+	// Same source of truth as the preview: whatever `getPreviewContentWidth`
+	// hands `--preview-max-width` is what the exported cap is built from, for
+	// every combination of stored value and full-width state.
+	for (const stored of [MIN_PREVIEW_MAX_WIDTH, 880, 1000, MAX_PREVIEW_MAX_WIDTH]) {
+		for (const isFullWidth of [false, true]) {
+			const contentWidth = getPreviewContentWidth(stored, isFullWidth);
+			assert.equal(
+				exportedMaxWidth(contentWidth),
+				isFullWidth ? 'none' : `${stored}px`,
+				`stored ${stored}, full-width ${isFullWidth}`,
+			);
+		}
+	}
+});
+
+test('a full-width export is uncapped, still padded and still centred', () => {
+	// `getPreviewContentWidth` returns null for full-width mode, and in a
+	// standalone file that means "no cap": `none` rather than the preview's
+	// `100%`. The two are equivalent for a block child of <body>, but `none` does
+	// not depend on that reasoning and cannot interact with `box-sizing`.
+	assert.equal(getPreviewContentWidth(1200, true), null);
+	assert.equal(exportedMaxWidth(null), 'none');
+
+	// The rest of the layout has to survive the cap being removed: `margin: 0
+	// auto` now has no slack to distribute (which is correct — that is what
+	// full-width means), and the padding is what still holds the text off the
+	// window edge.
+	const css = exportedStylesheet(
+		buildExportDocument({ theme: 'light', title: 'Notes', styles: '', articleHtml: '<p>body</p>', contentWidth: null }),
+	);
+	assert.deepEqual(declarationsFor(css, 'margin', 'screen'), [{ value: '0 auto', important: false }]);
+	assert.deepEqual(declarationsFor(css, 'padding', 'screen'), [{ value: '40px', important: true }]);
+});
+
+test('a corrupted stored width is clamped instead of reaching the stylesheet raw', () => {
+	// `previewMaxWidth` is restored from localStorage, so the value arriving here
+	// is only as trustworthy as that key. The export is where it stops being a
+	// number and becomes a CSS declaration, so it is normalized at that seam too
+	// — a hand-edited key must not be able to write its own rules.
+	const hostile: [unknown, string][] = [
+		[99999, `${MAX_PREVIEW_MAX_WIDTH}px`],
+		[-40, `${MIN_PREVIEW_MAX_WIDTH}px`],
+		[0, `${MIN_PREVIEW_MAX_WIDTH}px`],
+		['1e9', `${MAX_PREVIEW_MAX_WIDTH}px`],
+		['not-a-number', `${DEFAULT_PREVIEW_MAX_WIDTH}px`],
+		['900px; } body { display: none; } .x {', `${DEFAULT_PREVIEW_MAX_WIDTH}px`],
+		[Number.NaN, `${DEFAULT_PREVIEW_MAX_WIDTH}px`],
+		[Number.POSITIVE_INFINITY, `${DEFAULT_PREVIEW_MAX_WIDTH}px`],
+		[921.8, '922px'],
+	];
+
+	for (const [stored, expected] of hostile) {
+		const contentWidth = getPreviewContentWidth(stored, false);
+		assert.equal(exportedMaxWidth(contentWidth), expected, `stored ${JSON.stringify(stored)}`);
+
+		// Nothing that arrived as a string got out of the declaration.
+		const document_ = buildExportDocument({
+			theme: 'light',
+			title: 'Notes',
+			styles: '',
+			articleHtml: '<p>body</p>',
+			contentWidth,
+		});
+		assert.doesNotMatch(document_, /body \{ display: none/);
+		assert.equal(parseRules(exportedStylesheet(document_)).filter((r) => r.selectors.includes('body')).length, 1);
+	}
+
+	// Stated as a shape as well as a table, so a future value that is neither a
+	// clamped pixel count nor `none` cannot pass by being plausible.
+	for (const stored of hostile.map(([value]) => value).concat([null, '', undefined, {}, []])) {
+		assert.match(exportContentMaxWidth(getPreviewContentWidth(stored, false)), /^(?:6[4-9]\d|[7-9]\d\d|1[0-5]\d\d|1600)px$/);
+	}
+	assert.equal(exportContentMaxWidth(getPreviewContentWidth(undefined, true)), 'none');
+});
+
+test('the export cap loses to the print block, so the PDF route is unchanged', () => {
+	// `@media print` in styles.css already forces `.markdown-body` to
+	// `max-width: 100% !important` with its own .75in padding, and that block
+	// travels into the export with the rest of the sheet. Printing an exported
+	// file therefore never saw the 900px and must not start seeing the setting
+	// either — the two routes stay separate concerns.
+	const css = exportedStylesheet(exportDocumentWithAppStyles(MIN_PREVIEW_MAX_WIDTH));
+	const printed = declarationsFor(css, 'max-width', 'print');
+	assert.ok(printed.length >= 1, 'the print block must still cap .markdown-body');
+	assert.deepEqual(printed.at(-1), { value: '100%', important: true });
+	assert.deepEqual(declarationsFor(css, 'padding', 'print').at(-1), { value: '0.75in', important: true });
+});
+
+test('the app stylesheet copied into an export does not out-rank the cap', () => {
+	// The export appends its rules after the copied sheet, so with real styles in
+	// front of them the resolved screen cap still has to be the configured one.
+	// If it ever is not, the setting is dead again and this is where it shows.
+	assert.equal(exportedMaxWidth(1240, appStyles), '1240px');
+	assert.equal(exportedMaxWidth(null, appStyles), 'none');
+});
+
+function exportDocumentWithAppStyles(contentWidth: number | null): string {
+	return buildExportDocument({
+		theme: 'light',
+		title: 'Notes',
+		styles: appStyles,
+		articleHtml: '<p>body</p>',
+		contentWidth,
+	});
+}
+
+// ------------------------------------------------- the whole export, for real
+
+/**
+ * Runs `exportAsHtml` and returns the bytes it hands `save_file_content`.
+ *
+ * The stand-ins are the Tauri boundary (the save dialog, the comrak round trip,
+ * the write) and the rich-content libraries, all of which need either a real
+ * browser or a real backend. Everything between the `contentWidth` field and
+ * the finished file is Markpad's own code, running.
+ *
+ * `copiedStyles` stands for the app's stylesheets, which `exportAsHtml` reads
+ * out of `document.styleSheets` and copies in ahead of the export's own rules.
+ * It carries a decoy `.markdown-body { max-width: 900px }` so the run also
+ * answers "does the export's cap actually win the cascade" rather than merely
+ * "is it present in the file".
+ */
+async function exportedFile(contentWidth: number | null): Promise<string> {
+	let saved: { path: string; content: string } | null = null;
+
+	(globalThis as any).window.__TAURI_INTERNALS__ = {
+		convertFileSrc: (path: string) => `asset://localhost/${path}`,
+		invoke: async (command: string, args: any) => {
+			switch (command) {
+				case 'plugin:dialog|save':
+					return '/tmp/notes.html';
+				case 'render_markdown':
+					return '<h1>Notes</h1>\n<p>body</p>';
+				case 'save_file_content':
+					saved = { path: args.path, content: args.content };
+					return null;
+				default:
+					throw new Error(`unexpected command ${command}`);
+			}
+		},
+	};
+
+	const copiedStyles = ['.markdown-body { color: red; }', '.markdown-body { max-width: 900px; }'];
+	(globalThis as any).document.styleSheets = [
+		{ href: 'http://tauri.localhost/_app/immutable/assets/2.C6eSkZFI.css', cssRules: copiedStyles.map((cssText) => ({ cssText })) },
+	];
+
+	const result = await exportAsHtml({
+		rawContent: '# Notes\n',
+		tabTitle: 'Notes',
+		tabPath: '/documents/notes.md',
+		mermaidTheme: 'neutral',
+		libraries: {
+			hljs: { highlightElement() {} },
+			katex: { render() {} },
+			renderMathInElement() {},
+			mermaid: { initialize() {}, async render() { return { svg: '' }; } },
+		} as any,
+		contentWidth,
+	});
+
+	assert.equal(result?.path, '/tmp/notes.html', 'the export must have been written');
+	assert.ok(saved, 'save_file_content must have been called');
+	return (saved as unknown as { content: string }).content;
+}
+
+test('a real export writes a file capped at the configured width', async () => {
+	// End to end: the field on the context the component fills, through the
+	// renderer round trip, the sanitizer, the font pass and the copied
+	// stylesheet, to the bytes on disk.
+	for (const width of [MIN_PREVIEW_MAX_WIDTH, DEFAULT_PREVIEW_MAX_WIDTH, 1240, MAX_PREVIEW_MAX_WIDTH]) {
+		const file = await exportedFile(width);
+		assert.match(file, /<article class="markdown-body">/, 'the cap must apply to the element the export ships');
+		assert.equal(
+			declarationsFor(exportedStylesheet(file), 'max-width', 'screen').at(-1)!.value,
+			`${width}px`,
+			`an export made at ${width} must be readable at ${width}`,
+		);
+	}
+
+	// Full-width mode, likewise, all the way to the file.
+	assert.equal(
+		declarationsFor(exportedStylesheet(await exportedFile(null)), 'max-width', 'screen').at(-1)!.value,
+		'none',
+	);
+});
+
+test('a real export is not capped by a stale width in the copied stylesheet', async () => {
+	// The copied sheet in the harness declares `.markdown-body { max-width:
+	// 900px }` at the same specificity. The export's own rules are appended
+	// after it, so the file the reader opens is at the setting — which is the
+	// property that would break silently if the template ever moved.
+	const file = await exportedFile(1240);
+	assert.match(file, /max-width: 900px/, 'the decoy must really be in the copied sheet');
+	assert.equal(declarationsFor(exportedStylesheet(file), 'max-width', 'screen').at(-1)!.value, '1240px');
+});
+
+test('the exporter is handed the preview\'s own derived width', () => {
+	// The one link in the chain that cannot be executed here: `exportAsHtml`
+	// lives in a `.svelte` component, which the Node test runner cannot import
+	// (see sourceTree.ts). So the field is checked in the source of that one
+	// function — `functionSource` rather than a whole-file match, so a
+	// `contentWidth:` appearing anywhere else in a 3700-line component cannot
+	// satisfy it.
+	const exportCall = functionSource(viewerSource, 'exportAsHtml');
+	assert.match(exportCall, /contentWidth: previewContentWidth,/);
+
+	// And `previewContentWidth` is the same derived value the live preview
+	// renders with, which is what makes "one source of truth" true rather than
+	// merely intended. (previewWidth.test.ts holds the other end of this.)
+	assert.match(viewerSource, /previewContentWidth = \$derived\(getPreviewContentWidth\(settings\.previewMaxWidth, isFullWidth\)\)/);
+	assert.match(viewerSource, /--preview-max-width: \{previewContentWidth === null \? '100%' : `\$\{previewContentWidth\}px`\}/);
+});

--- a/scripts/exportFoldParity.test.ts
+++ b/scripts/exportFoldParity.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { buildExportDocument } from '../src/lib/utils/export.js';
+import { DEFAULT_PREVIEW_MAX_WIDTH } from '../src/lib/utils/previewWidth.js';
 import { readSource } from './sourceTree.js';
 
 const styles = readSource('src/styles.css');
@@ -222,7 +223,13 @@ const screenValue = (chain: Element[], property: string) => resolve(appRules, ch
 // what says whether the recipient can read a section — and in an exported file
 // there is no toggle and no script, so anything hidden is hidden for good.
 const exportedStyles = (() => {
-	const document_ = buildExportDocument({ theme: 'light', title: 'T', styles, articleHtml: '' });
+	const document_ = buildExportDocument({
+		theme: 'light',
+		title: 'T',
+		styles,
+		articleHtml: '',
+		contentWidth: DEFAULT_PREVIEW_MAX_WIDTH,
+	});
 	const match = document_.match(/<style>([\s\S]*)<\/style>/);
 	assert.ok(match, 'the export must carry a stylesheet');
 	return parseRules(stripComments(match[1]));

--- a/scripts/exportRichContent.test.ts
+++ b/scripts/exportRichContent.test.ts
@@ -49,6 +49,7 @@ const {
 	katexFontUrlsToEmbed,
 } = await import('../src/lib/utils/exportFonts.ts');
 const { exportAsHtml } = await import('../src/lib/utils/export.ts');
+const { DEFAULT_PREVIEW_MAX_WIDTH } = await import('../src/lib/utils/previewWidth.ts');
 const { renderRichContent } = await import('../src/lib/utils/richContent.ts');
 
 // ---------------------------------------------------------------- fixtures
@@ -184,6 +185,9 @@ async function runExport(
 		tabPath: '/documents/notes.md',
 		mermaidTheme: options.mermaidTheme ?? 'neutral',
 		libraries: fakeLibraries(record) as any,
+		// The width the preview was reading at, which the export follows (#467).
+		// Irrelevant to what this file asserts; `exportContentWidth.test.ts` owns it.
+		contentWidth: DEFAULT_PREVIEW_MAX_WIDTH,
 	});
 
 	return {

--- a/scripts/exportedThemeFidelity.test.ts
+++ b/scripts/exportedThemeFidelity.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { buildExportDocument, exportThemeAttribute } from '../src/lib/utils/export.js';
+import { DEFAULT_PREVIEW_MAX_WIDTH } from '../src/lib/utils/previewWidth.js';
 import { readSource } from './sourceTree.js';
 
 const styles = readSource('src/styles.css');
@@ -25,6 +26,7 @@ function build(theme: string | null | undefined, extra: Partial<{ styles: string
 		title: extra.title ?? 'Notes',
 		styles: extra.styles ?? '',
 		articleHtml: extra.articleHtml ?? '<p>body</p>',
+		contentWidth: DEFAULT_PREVIEW_MAX_WIDTH,
 	});
 }
 

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -1885,6 +1885,10 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			// so the diagrams have to be rendered for the same appearance.
 			mermaidTheme: currentMermaidTheme(),
 			libraries: richLibraries,
+			// The same value the live preview is wearing as `--preview-max-width`,
+			// so the exported file is read at the measure it was written at
+			// instead of the 900px the exporter used to hard-code (#467).
+			contentWidth: previewContentWidth,
 		});
 		if (result?.missingImages) {
 			addToast(`Exported HTML, but ${result.missingImages} local image(s) could not be embedded.`, 'warning');

--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -21,11 +21,20 @@ import {
 	inlineKatexFontFaces,
 	katexFontUrlsToEmbed,
 } from './exportFonts.js';
+import { normalizePreviewMaxWidth } from './previewWidth.js';
 
 interface ExportContext {
 	rawContent: string;
 	tabTitle: string;
 	tabPath: string;
+	/**
+	 * The cap the preview is currently reading at, i.e. the value
+	 * `getPreviewContentWidth(settings.previewMaxWidth, isFullWidth)` hands the
+	 * live `.markdown-body` as `--preview-max-width`. `null` is full-width mode.
+	 * The export follows it rather than carrying a width of its own — see
+	 * `exportContentMaxWidth`.
+	 */
+	contentWidth: number | null;
 	/**
 	 * Mermaid's theme name for the appearance this export is being made in.
 	 * Unlike the PDF route — paper is always white, so that one forces a light
@@ -121,6 +130,38 @@ export interface ExportDocumentInput {
 	styles: string;
 	/** The finished `.markdown-body` content. */
 	articleHtml: string;
+	/** See `ExportContext.contentWidth` and `exportContentMaxWidth`. */
+	contentWidth: number | null;
+}
+
+/**
+ * The `max-width` an exported `.markdown-body` is given.
+ *
+ * The export used to hard-code `900px`, which was nobody's number: not the
+ * user's Preview → Max width (#346–#349, renamed in #456), and not even the
+ * app's own default of 880. So a document read at 640 or at 1600 arrived at
+ * 900 regardless, and the setting that governs every other rendering of the
+ * same document silently stopped at the file dialog. It follows the setting
+ * now: one source of truth, and what leaves the app is the measure it was
+ * written and read at.
+ *
+ * `null` is full-width mode, and it becomes `none` rather than the preview's
+ * `100%`. The two are equivalent for this element — `.markdown-body` is a block
+ * child of `<body>`, so a percentage cap resolves to the width it already has —
+ * but `none` says the intended thing without depending on that reasoning, and
+ * it cannot interact with `box-sizing` the way a percentage can. `margin: 0
+ * auto` then centres nothing (there is no slack to distribute) and the
+ * `padding: 40px !important` still holds the text off the window edge, which is
+ * exactly how the preview behaves in full-width mode.
+ *
+ * The value is normalized here rather than trusted, because this is the seam
+ * where it stops being a number and becomes a CSS declaration: `previewMaxWidth`
+ * is restored from localStorage, and a corrupted or hand-edited key must not be
+ * able to interpolate itself raw into the exported stylesheet. An unusable value
+ * degrades to the app default the same way the preview's does.
+ */
+export function exportContentMaxWidth(contentWidth: number | null): string {
+	return contentWidth === null ? 'none' : `${normalizePreviewMaxWidth(contentWidth)}px`;
 }
 
 /**
@@ -148,7 +189,7 @@ html, body {
 }
 .markdown-body {
 	padding: 40px !important;
-	max-width: 900px;
+	max-width: ${exportContentMaxWidth(input.contentWidth)};
 	margin: 0 auto;
 	height: auto !important;
 	overflow: visible !important;
@@ -404,6 +445,7 @@ export async function exportAsHtml(ctx: ExportContext): Promise<ExportHtmlResult
 		title: ctx.tabTitle,
 		styles,
 		articleHtml: article.root.innerHTML,
+		contentWidth: ctx.contentWidth,
 	});
 
 	try {


### PR DESCRIPTION
Closes #467.

@Haiulus asked whether the width of the exported HTML can be changed. Today it cannot: `buildExportDocument` writes `.markdown-body { max-width: 900px }` into every file the export produces.

## What 900 was

Nothing, as far as the rest of the app is concerned. **Preview → Max width** has existed since #346–#349 (renamed to *Max width* in #456): bounded 640–1600, default **880**, persisted, with widen/narrow shortcuts and a modified-row indicator in Settings. The export ignored it and shipped 900 — not the user's choice, and not even the app's own default. That reads like an oversight rather than a decision, which is why this is a fix and not a feature.

## What changed

`exportAsHtml` in `MarkdownViewer.svelte` already had the value in hand: `previewContentWidth`, i.e. `getPreviewContentWidth(settings.previewMaxWidth, isFullWidth)` — the same derived value that becomes `--preview-max-width` on the article the user is looking at. It is now one more field on the export context, and `buildExportDocument` interpolates it where the constant used to be. One source of truth; what leaves the app is the measure it was read at.

**Full width → `max-width: none`.** `getPreviewContentWidth` returns `null` for full-width mode. In a standalone file that means "no cap". The preview spells the same thing `100%`, and for this element the two are equivalent — `.markdown-body` is a block child of `<body>`, so a percentage cap resolves to the width it already has — but `none` states the intention without depending on that reasoning and cannot interact with `box-sizing`. Confirmed on a real exported file in a browser: the column follows the window, `margin: 0 auto` simply has no slack left to distribute, and `padding: 40px !important` still holds the text off the window edge.

**Normalized at the seam.** The value goes through `normalizePreviewMaxWidth` inside `exportContentMaxWidth`, because that is where it stops being a number and becomes a CSS declaration. `previewMaxWidth` is restored from localStorage; a corrupted or hand-edited key must not be able to write its own rules into the exported stylesheet. Out of range clamps, unparseable degrades to the default — exactly as the preview does.

**Nothing else used the 900.** The only other occurrences in the repo are unrelated (a `scrollTop` fixture, an out-of-range font size in a persistence test, a `stroke-dashoffset` inside a captured Mermaid SVG).

**The print/PDF route is untouched, and now provably so.** `@media print` in `styles.css` already forces `.markdown-body` to `max-width: 100% !important` with its own `.75in` padding, and that block travels into the export with the rest of the sheet. Printing an exported file therefore never saw the 900 and does not see the setting either. There is a test for it, so the two routes staying separate concerns is pinned rather than assumed.

## The design call — follow the setting, or add a second one?

This is a real question and I would rather put it to you than pretend it is not.

**For following the preview width** (what this PR does): no new UI, no new i18n keys, one source of truth, and what you export matches what you were reading.

**For a separate export-only width**: an exported file is read on someone else's screen. An author's editing measure is not necessarily their publishing measure, and someone who reads narrow but publishes wide is not being unreasonable.

The reason I came down on "follow" anyway is that the escape hatch is already excellent. The export is a self-contained single HTML file with its `<style>` inline — anyone who wants a different width edits **one line in the file they just produced**. Adding a second width control to Settings, with its own label, its own translations, its own modified-row logic and its own reset, for something that is a one-line edit downstream, is not a good trade against the existing surface.

If you would rather have the separate setting, say so and I will add it — the plumbing here is the same either way, it just reads from a different field.

**Workaround for @Haiulus in the meantime**: open the exported `.html`, find `.markdown-body { … max-width: … }` in the `<style>` block near the top, and change that one value. The stylesheet is inline, so nothing else has to be touched and the file stays self-contained.

## Tests

`scripts/exportContentWidth.test.ts` (9 tests). They resolve the stylesheet the export **actually emits** rather than matching the template that emits it — a declaration only means something once it is inside the `<style>` block, attached to a selector the shipped `<article class="markdown-body">` matches, and last in the cascade.

- the exported cap is the configured one, at both bounds, the default and two values in between
- changing the setting changes the file, and the emitted cap matches `getPreviewContentWidth` for every combination of stored value and full-width state
- full width emits `none`, and the padding and centring survive it
- a corrupted stored value (`99999`, `-40`, `'1e9'`, `'900px; } body { display: none; } .x {'`, `NaN`, `Infinity`) is clamped or defaulted, never interpolated raw — asserted both as a table and as a shape, so a future value that is neither a clamped pixel count nor `none` cannot pass by looking plausible
- the export's cap loses to the `@media print` block, so the PDF route is unchanged
- the app's copied stylesheet does not out-rank the export's own rule

Two of the nine run **the real `exportAsHtml` end to end**, on the harness `exportRichContent.test.ts` established (Tauri boundary and the rich-content libraries stubbed, everything in between running), and read the bytes handed to `save_file_content`. One of them plants a decoy `.markdown-body { max-width: 900px }` in the copied stylesheet, so the run answers "does the export's cap win the cascade" and not merely "is the number in the file".

The one link that genuinely cannot be executed under the Node runner is the call site itself — it is in a `.svelte` component, which the runner cannot import (`scripts/sourceTree.ts` explains why). That one is checked against the source of that single function via `functionSource`, not a whole-file match, so a `contentWidth:` appearing anywhere else in a 3700-line component cannot satisfy it.

**Falsification.** Reverting the template to `max-width: 900px` and keeping the tests turns 7 of the 9 red, naming the actual problem:

```
✖ the exported file is capped at the width the preview was reading at
  AssertionError: an export made at 640 must cap at 640
  '900px' !== '640px'

✖ a real export writes a file capped at the configured width
  AssertionError: an export made at 640 must be readable at 640
  '900px' !== '640px'

✖ a full-width export is uncapped, still padded and still centred
  '900px' !== 'none'

ℹ tests 9 | pass 2 | fail 7
```

The two that stay green under that revert are the print-block test (correct — that path is unaffected) and the call-site test (correct — the wiring was not what was reverted). Reverting only the `MarkdownViewer.svelte` wiring instead inverts it exactly: 8 pass, and the call-site test alone fails.

## Verification

`npm audit` (0 vulnerabilities), `npm run check` (645 files, 0 errors), `npm test` (692 pass), and `cargo test` in `src-tauri/` (157 pass) — what `.github/workflows/test.yml` runs.

Beyond that, I drove the real `exportAsHtml` with the real `src/styles.css` to produce four actual export files (640, 880, 1600, full width) and opened them in a browser at a 1440px viewport. Measured: the 640 file lays out at 720px wide (640 + 2×40 padding), centred at x=360; the 880 file at 960px, centred at x=240; the full-width file fills the viewport with no horizontal overflow, and reflows to 700px when the window is narrowed to 700. Screenshot confirms the 640 file renders centred and correctly measured.

I did not export from a running Tauri build — the export path was driven directly rather than through the app's file dialog.
