### PR TITLE
fix(editor): make the Vim z-family scroll, and put zb/z- the way Vim has them

### DIFF
--- a/scripts/vimScrollCommands.test.ts
+++ b/scripts/vimScrollCommands.test.ts
@@ -1,0 +1,441 @@
+import assert from 'node:assert/strict';
+import { registerHooks } from 'node:module';
+import test from 'node:test';
+
+import { callbackBodies, readSource } from './sourceTree.js';
+
+/*
+ * Vim's scroll-cursor family — `zz`, `zt`, `zb`, `z.`, `z-`, `z<CR>` — does
+ * nothing in monaco-vim 0.4.4 (#104, #393), and `zb`/`z-` are additionally
+ * swapped with respect to `:help scroll-cursor`. `utils/vimScrollCommands.ts`
+ * repairs both through the package's own `Vim.defineAction`/`Vim.mapCommand`.
+ *
+ * WHAT RUNS HERE. The keys are *pressed*. Every test below drives real
+ * keystrokes into `Vim.handleKey` on a real `CMAdapter` built from the real
+ * `monaco-vim` package — the same `dist/index.mjs` Vite hands the app — and
+ * then asks the editor which reveal it was told to perform. Nothing in this
+ * file asserts that a source file contains a string; the closest it comes is
+ * lifting Editor.svelte's own `import("monaco-vim").then` callback out of the
+ * component and *running* it.
+ *
+ * Only `monaco-editor` is faked, and only because it cannot be imported under
+ * Node: it is 4 MB of code that reaches for `document` at module scope.
+ * monaco-vim imports it as two ordinary externals (`Range`, `Selection`,
+ * `KeyCode`, …) rather than bundling it, so a module hook can answer those two
+ * specifiers with the handful of value classes the adapter actually constructs.
+ * Everything downstream of that — the keymap, the command dispatcher, the
+ * action registry, `CMAdapter` itself — is upstream's own shipped code.
+ *
+ * WHAT IT DOES NOT ESTABLISH: that Monaco's `revealRangeInCenter` puts the line
+ * where a human would call the centre, that focus and key routing reach Vim
+ * mode in the running app, or anything about rendering. It establishes which
+ * reveal each key sequence asks the editor for, and where the cursor ends up.
+ */
+
+// ------------------------------------------------------- the monaco-editor fake
+//
+// A synthetic module URL, so the stub lives in this file instead of a second
+// one that would have to be kept in step with it. Nothing reads the path: the
+// `load` hook short-circuits before Node opens it.
+
+const MONACO_STUB = new URL('./monaco-editor.stub-for-vim-tests.js', import.meta.url).href;
+
+/**
+ * The monaco-editor value exports monaco-vim constructs or compares against.
+ *
+ * `Range.fromPositions` and `Selection.fromPositions` are the two that matter:
+ * `CMAdapter.moveCurrentLineTo` builds the range it reveals, and the motion
+ * path builds the selection it moves the cursor with. `KeyCode` is only ever
+ * used as a set of comparison constants, so a proxy answering with the property
+ * name is enough to keep those comparisons distinct and false.
+ */
+const MONACO_STUB_SOURCE = `
+	export const KeyCode = new Proxy({}, { get: (_target, key) => 'KeyCode:' + String(key) });
+	export class Position {
+		constructor(lineNumber, column) { this.lineNumber = lineNumber; this.column = column; }
+	}
+	export class Range {
+		constructor(startLineNumber, startColumn, endLineNumber, endColumn) {
+			this.startLineNumber = startLineNumber; this.startColumn = startColumn;
+			this.endLineNumber = endLineNumber; this.endColumn = endColumn;
+		}
+		static fromPositions(start, end = start) {
+			return new Range(start.lineNumber, start.column, end.lineNumber, end.column);
+		}
+		getStartPosition() { return new Position(this.startLineNumber, this.startColumn); }
+		getEndPosition() { return new Position(this.endLineNumber, this.endColumn); }
+	}
+	export const SelectionDirection = { LTR: 0, RTL: 1 };
+	export class Selection extends Range {
+		static fromPositions(start, end = start) {
+			return new Selection(start.lineNumber, start.column, end.lineNumber, end.column);
+		}
+		isEmpty() {
+			return this.startLineNumber === this.endLineNumber && this.startColumn === this.endColumn;
+		}
+		getDirection() { return SelectionDirection.LTR; }
+		getPosition() { return this.getEndPosition(); }
+	}
+	export const editor = {
+		EditorOption: {},
+		TrackedRangeStickiness: { NeverGrowsWhenTypingAtEdges: 0 },
+		setTheme() {},
+	};
+	export class ShiftCommand {}
+`;
+
+registerHooks({
+	resolve(specifier, context, next) {
+		if (specifier === 'monaco-editor' || specifier.startsWith('monaco-editor/')) {
+			return { url: MONACO_STUB, shortCircuit: true };
+		}
+		return next(specifier, context);
+	},
+	load(url, context, next) {
+		if (url === MONACO_STUB) {
+			return { format: 'module', shortCircuit: true, source: MONACO_STUB_SOURCE };
+		}
+		return next(url, context);
+	},
+});
+
+// ------------------------------------------------------------------- the editor
+
+type Pos = { lineNumber: number; column: number };
+/** What `moveCurrentLineTo` asked the editor to do, and to which line. */
+type Reveal = { position: 'top' | 'center' | 'bottom'; line: number };
+
+/**
+ * The Monaco editor widget, reduced to the state the z-family touches: a
+ * cursor, a document, and a viewport.
+ *
+ * The three reveal methods are the whole point. `revealRangeAtTop`,
+ * `revealRangeInCenter` and the private `_revealRange(range, 4)` are the only
+ * three calls `CMAdapter.moveCurrentLineTo` can make, so recording them records
+ * exactly what a keypress achieved — and recording *nothing* is what the defect
+ * looks like. `revealPosition`, which `setCursor` calls on every cursor move,
+ * is deliberately not one of them: it would log on motions that scrolled
+ * nothing and make the empty list impossible to observe.
+ */
+function fakeEditor(lines: string[], visible: { first: number; last: number }) {
+	let cursor: Pos = { lineNumber: 1, column: 1 };
+	const reveals: Reveal[] = [];
+	const disposable = () => ({ dispose() {} });
+
+	const validate = (position: Pos): Pos => {
+		const lineNumber = Math.min(Math.max(position.lineNumber, 1), lines.length);
+		const column = Math.min(Math.max(position.column, 1), lines[lineNumber - 1].length + 1);
+		return { lineNumber, column };
+	};
+
+	const selectionAt = (position: Pos) => ({
+		startLineNumber: position.lineNumber,
+		startColumn: position.column,
+		endLineNumber: position.lineNumber,
+		endColumn: position.column,
+		isEmpty: () => true,
+		getDirection: () => 0,
+		getPosition: () => ({ ...position }),
+		getStartPosition: () => ({ ...position }),
+		getEndPosition: () => ({ ...position }),
+	});
+
+	const model = {
+		getLineCount: () => lines.length,
+		getLineContent: (n: number) => lines[n - 1],
+		getLineMaxColumn: (n: number) => lines[n - 1].length + 1,
+		getLineFirstNonWhitespaceColumn: (n: number) => {
+			const at = lines[n - 1].search(/\S/);
+			return at < 0 ? 0 : at + 1;
+		},
+		getLineLastNonWhitespaceColumn: (n: number) => lines[n - 1].replace(/\s+$/, '').length + 1,
+		getValueInRange: () => '',
+		getOptions: () => ({ tabSize: 4, insertSpaces: true }),
+		validatePosition: validate,
+	};
+
+	const editor = {
+		getModel: () => model,
+		getPosition: () => ({ ...cursor }),
+		setPosition: (position: Pos) => {
+			cursor = validate(position);
+		},
+		getSelection: () => selectionAt(cursor),
+		getSelections: () => [selectionAt(cursor)],
+		setSelection: (range: { endLineNumber: number; endColumn: number }) => {
+			cursor = validate({ lineNumber: range.endLineNumber, column: range.endColumn });
+		},
+		setSelections: (selections: { endLineNumber: number; endColumn: number }[]) => {
+			const last = selections[selections.length - 1];
+			cursor = validate({ lineNumber: last.endLineNumber, column: last.endColumn });
+		},
+		getVisibleRanges: () => [{ startLineNumber: visible.first, endLineNumber: visible.last }],
+
+		revealRangeAtTop: (range: { startLineNumber: number }) =>
+			void reveals.push({ position: 'top', line: range.startLineNumber }),
+		revealRangeInCenter: (range: { startLineNumber: number }) =>
+			void reveals.push({ position: 'center', line: range.startLineNumber }),
+		_revealRange: (range: { startLineNumber: number }) =>
+			void reveals.push({ position: 'bottom', line: range.startLineNumber }),
+		revealPosition: () => {},
+
+		createContextKey: () => ({ set() {} }),
+		onDidChangeCursorPosition: disposable,
+		onDidChangeModelContent: disposable,
+		onKeyDown: disposable,
+		updateOptions: () => {},
+		getOption: () => ({}),
+		executeCommand: () => {},
+		trigger: () => {},
+		pushUndoStop: () => {},
+		focus: () => {},
+	};
+
+	return {
+		editor,
+		reveals,
+		placeCursor(position: Pos) {
+			cursor = validate(position);
+		},
+		get cursor() {
+			return { ...cursor };
+		},
+	};
+}
+
+// -------------------------------------------------------------- the vim harness
+
+const MONACO_VIM = import.meta.resolve('monaco-vim');
+let instances = 0;
+
+/**
+ * A private copy of monaco-vim, plus an editor to drive it with.
+ *
+ * A fresh copy per case, because both repairs mutate module-level tables that
+ * would otherwise leak between tests — and because the first test below is
+ * about what upstream does *un*repaired, which a shared instance would make
+ * unaskable after any other test had run. The query string is what buys it: the
+ * module URL differs, so Node evaluates the file again.
+ */
+async function freshVim() {
+	const { VimMode } = await import(`${MONACO_VIM}?instance=${(instances += 1)}`);
+	return { VimMode, Vim: VimMode.Vim as Record<string, Function> };
+}
+
+/** Five lines; line 2 is indented, so a cursor column change is visible. */
+const LINES = ['alpha', '    beta is indented', 'gamma', 'delta', 'epsilon'];
+/** The cursor's home for every run: line 2, on the `s` of `is`. */
+const START: Pos = { lineNumber: 2, column: 13 };
+
+const KEYSTROKES: Record<string, string[]> = {
+	zz: ['z', 'z'],
+	'z.': ['z', '.'],
+	zt: ['z', 't'],
+	'z<CR>': ['z', '<CR>'],
+	zb: ['z', 'b'],
+	'z-': ['z', '-'],
+};
+
+/**
+ * `installVimScrollCommands`, or a no-op when the app has no such module.
+ *
+ * The fallback is what makes a falsification run worth anything. Reverting the
+ * fix deletes the module; importing it directly would turn every test below red
+ * with the same "cannot find module", and not one of them would then be
+ * evidence about `zz`. An app that never installs the commands behaves exactly
+ * like one whose install does nothing — so that is what it is given, and each
+ * test fails on its own claim instead. Same reasoning as `lifted` in
+ * undoHistoryPerTab.ts.
+ */
+async function loadInstaller(): Promise<(vimMode: unknown) => boolean> {
+	try {
+		return (await import('../src/lib/utils/vimScrollCommands.js')).installVimScrollCommands;
+	} catch {
+		return () => false;
+	}
+}
+
+/** Press `command` in normal mode and report what the editor was asked to do. */
+async function press(command: string, options: { install: boolean }) {
+	const { VimMode, Vim } = await freshVim();
+	if (options.install) (await loadInstaller())(VimMode);
+
+	const host = fakeEditor(LINES, { first: 1, last: 3 });
+	const cm = new VimMode(host.editor);
+	host.placeCursor(START);
+
+	const keys = KEYSTROKES[command];
+	assert.ok(keys, `no keystrokes recorded for ${command}`);
+	for (const key of keys) Vim.handleKey(cm, key, 'user');
+
+	return { reveals: host.reveals, cursor: host.cursor };
+}
+
+// ----------------------------------------------------------------------- tests
+
+/*
+ * The defect, executed. This is the drift guard: the day an upgrade fixes
+ * `scrollToCursor` upstream, this test goes red and says the shim can go —
+ * which is the only way anyone would find out, since a working `zz` looks the
+ * same either way.
+ */
+test('unpatched monaco-vim performs no scroll for any of the six keys', async () => {
+	for (const command of Object.keys(KEYSTROKES)) {
+		const { reveals } = await press(command, { install: false });
+		assert.deepEqual(reveals, [], `${command} should still be dead in monaco-vim without the fix`);
+	}
+});
+
+test('unpatched monaco-vim has zb and z- the wrong way round', async () => {
+	// Vim: `zb` keeps the column, `z-` goes to the first non-blank. Upstream has
+	// the motion on `zb`. Reaching the cursor at all is what the scroll fix
+	// exposes, so this pins the second defect at the same level as the first.
+	const zb = await press('zb', { install: false });
+	assert.equal(zb.cursor.column, 5, 'unpatched zb wrongly jumps the cursor to the first non-blank');
+
+	const zMinus = await press('z-', { install: false });
+	assert.equal(zMinus.cursor.column, START.column, 'unpatched z- wrongly leaves the column alone');
+});
+
+test('every key in the z family scrolls to the position Vim documents', async () => {
+	const expected: Record<string, 'top' | 'center' | 'bottom'> = {
+		zz: 'center',
+		'z.': 'center',
+		zt: 'top',
+		'z<CR>': 'top',
+		zb: 'bottom',
+		'z-': 'bottom',
+	};
+
+	for (const [command, position] of Object.entries(expected)) {
+		const { reveals } = await press(command, { install: true });
+		assert.deepEqual(
+			reveals,
+			[{ position, line: START.lineNumber }],
+			`${command} should reveal the cursor line at the ${position}`,
+		);
+	}
+});
+
+test('the punctuation forms move to the first non-blank and the letter forms hold the column', async () => {
+	// `:help scroll-cursor`. Line 2 is `    beta is indented`, so the first
+	// non-blank is column 5 and the cursor starts at column 13.
+	const FIRST_NON_BLANK = 5;
+
+	for (const command of ['z.', 'z<CR>', 'z-']) {
+		const { cursor } = await press(command, { install: true });
+		assert.equal(cursor.column, FIRST_NON_BLANK, `${command} should move the cursor to the first non-blank`);
+		assert.equal(cursor.lineNumber, START.lineNumber, `${command} should not leave the line`);
+	}
+
+	for (const command of ['zz', 'zt', 'zb']) {
+		const { cursor } = await press(command, { install: true });
+		assert.equal(cursor.column, START.column, `${command} should leave the cursor column alone`);
+		assert.equal(cursor.lineNumber, START.lineNumber, `${command} should not leave the line`);
+	}
+});
+
+test('a second install does not map the commands a second time', async () => {
+	// `mapCommand` unshifts onto a module-global keymap, so an install per
+	// Vim-mode toggle would grow it without bound. Counted at the call rather
+	// than inferred from behaviour, because a doubled keymap behaves correctly
+	// right up until it does not fit in memory.
+	const { VimMode, Vim } = await freshVim();
+	const installVimScrollCommands = await loadInstaller();
+
+	const mapped: string[] = [];
+	const realMapCommand = Vim.mapCommand;
+	Vim.mapCommand = function (this: unknown, ...args: unknown[]) {
+		mapped.push(String(args[0]));
+		return realMapCommand.apply(this, args);
+	};
+
+	assert.equal(installVimScrollCommands(VimMode), true);
+	assert.equal(installVimScrollCommands(VimMode), true, 'a repeat install still reports the commands as present');
+	assert.equal(installVimScrollCommands(VimMode), true);
+
+	assert.deepEqual(mapped, ['zb', 'z-'], 'the swapped pair should be remapped exactly once');
+});
+
+test('an object that is not monaco-vim is left alone', async () => {
+	const { installVimScrollCommands } = await import('../src/lib/utils/vimScrollCommands.js');
+
+	// Every shape a changed or renamed upstream API could arrive as. None may
+	// throw: this runs while the user is switching Vim mode on, and a throw
+	// there takes the editor with it.
+	assert.equal(installVimScrollCommands(undefined), false);
+	assert.equal(installVimScrollCommands(null), false);
+	assert.equal(installVimScrollCommands({}), false, 'no Vim export');
+	assert.equal(installVimScrollCommands({ Vim: {} }), false, 'no defineAction');
+	assert.equal(installVimScrollCommands({ Vim: { defineAction: 'not a function' } }), false);
+
+	// defineAction without mapCommand: the scroll is repairable, the swap is
+	// not, and the half that works still goes in.
+	const actions: Record<string, unknown> = {};
+	assert.equal(
+		installVimScrollCommands({
+			Vim: {
+				defineAction: (name: string, fn: unknown) => {
+					actions[name] = fn;
+				},
+			},
+		}),
+		true,
+	);
+	assert.equal(typeof actions.scrollToCursor, 'function');
+});
+
+test('a cm without moveCurrentLineTo does not throw', async () => {
+	const { installVimScrollCommands } = await import('../src/lib/utils/vimScrollCommands.js');
+	let action: ((cm: unknown, args: unknown) => void) | undefined;
+	installVimScrollCommands({
+		Vim: {
+			defineAction: (_name: string, fn: (cm: unknown, args: unknown) => void) => {
+				action = fn;
+			},
+		},
+	});
+	assert.equal(typeof action, 'function');
+	action!({}, { position: 'center' });
+	action!(undefined, undefined);
+});
+
+test('Editor.svelte installs the commands on the module it just imported', async () => {
+	// The component's own callback, lifted and run — not read. It has to install
+	// before `initVimMode` attaches the adapter, and it has to install even on
+	// the disposed path, because the tables it writes to are the package's and
+	// outlive this editor.
+	const source = readSource('src/lib/components/Editor.svelte');
+	const bodies = callbackBodies(source, 'import("monaco-vim").then');
+	assert.equal(bodies.length, 1, `expected exactly one monaco-vim import callback, found ${bodies.length}`);
+
+	const run = new Function(
+		'installVimScrollCommands',
+		'initVimMode',
+		'VimMode',
+		'currentEditor',
+		'currentStatusNode',
+		'disposed',
+		`let vim = null; ${bodies[0]} return vim;`,
+	) as (...args: unknown[]) => unknown;
+
+	const calls: string[] = [];
+	const VimMode = { marker: 'the module export' };
+	const install = (mode: unknown) => {
+		assert.equal(mode, VimMode, 'the VimMode from the same import must be the one patched');
+		calls.push('install');
+		return true;
+	};
+	const initVimMode = () => {
+		calls.push('initVimMode');
+		return { dispose() {} };
+	};
+
+	const vim = run(install, initVimMode, VimMode, {}, {}, false);
+	assert.deepEqual(calls, ['install', 'initVimMode'], 'the commands must be in place before the adapter attaches');
+	assert.ok(vim, 'the adapter is still handed back for disposal');
+
+	calls.length = 0;
+	assert.ok(!run(install, initVimMode, VimMode, {}, {}, true), 'a disposed effect attaches nothing');
+	assert.deepEqual(calls, ['install'], 'a disposed effect still patches the package');
+});

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -5,6 +5,7 @@
 	import { t, type LanguageCode } from '../utils/i18n.js';
 	import { MARKDOWN_LANGUAGE_ID, shouldLinkifyPastedUrl } from '../utils/pasteContext.js';
 	import { toggleLineMarker, type LineMarkerToolId } from '../utils/editorToolbar.js';
+	import { installVimScrollCommands } from '../utils/vimScrollCommands.js';
 	import {
 		getScrollSyncPositionFromPixels,
 		getScrollTopForSyncPosition,
@@ -1319,7 +1320,12 @@
 			let vim: { dispose: () => void } | null = null;
 			const currentEditor = editor;
 			const currentStatusNode = vimStatusNode;
-			import("monaco-vim").then(({ initVimMode }) => {
+			import("monaco-vim").then(({ initVimMode, VimMode }) => {
+				// Before the adapter is attached, and unconditionally: it patches
+				// monaco-vim's own module-level command tables, which outlive this
+				// effect, and it is idempotent. See vimScrollCommands.ts for what
+				// 0.4.4 does to `zz`, `zt`, `zb`, `z.`, `z-` and `z<CR>` (#104).
+				installVimScrollCommands(VimMode);
 				if (disposed) return;
 				vim = initVimMode(currentEditor, currentStatusNode);
 			});

--- a/src/lib/utils/vimScrollCommands.ts
+++ b/src/lib/utils/vimScrollCommands.ts
@@ -1,0 +1,128 @@
+/*
+ * Vim's scroll-cursor family — `zz`, `zt`, `zb`, `z.`, `z-`, `z<CR>` — does
+ * nothing in monaco-vim 0.4.4 (#104, #393). Two separate defects, both here.
+ *
+ * 1. THE SCROLL NEVER HAPPENS. All six keys route to one action:
+ *
+ *        scrollToCursor: function (cm, actionArgs) {
+ *          var charCoords = cm.charCoords(new Pos(lineNum, 0), "local");
+ *          var y = charCoords.top;
+ *          var lineHeight = charCoords.bottom - y;
+ *          switch (actionArgs.position) { … }   // y becomes a pixel offset
+ *          cm.moveCurrentLineTo(y);
+ *        }
+ *
+ *    while the adapter it hands that number to is:
+ *
+ *        moveCurrentLineTo(viewPosition) {
+ *          switch (viewPosition) {
+ *            case "top":    editor.revealRangeAtTop(range); return;
+ *            case "center": editor.revealRangeInCenter(range); return;
+ *            case "bottom": editor._revealRange?.(range, Bottom); return;
+ *          }
+ *        }
+ *
+ *    No default branch, so a number matches nothing and the call silently
+ *    returns. The arithmetic is doubly meaningless in this adapter: its
+ *    `charCoords` returns `{ top: pos.line, left: pos.ch }` — line numbers, not
+ *    pixels, and with no `bottom` key at all, so `lineHeight` is `NaN` and `y`
+ *    is `NaN` for `center` and `bottom`.
+ *
+ *    The fix hands `moveCurrentLineTo` one of the three strings its switch is
+ *    written for and drops the pixel arithmetic, which nothing in this adapter
+ *    could have used.
+ *
+ * 2. `zb` AND `z-` ARE SWAPPED. Vim (`:help scroll-cursor`) pairs each position
+ *    with a letter form that keeps the cursor column and a punctuation form that
+ *    moves it to the first non-blank:
+ *
+ *        zt / z<CR>   top       zz / z.   center      zb / z-   bottom
+ *              ^ first non-blank      ^                    ^
+ *
+ *    0.4.4 gets top and center right and has bottom backwards: its `z-` keeps
+ *    the column and its `zb` carries `motion: "moveToFirstNonWhiteSpaceCharacter"`.
+ *    Nobody could see it while defect 1 made the whole family dead — fixing the
+ *    scroll is what would have made a wrong cursor visible, so both go together.
+ *
+ * WHY NOT AN UPGRADE: 0.4.4 is the latest release (2025-11-22) and upstream
+ * master has only dependency bumps since; `moveCurrentLineTo` is unchanged
+ * there. WHY NOT A PATCH: `Vim.defineAction` and `Vim.mapCommand` are the
+ * package's own extension points, so nothing here touches a dependency's file.
+ *
+ * DEGRADING: every step is guarded and the whole thing is a no-op if the API is
+ * not what this file expects, so an upgrade that renames or removes it costs a
+ * silent return, not a crash on entering Vim mode.
+ * `scripts/vimScrollCommands.test.ts` drives the six keys through the real
+ * package and fails when upstream's behaviour changes underneath.
+ */
+
+/** The three view positions the adapter's `moveCurrentLineTo` switch accepts. */
+type ViewPosition = 'top' | 'center' | 'bottom';
+
+/** The part of monaco-vim's `cm` an action for this family reaches. */
+type ScrollTarget = {
+	moveCurrentLineTo?: (viewPosition: ViewPosition) => void;
+};
+
+/**
+ * The part of `VimMode.Vim` used here.
+ *
+ * Written out rather than imported: monaco-vim's own `.d.ts` declares neither
+ * the `Vim` static nor this API, so there is nothing to import, and the
+ * structural check in `installVimScrollCommands` is what stands in for the
+ * types upstream does not ship.
+ */
+type VimApi = {
+	defineAction?: (name: string, fn: (cm: ScrollTarget, actionArgs: { position?: unknown }) => void) => void;
+	mapCommand?: (keys: string, type: string, name: string, args: unknown, extra: unknown) => void;
+};
+
+/**
+ * The Vim APIs already patched.
+ *
+ * `defineAction` overwrites an entry and is safe to repeat, but `mapCommand`
+ * *unshifts* onto a module-global keymap — running it once per Vim-mode toggle
+ * would grow that array for the life of the window. Keyed on the API object
+ * rather than a plain boolean because monaco-vim is a singleton in the app but
+ * not in a test, where each case imports a fresh copy.
+ */
+const patched = new WeakSet<object>();
+
+/**
+ * Give the Vim z-family the scroll it never performs, and put `zb`/`z-` the way
+ * Vim documents them.
+ *
+ * Takes monaco-vim's `VimMode` export. Returns whether the commands are in
+ * place — `false` means the API was not the shape this file expects and nothing
+ * was changed.
+ */
+export function installVimScrollCommands(vimMode: unknown): boolean {
+	const api: VimApi | undefined = (vimMode as { Vim?: VimApi } | null | undefined)?.Vim;
+	if (!api || typeof api !== 'object') return false;
+	if (patched.has(api)) return true;
+	if (typeof api.defineAction !== 'function') return false;
+
+	api.defineAction('scrollToCursor', (cm, actionArgs) => {
+		const position = actionArgs?.position;
+		// `center` is the default because it is what the keymap asks for when a
+		// mapping omits the argument, and because a scroll to a defensible place
+		// beats the silent nothing this replaces.
+		const viewPosition: ViewPosition = position === 'top' || position === 'bottom' ? position : 'center';
+		cm?.moveCurrentLineTo?.(viewPosition);
+	});
+
+	// A `mapCommand` entry is unshifted onto the keymap and the dispatcher takes
+	// the first full match, so these two win over the swapped defaults. They are
+	// user mappings as far as monaco-vim is concerned, which means `:mapclear`
+	// drops them and hands `zb`/`z-` back to upstream — a scroll to the right
+	// place with the wrong cursor column, not a dead key.
+	if (typeof api.mapCommand === 'function') {
+		api.mapCommand('zb', 'action', 'scrollToCursor', { position: 'bottom' }, {});
+		api.mapCommand('z-', 'action', 'scrollToCursor', { position: 'bottom' }, {
+			motion: 'moveToFirstNonWhiteSpaceCharacter',
+		});
+	}
+
+	patched.add(api);
+	return true;
+}


### PR DESCRIPTION
Fixes #104. Second half of #393.

`zz`, `zt`, `zb`, `z.`, `z-` and `z<CR>` have never done anything in Vim mode. Two defects, both upstream in `monaco-vim` 0.4.4, and the second one only becomes visible once the first is fixed — so they go together.

## 1. The scroll never happens

All six keys route to one action:

```js
scrollToCursor: function (cm, actionArgs) {
  var charCoords = cm.charCoords(new Pos(lineNum, 0), "local");
  var y = charCoords.top;
  var lineHeight = charCoords.bottom - y;
  switch (actionArgs.position) { … }   // y becomes a pixel offset
  cm.moveCurrentLineTo(y);
}
```

and the adapter it hands that number to is:

```js
moveCurrentLineTo(viewPosition) {
  switch (viewPosition) {
    case "top":    editor.revealRangeAtTop(range); return;
    case "center": editor.revealRangeInCenter(range); return;
    case "bottom": editor._revealRange?.(range, Bottom); return;
  }
}
```

No default branch, so a number matches nothing and the call silently returns.

Read out of the **shipped** `dist/index.mjs`, not from the write-up in #393 — and it turns out to be worse than described there. This adapter's `charCoords` returns `{ top: pos.line, left: pos.ch }`: line numbers, not pixels, and with no `bottom` key at all. So `lineHeight` is `NaN`, `y` is `NaN` for `center` and `bottom`, and the pixel arithmetic upstream is doing could not have produced a usable value even if the switch had accepted one.

The fix hands `moveCurrentLineTo` one of the three strings its switch is written for and drops the arithmetic.

## 2. `zb` and `z-` are swapped

Vim (`:help scroll-cursor`) pairs each position with a letter form that keeps the cursor column and a punctuation form that moves it to the first non-blank:

| | keeps the column | first non-blank |
|---|---|---|
| top | `zt` | `z<CR>` |
| centre | `zz` | `z.` |
| bottom | `zb` | `z-` |

0.4.4 gets top and centre right and has bottom backwards — its `zb` carries `motion: "moveToFirstNonWhiteSpaceCharacter"` and its `z-` does not. Nobody could see this while defect 1 made the whole family dead; fixing the scroll is exactly what would have made a wrong cursor column visible, which is why it is in this PR and not a follow-up.

## Which of the three routes

**Route 2 — the supported extension point.** `VimMode.Vim.defineAction` replaces an action by name (the dispatcher looks it up as `actions[command.action]` at call time) and `Vim.mapCommand` unshifts onto the keymap the dispatcher takes its first full match from. Both are part of the package's public `Vim` API. Nothing in `node_modules` is patched.

**Route 1 — an upgrade — was rejected because there is nothing to upgrade to.** 0.4.4 *is* `latest` on npm (published 2025‑11‑22). Upstream master has had only dependency bumps since, and `moveCurrentLineTo` there is byte-for-byte the code above. There is no upstream issue for it either — brijeshb42/monaco-vim#71, "Some Vim scrolling keybindings are not working", is about `<C-f>`/`<C-b>`. I will open one upstream separately; it does not block this.

**Route 3 — patching the dependency — was therefore never needed.**

## Degrading

`installVimScrollCommands` returns `false` and changes nothing if `VimMode.Vim` is absent, is not an object, or has no `defineAction`; if `defineAction` exists but `mapCommand` does not, the scroll is repaired and the swap is left alone. Nothing it does can throw, because it runs while the user is toggling Vim mode on and a throw there takes the editor with it. `:mapclear` drops the two remapped keys and hands `zb`/`z-` back to upstream — a scroll to the right place with the wrong cursor column, not a dead key.

The remap is guarded by a `WeakSet` on the Vim API object: `defineAction` overwrites and is safe to repeat, but `mapCommand` *unshifts* onto a module-global keymap, so an install per Vim-mode toggle would grow it for the life of the window.

## Testing

`scripts/vimScrollCommands.test.ts` **presses the keys**. It drives real keystrokes into `Vim.handleKey` on a real `CMAdapter` built from the real `monaco-vim` package — the same `dist/index.mjs` Vite hands the app — and then asks the editor which reveal it was told to perform.

Only `monaco-editor` is faked, and only because it cannot be imported under Node. monaco-vim imports it as two ordinary externals rather than bundling it, so a `module.registerHooks` pair answers those two specifiers with the handful of value classes the adapter actually constructs. Everything downstream — the keymap, the command dispatcher, the action registry, `CMAdapter` itself — is upstream's own shipped code.

No assertion in the file checks that a source file contains a string. The closest it comes is lifting Editor.svelte's own `import("monaco-vim").then` callback out of the component and *running* it, to establish that the commands are installed before the adapter attaches and that they are installed even on the disposed path.

Two of the eight tests state what upstream does **un**repaired. They are the drift guard: the day an upgrade fixes `scrollToCursor` these go red and say the shim can go, which is the only way anyone would find out — a working `zz` looks the same either way.

**What it does not establish:** that Monaco's `revealRangeInCenter` puts the line where a human would call the centre, that focus and key routing reach Vim mode in the running app, or anything about rendering. It establishes which reveal each key sequence asks the editor for, and where the cursor ends up.

**Not fixed here:** a count (`10zz`) still ignores the count. Upstream's `scrollToCursor` never read `actionArgs.repeat`, this change does not add it, and it is a separate behaviour.

## Falsification

Test kept, both source changes reverted to master — 6 of 8 red.

```
✔ unpatched monaco-vim performs no scroll for any of the six keys
✔ unpatched monaco-vim has zb and z- the wrong way round
✖ every key in the z family scrolls to the position Vim documents
✖ the punctuation forms move to the first non-blank and the letter forms hold the column
✖ a second install does not map the commands a second time
✖ an object that is not monaco-vim is left alone
✖ a cm without moveCurrentLineTo does not throw
✖ Editor.svelte installs the commands on the module it just imported
ℹ pass 2  ℹ fail 6
```

```
✖ every key in the z family scrolls to the position Vim documents
  AssertionError: zz should reveal the cursor line at the center
  + actual - expected
  + []
  - [ { line: 2, position: 'center' } ]

✖ the punctuation forms move to the first non-blank and the letter forms hold the column
  AssertionError: z- should move the cursor to the first non-blank
  13 !== 5

✖ Editor.svelte installs the commands on the module it just imported
  AssertionError: the commands must be in place before the adapter attaches
  + actual - expected
    [
  -   'install',
      'initVimMode'
    ]
```

The two green ones are the drift guards — they are about upstream, and they must **not** move when our fix is removed. Two of the six red ones fail on `ERR_MODULE_NOT_FOUND` rather than on a claim; those are the pair that test the module's own degradation guards, and with the module deleted there is nothing to guard. Every test that is about `zz` fails on what `zz` did, because `loadInstaller()` falls back to a no-op install rather than importing directly — the same reasoning as `lifted` in `undoHistoryPerTab.ts`.

## Verification

`npm audit` 0 vulnerabilities · `npm run check` 0 errors, 647 files · `npm test` 708/708 · `cargo test` 157/157.

## Note on #471

This touches `Editor.svelte`, which #471 also rewrites (one Monaco model per tab). I read #471's diff before starting; the two changes do not overlap — that one is about `documentOptions`, `acquireTabModel` and the activation effect, this one is two lines inside the Vim-mode effect plus a new util. Whichever lands second may still need a trivial rebase.
