### PR TITLE
docs(agents): correct three statements that no longer match the tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,9 +143,9 @@ src-tauri/
 - Export singleton instances (e.g., `export const tabManager = new TabManager()`)
 
 ### Tauri Invoke
-Use `invoke()` from `@tauri-apps/api` for Rust commands:
+Use `invoke()` from `@tauri-apps/api/core` for Rust commands:
 ```typescript
-import { invoke } from '@tauri-apps/api';
+import { invoke } from '@tauri-apps/api/core';
 const result = await invoke<string>('command_name', { arg: value });
 ```
 
@@ -155,8 +155,8 @@ All file operations go through Rust commands - never use Node.js fs APIs.
 ## Testing
 
 - **Rust**: `cargo test` in `src-tauri/` directory
-- **Frontend**: No test framework currently configured
-- **CI**: Runs `npm run check` and `cargo test` on PRs
+- **Frontend**: `npm test` runs the behavior tests in `scripts/*.test.ts` (`node --test --import tsx`)
+- **CI**: Runs `npm audit`, `npm run check`, `npm test` and `cargo test` on PRs
 
 ## Notes
 


### PR DESCRIPTION
`AGENTS.md` is the only contributor/agent guide in the repo, and is what a new contributor and every coding agent reads first. Three of its statements no longer match the tree, and each one changes what someone does. This is a correction of facts only — no guidance, convention, structure or voice changed.

I offered to send this in #385 and again in the index at #396 and had no answer either way, so I'm sending it rather than leaving it sitting; if you'd rather patch it yourself, close this and no harm done.

## The three statements

### 1. Tauri Invoke — the import does not exist

```diff
- import { invoke } from '@tauri-apps/api';
+ import { invoke } from '@tauri-apps/api/core';
```

The v2 root package does not export `invoke`. Against the installed `@tauri-apps/api@2.10.1`:

```
$ node -e "import('@tauri-apps/api').then(m => console.log(Object.keys(m).join(', ')))"
app, core, dpi, event, image, menu, mocks, path, tray, webview, webviewWindow, window

$ node -e "import('@tauri-apps/api/core').then(m => console.log(typeof m.invoke))"
function
```

Every `invoke` call site in `src/` already imports from `@tauri-apps/api/core` — `MarkdownViewer.svelte`, `Installer.svelte`, `Uninstaller.svelte`, `components/{Editor,Settings,Tab,TitleBar}.svelte`, `stores/settings.svelte.ts`, `sessions/{documentSession,windowSession}.svelte.ts`, `utils/{export,pathIdentity}.ts`. The snippet was the only place saying otherwise. The sentence above the snippet named the same wrong module, so it moved too.

### 2. Testing — "No test framework currently configured"

```diff
- - **Frontend**: No test framework currently configured
+ - **Frontend**: `npm test` runs the behavior tests in `scripts/*.test.ts` (`node --test --import tsx`)
```

`package.json` has `"test": "node --test --import tsx 'scripts/*.test.ts'"`, there are 89 such files, and a run on this branch reports:

```
ℹ tests 692
ℹ pass 692
ℹ fail 0
```

This is the one that costs the most: a contributor reading the old line concludes the project has no frontend tests, writes none, and finds out at CI.

I deliberately did **not** put the file or test count in the line. #385 quoted 67 files / 361 tests when I filed it four days ago; it is 89 / 692 today. A number there is a maintenance burden that goes stale silently, so the line names the runner and the glob instead, both of which stay true as tests are added.

### 3. CI — the list was incomplete

```diff
- - **CI**: Runs `npm run check` and `cargo test` on PRs
+ - **CI**: Runs `npm audit`, `npm run check`, `npm test` and `cargo test` on PRs
```

`.github/workflows/test.yml` runs four steps on `pull_request`, in this order:

```yaml
- name: audit complete dependency lockfile
  run: npm audit
- name: check frontend
  run: npm run check
- name: run frontend behavior tests
  run: npm test
- name: run cargo test
  run: cd src-tauri && cargo test
```

With two of the four undocumented, a PR can pass everything the guide lists and still fail CI.

## Things I checked and deliberately left alone

I read the whole file against the tree rather than only the three items in #385. The rest holds, with four caveats I am reporting instead of changing, because each needs your call rather than a fact swap:

- **`Result<T, String>` for Tauri commands.** The guide says "Always mark with `#[tauri::command]` and return `Result<T, String>`". Of the 56 commands in `src-tauri/src/`, a good number return plain values instead (`Vec<String>`, `bool`, `String`, `InstallStatus`, `()`), and `tab_transfer.rs` uses its own error type. But that line reads as a **convention for new code**, not a description of what exists, and rewriting it would be changing your guidance rather than correcting a fact. Left as is.
- **Project Structure.** The tree block omits `src/lib/sessions/`, `src/lib/utils/`, `src/assets/`, `scripts/`, and two of the five files in `src-tauri/src/` (`tab_transfer.rs`, `window_runtime.rs`); it also implies all components live in `lib/components/`, while `MarkdownViewer.svelte`, `Installer.svelte` and `Uninstaller.svelte` sit at `src/lib/` root. An abridged map is a legitimate choice and expanding it is an editorial decision, not a correction — so I left it. Flagging it only because `scripts/` is now referenced by the Testing line above and does not appear in the map.
- **The updater pubkey note.** "The placeholder string in PR-2 is replaced exactly once, by the maintainer" — the placeholder was in fact replaced, in `976d13c`, and `src-tauri/tauri.conf.json` now carries a real minisign key. The sentence describes something that has already happened, so it reads as slightly out of date, but the instruction it exists to give ("never modify `plugins.updater.pubkey`") is correct and important. Yours to reword if you want.
- **Quotes: single.** Mostly followed; a handful of files use double quotes (`utils/markdown.ts`, `components/Editor.svelte`). Again a convention, not a false statement — left alone.

One thing outside this file: `RELEASING.md` still says to add the signing secrets to `alecdotdev/Markpad`, which is the old repo path. Not touched here since this PR is scoped to `AGENTS.md`.

## Verification

Docs-only change, but run anyway on this branch:

```
$ npm run check
COMPLETED 645 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS

$ npm test
ℹ tests 692
ℹ pass 692
ℹ fail 0
```

Closes #385

