### PR TITLE
fix(scroll-sync): map the panes by source line instead of by ratio

### DIFF
--- a/scripts/scrollSyncBlockMapping.test.ts
+++ b/scripts/scrollSyncBlockMapping.test.ts
@@ -1,0 +1,1004 @@
+/**
+ * Split-view scroll sync: does the pane the reader is not touching show the
+ * same part of the document?
+ *
+ * The mapping used to be a ratio — the sending pane's share of its own scroll
+ * range became the receiving pane's share of its. That cannot be right in
+ * general. Forty source lines of table render as one tall block and forty of
+ * prose as a short one, so equal progress through the source is not equal
+ * progress through the rendered height, and the error accumulates towards the
+ * end of the document. That is the surviving half of #205: the reporter sees
+ * the panes "quite a few lines off" at the end of a document full of tables.
+ *
+ * So the unit of the measurement here is a SOURCE LINE, not a pixel. Every test
+ * drives the real mapping in one direction and then asks the receiving pane
+ * which source line it is now showing:
+ *
+ *   editor scrollTop -> line -> ScrollSyncPosition -> preview scrollTop -> line
+ *
+ * `RATIO_ONLY` re-runs the same sweep with the `line` field stripped out of the
+ * position, which is exactly the pre-fix mapping, and is kept as the control:
+ * if the block mapping ever collapses back into a proportional one the two
+ * drift figures collapse into each other.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT THE DOM SHIM CANNOT MODEL, AND WHAT IS DONE ABOUT IT
+ *
+ * `renderProtocolDom.ts` has no layout whatsoever — `grep -rn offsetTop
+ * scripts/` finds nothing — which is why #464's defect (anchors resolving to a
+ * boxless `<br>`) survived a suite that scored 100%. A mapping from pixels to
+ * lines is nothing BUT layout, so a test that only walked the shim would be
+ * measuring the same nothing.
+ *
+ * The layout is therefore injected. `layOut` below assigns every rendered block
+ * a top and a height, bottom-up, and `getSourceLineAtPreviewOffset` /
+ * `getPreviewOffsetForSourceLine` take that as the `measure` callback — the
+ * same parameter the browser fills with `offsetTop` / `offsetHeight`. What is
+ * asserted is the mapping's arithmetic and its choice of element over real
+ * `processMarkdownHtml` output; what is NOT asserted is that a browser lays a
+ * table out the way `BLOCK_HEIGHTS` says. The property under test does not
+ * depend on the specific numbers, only on rendered height not being
+ * proportional to source lines, which is the premise of the bug.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { installShimDom, parseHtml, NODE_ELEMENT, type ShimElement } from './renderProtocolDom.ts';
+
+installShimDom();
+
+const { processMarkdownHtml } = await import('../src/lib/utils/markdown.ts');
+const { getPreviewOffsetForSourceLine, getSourceLineAtPreviewOffset } = await import(
+	'../src/lib/utils/previewAnchor.ts'
+);
+const {
+	getLineAtVerticalOffset,
+	getScrollSyncPositionFromPixels,
+	getScrollTopForSyncPosition,
+	getVerticalOffsetForLine,
+} = await import('../src/lib/utils/scrollSync.ts');
+
+type AnchorNode = Parameters<typeof getSourceLineAtPreviewOffset>[0];
+type ScrollSyncPosition = Parameters<typeof getScrollTopForSyncPosition>[0];
+
+const FILE_PATH = '/documents/stress.md';
+
+/* ------------------------------------------------------------------ */
+/* a document whose rendered height is not proportional to its source  */
+/* ------------------------------------------------------------------ */
+
+class DocumentBuilder {
+	private line = 1;
+	private readonly parts: string[] = [];
+
+	private push(html: string, lines: number) {
+		this.parts.push(html);
+		this.line += lines;
+	}
+
+	blank() {
+		this.line += 1;
+	}
+
+	heading(level: number, text: string, slug: string) {
+		const line = this.line;
+		this.push(
+			`<h${level} data-sourcepos="${line}:1-${line}:${text.length + level + 1}">` +
+				`<a href="#${slug}" aria-hidden="true" class="anchor" id="${slug}"></a>${text}</h${level}>`,
+			1,
+		);
+	}
+
+	paragraph(text: string) {
+		const line = this.line;
+		this.push(`<p data-sourcepos="${line}:1-${line}:${text.length}">${text}</p>`, 1);
+	}
+
+	/** Three source lines — header, separator, one row — for a whole rendered table. */
+	table(rows: number, label: string) {
+		const start = this.line;
+		const end = start + rows + 1;
+		const body = Array.from(
+			{ length: rows },
+			(_, index) => `<tr><td>${label} ${index}</td><td>value ${index}</td></tr>`,
+		).join('');
+		this.push(
+			`<table data-sourcepos="${start}:1-${end}:20"><thead><tr><th>${label}</th><th>value</th></tr></thead>` +
+				`<tbody>${body}</tbody></table>`,
+			end - start + 1,
+		);
+	}
+
+	/** One source line for a block that renders hundreds of pixels tall. */
+	image(alt: string) {
+		const line = this.line;
+		// An absolute URL: `processMarkdownHtml` rewrites relative image paths
+		// through Tauri's `convertFileSrc`, which needs a `window` the shim has no
+		// reason to provide. The layout is what this fixture is about.
+		this.push(`<p data-sourcepos="${line}:1-${line}:40"><img src="https://example.invalid/${alt}.png" alt="${alt}" /></p>`, 1);
+	}
+
+	code(lines: number, label: string) {
+		const start = this.line;
+		const end = start + lines + 1;
+		const body = Array.from({ length: lines }, (_, index) => `${label} step ${index}`).join('\n');
+		this.push(`<pre data-sourcepos="${start}:1-${end}:3"><code class="language-sh">${body}\n</code></pre>`, end - start + 1);
+	}
+
+	list(items: string[]) {
+		const start = this.line;
+		const end = start + items.length - 1;
+		const html = items
+			.map((item, index) => `<li data-sourcepos="${start + index}:1-${start + index}:${item.length + 2}">${item}</li>`)
+			.join('\n');
+		this.push(`<ul data-sourcepos="${start}:1-${end}:20">\n${html}\n</ul>`, items.length);
+	}
+
+	/** `render.hardbreaks` is on, so soft-wrapped prose ends every line but the last in a `<br>`. */
+	wrappedParagraph(lines: string[]) {
+		const start = this.line;
+		const end = start + lines.length - 1;
+		const html = lines
+			.map((text, index) =>
+				index === lines.length - 1
+					? text
+					: `${text}<br data-sourcepos="${start + index}:${text.length + 1}-${start + index}:${text.length + 1}" />\n`,
+			)
+			.join('');
+		this.push(`<p data-sourcepos="${start}:1-${end}:${lines[lines.length - 1].length}">${html}</p>`, lines.length);
+	}
+
+	get lineCount() {
+		return this.line - 1;
+	}
+
+	html() {
+		return this.parts.join('\n') + '\n';
+	}
+}
+
+/**
+ * The reporter's shape: prose for most of the document, then a run of tables,
+ * figures and code listings — a great deal of rendered height for very few
+ * source lines — near the end. The proportional mapping spends the preview's
+ * last pixels on those blocks while the editor is still spending source lines
+ * at a steady rate, so the two disagree by more and more the further down the
+ * reader goes. That is why what gets noticed is the END of the document.
+ */
+function buildStressDocument() {
+	const doc = new DocumentBuilder();
+	doc.paragraph('An introduction before anything else.');
+	doc.blank();
+
+	for (let section = 1; section <= 30; section += 1) {
+		doc.heading(2, `Prose section ${section}`, `prose-section-${section}`);
+		doc.blank();
+		doc.wrappedParagraph([
+			`Prose ${section} first line, the kind of sentence an author soft-wraps.`,
+			`Prose ${section} second line, still inside the same markdown block.`,
+			`Prose ${section} third line, closing the paragraph off.`,
+		]);
+		doc.blank();
+		doc.list([`point ${section} one`, `point ${section} two`, `point ${section} three`]);
+		doc.blank();
+		doc.paragraph(`Prose ${section} closing remark.`);
+		doc.blank();
+	}
+
+	for (let section = 1; section <= 10; section += 1) {
+		doc.heading(2, `Table section ${section}`, `table-section-${section}`);
+		doc.blank();
+		doc.paragraph(`Prose introducing table ${section}.`);
+		doc.blank();
+		doc.table(14, `row ${section}`);
+		doc.blank();
+		doc.image(`figure-${section}`);
+		doc.blank();
+		doc.code(6, `deploy-${section}`);
+		doc.blank();
+	}
+
+	return doc;
+}
+
+/* ------------------------------------------------------------------ */
+/* the layout the shim does not have                                   */
+/* ------------------------------------------------------------------ */
+
+const BOXLESS = new Set(['BR', 'WBR']);
+const BLOCK_GAP = 16;
+
+/** Height of a block that has no laid-out children, in the units a browser would use. */
+function leafHeight(element: ShimElement, sourceLines: number): number {
+	switch (element.tagName) {
+		case 'H1':
+			return 44;
+		case 'H2':
+			return 38;
+		case 'H3':
+			return 32;
+		// Three source lines of pipe syntax; twelve rendered rows plus a header.
+		case 'TABLE':
+			return 34 * (element.querySelectorAll('tr').length || 1);
+		case 'PRE':
+			return 20 * sourceLines;
+		case 'LI':
+			return 26;
+		default:
+			// A paragraph holding nothing but an image is one source line and a
+			// picture; ordinary prose is a line box per source line.
+			return element.querySelectorAll('img').length > 0 ? 360 : 26 * sourceLines;
+	}
+}
+
+function elementChildren(node: ShimElement): ShimElement[] {
+	return node.childNodes.filter(
+		(child): child is ShimElement => child.nodeType === NODE_ELEMENT && !BOXLESS.has((child as ShimElement).tagName),
+	);
+}
+
+function sourceLineSpan(element: ShimElement): number {
+	const sourcepos = element.getAttribute('data-sourcepos');
+	if (!sourcepos) return 1;
+	const [start, end] = sourcepos.split('-');
+	const startLine = parseInt(start.split(':')[0], 10);
+	const endLine = parseInt(end.split(':')[0], 10);
+	return Number.isNaN(startLine) || Number.isNaN(endLine) ? 1 : Math.max(1, endLine - startLine + 1);
+}
+
+/** Does anything in here carry a source range? Non-participants get no box. */
+function isAnnotated(element: ShimElement): boolean {
+	if (element.getAttribute('data-sourcepos')) return true;
+	return elementChildren(element).some(isAnnotated);
+}
+
+export type Box = { top: number; height: number };
+
+/**
+ * Assign every annotated block a top and a height, laying children out in
+ * document order inside their parent. Bottom-up, so a container's box really
+ * does contain its children's — the one property a browser guarantees and the
+ * mapping's descent relies on.
+ */
+function layOut(root: ShimElement, startTop = 0, gap = BLOCK_GAP): Map<ShimElement, Box> {
+	const boxes = new Map<ShimElement, Box>();
+
+	function place(element: ShimElement, top: number): number {
+		const children = elementChildren(element).filter(isAnnotated);
+
+		if (children.length === 0) {
+			const height = leafHeight(element, sourceLineSpan(element));
+			boxes.set(element, { top, height });
+			return height;
+		}
+
+		let cursor = top;
+		children.forEach((child, index) => {
+			if (index > 0) cursor += gap;
+			cursor += place(child, cursor);
+		});
+
+		const height = cursor - top;
+		boxes.set(element, { top, height });
+		return height;
+	}
+
+	let cursor = startTop;
+	for (const child of elementChildren(root)) {
+		if (!isAnnotated(child)) continue;
+		cursor += place(child, cursor) + gap;
+	}
+
+	return boxes;
+}
+
+/* ------------------------------------------------------------------ */
+/* the two panes                                                       */
+/* ------------------------------------------------------------------ */
+
+const VIEWPORT = 800;
+const EDITOR_LINE_HEIGHT = 19;
+
+type Preview = {
+	body: ShimElement;
+	measure: (node: AnchorNode) => Box;
+	contentHeight: number;
+	scrollMax: number;
+};
+
+function buildPreview(doc: DocumentBuilder, gap = BLOCK_GAP): Preview {
+	const body = parseHtml(processMarkdownHtml(doc.html(), FILE_PATH, new Set<string>())).body;
+	const boxes = layOut(body, 0, gap);
+
+	let contentHeight = 0;
+	for (const box of boxes.values()) contentHeight = Math.max(contentHeight, box.top + box.height);
+
+	return {
+		body,
+		measure: (node) => boxes.get(node as ShimElement) ?? { top: Number.NaN, height: Number.NaN },
+		contentHeight,
+		scrollMax: Math.max(0, contentHeight - VIEWPORT),
+	};
+}
+
+type Editor = {
+	lineCount: number;
+	topForLine: (line: number) => number;
+	scrollMax: number;
+};
+
+function buildEditor(doc: DocumentBuilder): Editor {
+	const lineCount = doc.lineCount;
+	return {
+		lineCount,
+		topForLine: (line) => (line - 1) * EDITOR_LINE_HEIGHT,
+		scrollMax: Math.max(0, lineCount * EDITOR_LINE_HEIGHT - VIEWPORT),
+	};
+}
+
+/* --------------------------------------------------- the shipped mapping */
+//
+// These four functions are the arithmetic of `getEditorScrollSyncPosition`,
+// `syncScrollToPosition`, `getPreviewScrollSyncPosition` and
+// `scrollPreviewToSyncPosition`, over injected measurements instead of Monaco
+// and the DOM. Everything they call is imported from `src/`.
+
+function editorPositionAt(editor: Editor, scrollTop: number, frontMatterEnd = 0): ScrollSyncPosition {
+	const position = getScrollSyncPositionFromPixels(scrollTop, editor.scrollMax, frontMatterEnd);
+	if (position.section !== 'body') return position;
+
+	const line = getLineAtVerticalOffset(scrollTop, editor.lineCount, editor.topForLine);
+	return Number.isFinite(line) ? { ...position, line } : position;
+}
+
+/**
+ * `clamped` is the part of the answer the components throw away. A pane that
+ * has run out of scroll range cannot honour the position it was sent, and the
+ * two panes disagreeing there is not the mapping being wrong — every mapping
+ * ends up at the bottom of a pane that is already at the bottom. The drift
+ * measurements below therefore skip those, and assert the ends separately.
+ */
+function editorScrollTopFor(
+	editor: Editor,
+	position: ScrollSyncPosition,
+	frontMatterEnd = 0,
+): { scrollTop: number; clamped: boolean } {
+	let target: number | null = null;
+
+	if (position.section === 'body' && position.line !== undefined) {
+		const offset = getVerticalOffsetForLine(position.line, editor.lineCount, editor.topForLine);
+		if (Number.isFinite(offset)) target = offset;
+	}
+
+	if (target === null) target = getScrollTopForSyncPosition(position, editor.scrollMax, frontMatterEnd);
+
+	const scrollTop = Math.max(0, Math.min(editor.scrollMax, target));
+	return { scrollTop, clamped: scrollTop !== target };
+}
+
+function previewPositionAt(preview: Preview, scrollTop: number, frontMatterEnd = 0): ScrollSyncPosition {
+	const position = getScrollSyncPositionFromPixels(scrollTop, preview.scrollMax, frontMatterEnd);
+	if (position.section !== 'body') return position;
+
+	const line = getSourceLineAtPreviewOffset(
+		preview.body,
+		scrollTop,
+		preview.measure,
+	);
+	return line === null ? position : { ...position, line };
+}
+
+function previewScrollTopFor(
+	preview: Preview,
+	position: ScrollSyncPosition,
+	frontMatterEnd = 0,
+): { scrollTop: number; clamped: boolean } {
+	let target: number | null = null;
+
+	if (position.section === 'body' && position.line !== undefined) {
+		const offset = getPreviewOffsetForSourceLine(preview.body, position.line, preview.measure);
+		if (offset !== null) target = offset;
+	}
+
+	if (target === null) target = getScrollTopForSyncPosition(position, preview.scrollMax, frontMatterEnd);
+
+	const scrollTop = Math.max(0, Math.min(preview.scrollMax, target));
+	return { scrollTop, clamped: scrollTop !== target };
+}
+
+/** The pre-fix mapping: the same position with the source line taken away. */
+function ratioOnly(position: ScrollSyncPosition): ScrollSyncPosition {
+	return { section: position.section, ratio: position.ratio };
+}
+
+/* ------------------------------------------------------------------ */
+/* fixtures                                                            */
+/* ------------------------------------------------------------------ */
+
+const DOC = buildStressDocument();
+const PREVIEW = buildPreview(DOC);
+const EDITOR = buildEditor(DOC);
+
+/** Which source line each pane is showing at the top of its viewport. */
+function editorLineAt(scrollTop: number): number {
+	return getLineAtVerticalOffset(scrollTop, EDITOR.lineCount, EDITOR.topForLine);
+}
+
+function previewLineAt(scrollTop: number): number {
+	const line = getSourceLineAtPreviewOffset(PREVIEW.body, scrollTop, PREVIEW.measure);
+	assert.ok(line !== null, `the preview must resolve a source line at ${scrollTop}px`);
+	return line;
+}
+
+function sweep(scrollMax: number, from: number, to: number, steps: number): number[] {
+	const out: number[] = [];
+	for (let index = 0; index <= steps; index += 1) {
+		out.push(scrollMax * (from + ((to - from) * index) / steps));
+	}
+	return out;
+}
+
+/* ------------------------------------------------------------------ */
+/* the fixture itself                                                  */
+/* ------------------------------------------------------------------ */
+
+test('the fixture renders at a height the source lines do not predict', (t) => {
+	t.diagnostic(`${DOC.lineCount} source lines, preview content ${Math.round(PREVIEW.contentHeight)}px`);
+
+	// Where a ratio goes wrong: half the source is in the first 8 sections, but
+	// those sections take far more than half the rendered height.
+	const halfway = previewLineAt(PREVIEW.scrollMax / 2);
+	const proportionalGuess = DOC.lineCount / 2;
+
+	t.diagnostic(`preview halfway shows source line ${Math.round(halfway)}, a ratio would say ${Math.round(proportionalGuess)}`);
+	assert.ok(
+		Math.abs(halfway - proportionalGuess) > 25,
+		'the fixture must not be one where rendered height happens to track source lines, ' +
+			`got ${Math.round(halfway)} vs ${Math.round(proportionalGuess)}`,
+	);
+});
+
+/* ------------------------------------------------------------------ */
+/* the complaint: the end of the document                              */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Drive one pane, read the other, and report the disagreement in source lines.
+ * This is the reporter's measurement: "when reaching the end of the file it is
+ * quite a few lines off".
+ */
+function driftEditorToPreview(scrollTops: number[], strip: boolean) {
+	let worst = 0;
+	let worstAt = 0;
+
+	for (const scrollTop of scrollTops) {
+		const sent = editorPositionAt(EDITOR, scrollTop);
+		const preview = previewScrollTopFor(PREVIEW, strip ? ratioOnly(sent) : sent);
+		if (preview.clamped) continue;
+
+		const drift = Math.abs(previewLineAt(preview.scrollTop) - editorLineAt(scrollTop));
+		if (drift > worst) {
+			worst = drift;
+			worstAt = scrollTop;
+		}
+	}
+
+	return { worst, worstAt };
+}
+
+// The editor's anchor lands part way down a source line and the preview's part
+// way down a rendered block, so the two can differ by the fraction of a line
+// their interpolations meet at.
+const LINE_SLACK = 1;
+
+test('the tail of the document stays on the same source line', (t) => {
+	// The last part of the document that both panes can still scroll to. The
+	// final screenful is asserted separately below, because there both mappings
+	// simply run out of range.
+	const tail = sweep(EDITOR.scrollMax, 0.6, 1, 60);
+
+	const blockMapping = driftEditorToPreview(tail, false);
+	const ratioMapping = driftEditorToPreview(tail, true);
+
+	t.diagnostic(`ratio mapping: worst drift ${ratioMapping.worst.toFixed(1)} source lines`);
+	t.diagnostic(`block mapping: worst drift ${blockMapping.worst.toFixed(1)} source lines`);
+
+	// The control. If this ever falls to the block mapping's figure, the block
+	// mapping has collapsed back into a proportional one and the assertion below
+	// stopped meaning anything.
+	assert.ok(
+		ratioMapping.worst > 20,
+		`the proportional mapping is expected to be far off near the end of this document, got ${ratioMapping.worst.toFixed(1)} lines`,
+	);
+
+	assert.ok(
+		blockMapping.worst <= LINE_SLACK,
+		`the preview drifted ${blockMapping.worst.toFixed(1)} source lines from the editor at ` +
+			`scrollTop ${Math.round(blockMapping.worstAt)} (of ${Math.round(EDITOR.scrollMax)})`,
+	);
+});
+
+test('every part of the document stays on the same source line, not only the tail', (t) => {
+	const whole = sweep(EDITOR.scrollMax, 0, 1, 200);
+
+	const blockMapping = driftEditorToPreview(whole, false);
+	const ratioMapping = driftEditorToPreview(whole, true);
+
+	t.diagnostic(`ratio mapping: worst drift ${ratioMapping.worst.toFixed(1)} source lines`);
+	t.diagnostic(`block mapping: worst drift ${blockMapping.worst.toFixed(1)} source lines`);
+
+	assert.ok(ratioMapping.worst > 20, `control: got ${ratioMapping.worst.toFixed(1)} lines`);
+	assert.ok(
+		blockMapping.worst <= LINE_SLACK,
+		`the preview drifted ${blockMapping.worst.toFixed(1)} source lines at scrollTop ${Math.round(blockMapping.worstAt)}`,
+	);
+});
+
+test('driving the preview lands the editor on the same source line', (t) => {
+	let worst = 0;
+	let worstAt = 0;
+
+	for (const scrollTop of sweep(PREVIEW.scrollMax, 0, 1, 200)) {
+		const sent = previewPositionAt(PREVIEW, scrollTop);
+		const editor = editorScrollTopFor(EDITOR, sent);
+		if (editor.clamped) continue;
+
+		const drift = Math.abs(editorLineAt(editor.scrollTop) - previewLineAt(scrollTop));
+		if (drift > worst) {
+			worst = drift;
+			worstAt = scrollTop;
+		}
+	}
+
+	t.diagnostic(`preview -> editor: worst drift ${worst.toFixed(1)} source lines`);
+	assert.ok(
+		worst <= LINE_SLACK,
+		`the editor drifted ${worst.toFixed(1)} source lines at preview scrollTop ${Math.round(worstAt)}`,
+	);
+});
+
+test('the ends of the document are the ends of the mapping', (t) => {
+	// What the mapping aligns is the line at the TOP of each viewport, which is
+	// the only thing two panes of different heights can agree on. The panes'
+	// last screenfuls are not the same amount of document — the preview's tail is
+	// tables, so 800px of it is a handful of source lines, while 800px of editor
+	// is 42 — and the consequence is visible at the very bottom.
+	const atEditorBottom = previewScrollTopFor(PREVIEW, editorPositionAt(EDITOR, EDITOR.scrollMax));
+	const drift = Math.abs(previewLineAt(atEditorBottom.scrollTop) - editorLineAt(EDITOR.scrollMax));
+	t.diagnostic(
+		`editor at its bottom: preview at ${Math.round(atEditorBottom.scrollTop)} of ${Math.round(PREVIEW.scrollMax)}, ` +
+			`same top line to within ${drift.toFixed(2)}`,
+	);
+
+	// The top lines agree exactly...
+	assert.ok(drift <= LINE_SLACK, `the preview's top line was ${drift.toFixed(1)} lines from the editor's`);
+	// ...and the preview therefore still has room below, because the same lines
+	// take more height there. Anything else would mean abandoning the alignment
+	// at the one position the reporter looks at.
+	assert.ok(atEditorBottom.scrollTop < PREVIEW.scrollMax);
+
+	// Driven the other way the editor runs out first, and clamps rather than
+	// trying to scroll past its own last line.
+	const atPreviewBottom = editorScrollTopFor(EDITOR, previewPositionAt(PREVIEW, PREVIEW.scrollMax));
+	assert.equal(atPreviewBottom.scrollTop, EDITOR.scrollMax);
+	assert.ok(atPreviewBottom.clamped);
+
+	// The top of the document is a fixed point in both directions.
+	assert.equal(previewScrollTopFor(PREVIEW, editorPositionAt(EDITOR, 0)).scrollTop, 0);
+	assert.equal(editorScrollTopFor(EDITOR, previewPositionAt(PREVIEW, 0)).scrollTop, 0);
+});
+
+/* ------------------------------------------------------------------ */
+/* no feedback loop                                                    */
+/* ------------------------------------------------------------------ */
+
+/**
+ * The panes are kept from echoing each other by two flags
+ * (`isProgrammaticScroll` in the viewer, `isApplyingExternalScroll` in the
+ * editor), and a flag is a promise about event ordering, not about the mapping.
+ * What is asserted here is the mapping's own contribution — that an echo which
+ * did get through, because a flag was consumed by the wrong event or a scroll
+ * was coalesced, would die instead of building up.
+ *
+ * The property is IDEMPOTENCE, not identity, and the difference is the point.
+ * A block mapping quantises: a scroll offset in the margin between two blocks
+ * belongs to no block, so it resolves to the nearest block edge, and a round
+ * trip from there snaps by up to that margin. It snaps ONCE — the result is a
+ * block edge, which is its own image — so the panes settle instead of walking.
+ * Both components stop below a 5px threshold, so a settled round trip sends
+ * nothing further.
+ */
+const ECHO_THRESHOLD = 5;
+
+function editorRoundTrip(scrollTop: number): number {
+	const preview = previewScrollTopFor(PREVIEW, editorPositionAt(EDITOR, scrollTop));
+	return editorScrollTopFor(EDITOR, previewPositionAt(PREVIEW, preview.scrollTop)).scrollTop;
+}
+
+function previewRoundTrip(scrollTop: number): number {
+	const editor = editorScrollTopFor(EDITOR, previewPositionAt(PREVIEW, scrollTop));
+	return previewScrollTopFor(PREVIEW, editorPositionAt(EDITOR, editor.scrollTop)).scrollTop;
+}
+
+test('an echo through the other pane settles in one step', (t) => {
+	let worstFirst = 0;
+	let worstSecond = 0;
+	let worstAt = 0;
+
+	for (const scrollTop of sweep(EDITOR.scrollMax, 0, 1, 200)) {
+		const once = editorRoundTrip(scrollTop);
+		const twice = editorRoundTrip(once);
+
+		worstFirst = Math.max(worstFirst, Math.abs(once - scrollTop));
+		if (Math.abs(twice - once) > worstSecond) {
+			worstSecond = Math.abs(twice - once);
+			worstAt = scrollTop;
+		}
+	}
+
+	t.diagnostic(`editor -> preview -> editor: first echo up to ${worstFirst.toFixed(1)}px, second ${worstSecond.toFixed(3)}px`);
+
+	// The second round trip is where an oscillation would show: it is the same
+	// arithmetic on the settled position, so anything but zero here compounds.
+	assert.ok(
+		worstSecond < ECHO_THRESHOLD,
+		`a second echo would move the editor a further ${worstSecond.toFixed(1)}px at scrollTop ${Math.round(worstAt)}`,
+	);
+	// And the first snap is bounded by the gap between two rendered blocks, not
+	// by anything that scales with the document.
+	assert.ok(worstFirst < 4 * BLOCK_GAP, `the first echo moved the editor ${worstFirst.toFixed(1)}px`);
+});
+
+test('the preview echo settles too', () => {
+	let worstSecond = 0;
+
+	for (const scrollTop of sweep(PREVIEW.scrollMax, 0, 1, 200)) {
+		const once = previewRoundTrip(scrollTop);
+		worstSecond = Math.max(worstSecond, Math.abs(previewRoundTrip(once) - once));
+	}
+
+	assert.ok(worstSecond < ECHO_THRESHOLD, `a second preview echo moved it ${worstSecond.toFixed(1)}px`);
+});
+
+/**
+ * The case the synthetic layout above nearly hid, and the reason this file
+ * insists on more than one of them.
+ *
+ * Margins collapse, so in a real preview one block's bottom edge IS the next
+ * block's top — the two boxes touch. A line mapped back to a pixel lands on the
+ * top edge of its own block, and if the block above is allowed to claim that
+ * pixel too, the round trip resolves to the block above. Every echo then walks
+ * the reader one block up the document: a feedback loop that the flags happen
+ * to stop, and that nothing in the mapping did.
+ *
+ * With `BLOCK_GAP` set to 16 no two boxes ever touched and the round trip was a
+ * perfect fixed point. It was measured in Chrome, over this pipeline's own
+ * output, before it was fixed; this is the guard.
+ */
+test('touching blocks do not walk the panes up the document', () => {
+	const touching = buildPreview(DOC, 0);
+
+	const roundTrip = (offset: number) => {
+		const line = getSourceLineAtPreviewOffset(touching.body, offset, touching.measure);
+		assert.ok(line !== null);
+		const back = getPreviewOffsetForSourceLine(touching.body, line, touching.measure);
+		assert.ok(back !== null);
+		return back;
+	};
+
+	let worstSecond = 0;
+	let worstThird = 0;
+	for (const offset of sweep(touching.scrollMax, 0, 1, 400)) {
+		const once = roundTrip(offset);
+		const twice = roundTrip(once);
+		worstSecond = Math.max(worstSecond, Math.abs(twice - once));
+		worstThird = Math.max(worstThird, Math.abs(roundTrip(twice) - twice));
+	}
+
+	assert.equal(worstSecond, 0, `a second echo moved the preview ${worstSecond.toFixed(1)}px between touching blocks`);
+	assert.equal(worstThird, 0, `a third echo moved the preview ${worstThird.toFixed(1)}px`);
+});
+
+test('the pixel two blocks share belongs to the lower one', () => {
+	// Stated directly, because the loop above only shows the consequence. The
+	// boundary pixel is the top of the block below, not the bottom of the block
+	// above, and a mapping that says otherwise cannot have a fixed point there.
+	const doc = new DocumentBuilder();
+	doc.paragraph('First.');
+	doc.blank();
+	doc.paragraph('Second.');
+	doc.blank();
+	doc.paragraph('Third.');
+
+	const preview = buildPreview(doc, 0);
+	const second = preview.body
+		.querySelectorAll('p')
+		.find((el) => (el.getAttribute('data-sourcepos') ?? '').startsWith('3:'));
+	assert.ok(second, 'fixture must contain the second paragraph');
+	const box = preview.measure(second);
+
+	assert.equal(getSourceLineAtPreviewOffset(preview.body, box.top, preview.measure), 3);
+	assert.equal(getSourceLineAtPreviewOffset(preview.body, box.top + box.height, preview.measure), 5);
+	assert.equal(getPreviewOffsetForSourceLine(preview.body, 3, preview.measure), box.top);
+});
+
+test('repeating the echo does not walk the panes down the document', () => {
+	// Twenty round trips from a settled position. A mapping that was merely
+	// *close* to idempotent would creep, and creep is what an unguarded feedback
+	// loop looks like from the outside.
+	const started = editorRoundTrip(EDITOR.scrollMax * 0.8);
+	let scrollTop = started;
+
+	for (let round = 0; round < 20; round += 1) scrollTop = editorRoundTrip(scrollTop);
+
+	assert.ok(
+		Math.abs(scrollTop - started) < ECHO_THRESHOLD,
+		`twenty echoes moved the editor ${Math.abs(scrollTop - started).toFixed(1)}px`,
+	);
+});
+
+test('scrolling one pane down always moves the other pane down', () => {
+	// The failure shape #433 shipped: a sync that reports something constant, so
+	// the other pane never follows. Monotonicity covers the whole range at once.
+	const scrollTops = sweep(EDITOR.scrollMax, 0, 1, 200);
+	const mapped = scrollTops.map(
+		(scrollTop) => previewScrollTopFor(PREVIEW, editorPositionAt(EDITOR, scrollTop)).scrollTop,
+	);
+
+	for (let index = 1; index < mapped.length; index += 1) {
+		assert.ok(
+			mapped[index] >= mapped[index - 1],
+			`editor ${Math.round(scrollTops[index - 1])} -> ${Math.round(scrollTops[index])} moved the preview ` +
+				`backwards: ${mapped[index - 1].toFixed(1)} -> ${mapped[index].toFixed(1)}`,
+		);
+	}
+
+	assert.ok(mapped[mapped.length - 1] > mapped[0], 'the preview must actually travel');
+});
+
+/* ------------------------------------------------------------------ */
+/* what the mapping must never resolve to                              */
+/* ------------------------------------------------------------------ */
+
+/**
+ * #464's trap. `render.hardbreaks` is on, so soft-wrapped prose is full of
+ * `<br data-sourcepos>` elements that carry a source range and generate no box;
+ * a browser reports `offsetTop === 0, offsetHeight === 0` for every one. A
+ * mapping that let one win resolves the reader's position to the top of the
+ * document.
+ *
+ * The shim has no layout, so this is modelled rather than measured: the `<br>`s
+ * are given the box a browser gives them — the origin — and the assertion is
+ * that a position deep in the document does not come back as line 1.
+ */
+test('a boxless <br> at the origin never captures a scroll position', () => {
+	const doc = new DocumentBuilder();
+	for (let index = 1; index <= 40; index += 1) {
+		doc.wrappedParagraph([
+			`Paragraph ${index} first line of prose the author soft-wrapped.`,
+			`Paragraph ${index} second line, still the same markdown block.`,
+			`Paragraph ${index} third and final line of the block.`,
+		]);
+		doc.blank();
+	}
+
+	const body = parseHtml(processMarkdownHtml(doc.html(), FILE_PATH, new Set())).body;
+	assert.ok(body.querySelectorAll('br[data-sourcepos]').length > 0, 'fixture must contain annotated hard breaks');
+
+	const boxes = layOut(body);
+	// Every `<br>` reports the box a browser reports for it: none, at the origin.
+	const measure = (node: AnchorNode) => {
+		const element = node as ShimElement;
+		if (BOXLESS.has(element.tagName)) return { top: 0, height: 0 };
+		return boxes.get(element) ?? { top: Number.NaN, height: Number.NaN };
+	};
+
+	let contentHeight = 0;
+	for (const box of boxes.values()) contentHeight = Math.max(contentHeight, box.top + box.height);
+
+	for (const offset of [400, 800, 1200, 1600, 2000]) {
+		const line = getSourceLineAtPreviewOffset(body, offset, measure);
+		assert.ok(line !== null, `offset ${offset} must resolve`);
+		assert.ok(line > 1, `offset ${offset}px of ${Math.round(contentHeight)}px resolved to line ${line}`);
+
+		// ...and the line it resolved to maps back to roughly that offset, which
+		// a `<br>` at the origin could never do.
+		const back = getPreviewOffsetForSourceLine(body, line, measure);
+		assert.ok(back !== null && Math.abs(back - offset) < 40, `offset ${offset} came back as ${back}`);
+	}
+});
+
+/* ------------------------------------------------------------------ */
+/* the fallback                                                        */
+/* ------------------------------------------------------------------ */
+
+test('front matter is still carried by the section ratio, not by a line', () => {
+	// The carve-out `scrollSync.ts` exists for. The preview renders front matter
+	// as a fixed-height panel with no source range at all, so there is no line to
+	// send and the section/ratio pair is the only thing that can describe it.
+	const editorFrontMatterEnd = 200;
+	const previewFrontMatterEnd = 60;
+
+	const inside = editorPositionAt(EDITOR, 100, editorFrontMatterEnd);
+	assert.equal(inside.section, 'frontmatter');
+	assert.equal(inside.line, undefined, 'a front-matter position must not carry a source line');
+	assert.equal(inside.ratio, 0.5);
+
+	// ...and it still lands on the preview's own boundary, proportionally.
+	assert.equal(previewScrollTopFor(PREVIEW, inside, previewFrontMatterEnd).scrollTop, 30);
+	assert.equal(
+		previewScrollTopFor(
+			PREVIEW,
+			editorPositionAt(EDITOR, editorFrontMatterEnd - 1, editorFrontMatterEnd),
+			previewFrontMatterEnd,
+		).scrollTop,
+		previewFrontMatterEnd * ((editorFrontMatterEnd - 1) / editorFrontMatterEnd),
+	);
+
+	// The first body pixel picks the line mapping straight back up.
+	const body = editorPositionAt(EDITOR, editorFrontMatterEnd, editorFrontMatterEnd);
+	assert.equal(body.section, 'body');
+	assert.ok(body.line !== undefined, 'a body position must carry a source line');
+});
+
+test('a preview holding no annotated block falls back to the ratio', () => {
+	// The other trigger: a document the renderer produced nothing anchorable
+	// from. The position then has no line, and the receiving pane is back on the
+	// mapping that was there before — which is a degraded sync, not a dead one.
+	const empty = parseHtml('<div class="notice">Nothing rendered.</div>').body;
+	const measure = () => ({ top: 0, height: 0 });
+
+	assert.equal(getSourceLineAtPreviewOffset(empty, 400, measure), null);
+	assert.equal(getPreviewOffsetForSourceLine(empty, 12, measure), null);
+
+	const emptyPreview: Preview = { body: empty, measure, contentHeight: 0, scrollMax: 600 };
+	const position = previewPositionAt(emptyPreview, 300);
+	assert.equal(position.line, undefined);
+	assert.equal(position.section, 'body');
+	assert.equal(position.ratio, 0.5);
+
+	// And a line arriving from the editor still moves it, by ratio.
+	assert.equal(previewScrollTopFor(emptyPreview, { section: 'body', ratio: 0.25, line: 400 }).scrollTop, 150);
+});
+
+test('an element the app renders around the document does not swallow the offset', () => {
+	// The front-matter panel and the table of contents are real children of the
+	// scroll container with no `data-sourcepos` anywhere inside them. Descending
+	// into one would resolve every offset it covers to nothing.
+	const doc = new DocumentBuilder();
+	doc.paragraph('First paragraph.');
+	doc.blank();
+	doc.paragraph('Second paragraph.');
+
+	const document = parseHtml(processMarkdownHtml(doc.html(), FILE_PATH, new Set()));
+	const body = document.body;
+	const panel = document.createElement('details');
+	panel.setAttribute('class', 'frontmatter-panel');
+	body.insertBefore(panel, body.childNodes[0]);
+
+	// The panel occupies the first 120px of the scroll content; the document
+	// starts underneath it.
+	const boxes = layOut(body, 120);
+	const measure = (node: AnchorNode) => {
+		if (node === panel) return { top: 0, height: 120 };
+		return boxes.get(node as ShimElement) ?? { top: Number.NaN, height: Number.NaN };
+	};
+
+	// An offset squarely inside the panel resolves to the nearest real block
+	// rather than to nothing.
+	const line = getSourceLineAtPreviewOffset(body, 60, measure);
+	assert.ok(line !== null, 'an offset over the front-matter panel must still resolve to a block');
+	assert.equal(line, 1);
+
+	// ...and the block under it still answers for itself.
+	assert.equal(getSourceLineAtPreviewOffset(body, 130, measure), 1);
+	assert.equal(getSourceLineAtPreviewOffset(body, 175, measure), 3);
+});
+
+test('a position past the last block resolves to the last block, not to nothing', () => {
+	// The preview has padding under the last block, so the anchor offset at the
+	// bottom of the document is past every box. Returning null there would put
+	// the very end of the document — the thing #205 is about — back on the
+	// proportional mapping.
+	const line = getSourceLineAtPreviewOffset(PREVIEW.body, PREVIEW.contentHeight + 500, PREVIEW.measure);
+	assert.ok(line !== null);
+	assert.ok(
+		line > DOC.lineCount - 10,
+		`an offset past the end resolved to line ${line} of ${DOC.lineCount}`,
+	);
+});
+
+test('a collapsed fold answers for its hidden contents', () => {
+	// A collapsed wrapper is `height: 0; overflow: hidden`, so its children still
+	// report offsets and those offsets point at where the content would be. The
+	// mapping must stop at the wrapper, which is where the reader actually sees
+	// that part of the document.
+	const doc = new DocumentBuilder();
+	doc.heading(2, 'Collapsed', 'collapsed');
+	doc.blank();
+	doc.paragraph('Hidden body text.');
+	doc.blank();
+	doc.heading(2, 'After', 'after');
+	doc.blank();
+	doc.paragraph('Visible body text.');
+
+	const body = parseHtml(processMarkdownHtml(doc.html(), FILE_PATH, new Set(['collapsed']))).body;
+	const wrapper = body.querySelector('.foldable-content-wrapper.is-collapsed');
+	assert.ok(wrapper, 'fixture must contain a collapsed wrapper');
+
+	const boxes = layOut(body);
+	const measure = (node: AnchorNode) => {
+		if (node === wrapper) return { top: 38, height: 0 };
+		return boxes.get(node as ShimElement) ?? { top: Number.NaN, height: Number.NaN };
+	};
+
+	// Line 3 is inside the collapsed section; it must map to the wrapper's own
+	// position and not to where its hidden paragraph claims to be.
+	const offset = getPreviewOffsetForSourceLine(body, 3, measure);
+	assert.equal(offset, 38);
+});
+
+/* ------------------------------------------------------------------ */
+/* the editor half of the mapping                                      */
+/* ------------------------------------------------------------------ */
+
+test('the editor line lookup is the exact inverse of Monaco line tops', () => {
+	// Monaco publishes line -> pixel and nothing for the inverse, so the inverse
+	// is a binary search over the same function. Folded regions and wrapped lines
+	// make the heights non-uniform, which is why a division by a line height
+	// would not do: this table has three different ones.
+	const heights = [24, 24, 96, 24, 48, 48, 24, 24, 24, 240, 24, 24];
+	const tops = [0];
+	for (const height of heights) tops.push(tops[tops.length - 1] + height);
+	const topForLine = (line: number) => tops[Math.max(0, Math.min(tops.length - 1, line - 1))];
+	const lineCount = heights.length;
+
+	for (let line = 1; line <= lineCount; line += 1) {
+		assert.equal(getVerticalOffsetForLine(line, lineCount, topForLine), tops[line - 1]);
+		assert.equal(getLineAtVerticalOffset(tops[line - 1], lineCount, topForLine), line);
+	}
+
+	// Fractional positions survive the round trip, which is what keeps the paired
+	// pane moving smoothly instead of jumping a line at a time.
+	for (const line of [1.25, 3.5, 6.75, 10.1, 11.9]) {
+		const offset = getVerticalOffsetForLine(line, lineCount, topForLine);
+		assert.ok(
+			Math.abs(getLineAtVerticalOffset(offset, lineCount, topForLine) - line) < 1e-9,
+			`line ${line} returned as ${getLineAtVerticalOffset(offset, lineCount, topForLine)}`,
+		);
+	}
+
+	// The bottom edge of the last line is `lineCount + 1`, and both directions
+	// accept it: it is a position the reader can scroll to, and rounding it down
+	// to the top of the last line would leave the very end of the document —
+	// what #205 is about — as the one place the round trip did not close.
+	assert.equal(getLineAtVerticalOffset(tops[lineCount], lineCount, topForLine), lineCount + 1);
+	assert.equal(getVerticalOffsetForLine(lineCount + 1, lineCount, topForLine), tops[lineCount]);
+
+	// Out of range in either direction clamps into the document.
+	assert.equal(getLineAtVerticalOffset(-500, lineCount, topForLine), 1);
+	assert.equal(getLineAtVerticalOffset(99999, lineCount, topForLine), lineCount + 1);
+	assert.equal(getVerticalOffsetForLine(0, lineCount, topForLine), 0);
+	assert.equal(getVerticalOffsetForLine(lineCount + 50, lineCount, topForLine), tops[lineCount]);
+
+	// An empty or unmeasurable model never produces NaN pixels.
+	assert.equal(getLineAtVerticalOffset(100, 0, topForLine), 1);
+	assert.equal(getVerticalOffsetForLine(4, 0, topForLine), 0);
+	assert.equal(getLineAtVerticalOffset(Number.NaN, lineCount, topForLine), 1);
+	assert.equal(getVerticalOffsetForLine(Number.NaN, lineCount, topForLine), 0);
+});
+
+test('the binary search costs a logarithm, not a walk', () => {
+	// The mapping runs on every scroll event, so the number of measurements it
+	// asks Monaco for is part of the contract, not an implementation detail.
+	const lineCount = 100_000;
+	let calls = 0;
+	const topForLine = (line: number) => {
+		calls += 1;
+		return (line - 1) * 20;
+	};
+
+	getLineAtVerticalOffset(1_234_567, lineCount, topForLine);
+	assert.ok(calls <= 2 * Math.ceil(Math.log2(lineCount)), `binary search made ${calls} measurements`);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -41,8 +41,11 @@ import { observeFoldLayout } from './utils/foldLayout.js';
 import {
 	findAnchorElement,
 	getAnchorScrollTop,
-	parseSourceposLineRange,
+	getPreviewOffsetForSourceLine,
+	getSourceLineAtPreviewOffset,
 	PREVIEW_ANCHOR_OFFSET,
+	type AnchorBox,
+	type AnchorNode,
 } from './utils/previewAnchor.js';
 import {
 	addFrontMatterListItems,
@@ -1194,22 +1197,57 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		return Math.max(0, Math.min(getPreviewScrollMax(target), panel.offsetTop + panel.offsetHeight));
 	}
 
-	function getPreviewScrollSyncPosition(target: HTMLElement) {
-		return getScrollSyncPositionFromPixels(
+	// `offsetTop` is relative to the offset parent rather than to the scroll
+	// container, but every measurement in the sync path reads the same property
+	// on elements sharing one offset parent, so the difference is a constant that
+	// cancels — the same reasoning `getAnchorScrollTop` documents for the restore.
+	function measurePreviewBox(node: AnchorNode): AnchorBox {
+		const element = node as HTMLElement;
+		return { top: element.offsetTop, height: element.offsetHeight };
+	}
+
+	function getPreviewScrollSyncPosition(target: HTMLElement): ScrollSyncPosition {
+		const position = getScrollSyncPositionFromPixels(
 			target.scrollTop,
 			getPreviewScrollMax(target),
 			getPreviewFrontMatterScrollEnd(target),
 		);
+
+		// Front matter is a rendered panel with no source range, so there is no
+		// line to send and the section ratio is the only thing that can carry it.
+		// This is the carve-out `scrollSync.ts` exists for, unchanged.
+		if (position.section !== 'body') return position;
+
+		const line = getSourceLineAtPreviewOffset(target, target.scrollTop, measurePreviewBox);
+
+		return line === null ? position : { ...position, line };
 	}
 
 	function scrollPreviewToSyncPosition(position: ScrollSyncPosition) {
 		if (!markdownBody) return;
 
-		const targetScroll = getScrollTopForSyncPosition(
-			position,
-			getPreviewScrollMax(markdownBody),
-			getPreviewFrontMatterScrollEnd(markdownBody),
-		);
+		const scrollMax = getPreviewScrollMax(markdownBody);
+		let targetScroll: number | null = null;
+
+		if (position.section === 'body' && position.line !== undefined) {
+			const offset = getPreviewOffsetForSourceLine(markdownBody, position.line, measurePreviewBox);
+			if (offset !== null) targetScroll = offset;
+		}
+
+		if (targetScroll === null) {
+			targetScroll = getScrollTopForSyncPosition(
+				position,
+				scrollMax,
+				getPreviewFrontMatterScrollEnd(markdownBody),
+			);
+		}
+
+		// The line mapping can point past either end — the last block interpolates
+		// beyond the bottom of a preview that has no room left to scroll. Clamping
+		// before the threshold check is what keeps `isProgrammaticScroll` honest:
+		// an unreachable target fires no scroll event, and the flag would then be
+		// spent swallowing the reader's next real scroll instead.
+		targetScroll = Math.max(0, Math.min(scrollMax, targetScroll));
 
 		if (Math.abs(markdownBody.scrollTop - targetScroll) <= 5) return;
 
@@ -1223,41 +1261,29 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		}
 	}
 
-	type PreviewScrollAnchor = {
-		line: number;
-		ratio: number;
-	};
+	/**
+	 * The source line to save as this tab's reading position: the one rendered
+	 * `PREVIEW_ANCHOR_OFFSET` below the top of the viewport, which is where the
+	 * restore puts it back.
+	 *
+	 * This used to be its own scan — `querySelectorAll('[data-sourcepos]')` over
+	 * the whole preview, then `offsetTop` and `offsetHeight` on every element it
+	 * returned, on every scroll event. Two things were wrong with that beyond the
+	 * cost (8.3ms per event on a 13,000-line document, measured in Chrome). It
+	 * took the FIRST element covering the offset in document order, which is the
+	 * outermost, while the restore's `findAnchorElement` takes the narrowest — so
+	 * capture and restore disagreed about which block a position belonged to. And
+	 * it had no opinion about `<br>`, which carries a source range and no box, so
+	 * an anchor at the top of the document could resolve to one (#464).
+	 */
+	function getPreviewScrollAnchor(target: HTMLElement): number | null {
+		const line = getSourceLineAtPreviewOffset(
+			target,
+			target.scrollTop + PREVIEW_ANCHOR_OFFSET,
+			measurePreviewBox,
+		);
 
-	function getPreviewScrollAnchor(target: HTMLElement): PreviewScrollAnchor | null {
-		const anchorOffset = target.scrollTop + PREVIEW_ANCHOR_OFFSET;
-		const viewportRatio =
-			target.clientHeight > 0 ? Math.min(1, PREVIEW_ANCHOR_OFFSET / target.clientHeight) : 0;
-		const candidates = Array.from(target.querySelectorAll<HTMLElement>('[data-sourcepos]'));
-
-		let best: { el: HTMLElement; startLine: number; endLine: number; distance: number } | null = null;
-		for (const el of candidates) {
-			const range = parseSourceposLineRange(el.dataset.sourcepos);
-			if (!range) continue;
-
-			const top = el.offsetTop;
-			const bottom = top + el.offsetHeight;
-			const distance = anchorOffset < top ? top - anchorOffset : anchorOffset > bottom ? anchorOffset - bottom : 0;
-
-			if (!best || distance < best.distance) {
-				best = { el, startLine: range.startLine, endLine: range.endLine, distance };
-				if (distance === 0) break;
-			}
-		}
-
-		if (!best) return null;
-
-		const elementHeight = best.el.offsetHeight;
-		const relativeOffset = Math.max(0, Math.min(elementHeight, anchorOffset - best.el.offsetTop));
-		const elementRatio = elementHeight > 0 ? relativeOffset / elementHeight : 0;
-		const totalLines = best.endLine - best.startLine;
-		const line = best.startLine + Math.round(Math.max(0, totalLines) * elementRatio);
-
-		return { line, ratio: viewportRatio };
+		return line === null ? null : Math.round(line);
 	}
 
 	function syncEditorToPreviewScroll(target: HTMLElement) {
@@ -1299,9 +1325,9 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 				tabManager.updateTabScrollPercentage(tabManager.activeTabId, percentage);
 			}
 
-			const anchor = getPreviewScrollAnchor(target);
-			if (anchor) {
-				tabManager.updateTabAnchorLine(tabManager.activeTabId, anchor.line);
+			const anchorLine = getPreviewScrollAnchor(target);
+			if (anchorLine !== null) {
+				tabManager.updateTabAnchorLine(tabManager.activeTabId, anchorLine);
 			}
 		}
 

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -6,8 +6,10 @@
 	import { MARKDOWN_LANGUAGE_ID, shouldLinkifyPastedUrl } from '../utils/pasteContext.js';
 	import { toggleLineMarker, type LineMarkerToolId } from '../utils/editorToolbar.js';
 	import {
+		getLineAtVerticalOffset,
 		getScrollSyncPositionFromPixels,
 		getScrollTopForSyncPosition,
+		getVerticalOffsetForLine,
 		type ScrollSyncPosition,
 	} from '../utils/scrollSync.js';
 
@@ -1185,26 +1187,58 @@
 		return Math.max(0, Math.min(getEditorContentScrollMax(), editor.getTopForLineNumber(safeBodyStartLine)));
 	}
 
+	// Monaco's own line -> pixel measurement, which already accounts for folded
+	// regions, wrapped lines and view zones. `getLineAtVerticalOffset` inverts it
+	// by binary search, so this is called ~log2(lineCount) times per sync.
+	function getEditorLineTop(line: number) {
+		return editor ? editor.getTopForLineNumber(line) : 0;
+	}
+
 	function getEditorScrollSyncPosition() {
 		if (!editor) {
 			return { section: 'body', ratio: 0 } satisfies ScrollSyncPosition;
 		}
 
-		return getScrollSyncPositionFromPixels(
+		const position = getScrollSyncPositionFromPixels(
 			editor.getScrollTop(),
 			getEditorContentScrollMax(),
 			getEditorFrontMatterScrollEnd(),
 		);
+
+		// Front matter renders as a panel in the preview with no source range, so
+		// there is nothing for a line to resolve against there; the section ratio
+		// carries it, exactly as before.
+		const model = position.section === 'body' ? editor.getModel() : null;
+		if (!model) return position;
+
+		const line = getLineAtVerticalOffset(editor.getScrollTop(), model.getLineCount(), getEditorLineTop);
+
+		return Number.isFinite(line) ? { ...position, line } : position;
 	}
 
 	export function syncScrollToPosition(position: ScrollSyncPosition) {
 		if (!editor) return;
 
-		const targetScroll = getScrollTopForSyncPosition(
-			position,
-			getEditorContentScrollMax(),
-			getEditorFrontMatterScrollEnd(),
-		);
+		const scrollMax = getEditorContentScrollMax();
+		let targetScroll: number | null = null;
+
+		if (position.section === 'body' && position.line !== undefined) {
+			const model = editor.getModel();
+			if (model) {
+				const offset = getVerticalOffsetForLine(position.line, model.getLineCount(), getEditorLineTop);
+				if (Number.isFinite(offset)) targetScroll = offset;
+			}
+		}
+
+		if (targetScroll === null) {
+			targetScroll = getScrollTopForSyncPosition(position, scrollMax, getEditorFrontMatterScrollEnd());
+		}
+
+		// Clamp before the threshold: a line near the end of the document resolves
+		// to an offset the editor cannot reach, and an unreachable target produces
+		// no scroll event — which would leave `isApplyingExternalScroll` to be
+		// spent on the reader's next real scroll instead of on this one.
+		targetScroll = Math.max(0, Math.min(scrollMax, targetScroll));
 
 		if (Math.abs(editor.getScrollTop() - targetScroll) <= 5) return;
 

--- a/src/lib/utils/previewAnchor.ts
+++ b/src/lib/utils/previewAnchor.ts
@@ -1,10 +1,12 @@
 /**
- * Resolving a saved source line back to a rendered preview element.
+ * Resolving a source line to a rendered preview element, and back.
  *
- * Scrolling the preview saves a source line (`tab.anchorLine`, produced by
- * `getPreviewScrollAnchor`) and re-activating the tab has to turn that line
- * back into a scroll offset. Both directions key off the `data-sourcepos`
- * attributes comrak writes onto the rendered blocks.
+ * Two features share this. Scrolling the preview saves a source line
+ * (`tab.anchorLine`, produced by `getPreviewScrollAnchor`) and re-activating the
+ * tab has to turn that line back into a scroll offset; split-view scroll sync
+ * has to turn the preview's scroll offset into a source line for the editor and
+ * a source line from the editor back into a preview offset. Both directions key
+ * off the `data-sourcepos` attributes comrak writes onto the rendered blocks.
  *
  * The one thing that makes this non-trivial: `processMarkdownHtml` re-parents
  * everything that follows a heading into a `.foldable-content-wrapper` it
@@ -13,14 +15,17 @@
  * shallowest headings in the document, so a scan of `body.children` can only
  * ever match an anchor that landed exactly on one of those heading lines.
  *
- * `findAnchorElement` therefore descends. It treats an element without a source
+ * Every lookup here therefore descends. It treats an element without a source
  * range as a transparent container whose span is derived from its first and
  * last annotated descendants, which lets it skip a whole section in one
  * comparison instead of visiting every annotated element in the document. The
  * work is proportional to the number of siblings along the path to the match
- * (plus the fold depth), not to the document size — the restore runs once per
- * tab activation, but this keeps it off the same O(all elements) footing as the
- * per-scroll-event capture path.
+ * (plus the fold depth), not to the document size. That matters more than it
+ * used to: scroll sync runs a lookup on every scroll event, where the flat
+ * `querySelectorAll('[data-sourcepos]')` scan it replaced cost 8.3ms per event
+ * on a 13,000-line document (measured in Chrome over this pipeline's output;
+ * the descent, with the memos below, is 0.9ms on the same document and 0.2ms
+ * on a 1,700-line one).
  */
 
 /** Inclusive source line range, as written in `data-sourcepos`. */
@@ -45,6 +50,18 @@ export type AnchorNode = {
 export type AnchorMatch = LineRange & {
 	element: AnchorNode;
 };
+
+/**
+ * Where an element sits in the preview's scroll content, in the same space as
+ * the container's `scrollTop`. In the browser this is `offsetTop` /
+ * `offsetHeight`, which is what every other measurement in this file assumes.
+ */
+export type AnchorBox = {
+	top: number;
+	height: number;
+};
+
+export type MeasureAnchorBox = (node: AnchorNode) => AnchorBox;
 
 const ELEMENT_NODE = 1;
 
@@ -87,8 +104,34 @@ function elementChildren(node: AnchorNode): AnchorNode[] {
 	return out;
 }
 
+/*
+ * Both lookups below are memoised on the node, and both memos are WeakMaps
+ * keyed by the element itself.
+ *
+ * This is what makes the mapping affordable on a scroll event. A source range
+ * is parsed out of a string and a container's span is derived by walking to its
+ * first and last annotated descendants; without a memo both are recomputed for
+ * every candidate sibling on every call, and on a 13,000-line document that is
+ * ~6ms per mapping — measured, in Chrome, over this pipeline's own output.
+ *
+ * WHAT INVALIDATES THEM: nothing, explicitly. The answer for a node is a
+ * function of that node's own attribute and of its subtree's annotated blocks,
+ * neither of which is edited in place — the preview is rebuilt wholesale by
+ * `bind:innerHTML` on every render pass, so a changed document is a new set of
+ * nodes, and the entries describing the old ones are collected with them.
+ * Folding, task checkboxes and rich-content rendering all leave the annotated
+ * blocks and their ranges exactly where they were.
+ */
+const ownRangeCache = new WeakMap<object, LineRange | null>();
+const spanCache = new WeakMap<object, LineRange | null>();
+
 function ownRange(node: AnchorNode): LineRange | null {
-	return parseSourceposLineRange(node.getAttribute?.('data-sourcepos'));
+	const cached = ownRangeCache.get(node as object);
+	if (cached !== undefined) return cached;
+
+	const range = parseSourceposLineRange(node.getAttribute?.('data-sourcepos'));
+	ownRangeCache.set(node as object, range);
+	return range;
 }
 
 /**
@@ -107,6 +150,15 @@ function isCollapsedContainer(node: AnchorNode): boolean {
  * pipeline created — the range from its first to its last annotated descendant.
  */
 function resolveSpan(node: AnchorNode): LineRange | null {
+	const cached = spanCache.get(node as object);
+	if (cached !== undefined) return cached;
+
+	const span = computeSpan(node);
+	spanCache.set(node as object, span);
+	return span;
+}
+
+function computeSpan(node: AnchorNode): LineRange | null {
 	const own = ownRange(node);
 	if (own) return own;
 
@@ -128,25 +180,100 @@ function resolveSpan(node: AnchorNode): LineRange | null {
 	return { startLine: first.startLine, endLine: Math.max(first.endLine, last?.endLine ?? first.endLine) };
 }
 
-function contains(range: LineRange, line: number): boolean {
-	return line >= range.startLine && line <= range.endLine;
+/**
+ * How far a candidate element is from what the caller is looking for: `0` when
+ * it is the thing, otherwise the size of the gap. `NaN` disqualifies a
+ * candidate outright, which is how an element the browser could not measure
+ * drops out (`NaN < best` is false).
+ *
+ * One descent serves three lookups — an exact line, the nearest line, and a
+ * pixel offset — so the element the two sync directions pick is chosen by the
+ * same walk over the same tree with the same skip rules. That is what makes
+ * line -> offset -> line an identity rather than an approximation: if the two
+ * directions descended differently they could land on an ancestor one way and
+ * a descendant the other, and the round trip would drift by the difference.
+ */
+type AnchorDistance = (span: LineRange, node: AnchorNode) => number;
+
+function lineDistance(span: LineRange, line: number): number {
+	if (line < span.startLine) return span.startLine - line;
+	if (line > span.endLine) return line - span.endLine;
+	return 0;
 }
 
-function search(node: AnchorNode, line: number, inherited: AnchorMatch | null): AnchorMatch | null {
+/**
+ * A block owns the pixels `[top, top + height)` — half open at the bottom.
+ *
+ * Adjacent blocks touch: margins collapse, and one block's bottom edge is the
+ * next one's top. If both claim that pixel the earlier one wins, because the
+ * descent stops at the first candidate whose distance is zero. That is a
+ * feedback loop rather than an off-by-one: a line resolved back to a pixel
+ * lands on the TOP edge of its block, which the block ABOVE then claims, so
+ * every echo between the panes walks the reader one block up the document.
+ * (Observed in Chrome over this pipeline's own output; the DOM shim has no
+ * layout, so its blocks never touched and the loop was invisible there.)
+ *
+ * A block whose bottom edge is exactly the offset therefore reports the
+ * smallest positive distance instead of zero: still the nearest thing when
+ * nothing contains the offset, but beaten by whatever does.
+ */
+function boxDistance(box: AnchorBox, offset: number): number {
+	if (!Number.isFinite(box.top) || !Number.isFinite(box.height)) return Number.NaN;
+	if (offset < box.top) return box.top - offset;
+
+	const below = offset - (box.top + box.height);
+	if (below < 0) return 0;
+	return below > 0 ? below : Number.EPSILON;
+}
+
+/**
+ * Descend to the narrowest annotated element `distanceOf` says is closest.
+ *
+ * `strict` is the difference between "which block owns this line" (a line
+ * between two blocks owns nothing, and the caller has a fallback for that) and
+ * "which block is this scroll position in" — where returning nothing would put
+ * a gap between two blocks, or the padding under the last one, back on the
+ * proportional mapping and make the panes jump every time the reader crossed
+ * one.
+ */
+function descend(
+	node: AnchorNode,
+	inherited: AnchorMatch | null,
+	distanceOf: AnchorDistance,
+	strict: boolean,
+): AnchorMatch | null {
+	let chosen: AnchorNode | null = null;
+	let chosenSpan: LineRange | null = null;
+	let chosenOwn: LineRange | null = null;
+	let best = Number.POSITIVE_INFINITY;
+
 	for (const child of elementChildren(node)) {
 		const own = ownRange(child);
 		const span = own ?? resolveSpan(child);
-		if (!span || !contains(span, line)) continue;
+		// No annotated descendant: the front-matter panel, the table of contents,
+		// anything else the app renders around the document. Nothing here maps to
+		// a source line, so it must not swallow the offset.
+		if (!span) continue;
 
-		const carried: AnchorMatch | null = own ? { element: child, ...own } : inherited;
-		const fallback: AnchorMatch = carried ?? { element: child, ...span };
+		const distance = distanceOf(span, child);
+		if (!(distance < best)) continue;
 
-		if (!own && isCollapsedContainer(child)) return { element: child, ...span };
-
-		return search(child, line, carried) ?? fallback;
+		best = distance;
+		chosen = child;
+		chosenSpan = span;
+		chosenOwn = own;
+		if (distance === 0) break;
 	}
 
-	return null;
+	if (!chosen || !chosenSpan) return null;
+	if (strict && best > 0) return null;
+
+	const carried: AnchorMatch | null = chosenOwn ? { element: chosen, ...chosenOwn } : inherited;
+	const fallback: AnchorMatch = carried ?? { element: chosen, ...chosenSpan };
+
+	if (!chosenOwn && isCollapsedContainer(chosen)) return { element: chosen, ...chosenSpan };
+
+	return descend(chosen, carried, distanceOf, strict) ?? fallback;
 }
 
 /**
@@ -157,7 +284,38 @@ function search(node: AnchorNode, line: number, inherited: AnchorMatch | null): 
  */
 export function findAnchorElement(root: AnchorNode, line: number): AnchorMatch | null {
 	if (!Number.isFinite(line) || line <= 0) return null;
-	return search(root, line, null);
+	return descend(root, null, (span) => lineDistance(span, line), true);
+}
+
+/**
+ * As `findAnchorElement`, but a line no block owns resolves to the nearest
+ * block instead of to nothing. Only the scroll-sync mapping wants this: the
+ * blank lines between blocks are a third of a typical document, and falling
+ * back to the proportional mapping on every one of them would make the paired
+ * pane jump back and forth as the reader scrolled.
+ */
+export function findNearestAnchorElement(root: AnchorNode, line: number): AnchorMatch | null {
+	if (!Number.isFinite(line) || line <= 0) return null;
+	return descend(root, null, (span) => lineDistance(span, line), false);
+}
+
+/**
+ * The narrowest annotated element whose box covers `offset`, or the nearest one
+ * when the offset falls in the margin between two blocks or in the padding
+ * below the last one.
+ *
+ * `measure` supplies the layout — `offsetTop` / `offsetHeight` in the browser.
+ * It is a parameter because this module is otherwise pure enough to run against
+ * the render-protocol DOM shim, and that shim has no layout at all; injecting
+ * one is what lets the mapping be tested over real pipeline output.
+ */
+export function findAnchorElementAtOffset(
+	root: AnchorNode,
+	offset: number,
+	measure: MeasureAnchorBox,
+): AnchorMatch | null {
+	if (!Number.isFinite(offset)) return null;
+	return descend(root, null, (_span, node) => boxDistance(measure(node), offset), false);
 }
 
 /**
@@ -180,4 +338,56 @@ export function getAnchorScrollTop(
 	const ratio = totalLines > 0 ? Math.max(0, Math.min(1, (line - range.startLine) / totalLines)) : 0;
 
 	return Math.max(0, elementTop + elementHeight * ratio - offset);
+}
+
+/**
+ * The source line rendered at `offset` in the preview's scroll content —
+ * fractional, interpolated across the block that owns the offset.
+ *
+ * This is the half of split-view scroll sync that a ratio cannot do. Forty
+ * source lines of table render as a tall block and forty of prose as a short
+ * one, so the share of the preview's scroll range a position occupies is not
+ * the share of the document it corresponds to. Asking which block is on screen
+ * and where inside it does not care.
+ *
+ * `null` only when the preview holds no annotated block at all.
+ */
+export function getSourceLineAtPreviewOffset(
+	root: AnchorNode,
+	offset: number,
+	measure: MeasureAnchorBox,
+): number | null {
+	const match = findAnchorElementAtOffset(root, offset, measure);
+	if (!match) return null;
+
+	const box = measure(match.element);
+	if (!Number.isFinite(box.top) || !Number.isFinite(box.height)) return null;
+
+	const totalLines = match.endLine - match.startLine;
+	if (totalLines <= 0 || box.height <= 0) return match.startLine;
+
+	const ratio = Math.max(0, Math.min(1, (offset - box.top) / box.height));
+	return match.startLine + totalLines * ratio;
+}
+
+/**
+ * The inverse: where in the preview's scroll content `line` is rendered.
+ * Interpolates through `getAnchorScrollTop` — the same interpolation the tab
+ * restore uses — with no viewport offset applied, so the caller decides where
+ * on screen to put it.
+ *
+ * `null` only when the preview holds no annotated block at all.
+ */
+export function getPreviewOffsetForSourceLine(
+	root: AnchorNode,
+	line: number,
+	measure: MeasureAnchorBox,
+): number | null {
+	const match = findNearestAnchorElement(root, line);
+	if (!match) return null;
+
+	const box = measure(match.element);
+	if (!Number.isFinite(box.top) || !Number.isFinite(box.height)) return null;
+
+	return getAnchorScrollTop(box.top, box.height, match, line, 0);
 }

--- a/src/lib/utils/scrollSync.ts
+++ b/src/lib/utils/scrollSync.ts
@@ -17,10 +17,35 @@
 // Editor.svelte and MarkdownViewer.svelte; neither copy could be imported by a
 // test, because `node --test` cannot load a `.svelte` file. Here they are
 // covered for real by scripts/scrollSync.test.ts.
+//
+// Splitting the range at the front matter is not enough on its own. Inside the
+// body a ratio is still wrong, for the same reason it is wrong across the
+// boundary: forty source lines of table render as a tall block and forty of
+// prose as a short one, so equal progress through the source is not equal
+// progress through the rendered height, and the error accumulates towards the
+// end of the document — which is where #205 reports it. A position therefore
+// also carries the SOURCE LINE at the pane's anchor, and each pane resolves
+// that line through its own layout. The ratio stays in the payload as the
+// fallback for the positions no line can describe.
+
+// The line each pane reports is the one at the TOP of its own viewport — the
+// pane's `scrollTop` exactly, with nothing added. That is the only offset at
+// which the ends of the document are fixed points of the mapping: pin the line
+// 60px down instead, as the tab restore does, and a reader at the top of the
+// editor puts the preview 36px into the document, because 60px is a different
+// line in each pane. `PREVIEW_ANCHOR_OFFSET` is a separate decision about a
+// separate feature — where to put a line the reader is being *returned* to.
 
 export type ScrollSyncPosition = {
 	section: 'frontmatter' | 'body';
 	ratio: number;
+	/**
+	 * Fractional source line at the sending pane's anchor. Absent when the
+	 * sender could not resolve one — front matter (which renders as a panel with
+	 * no source range at all, so only `section`/`ratio` can carry it) or a
+	 * document with no annotated block. The receiver falls back to the ratio.
+	 */
+	line?: number;
 };
 
 function clampScrollRatio(value: number) {
@@ -58,4 +83,60 @@ export function getScrollTopForSyncPosition(position: ScrollSyncPosition, scroll
 
 	const bodyRange = Math.max(0, safeMax - safeFrontMatterEnd);
 	return safeFrontMatterEnd + bodyRange * ratio;
+}
+
+/*
+ * The editor's half of the line mapping.
+ *
+ * Monaco publishes line -> pixel (`getTopForLineNumber`) and nothing for the
+ * inverse, so the inverse is a binary search over the same function: it is
+ * non-decreasing in the line number, which is all a search needs. That costs
+ * ~log2(lineCount) calls — 14 on a 10,000-line document — instead of the walk
+ * a line-height table would need, and it stays correct with folded regions,
+ * wrapped lines and view zones, none of which have a uniform height.
+ *
+ * `topForLine` must accept `lineCount + 1` (Monaco does; it answers with the
+ * bottom of the last line), because that is the height of the last line. That
+ * is also why the line these two agree on runs to `lineCount + 1` rather than
+ * to `lineCount`: the bottom edge of the document is a position the reader can
+ * scroll to, and rounding it down to the top of the last line would make the
+ * end of the document — the part #205 is about — the one place the round trip
+ * did not close.
+ */
+export type LineTopLookup = (line: number) => number;
+
+/** Fractional line number rendered at `offset`. Inverse of the function below. */
+export function getLineAtVerticalOffset(offset: number, lineCount: number, topForLine: LineTopLookup): number {
+	if (!Number.isFinite(offset) || !Number.isFinite(lineCount) || lineCount < 1) return 1;
+
+	let low = 1;
+	let high = Math.floor(lineCount);
+	while (low < high) {
+		const mid = Math.ceil((low + high) / 2);
+		if (topForLine(mid) <= offset) low = mid;
+		else high = mid - 1;
+	}
+
+	const top = topForLine(low);
+	const bottom = topForLine(low + 1);
+	const height = bottom - top;
+	if (!Number.isFinite(height) || height <= 0) return low;
+
+	return low + Math.max(0, Math.min(1, (offset - top) / height));
+}
+
+/** Vertical offset of a fractional line. Inverse of the function above. */
+export function getVerticalOffsetForLine(line: number, lineCount: number, topForLine: LineTopLookup): number {
+	if (!Number.isFinite(line) || !Number.isFinite(lineCount) || lineCount < 1) return 0;
+
+	const clamped = Math.max(1, Math.min(lineCount + 1, line));
+	const index = Math.floor(clamped);
+	const top = topForLine(index);
+
+	const fraction = clamped - index;
+	if (fraction <= 0) return top;
+
+	const bottom = topForLine(index + 1);
+	const height = bottom - top;
+	return Number.isFinite(height) && height > 0 ? top + height * fraction : top;
 }


### PR DESCRIPTION
Closes the surviving half of #205 — the end-of-document drift.

#316 removed Monaco's scroll-past-last-line padding from the sync range, which was the largest part of it, but the mapping was still proportional: a position became a share of the sending pane's scroll range and was read off the receiving pane's.

### Why a ratio cannot be right

Forty source lines of table render as one tall block; forty of prose render as a short one. Equal progress through the source is not equal progress through the rendered height, so the two panes' shares mean different things, and the difference accumulates. That is why what gets noticed is the end of the document.

### What replaces it

A `ScrollSyncPosition` now also carries the **source line** at the top of the sending pane's viewport, and each pane resolves that line through its own layout.

* **preview → editor** — the preview descends its `data-sourcepos` blocks to the narrowest one covering `scrollTop`, interpolates the line inside it, and Monaco reveals that line. Inverting Monaco's `getTopForLineNumber` by binary search keeps it correct with folded regions, wrapped lines and view zones, none of which have a uniform height.
* **editor → preview** — the top visible line goes to `findNearestAnchorElement`, and `getAnchorScrollTop` (the interpolation the tab restore already used) turns it into an offset.

Both directions are the *same* descent over the same tree with the same skip rules, so line → pixel → line is an identity rather than an approximation.

### Fallback

The front-matter carve-out is untouched and is now also the fallback. Front matter renders as a panel with no source range at all, so a front-matter position carries no line and travels as `section`+`ratio` exactly as before; a body position falls back the same way when the preview holds no annotated block.

A line no block *owns* — a blank line between blocks, or a position past the last one — resolves to the **nearest** block rather than falling back. Blank lines are about a third of a typical document, and falling back on each of them would put the panes back on the proportional mapping every time the reader crossed one.

### No feedback loop

The existing `isProgrammaticScroll` / `isApplyingExternalScroll` flags stop the echo. What is asserted here is that the mapping could not sustain a loop if an echo did get through: A → B → A is **idempotent** — it snaps once, by at most the margin between two blocks, onto a position that is its own image, and both components already ignore a move under 5px.

Getting there needed one fix a browser found and the DOM shim could not. Blocks touch — margins collapse, so one block's bottom edge is the next one's top — and letting both claim that shared pixel made the earlier one win, so a line mapped back to a pixel landed on a block top that the block *above* then claimed. Every echo walked the reader one block up the document. A block now owns `[top, bottom)`.

Both `setScrollTop` targets are also clamped into range before the 5px threshold check: a line near the end resolves to an offset a pane cannot reach, and an unreachable target fires no scroll event, which would leave the flag to be spent swallowing the reader's *next* real scroll.

### Cost — measured, not asserted

Chrome, over this pipeline's own output:

| document | offset → line | line → offset |
|---|---|---|
| 13,356 lines / 320,000px / 6,709 blocks | 0.89 ms | 0.28 ms |
| 1,757 lines / 43,000px | 0.21 ms | 0.12 ms |
| 437 lines / 11,000px | 0.17 ms | 0.10 ms |

Source ranges and derived container spans are memoised in `WeakMap`s keyed on the element; without them the same walk is ~6 ms. **Nothing invalidates them explicitly** — the preview is rebuilt wholesale by `bind:innerHTML`, so a changed document is a new set of nodes and the entries describing the old ones are collected with them. Folding, task checkboxes and rich-content rendering all leave the annotated blocks and their ranges where they were.

**The scroll handler got cheaper overall, not dearer.** Capturing the tab's reading position was a separate `querySelectorAll('[data-sourcepos]')` over the whole preview plus `offsetTop`/`offsetHeight` on every element it returned, on the same event — 8.3 ms on the 13,356-line document. It now shares the one descent, which also settles two disagreements it had with the restore: it took the *outermost* element covering an offset where `findAnchorElement` takes the narrowest, and it had no opinion about the boxless `<br>` of #464.

### Trade-off worth naming

What the mapping aligns is the line at the **top** of each viewport, which is the only thing two panes of different heights can agree on. When the editor is scrolled to its last line the preview is therefore not necessarily at its own last pixel — the same lines take more height there. The top lines agree exactly, which is the alignment the report is about.

### Tests

`scripts/scrollSyncBlockMapping.test.ts` drives the mapping in both directions over real `processMarkdownHtml` output and measures the disagreement in **source lines**, with the pre-fix mapping kept alongside as the control:

```
ratio mapping: worst drift 54.9 source lines   (tail of the document)
block mapping: worst drift 0.9 source lines
ratio mapping: worst drift 64.8 source lines   (whole document)
block mapping: worst drift 0.9 source lines
preview -> editor: worst drift 0.0 source lines
editor -> preview -> editor: first echo up to 17.8px, second 0.000px
```

The shim has no layout at all — `grep -rn offsetTop scripts/` returns nothing, which is why #464's defect survived a suite scoring 100% — so the layout is injected through the same `measure` callback the browser fills with `offsetTop`. What that **cannot** model is whether a browser really lays a table out the way the fixture's heights say; the property under test only needs rendered height not to be proportional to source lines, which is the premise of the bug. The touching-block case gets a second fixture, because the first one's synthetic margins hid it and only Chrome found it.

Falsification — mapping reverted, tests kept:

```
✖ the tail of the document stays on the same source line
  AssertionError: the preview drifted 54.9 source lines from the editor at scrollTop 7295 (of 12158)
✖ every part of the document stays on the same source line, not only the tail
  AssertionError: the preview drifted 64.8 source lines at scrollTop 5775
✖ an echo through the other pane settles in one step
  AssertionError: a second echo would move the editor a further 1238.5px at scrollTop 4985
✖ repeating the echo does not walk the panes down the document
  AssertionError: twenty echoes moved the editor 1841.0px
ℹ pass 9   ℹ fail 10
```

And with only the boundary-pixel fix reverted:

```
✖ touching blocks do not walk the panes up the document
  AssertionError: a second echo moved the preview 38.0px between touching blocks
✖ the pixel two blocks share belongs to the lower one
```

### Verification

`npm audit` (0 vulnerabilities), `npm run check` (0 errors), `npm test` (702 passing), `cargo test` (157 passing).

---

@Guardiancelte — this is the per-block mapping I mentioned. Your two stress-test files are exactly the shape it is meant to fix (the fixture here is modelled on them: prose for most of the document, then tables and figures near the end). Would you retest both once this lands?
