### PR TITLE
fix(editor): give each tab its own Monaco model so undo survives a switch

### DIFF
--- a/scripts/editorOptionWiring.test.ts
+++ b/scripts/editorOptionWiring.test.ts
@@ -212,15 +212,19 @@ function createdEditorOptions(): Record<string, unknown> {
 		compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ESNext },
 	}).outputText;
 
-	// The literal closes over four locals. None of them can reach
+	// The literal closes over five locals. None of them can reach
 	// `unicodeHighlight`, which is a constant, so they are stubbed rather than
 	// reconstructed — the settings proxy answers undefined for every key, which
-	// is enough to let the object build.
-	return new Function('settings', 'value', 'language', 'getTheme', `return ${js};`)(
+	// is enough to let the object build. `documentOptions` is the spread that
+	// hands the editor the active tab's model (or `value`/`language` when there
+	// is no tab); an empty object is the right stub because nothing it can
+	// contain is an option this file asserts on.
+	return new Function('settings', 'value', 'language', 'getTheme', 'documentOptions', `return ${js};`)(
 		new Proxy({}, { get: () => undefined }),
 		'',
 		'markdown',
 		() => 'app-theme-dark',
+		{},
 	) as Record<string, unknown>;
 }
 

--- a/scripts/imageUndoKeepsFile.test.ts
+++ b/scripts/imageUndoKeepsFile.test.ts
@@ -141,6 +141,7 @@ function createDocument(initial: string) {
 			getValue: () => buffer,
 			getValueInRange: (range: FakeRange) => buffer.slice(range.startColumn - 1, range.endColumn - 1),
 			getLineContent: () => buffer,
+			getLanguageId: () => 'markdown',
 		}),
 		getPosition: () => ({ lineNumber: 1, column: buffer.length + 1 }),
 		getSelection: () => null,
@@ -230,6 +231,13 @@ const factorySource = ts.transpileModule(
 	`const __component = (invoke, settings, tabManager, monaco, editor) => {
 		let value = '';
 		let wordCount = 0;
+		let currentLanguage = 'markdown';
+
+		// The status-bar refresh the content-change listener calls. Lifted from
+		// the component rather than stubbed, so the listener under test runs
+		// exactly the statements it runs in the app; nothing here asserts on
+		// what it writes.
+		${functionSource(source, 'syncStatusFromModel')}
 
 		// Reached only by the text-paste path, which no test here exercises.
 		const insertTextAtCursor = () => { throw new Error('text paste path not modelled'); };

--- a/scripts/undoHistoryPerTab.test.ts
+++ b/scripts/undoHistoryPerTab.test.ts
@@ -1,0 +1,792 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import ts from 'typescript';
+
+import { callbackBodies, functionSource, readSource } from './sourceTree.js';
+
+/*
+ * Undo history has to survive a tab switch (#391), and every model that is
+ * created has to be disposed.
+ *
+ * The defect: one Monaco editor, one implicit model, and a tab switch that
+ * overwrote it with `editor.setValue(content)`. `TextModel.setValue` is
+ * *defined* to throw the undo stack away — `_setValueFromTextBuffer` runs
+ * `this._commandManager.clear()` under the comment "Destroy my edit history and
+ * settings" — so leaving a document and coming back cost the user everything
+ * they could have undone.
+ *
+ * The fix is one `ITextModel` per tab, which is Monaco's intended usage and how
+ * VS Code works: the editor is a view, `setModel` swaps which document it shows,
+ * and undo belongs to the document. The price is lifetime: Monaco models are
+ * registered with the model service and are NOT garbage collected while
+ * registered, so a model whose tab is gone leaks its buffer, its tokenization
+ * state and its worker-side copy for the life of the window.
+ *
+ * WHAT RUNS HERE. The component's own tab-activation `$effect`, its
+ * `acquireTabModel`, its `onDidChangeModelContent` listener and its exported
+ * `undo` are lifted out of Editor.svelte and evaluated over one scope, against
+ * the REAL `TabManager` and the REAL model registry (`utils/tabModels.ts`).
+ * Only Monaco itself is a fake — a `.svelte` file cannot be imported by the Node
+ * test runner and Monaco needs a DOM — and the fake reproduces the two
+ * semantics the whole question turns on, both read out of the bundled 0.55.1
+ * source and cited at `FakeModel` below: `setValue` clears the undo stack,
+ * `setModel` does not.
+ *
+ * WHAT IT DOES NOT ESTABLISH: rendering, focus, Svelte's scheduling, or that
+ * Monaco's real undo stack behaves as its source says. It establishes what the
+ * component does when its handlers run.
+ */
+
+// ---------------------------------------------------------------- environment
+// Svelte runes and the Tauri bridge, faked as windowTagEditor.ts does, so
+// `tabs.svelte.ts` imports under plain node.
+
+const g = globalThis as any;
+const runeEffect = (fn: () => void) => {
+	void fn;
+};
+runeEffect.root = (fn: () => unknown) => fn();
+g.$state = (value: unknown) => value;
+g.$state.raw = (value: unknown) => value;
+g.$state.snapshot = (value: unknown) => value;
+g.$derived = (value: unknown) => value;
+g.$derived.by = (fn: () => unknown) => fn();
+g.$effect = runeEffect;
+g.window = g.window ?? {};
+
+const localStore = new Map<string, string>();
+g.localStorage = {
+	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
+	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
+	removeItem: (key: string) => void localStore.delete(key),
+	clear: () => localStore.clear(),
+};
+g.window.__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { getTabModel, tabModelUri, trackedTabModelIds } = await import('../src/lib/utils/tabModels.js');
+const { buildTransferredTab } = await import('../src/lib/utils/tabTransfer.js');
+
+// ------------------------------------------------- the component, as written
+
+const EDITOR = 'src/lib/components/Editor.svelte';
+const source = readSource(EDITOR);
+
+/**
+ * The tab-activation effect — the one that files a view state under the tab it
+ * is leaving. Identified by what it does rather than by its position in the
+ * file, and pinned to exactly one so a split or a merge fails here loudly
+ * instead of quietly running half the code.
+ */
+const activationEffectBody = (() => {
+	const bodies = callbackBodies(source, '$effect').filter((body) => body.includes('updateTabEditorState'));
+	assert.equal(bodies.length, 1, `expected exactly one tab-activation $effect in ${EDITOR}, found ${bodies.length}`);
+	return bodies[0];
+})();
+
+const contentChangeBody = (() => {
+	const bodies = callbackBodies(source, 'editor.onDidChangeModelContent');
+	assert.equal(bodies.length, 1, `expected exactly one model-content listener in ${EDITOR}, found ${bodies.length}`);
+	return bodies[0];
+})();
+
+/**
+ * The one function bound to `name`, or `fallback` when the component has no
+ * such function.
+ *
+ * The fallback exists for the falsification run, and it is what makes that run
+ * worth anything. Reverting the fix deletes `acquireTabModel`; asserting on its
+ * presence here would turn every test in this file red with the same structural
+ * message, and none of them would then be evidence about undo. A component that
+ * never acquires a per-tab model behaves exactly like one whose acquire does
+ * nothing — so that is what it is given, and each test fails on its own claim.
+ * Same reasoning as `runnable` in windowTagEditor.ts.
+ */
+function lifted(name: string, fallback: string): string {
+	try {
+		return functionSource(source, name);
+	} catch {
+		return fallback;
+	}
+}
+
+// ------------------------------------------------------------------ the fakes
+
+/**
+ * A Monaco text model, with the two behaviours this file is about.
+ *
+ * `setValue` clearing the undo stack is not an approximation — it is what the
+ * bundled Monaco does, and the reason #391 exists:
+ *
+ *     _setValueFromTextBuffer(textBuffer, …) {
+ *         …
+ *         // Destroy my edit history and settings
+ *         this._commandManager.clear();
+ *
+ * (monaco-editor@0.55.1, esm/vs/editor/common/model/textModel.js). `setModel`
+ * has no such line: it detaches one document and attaches another, and each
+ * keeps its own `_commandManager`.
+ *
+ * A model is registered under its URI and `createModel` throws on a duplicate,
+ * as Monaco's model service does — which is what makes the "two tabs never
+ * collide" claim below a real test rather than a restatement of the code.
+ */
+class FakeModel {
+	private buffer: string;
+	private undoStack: string[] = [];
+	private redoStack: string[] = [];
+	private disposed = false;
+
+	constructor(
+		readonly uri: string,
+		value: string,
+		private language: string,
+		private readonly onDispose: (model: FakeModel) => void,
+	) {
+		this.buffer = value;
+	}
+
+	getValue() {
+		this.assertLive();
+		return this.buffer;
+	}
+
+	setValue(value: string) {
+		this.assertLive();
+		this.buffer = value;
+		// "Destroy my edit history and settings" — TextModel._setValueFromTextBuffer.
+		this.undoStack = [];
+		this.redoStack = [];
+	}
+
+	getLanguageId() {
+		return this.language;
+	}
+
+	setLanguage(language: string) {
+		this.language = language;
+	}
+
+	isDisposed() {
+		return this.disposed;
+	}
+
+	dispose() {
+		this.disposed = true;
+		this.onDispose(this);
+	}
+
+	// --- test-side document mutation, not part of the ITextModel surface ---
+
+	/** A user edit: the kind of change that goes on the undo stack. */
+	edit(value: string) {
+		this.assertLive();
+		this.undoStack.push(this.buffer);
+		this.redoStack = [];
+		this.buffer = value;
+	}
+
+	undo() {
+		this.assertLive();
+		const previous = this.undoStack.pop();
+		if (previous === undefined) return false;
+		this.redoStack.push(this.buffer);
+		this.buffer = previous;
+		return true;
+	}
+
+	undoDepth() {
+		return this.undoStack.length;
+	}
+
+	private assertLive() {
+		// Monaco's `_assertNotDisposed`. A disposed model handed back to the
+		// editor is a crash in the app, so it must be one here too.
+		assert.ok(!this.disposed, `model ${this.uri} was used after dispose()`);
+	}
+}
+
+/** Every model this run has built, disposed or not — the leak ledger. */
+let createdModels: FakeModel[] = [];
+/** URI → model, standing in for Monaco's model service registry. */
+let registeredModels = new Map<string, FakeModel>();
+
+const monacoStub = {
+	Uri: { parse: (uri: string) => uri },
+	editor: {
+		createModel(value: string, language: string, uri: string) {
+			assert.ok(
+				!registeredModels.has(uri),
+				`Monaco refuses a second model on the URI ${uri} — two tabs must never share one`,
+			);
+			const model = new FakeModel(uri, value, language, (m) => registeredModels.delete(m.uri));
+			registeredModels.set(uri, model);
+			createdModels.push(model);
+			return model;
+		},
+		setModelLanguage(model: FakeModel, language: string) {
+			model.setLanguage(language);
+		},
+	},
+};
+
+type ViewState = { marker: string } | null;
+
+/**
+ * The editor as a VIEW onto whichever model is attached, which is the shape the
+ * fix depends on. `getValue`/`setValue` delegate to the attached model exactly
+ * as `CodeEditorWidget` does (`this._modelData.model.setValue(newValue)`), and
+ * both answer for a detached editor the way it does: `''`, and nothing.
+ */
+function createEditorStub() {
+	// The editor starts attached to a model it built for itself — what
+	// `monaco.editor.create(container, { value, language })` does, and what "one
+	// implicit model shared by every tab" IS. Whether a tab's own model ever
+	// replaces it is the question under test, so the harness must not assume one
+	// is there. Built directly rather than through `monaco.editor.createModel`
+	// so it stays out of the leak ledger: this one belongs to the editor and
+	// goes with it, which is the one case Monaco disposes for you.
+	let model: FakeModel | null = new FakeModel('inmemory://markpad/editor-owned', '', 'markdown', () => {});
+	let viewState: ViewState = null;
+	const restored: ViewState[] = [];
+	const contentListeners: (() => void)[] = [];
+
+	// Monaco raises a content change for every mutation of the attached model,
+	// `setValue` included (it is emitted as a flush). Modelling that matters:
+	// it is how an undo reaches `tab.rawContent` at all, and leaving it out
+	// would let the editor and the document disagree with nothing to notice.
+	const dispatch = () => {
+		for (const listener of contentListeners) listener();
+	};
+
+	return {
+		restored,
+		getModel: () => model,
+		setModel: (next: FakeModel | null) => void (model = next),
+		getValue: () => (model ? model.getValue() : ''),
+		setValue: (value: string) => {
+			if (!model) return;
+			model.setValue(value);
+			dispatch();
+		},
+		saveViewState: () => viewState,
+		restoreViewState: (state: ViewState) => void restored.push(state),
+		setScrollTop: () => {},
+		setPosition: () => {},
+		focus: () => {},
+		trigger: (_source: string, command: string) => {
+			if (command === 'undo' && model?.undo()) dispatch();
+		},
+		/** Test-side: the component's `onDidChangeModelContent` registration. */
+		onContentChange: (listener: () => void) => void contentListeners.push(listener),
+		/** Test-side: a user edit in the attached document. */
+		edit: (text: string) => {
+			assert.ok(model, 'precondition: a document is attached');
+			model!.edit(text);
+			dispatch();
+		},
+		/** Test-side: mark the view state so a restore can be identified. */
+		markViewState: (marker: string) => void (viewState = { marker }),
+	};
+}
+
+// ----------------------------------------------------------------- the harness
+
+type Editor = ReturnType<typeof createEditorStub>;
+
+type Component = {
+	/** The tab-activation effect, run the way Svelte would run it. */
+	activate: () => void;
+	/** The `onDidChangeModelContent` listener. */
+	contentChanged: () => void;
+	/** The component's exported undo. */
+	undo: () => void;
+	acquireTabModel: (tabId: string, seed: string, language: string) => FakeModel | null;
+	setLanguage: (language: string) => void;
+	/** Svelte's `bind:value={tabManager.activeTab.rawContent}`, by hand. */
+	syncBoundValue: () => void;
+	value: () => string;
+	currentTabId: () => string | null;
+	currentLanguage: () => string;
+	wordCount: () => number;
+};
+
+/**
+ * The lifted code is TypeScript (`function acquireTabModel(tabId: string, …)`)
+ * and `new Function` only parses JavaScript, so it goes through `tsc` first —
+ * as imageUndoKeepsFile.test.ts and foldStatePerDocument.test.ts already do.
+ * Types are erased, nothing else: the statements that run are the component's.
+ */
+const factorySource = ts.transpileModule(
+	`const __component = (tabManager, monaco, editor, getTabModel, tabModelUri) => {
+		let value = '';
+		let currentTabId = null;
+		let language = 'markdown';
+		let currentLanguage = 'markdown';
+		let wordCount = 0;
+		const editorReady = true;
+
+		${lifted('syncStatusFromModel', 'function syncStatusFromModel() {}')}
+		${lifted('acquireTabModel', 'function acquireTabModel() { return null; }')}
+		// The component binds undo to an arrow function, so what comes back is
+		// the expression rather than a declaration: it needs its own binding.
+		const undo = ${lifted('undo', '() => {}')};
+
+		return {
+			activate: () => ${activationEffectBody},
+			contentChanged: () => ${contentChangeBody},
+			undo,
+			acquireTabModel,
+			setLanguage: (next) => { language = next; },
+			syncBoundValue: () => { value = tabManager.activeTab ? tabManager.activeTab.rawContent : ''; },
+			value: () => value,
+			currentTabId: () => currentTabId,
+			currentLanguage: () => currentLanguage,
+			wordCount: () => wordCount,
+		};
+	};`,
+	{ compilerOptions: { target: ts.ScriptTarget.ES2022 } },
+).outputText;
+
+function createComponent(editor: Editor): Component {
+	const factory = new Function(`${factorySource}\nreturn __component;`)() as (
+		tabManager: unknown,
+		monaco: unknown,
+		editor: unknown,
+		getTabModel: unknown,
+		tabModelUri: unknown,
+	) => Component;
+
+	return factory(tabManager, monacoStub, editor, getTabModel, tabModelUri);
+}
+
+type Harness = {
+	editor: Editor;
+	component: Component;
+	/** Open a tab and return its id. */
+	open: (path: string, content: string) => string;
+	/** Activate a tab the way the app does: set active, re-bind, run the effect. */
+	show: (tabId: string) => void;
+	/** A keystroke in the attached document, propagated as Monaco would. */
+	type: (text: string) => void;
+	/** The text the user sees. */
+	text: () => string;
+	modelOf: (tabId: string) => FakeModel | undefined;
+};
+
+function setup(): Harness {
+	tabManager.closeAll();
+	createdModels = [];
+	registeredModels = new Map();
+
+	const editor = createEditorStub();
+	const component = createComponent(editor);
+	editor.onContentChange(component.contentChanged);
+
+	const show = (tabId: string) => {
+		tabManager.setActive(tabId);
+		component.syncBoundValue();
+		component.activate();
+	};
+
+	return {
+		editor,
+		component,
+		open: (path, content) => {
+			tabManager.addTab(path, content);
+			return tabManager.activeTabId!;
+		},
+		show,
+		type: (text: string) => editor.edit(editor.getValue() + text),
+		text: () => editor.getValue(),
+		modelOf: (tabId: string) => registeredModels.get(tabModelUri(tabId)),
+	};
+}
+
+/**
+ * The lifetime invariant, stated once: no model outlives its tab, and no model
+ * is alive outside the registry that is supposed to be reaping it.
+ *
+ * Two claims, because either alone is satisfiable by a broken implementation. A
+ * registry that only holds live tabs proves nothing if models are also created
+ * behind its back; a ledger of disposed models proves nothing if the registry
+ * still points at them.
+ *
+ * `expectModels` is the vacuity guard. Every assertion below is trivially true
+ * for a run that never built a model, which is precisely the state a broken
+ * `acquireTabModel` produces — so each caller says how many it expects to have
+ * seen.
+ */
+function assertNoModelOutlivesItsTab(expectModels: number, context: string) {
+	assert.equal(createdModels.length, expectModels, `${context}: models built during this test`);
+
+	const tabIds = tabManager.tabs.map((tab) => tab.id);
+	const tracked = trackedTabModelIds();
+
+	assert.deepEqual(
+		tracked.filter((id) => !tabIds.includes(id)),
+		[],
+		`${context}: the registry still holds a model for a tab that is gone`,
+	);
+
+	const aliveUris = createdModels.filter((model) => !model.isDisposed()).map((model) => model.uri).sort();
+	const trackedUris = tracked.map((id) => tabModelUri(id)).sort();
+	assert.deepEqual(
+		aliveUris,
+		trackedUris,
+		`${context}: a model is still alive that nothing is tracking — it can never be disposed`,
+	);
+}
+
+// ------------------------------------------------------- the reported defect
+
+test('an edit can still be undone after switching to another tab and back', () => {
+	// #391, verbatim: "Switch to another tab and back, then press Ctrl/⌘+Z —
+	// the document's undo history is gone."
+	const h = setup();
+	const notes = h.open('/docs/notes.md', 'hello');
+	const other = h.open('/docs/other.md', 'elsewhere');
+
+	h.show(notes);
+	h.type(' world');
+	assert.equal(h.text(), 'hello world', 'precondition: the edit landed');
+
+	h.show(other);
+	h.show(notes);
+
+	h.component.undo();
+
+	assert.equal(
+		h.text(),
+		'hello',
+		'undo did nothing after a round trip through another tab — the switch destroyed the undo stack, which is what setValue is defined to do',
+	);
+	assert.equal(
+		tabManager.tabs.find((tab) => tab.id === notes)!.rawContent,
+		'hello',
+		'the undone text never reached the tab buffer, so the document and the editor disagree',
+	);
+});
+
+test('the undo history of a background tab is not touched by editing another one', () => {
+	const h = setup();
+	const a = h.open('/docs/a.md', 'A');
+	const b = h.open('/docs/b.md', 'B');
+
+	h.show(a);
+	h.type('1');
+	h.show(b);
+	h.type('2');
+	h.show(a);
+
+	h.component.undo();
+	assert.equal(h.text(), 'A', 'the edit in A did not come back');
+
+	h.show(b);
+	h.component.undo();
+	assert.equal(h.text(), 'B', "editing A consumed B's undo history");
+});
+
+test('undo does not reach past the point where the document was opened', () => {
+	// The other half of "undo follows the document": a per-tab stack must not
+	// let one document's undo walk into text it never contained.
+	const h = setup();
+	const a = h.open('/docs/a.md', 'A');
+	h.show(a);
+	h.type('1');
+
+	h.component.undo();
+	assert.equal(h.text(), 'A');
+	h.component.undo();
+	assert.equal(h.text(), 'A', 'undo went past the opened state');
+});
+
+// ------------------------------------------- what setValue is still there for
+
+test('a buffer replaced behind the editor still clears undo', () => {
+	// External writes — a reload from disk, an accepted external change, a
+	// truncated buffer completed, a task checkbox toggled from the preview —
+	// hand the tab a DIFFERENT document. Undo across that boundary would splice
+	// two texts together, so `setValue` (and its stack clearing) is the right
+	// call and is deliberately kept. Stated as a test because it is a decision,
+	// not an oversight.
+	const h = setup();
+	const a = h.open('/docs/a.md', 'A');
+	h.show(a);
+	h.type('1');
+
+	tabManager.setTabRawContent(a, 'from disk');
+	h.component.syncBoundValue();
+	h.component.activate();
+
+	assert.equal(h.text(), 'from disk', 'the external write did not reach the editor');
+	h.component.undo();
+	assert.equal(h.text(), 'from disk', 'undo resurrected a buffer the reload replaced');
+});
+
+test('a tab pointed at another document does not carry its undo history across', () => {
+	// `navigate` — following a link inside the same tab. Same tab id, so the
+	// same model, but a different document: the text is replaced and the stack
+	// has to go with it.
+	const h = setup();
+	const a = h.open('/docs/a.md', 'A');
+	h.show(a);
+	h.type('1');
+
+	tabManager.navigate(a, '/docs/linked.md');
+	tabManager.setTabRawContent(a, 'linked');
+	h.component.syncBoundValue();
+	h.component.activate();
+
+	h.component.undo();
+	assert.equal(h.text(), 'linked', 'undo reached back into the document this tab used to hold');
+});
+
+test('renaming a tab keeps the undo history, because the document did not change', () => {
+	// Save As and rename change the path while the text on screen stays put —
+	// the mirror image of the test above, and the reason the model is keyed by
+	// tab id rather than by path.
+	const h = setup();
+	const a = h.open('/docs/a.md', 'A');
+	h.show(a);
+	h.type('1');
+
+	tabManager.renameTab(a, '/docs/renamed.md');
+	h.component.syncBoundValue();
+	h.component.activate();
+
+	h.component.undo();
+	assert.equal(h.text(), 'A', 'renaming the file threw away the undo history of its buffer');
+});
+
+// -------------------------------------------------------------- the language
+
+test('a tab that follows a link into another file type re-languages its model', () => {
+	// `language` is derived from the ACTIVE TAB'S PATH, and the model outlives
+	// every route that repoints a tab. A language fixed at creation would be the
+	// extension of whatever file the tab held the first time it was edited.
+	const h = setup();
+	const a = h.open('/docs/a.md', 'A');
+	h.show(a);
+	assert.equal(h.modelOf(a)?.getLanguageId(), 'markdown');
+
+	tabManager.navigate(a, '/docs/script.ts');
+	h.component.setLanguage('typescript');
+	h.component.syncBoundValue();
+	h.component.activate();
+
+	assert.equal(h.modelOf(a)?.getLanguageId(), 'typescript', 'the model kept the language of the previous document');
+	assert.equal(h.component.currentLanguage(), 'typescript', 'the status bar kept the previous language');
+});
+
+test('switching tabs refreshes the readings that used to arrive with setValue', () => {
+	// `setValue` fired a content change as a side effect, which is what kept the
+	// word count current. `setModel` does not — no content changed, a different
+	// document arrived — so the switch has to ask.
+	const h = setup();
+	const a = h.open('/docs/a.md', 'one');
+	const b = h.open('/docs/b.md', 'one two three four');
+
+	h.show(a);
+	assert.equal(h.component.wordCount(), 1);
+	h.show(b);
+	assert.equal(h.component.wordCount(), 4, 'the word count still describes the tab that was left');
+});
+
+// -------------------------------------------------------- view state on switch
+
+test('a switch files the outgoing view state and restores the incoming one', () => {
+	// The view state is the EDITOR's — cursor, scroll, folding — not the
+	// model's, so it still has to be saved and restored by hand, and only after
+	// the model it describes is attached.
+	const h = setup();
+	const a = h.open('/docs/a.md', 'A');
+	const b = h.open('/docs/b.md', 'B');
+
+	h.show(a);
+	h.editor.markViewState('in-a');
+	h.show(b);
+
+	assert.deepEqual(
+		tabManager.tabs.find((tab) => tab.id === a)!.editorViewState,
+		{ marker: 'in-a' },
+		'leaving a tab did not file its view state',
+	);
+
+	h.show(a);
+	assert.deepEqual(
+		h.editor.restored.at(-1),
+		{ marker: 'in-a' },
+		'coming back to a tab did not restore its view state',
+	);
+});
+
+// ------------------------------------------------------------------- lifetime
+//
+// A leak is invisible until it is not, so these run the real `TabManager` over
+// every route that can remove a tab and assert the invariant itself.
+
+test('closing a tab disposes its model and nothing else', () => {
+	const h = setup();
+	const a = h.open('/docs/a.md', 'A');
+	const b = h.open('/docs/b.md', 'B');
+	h.show(a);
+	h.show(b);
+
+	tabManager.closeTab(a);
+
+	assertNoModelOutlivesItsTab(2, 'closeTab');
+	assert.ok(h.modelOf(b), "closing one tab disposed another tab's model");
+});
+
+test('closing every tab disposes every model', () => {
+	const h = setup();
+	const a = h.open('/docs/a.md', 'A');
+	const b = h.open('/docs/b.md', 'B');
+	h.show(a);
+	h.show(b);
+
+	tabManager.closeTab(b);
+	tabManager.closeTab(a);
+
+	assertNoModelOutlivesItsTab(2, 'closing every tab one at a time');
+	assert.deepEqual(trackedTabModelIds(), []);
+});
+
+test('closeAll disposes every model', () => {
+	// Reached by the window-close path, which never calls closeTab.
+	const h = setup();
+	const a = h.open('/docs/a.md', 'A');
+	const b = h.open('/docs/b.md', 'B');
+	h.show(a);
+	h.show(b);
+
+	tabManager.closeAll();
+
+	assertNoModelOutlivesItsTab(2, 'closeAll');
+});
+
+test('a session restore that replaces the open tabs disposes their models', () => {
+	// `restoreState` assigns `this.tabs` wholesale — the one tab removal in the
+	// store that never goes through `closeTab`, and the one a per-call-site
+	// dispose would have missed.
+	const h = setup();
+	const a = h.open('/docs/a.md', 'A');
+	const b = h.open('/docs/b.md', 'B');
+	h.show(a);
+	h.show(b);
+
+	tabManager.restoreState(
+		JSON.stringify({ version: 2, activeTabId: 'restored-1', tabs: [{ id: 'restored-1', path: '/docs/c.md', title: 'c.md' }] }),
+	);
+
+	assert.deepEqual(tabManager.tabs.map((tab) => tab.path), ['/docs/c.md'], 'precondition: the restore replaced the tabs');
+	assertNoModelOutlivesItsTab(2, 'restoreState');
+});
+
+test('a tab that loses its path to another tab has its model disposed with it', () => {
+	// `claimPath`: Save As onto a file that is already open closes the clean
+	// loser. It calls `closeTab`, but through the store rather than through any
+	// UI, so nothing in the viewer would have known to dispose anything.
+	const h = setup();
+	const open = h.open('/docs/target.md', 'target');
+	const untitled = (tabManager.addNewTab(), tabManager.activeTabId!);
+	h.show(open);
+	h.show(untitled);
+
+	tabManager.updateTabPath(untitled, '/docs/target.md');
+
+	assert.equal(tabManager.tabs.length, 1, 'precondition: the clean loser was closed');
+	assertNoModelOutlivesItsTab(2, 'claimPath via Save As');
+});
+
+test('a tab moved to another window has its model disposed on the way out', () => {
+	// Cross-window transfer, both halves in one window: the source closes its
+	// tab, the destination inserts a new one. A model is a JavaScript object in
+	// one webview, so it cannot travel — the arriving tab starts a fresh one,
+	// with an empty undo history.
+	const h = setup();
+	const a = h.open('/docs/a.md', 'A');
+	h.show(a);
+	h.type('1');
+	const sourceModel = h.modelOf(a);
+	assert.ok(sourceModel, 'the tab about to move never had a model of its own');
+
+	const snapshot = buildTransferredTab(
+		{
+			path: '/docs/a.md',
+			title: 'a.md',
+			rawContent: 'A1',
+			originalContent: 'A',
+			isDirty: true,
+			isEditing: true,
+			isSplit: false,
+			splitRatio: 0.5,
+			isScrollSynced: false,
+			scrollTop: 0,
+			scrollPercentage: 0,
+			anchorLine: 0,
+			hasReplacementChars: false,
+			history: ['/docs/a.md'],
+			historyIndex: 0,
+		},
+		[],
+		'Untitled',
+	);
+	tabManager.closeTab(a);
+	const arrived = tabManager.insertTransferredTab(snapshot);
+	h.show(arrived);
+
+	assert.ok(sourceModel!.isDisposed(), 'the source window kept the model of a tab it no longer has');
+	assert.equal(h.modelOf(arrived)?.undoDepth(), 0, 'undo history cannot cross a window boundary and must not appear to');
+	assertNoModelOutlivesItsTab(2, 'cross-window transfer');
+});
+
+test('reopening a closed document starts a new model with no undo history', () => {
+	// The honest answer to "what happens to undo when a tab is closed and the
+	// document reopened": nothing survives. Monaco cannot preserve an undo stack
+	// across `dispose()`, and every editor that keys undo to a document behaves
+	// the same way — VS Code included. Pretending otherwise would be a worse
+	// bug than the one this change fixes, so it is written down as a test.
+	const h = setup();
+	const a = h.open('/docs/a.md', 'A');
+	h.show(a);
+	h.type('1');
+	assert.equal(h.modelOf(a)?.undoDepth(), 1, 'precondition: the document has undo history of its own to lose');
+
+	tabManager.closeTab(a);
+	assert.equal(tabManager.popRecentlyClosed(), '/docs/a.md', 'precondition: the path is on the reopen stack');
+
+	const reopened = h.open('/docs/a.md', 'A');
+	h.show(reopened);
+
+	assert.notEqual(reopened, a, 'a reopened document is a new tab');
+	assert.equal(h.modelOf(reopened)?.undoDepth(), 0, 'a reopened document must not appear to carry undo history');
+	assertNoModelOutlivesItsTab(2, 'close and reopen');
+});
+
+// -------------------------------------------------------------------- the URI
+
+test('every tab gets its own model, and two tabs can never share one', () => {
+	// Monaco keys models by URI and refuses a duplicate. Keying by tab id — a
+	// UUID — is what makes that unreachable: untitled tabs have no path to key
+	// by, and a path is not stable for the life of a tab anyway.
+	const h = setup();
+	const a = h.open('/docs/a.md', 'A');
+	tabManager.addNewTab();
+	const untitledOne = tabManager.activeTabId!;
+	tabManager.addNewTab();
+	const untitledTwo = tabManager.activeTabId!;
+
+	h.show(a);
+	h.show(untitledOne);
+	h.show(untitledTwo);
+
+	const uris = [a, untitledOne, untitledTwo].map((id) => h.modelOf(id)?.uri);
+	assert.equal(new Set(uris).size, 3, 'two tabs resolved to the same model URI');
+	assert.ok(uris.every((uri) => typeof uri === 'string'), 'a tab was shown without acquiring a model');
+});

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -5,6 +5,7 @@
 	import { t, type LanguageCode } from '../utils/i18n.js';
 	import { MARKDOWN_LANGUAGE_ID, shouldLinkifyPastedUrl } from '../utils/pasteContext.js';
 	import { toggleLineMarker, type LineMarkerToolId } from '../utils/editorToolbar.js';
+	import { getTabModel, tabModelUri } from '../utils/tabModels.js';
 	import {
 		getScrollSyncPositionFromPixels,
 		getScrollTopForSyncPosition,
@@ -134,6 +135,48 @@
 		return /^(Mac|iPhone|iPad|iPod)/i.test(navigator.platform || '');
 	}
 
+	/**
+	 * The `ITextModel` belonging to a tab — Monaco's document object, and the
+	 * thing that owns the undo stack.
+	 *
+	 * One per tab, created here because this component holds the dynamically
+	 * imported Monaco namespace, and reaped by `TabManager` because that is
+	 * what knows a tab is gone; see `utils/tabModels.ts` for both halves.
+	 *
+	 * The language is re-applied on every call rather than only at creation.
+	 * `language` is derived from the ACTIVE TAB'S PATH, and a tab can be
+	 * repointed at a file of another type without being recreated — following a
+	 * link, back/forward, Save As. The model outlives all of those, so a
+	 * language fixed at creation would be the extension of whatever file the tab
+	 * held the first time it was edited. `setModelLanguage` is a no-op when the
+	 * id already matches.
+	 */
+	function acquireTabModel(tabId: string, seed: string, languageId: string) {
+		const model = getTabModel(tabId, () =>
+			monaco.editor.createModel(seed, languageId, monaco.Uri.parse(tabModelUri(tabId))),
+		);
+		if (model.getLanguageId() !== languageId) monaco.editor.setModelLanguage(model, languageId);
+		return model;
+	}
+
+	/**
+	 * The status-bar readings that are properties of the DOCUMENT rather than of
+	 * an edit: the language and the word count.
+	 *
+	 * They used to be refreshed only by `onDidChangeModelContent`, which was
+	 * enough while a tab switch went through `setValue` — that fires a content
+	 * change (a flush) as a side effect. `setModel` does not, because no content
+	 * changed: a different document arrived. So switching tabs has to ask for
+	 * these explicitly, or the status bar keeps the previous document's numbers.
+	 */
+	function syncStatusFromModel() {
+		const model = editor.getModel();
+		if (!model) return;
+		currentLanguage = model.getLanguageId();
+		const text = model.getValue();
+		wordCount = (text.match(/\S+/g) || []).filter((w) => /\w/.test(w)).length;
+	}
+
 	self.MonacoEnvironment = {
 		getWorker: function (_moduleId: any, label: string) {
 			if (label === "json") {
@@ -246,9 +289,25 @@
 			return theme === "dark" ? "app-theme-dark" : "app-theme-light";
 		};
 
+		// The editor is a VIEW; the document it shows is the active tab's model.
+		// Passing `model` rather than `value`/`language` also settles ownership:
+		// `StandaloneEditor` only sets `_ownsModel` when it had to build the
+		// model itself, and `_postDetachModelCleanup` disposes the model on
+		// `editor.dispose()` only when it owns it. So a model handed in here
+		// SURVIVES the editor — which is the point, because this component is
+		// unmounted every time the user switches a tab to reading mode.
+		//
+		// With no active tab there is nothing to key a model by, so the editor
+		// builds and owns a throwaway one, exactly as it did before. That state
+		// is not reachable from the markup (the pane renders under
+		// `tabManager.activeTab`); it is the honest fallback for the window
+		// between the Monaco chunk resolving and this function running.
+		const documentOptions = currentTabId
+			? { model: acquireTabModel(currentTabId, value, language) }
+			: { value, language };
+
 		editor = monaco.editor.create(container, {
-			value: value,
-			language: language,
+			...documentOptions,
 			theme: getTheme(),
 			dragAndDrop: true,
 			automaticLayout: true,
@@ -349,13 +408,7 @@
 				}
 			}
 
-			const model = editor.getModel();
-			if (model) {
-				const text = model.getValue();
-				wordCount = (text.match(/\S+/g) || []).filter((w) =>
-					/\w/.test(w),
-				).length;
-			}
+			syncStatusFromModel();
 		});
 
 		editor.onDidChangeCursorPosition((e) => {
@@ -379,11 +432,7 @@
 			}
 		});
 
-		if (editor.getModel()) {
-			currentLanguage = editor.getModel()?.getLanguageId() || "markdown";
-			const text = editor.getModel()?.getValue() || "";
-			wordCount = (text.match(/\S+/g) || []).filter((w) => /\w/.test(w)).length;
-		}
+		syncStatusFromModel();
 
 		const wheelListener = (e: WheelEvent) => {
 			if (e.ctrlKey || e.metaKey) {
@@ -1240,35 +1289,68 @@
 		}
 	});
 
+	// Tab activation. A switch swaps the editor's MODEL; it does not overwrite
+	// one shared buffer any more, which is the whole of #391: `setValue` is
+	// defined to clear the undo stack (`TextModel._setValueFromTextBuffer` →
+	// `_commandManager.clear()`), so every switch away and back used to cost the
+	// user their undo history. Undo now lives on the document, which is Monaco's
+	// intended usage and how VS Code works.
+	//
+	// `setValue` is still here, and still clears undo, for the case it is
+	// actually right for: the tab's buffer was REPLACED behind the editor's back
+	// — a reload from disk, an external change the user accepted, a truncated
+	// buffer completed, a link followed inside this tab, a task checkbox toggled
+	// from the preview. Those hand the model a different document, and an undo
+	// stack from the old one would splice two texts together. The `getValue()`
+	// comparison is what tells the two apart: an ordinary tab switch finds the
+	// model already holding its own text and touches nothing.
+	//
+	// Making external writes undoable instead (`pushEditOperation`) is a real
+	// option and #391 suggests it, but it is a second behaviour change — it
+	// would let Ctrl+Z resurrect a buffer that the truncation and lossy-decode
+	// guards (#374, #379) exist to keep away from the file — so it is
+	// deliberately not part of this one.
 	$effect(() => {
 		const activeTabId = tabManager.activeTabId;
 		const content = value;
+		const languageId = language;
 
 		if (!editorReady || !editor) return;
 
-		if (activeTabId !== currentTabId) {
-			if (currentTabId) {
-				const state = editor.saveViewState();
-				tabManager.updateTabEditorState(currentTabId, state);
-			}
+		const switched = activeTabId !== currentTabId;
 
-			currentTabId = activeTabId;
-			
-			if (editor.getValue() !== content) {
-				editor.setValue(content);
-			}
+		if (switched && currentTabId) {
+			const state = editor.saveViewState();
+			tabManager.updateTabEditorState(currentTabId, state);
+		}
 
+		currentTabId = activeTabId;
+
+		if (activeTabId) {
+			const model = acquireTabModel(activeTabId, content, languageId);
+			if (editor.getModel() !== model) editor.setModel(model);
+		}
+
+		if (editor.getValue() !== content) {
+			editor.setValue(content);
+		}
+
+		if (switched) {
+			// The view state is the editor's, not the model's — cursor, scroll,
+			// selections and the folding contribution — so it still has to be
+			// restored by hand, and only after the model it describes is
+			// attached.
 			if (tabManager.activeTab?.editorViewState) {
 				editor.restoreViewState(tabManager.activeTab.editorViewState);
 			} else {
 				editor.setScrollTop(0);
 				editor.setPosition({ lineNumber: 1, column: 1 });
 			}
-		} else {
-			if (editor.getValue() !== content) {
-				editor.setValue(content);
-			}
 		}
+
+		// Cheap on the hot path: this effect re-runs on every keystroke (it
+		// reads `value`), and on a keystroke neither test holds.
+		if (switched || currentLanguage !== languageId) syncStatusFromModel();
 	});
 
 	$effect(() => {

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -5,6 +5,7 @@ import { hasRealFilePath } from '../utils/tabFileActions.js';
 import { HOME_TAB_PATH, isHomePath } from '../utils/homeTab.js';
 import { buildTransferredTab, type TransferableTab } from '../utils/tabTransfer.js';
 import { canonicalizePath, isSameFilePath } from '../utils/pathIdentity.js';
+import { retainTabModels } from '../utils/tabModels.js';
 import {
 	canGoBackInHistory,
 	canGoForwardInHistory,
@@ -314,6 +315,9 @@ class TabManager {
 			this.activeTabId = restored.some((t) => t.id === data.activeTabId)
 				? data.activeTabId
 				: restored[0]?.id ?? null;
+			// Every tab that was open is gone, replaced wholesale — the one tab
+			// removal in this file that never calls `closeTab`.
+			this.releaseModelsOfRemovedTabs();
 			// Snapshots store paths as they were typed, and the restore reads
 			// each file directly rather than through `loadMarkdown`, so nothing
 			// else would ever resolve these. Without this a restored window sits
@@ -541,6 +545,32 @@ class TabManager {
 		return tab.id;
 	}
 
+	/**
+	 * Release the Monaco models of tabs that no longer exist.
+	 *
+	 * Called after every removal rather than paired with each one, because the
+	 * question it asks — "which models have no tab?" — is answered from the tab
+	 * list, so a route that removes a tab in some way not listed below is still
+	 * covered. A model that is dropped without `dispose()` is not collected:
+	 * Monaco registers it with the model service, and its buffer, tokenization
+	 * state and worker-side copy stay alive for the life of the window. See
+	 * `utils/tabModels.ts`.
+	 *
+	 * The three call sites are the three places a tab stops existing: `closeTab`
+	 * (the close button, ⌘W, close-others/close-to-the-right, a clean tab losing
+	 * its path in `claimPath`, a tab moved to another window, a rolled-back
+	 * transfer), `closeAll`, and `restoreState`, which replaces the whole array.
+	 *
+	 * Whether the model being disposed is the one on screen does not matter
+	 * here: Monaco's editor detaches itself from a model that is disposed
+	 * (`_attachModel` registers `model.onWillDispose(() => this.setModel(null))`),
+	 * and `Editor.svelte` attaches the newly active tab's model in the same
+	 * flush.
+	 */
+	private releaseModelsOfRemovedTabs() {
+		retainTabModels(this.tabs.map((tab) => tab.id));
+	}
+
 	closeTab(id: string) {
 		const index = this.tabs.findIndex((t) => t.id === id);
 		if (index === -1) return;
@@ -555,11 +585,13 @@ class TabManager {
 			this.recentlyClosed.push(tab.path);
 		}
 		this.tabs.splice(index, 1);
+		this.releaseModelsOfRemovedTabs();
 	}
 
 	closeAll() {
 		this.tabs = [];
 		this.activeTabId = null;
+		this.releaseModelsOfRemovedTabs();
 	}
 
 	setActive(id: string) {

--- a/src/lib/utils/tabModels.ts
+++ b/src/lib/utils/tabModels.ts
@@ -1,0 +1,131 @@
+import type * as Monaco from 'monaco-editor';
+
+/**
+ * One Monaco `ITextModel` per tab, and the disposal that has to go with it.
+ *
+ * WHY A MODEL PER TAB. A model is Monaco's document: the text, its language,
+ * its decorations and — the reason this module exists — its undo stack. One
+ * model shared by every tab meant a tab switch had to overwrite it with
+ * `setValue`, and `setValue` is *defined* to throw the undo stack away
+ * (`TextModel._setValueFromTextBuffer` → `this._commandManager.clear()`, under
+ * the comment "Destroy my edit history and settings"). So every switch away
+ * from a document and back cost the user their undo history (#391). Giving each
+ * tab its own model and switching with `editor.setModel(...)` is Monaco's
+ * intended usage and how VS Code itself works — undo then belongs to the
+ * document rather than to whichever tab happens to be on screen.
+ *
+ * WHY THE MAP LIVES HERE AND NOT ON THE TAB. `Tab` is a plain data record in a
+ * store that is imported by the whole app, and Monaco is loaded with a dynamic
+ * `import()` from `Editor.svelte` precisely so it stays out of the startup
+ * chunk (~86% of the startup JavaScript — see `monacoStartupGraph.test.ts`).
+ * A model field on `Tab` would either put Monaco back in that graph or type the
+ * field as `any`. This module keeps the models, imports Monaco for its TYPES
+ * only — `import type` is erased, so it costs nothing at runtime and adds no
+ * static edge to the module graph — and lets the two sides own what each is
+ * actually responsible for: `Editor.svelte` creates models, because it is the
+ * only place that has Monaco; `TabManager` reaps them, because it is the only
+ * place that knows a tab is gone.
+ *
+ * LIFETIME. Monaco models are registered with the editor's model service and
+ * are NOT garbage collected while registered: a model that is dropped without
+ * `dispose()` keeps its whole text buffer, its tokenization state and its
+ * worker-side copy alive for the life of the window. So the invariant this
+ * module exists to hold is:
+ *
+ *     the set of live models is exactly the set of live tabs
+ *
+ * and it is held by reconciliation (`retainTabModels`), not by a matching
+ * `dispose()` at each of the places a tab can disappear. Tabs are removed by
+ * the close button, ⌘W, "close others", "close to the right", a clean tab
+ * losing its path to another tab (`claimPath`), a tab moving to another window,
+ * a failed transfer being rolled back, `closeAll`, and a session restore
+ * REPLACING the whole tab array. Pairing a dispose with each of those is eight
+ * chances to forget; asking "which models no longer have a tab?" after each of
+ * them is one rule that a ninth route cannot silently escape.
+ */
+
+type TextModel = Monaco.editor.ITextModel;
+
+const models = new Map<string, TextModel>();
+
+/**
+ * The URI a tab's model is registered under.
+ *
+ * Keyed by TAB ID, not by file path, for three reasons that each rule the path
+ * out on its own:
+ *
+ * - a path is not stable for the life of a tab. Save As, rename, following a
+ *   link and back/forward all repoint a tab at another file, and a model's URI
+ *   cannot be changed after creation — so a path-keyed registry would have to
+ *   dispose and rebuild the model on every one of those, throwing away the undo
+ *   history this module exists to preserve on the two (Save As, rename) where
+ *   the text on screen never changed at all.
+ * - untitled tabs have no path, and several of them are normal.
+ * - `monaco.editor.createModel` throws on a duplicate URI. A tab id is a UUID,
+ *   so two tabs can never collide, whatever they hold.
+ *
+ * `inmemory:` rather than `file:` because these models are not the file: the
+ * buffer can be dirty, truncated, or a lossy decode of bytes that are not
+ * UTF-8, and nothing in Monaco should be tempted to treat the URI as something
+ * it can read from or write to.
+ */
+export function tabModelUri(tabId: string): string {
+	return `inmemory://markpad/${tabId}`;
+}
+
+/**
+ * This tab's model, created on first use.
+ *
+ * `create` is a callback rather than a `(value, language)` pair because this
+ * module has no Monaco at runtime — the caller in `Editor.svelte` holds the
+ * dynamically imported namespace and builds the model with it.
+ *
+ * A model already in the map is re-checked with `isDisposed()`: handing back a
+ * disposed model would throw on the first read (`_assertNotDisposed`), and the
+ * one thing that can dispose a model out from under this map is Monaco itself,
+ * which is not something a caller can be asked to keep track of.
+ */
+export function getTabModel(tabId: string, create: () => TextModel): TextModel {
+	const existing = models.get(tabId);
+	if (existing && !existing.isDisposed()) return existing;
+
+	const model = create();
+	models.set(tabId, model);
+	return model;
+}
+
+/**
+ * Dispose every model whose tab is gone — the whole of the lifetime scheme.
+ *
+ * Called with the ids of the tabs that still exist, so the answer is derived
+ * from the tab list rather than from remembering which tab was just removed.
+ * That is what makes it total: a route that closes a tab in some way nobody has
+ * thought of yet still leaves a tab list without that id in it.
+ *
+ * Disposing the model the editor currently has attached is safe and does not
+ * need special-casing here: `CodeEditorWidget._attachModel` registers
+ * `model.onWillDispose(() => this.setModel(null))`, so the editor detaches
+ * itself, and the effect in `Editor.svelte` attaches the newly active tab's
+ * model in the same flush. Verified in the bundled Monaco (0.55.1).
+ */
+export function retainTabModels(liveTabIds: Iterable<string>): void {
+	const live = new Set(liveTabIds);
+
+	for (const [tabId, model] of [...models]) {
+		if (live.has(tabId)) continue;
+		models.delete(tabId);
+		if (!model.isDisposed()) model.dispose();
+	}
+}
+
+/**
+ * The tab ids that currently hold a model.
+ *
+ * Exported for the lifetime test, which asserts the invariant above directly —
+ * "every model created is disposed, over every path that closes a tab" — rather
+ * than asserting that some particular call site spells `dispose()`. A leak is
+ * invisible until it is not, so the check has to be the invariant itself.
+ */
+export function trackedTabModelIds(): string[] {
+	return [...models.keys()];
+}


### PR DESCRIPTION
> This is the change #396 asked about (#391), and it is **easy to decline** — it is one commit touching two files plus a new module, and nothing else depends on it. If you would rather not take on model lifetime, close it and nothing is lost.

Fixes #391.

## The defect

Switch to another tab and back, press <kbd>Ctrl</kbd>/<kbd>⌘</kbd>+<kbd>Z</kbd> — the undo history is gone.

There is one editor and one **implicit** model: `Editor.svelte` never calls `monaco.editor.createModel`, so `monaco.editor.create(container, { value, language })` builds one and every tab shares it. A tab switch therefore has to overwrite it, and the overwrite is `editor.setValue(content)`.

`TextModel.setValue` is *defined* to discard the undo stack. From the bundled monaco-editor@0.55.1:

```js
_setValueFromTextBuffer(textBuffer, textBufferDisposable, reason) {
    …
    // Destroy all my decorations
    this._decorations = Object.create(null);
    …
    // Destroy my edit history and settings
    this._commandManager.clear();
```

Verified in the code, not from memory: the diagnosis in #391 holds exactly as written.

## The fix

One `ITextModel` per tab, created with the tab and disposed with it; a switch becomes `editor.setModel(...)`. Undo then belongs to the document, which is Monaco's intended usage and how VS Code works. `tabs.svelte.ts` already said so, in a comment that has been sitting next to `history`/`historyIndex` for a while:

> Text undo belongs to Monaco's model, not to the tab.

## Model lifetime

Monaco models are registered with the model service and are **not** garbage collected while registered — a dropped model keeps its buffer, its tokenization state and its worker-side copy for the life of the window. So the invariant is:

> the set of live models is exactly the set of live tabs

and it is held by **reconciliation**, not by a `dispose()` paired with each removal. `retainTabModels(liveTabIds)` asks "which models have no tab?" and is called after every removal, so a route added later is covered by construction rather than by somebody remembering. There are three call sites because there are three places a tab stops existing:

| | what reaches it |
|---|---|
| `closeTab` | the close button, <kbd>Ctrl</kbd>/<kbd>⌘</kbd>+<kbd>W</kbd>, close-others, close-to-the-right, a **clean tab losing its path** in `claimPath` (#413), a tab **moved to another window**, a **rolled-back transfer**, `dropRestoredTab` |
| `closeAll` | window close |
| `restoreState` | session restore — **assigns `this.tabs` wholesale**, the one removal in the store that never calls `closeTab`, and the one a per-call-site dispose would have missed |

Quitting or closing a window destroys the webview, which frees everything regardless.

**Disposing a model the editor currently has attached needs no special case.** `CodeEditorWidget._attachModel` registers `model.onWillDispose(() => this.setModel(null))`, so the editor detaches itself, and the activation effect attaches the newly active tab's model in the same flush. Checked in the bundled source rather than assumed.

**Where the models live.** `utils/tabModels.ts`, not a field on `Tab`. A model on the store record would either drag Monaco back into the startup chunk — ~86% of the startup JavaScript, kept out by a dynamic `import()` and locked by `monacoStartupGraph.test.ts` — or be typed `any`. That module imports Monaco for its **types** only, which `tsc` erases, so it adds no static edge to the graph. `Editor.svelte` creates models because it is the only place with Monaco; `TabManager` reaps them because it is the only place that knows a tab is gone.

## What happens to undo when a tab is closed and the document reopened

**It is gone, and the PR says so rather than pretending.** Monaco cannot preserve an undo stack across `dispose()`; closing a tab disposes the model, so reopening gives a new tab, a new model and an empty history. VS Code behaves the same way and for the same reason. A cross-window move is the same case — a model is a JavaScript object in one webview and cannot travel — so the arriving tab starts fresh. Both are written down as tests (`reopening a closed document starts a new model with no undo history`, `a tab moved to another window has its model disposed on the way out`) so a later change cannot quietly claim otherwise.

## Everything that assumed a single model

| assumption | what it is now |
|---|---|
| keyed by nothing (there was only one) | keyed by **tab id**, not path. A path is not stable for the life of a tab — Save As, rename, following a link, back/forward — and a model's URI cannot change after creation, so a path key would have to rebuild the model (and drop the undo history) on routes where the text on screen never changed. Untitled tabs have no path, and `createModel` throws on a duplicate URI. A UUID collides with nothing, including the two-tabs-one-path window #413/#416 are about. |
| `language` applied once, at `create` | re-applied on acquire. The model now outlives every route that repoints a tab, so a language fixed at creation would be the extension of whatever file the tab held the *first* time it was edited. This also fixes a tab that follows a link from `.md` into `.ts` keeping the old language. |
| word count / language refreshed by `onDidChangeModelContent` | asked for explicitly on switch. `setValue` fired a content change as a side effect; `setModel` does not, because no content changed — a different document arrived. `syncStatusFromModel` also replaces two hand-rolled copies of the word count. |
| `editor.dispose()` disposes the model | it does not, and that is the point. `StandaloneEditor` sets `_ownsModel` only when it built the model itself, and this component is unmounted every time a tab goes to reading mode. |
| `editorViewState` | unchanged, still saved and restored by hand — it is the *editor's* state (cursor, scroll, folding contribution), not the model's — but it must be applied **after** the model it describes is attached. |
| `monaco-vim` | **holds no model reference.** Read from source: every `getModel()` in `cm_adapter.ts` is an on-demand local, and it registers `editor.onDidChangeCursorPosition` / `editor.onDidChangeModelContent`, which `CodeEditorWidget` re-forwards across `setModel`. Nothing to change. |
| the completion provider | registered per *language*, globally (`registerCompletionItemProvider("markdown", …)`), and it reads `tabManager.activeTab`, not the model. Unaffected. |
| decorations (`deltaDecorations` for the drag caret) | tolerant by construction — `_deltaDecorationsImpl` skips ids it does not know (`while (!node && …)`), and the caret only exists during a drag. |
| folding | rides on `editorViewState`, per tab already (#448). |
| `updateOptions` | editor-level, model-independent. |
| the `setValue`/`getValue` exports on the component | dead — no caller outside `Editor.svelte`. Left alone. |

## What `setValue` is still there for

External writes hand the tab a **different document**: a reload from disk, an accepted external change, a truncated buffer completed (#374), a task checkbox toggled from the preview, a link followed inside the tab. An undo stack from the previous text across that boundary would splice two documents together, so those still go through `setValue` and still clear undo — **unchanged from today**. The `editor.getValue() !== content` comparison is what distinguishes them from an ordinary switch, where the model is already holding its own text and nothing is touched.

`#391` also suggests making external writes undoable with `pushEditOperation`. That is deliberately **not** in this PR: it would let <kbd>Ctrl</kbd>+<kbd>Z</kbd> resurrect a buffer that the truncated (#374) and lossy-decode (#379) guards exist to keep away from the file. It is a second behaviour change and deserves its own decision.

## Tests

`scripts/undoHistoryPerTab.test.ts` — 17 assertions that **run** the component's own tab-activation `$effect`, its `acquireTabModel`, its `onDidChangeModelContent` listener and its exported `undo`, lifted out of `Editor.svelte` and evaluated over the **real** `TabManager` and the **real** model registry. Only Monaco is a fake, and the fake reproduces the two semantics the question turns on, both cited to the bundled source: `setValue` clears the undo stack, `setModel` does not. It also refuses a duplicate URI, as the model service does, so "two tabs never collide" is a test rather than a restatement of the code.

The lifetime tests assert the **invariant**, not a spelling: for every closing path, no model is left alive outside the registry and the registry holds no id that is not a tab. Each carries a vacuity guard on the number of models built, because every one of those assertions is trivially true for a run that never built one — which is exactly the state a broken acquire produces.

### Falsification

Both source files reverted to `master`, `scripts/undoHistoryPerTab.test.ts` kept:

```
✖ an edit can still be undone after switching to another tab and back
  AssertionError: undo did nothing after a round trip through another tab —
  the switch destroyed the undo stack, which is what setValue is defined to do
  + 'hello world'
  - 'hello'

✖ the undo history of a background tab is not touched by editing another one
  AssertionError: the edit in A did not come back    'A1' !== 'A'

✖ closing a tab disposes its model and nothing else
  AssertionError: closeTab: models built during this test    0 !== 2
✖ closeAll disposes every model
  AssertionError: closeAll: models built during this test    0 !== 2
✖ a session restore that replaces the open tabs disposes their models
  AssertionError: restoreState: models built during this test    0 !== 2
✖ a tab that loses its path to another tab has its model disposed with it
  AssertionError: claimPath via Save As: models built during this test    0 !== 2
✖ a tab moved to another window has its model disposed on the way out
  AssertionError: the tab about to move never had a model of its own
✖ reopening a closed document starts a new model with no undo history
  AssertionError: precondition: the document has undo history of its own to lose
✖ every tab gets its own model, and two tabs can never share one
  AssertionError: two tabs resolved to the same model URI    1 !== 3
✖ a tab that follows a link into another file type re-languages its model

ℹ tests 17
ℹ pass 6
ℹ fail 11
```

The six that stay green are deliberate: locks on behaviour this change **preserves** (an external write still clears undo; a `navigate` clears it; a rename does *not*, because the document did not change; the word count; the view state) plus one negative control (undo does not reach past the state the document was opened in).

### Two existing test files needed a line each

- `editorOptionWiring.test.ts` evaluates the `monaco.editor.create` options literal, which now closes over a fifth local (`documentOptions`); stubbed `{}`, since nothing it can contain is an option that file asserts on.
- `imageUndoKeepsFile.test.ts` lifts the model-content listener, which now calls `syncStatusFromModel`; the function is lifted alongside it rather than stubbed, so the listener under test runs exactly what it runs in the app.

## Validation

```
npm audit       0 vulnerabilities
npm run check   0 errors, 0 warnings
npm test        700 / 700
cargo test      157 / 157
npm run build   clean; Monaco still lands in its own 3.1 MB chunk,
                not reachable from the page node's static imports
```

Not done: I have not run the built app by hand. Everything above is from the source, the bundled Monaco, and tests that execute the component's own handlers.
