### PR TITLE
ci(deps): keep major bumps out of the grouped pull request, and split the cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,44 @@
 # dependency bot stops being read. Each ecosystem instead gets one grouped pull
 # request a month.
 #
+# That grouping is only safe for updates that promise to be compatible, so each
+# group is limited to `minor` and `patch`. Majors fall outside every group and
+# arrive as one pull request per dependency, each carrying its own changelog --
+# this is the documented shape, "Example: Individual pull requests for major
+# updates and grouped for minor/patch updates" in GitHub's guide to optimizing
+# pull request creation. Note that it is `update-types` alone that does this:
+# suppressing majors outright takes an additional `ignore` condition on
+# `version-update:semver-major`, which is deliberately not written here.
+#
+# The first run without that limit produced an eleven-package npm batch that
+# crossed TypeScript 5 -> 7 and Vite 6 -> 8 (#477), and a seventeen-crate cargo
+# batch that crossed tauri-plugin-prevent-default 2 -> 5 (#478) -- toolchain
+# migrations under a `chore(deps)` title, which is not a thing anyone can review
+# as a batch.
+#
+# One caveat, because it is invisible from the config: on a run where a grouped
+# pull request is already open, Dependabot marks every dependency matching the
+# group's `patterns` as handled before it looks at `update-types`, so that run
+# opens no individual major pull requests at all. They appear on the first run
+# after the grouped pull request is merged or closed. Majors are deferred by an
+# unreviewed batch, not dropped by it -- but they are deferred.
+#
+# One thing no `update-types` setting can fix, because it is not about semver:
+# the Tauri plugins ship as coupled pairs, one crate and one npm package, and
+# `tauri build` refuses to run when the two halves disagree --
+#
+#   Found version mismatched Tauri packages. Make sure the NPM package and Rust
+#   crate versions are on the same major/minor releases:
+#   tauri-plugin-dialog (v2.7.2) : @tauri-apps/plugin-dialog (v2.6.0)
+#
+# npm and cargo are separate ecosystems to Dependabot, so the two halves land in
+# two different pull requests that cannot see each other, and neither is green
+# on its own. The guard compares major *and minor*, so grouping by minor and
+# patch does not avoid it. When a Tauri plugin appears in both the npm and the
+# cargo pull request, the two have to be merged as a pair -- merge one, then
+# rebase and merge the other, and treat the red build on the first as expected
+# rather than as a reason to close it.
+#
 # Security updates are not configured here -- they are a repository setting
 # (Settings -> Advanced Security -> Dependabot security updates) and they open
 # their own pull requests as advisories land, independent of the schedule below.
@@ -19,14 +57,20 @@ updates:
     directory: /
     schedule:
       interval: monthly
-    # One group covers everything, so in practice this is 1. The headroom is
-    # for the case where a grouped pull request is open and stale.
-    open-pull-requests-limit: 2
+    # One slot for the grouped minor/patch pull request, three for the majors
+    # that now open individually alongside it. At the old limit of 2 a single
+    # major filled the file and the rest were invisible. Anything past the limit
+    # waits for a later run rather than being skipped, so this is how many stay
+    # visible at once, not a cap on how many are pending.
+    open-pull-requests-limit: 4
     groups:
       npm:
         applies-to: version-updates
         patterns:
           - '*'
+        update-types:
+          - minor
+          - patch
     commit-message:
       prefix: chore
       prefix-development: chore
@@ -37,28 +81,37 @@ updates:
     directory: /src-tauri
     schedule:
       interval: monthly
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 4
     groups:
       cargo:
         applies-to: version-updates
         patterns:
           - '*'
+        update-types:
+          - minor
+          - patch
     commit-message:
       prefix: chore
       include: scope
 
   # .github/workflows/*.yml. Four of the five actions in use are tracked by
-  # major tag, so this moves once or twice a year.
+  # major tag (`@v7`, `@v3`; the fifth is `dtolnay/rust-toolchain@stable`, which
+  # carries no version for Dependabot to compare), so a bump here is usually the
+  # tag moving to a new major -- exactly the case the group excludes. In
+  # practice this ecosystem will open single pull requests rather than a batch.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 4
     groups:
       github-actions:
         applies-to: version-updates
         patterns:
           - '*'
+        update-types:
+          - minor
+          - patch
     commit-message:
       prefix: ci
       include: scope

--- a/scripts/dependabotConfig.test.ts
+++ b/scripts/dependabotConfig.test.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readSource } from './sourceTree.js';
+
+// What this file locks, and why it is not visible from reading the config once.
+//
+// Dependabot's own schema check accepts a config that groups majors, and the
+// consequence only appears a month later as a pull request nobody can review:
+// the first run after #472 batched eleven npm packages across TypeScript 5 -> 7
+// and Vite 6 -> 8 (#477), and seventeen crates across
+// tauri-plugin-prevent-default 2 -> 5 (#478). Nothing failed. It just produced a
+// `chore(deps)` title wrapped around a toolchain migration.
+//
+// Blocks are checked one at a time rather than by searching the whole file, so
+// that a fourth ecosystem added without the same limits fails here instead of
+// passing because the other three still match.
+//
+// `ecosystemBlocks` asserts it found something because every check below is a
+// `for` over its result, and a `for` over an empty list passes. Measured: an
+// extra space after the `-` in each `- package-ecosystem:` line left the four
+// property checks green and only the coverage check red. That is the shape
+// where a guard and the thing it guards share one detector, so the detector
+// states its own precondition rather than leaving it to a sibling test.
+
+const config = readSource('.github/dependabot.yml');
+
+/**
+ * The prose above `version: 2` — the argument that justifies the settings below
+ * it — as one line, with the `#` markers and the wrapping removed.
+ *
+ * Unwrapped because a sentence in a YAML comment is broken across lines at
+ * whatever column it reaches, so `/one grouped pull request a month/` against
+ * the raw text is a claim about where the author happened to press enter. It
+ * did not match: the phrase is split after "pull".
+ */
+const header = config
+	.slice(0, config.indexOf('version: 2'))
+	.replace(/^#[ \t]?/gm, '')
+	.replace(/\s+/g, ' ');
+
+type EcosystemBlock = { ecosystem: string; text: string };
+
+function ecosystemBlocks(): EcosystemBlock[] {
+	const blocks: EcosystemBlock[] = [];
+	const starts: number[] = [];
+	const marker = /^ {2}- package-ecosystem: (\S+)$/gm;
+	const names: string[] = [];
+	for (let m = marker.exec(config); m; m = marker.exec(config)) {
+		starts.push(m.index);
+		names.push(m[1]);
+	}
+	assert.ok(
+		starts.length > 0,
+		'found no `- package-ecosystem:` block in .github/dependabot.yml; every check in this ' +
+			'file iterates over these blocks, so an unparsed file passes all of them silently',
+	);
+	for (let i = 0; i < starts.length; i += 1) {
+		blocks.push({
+			ecosystem: names[i],
+			text: config.slice(starts[i], starts[i + 1] ?? config.length),
+		});
+	}
+	return blocks;
+}
+
+test('every ecosystem the repository has is configured', () => {
+	const found = ecosystemBlocks().map((b) => b.ecosystem);
+	// Sorted so the assertion is about coverage rather than about ordering.
+	assert.deepEqual([...found].sort(), ['cargo', 'github-actions', 'npm']);
+});
+
+test('no group may batch a major version', () => {
+	for (const { ecosystem, text } of ecosystemBlocks()) {
+		assert.match(
+			text,
+			/update-types:\n\s+- minor\n\s+- patch\n/,
+			`the ${ecosystem} group must limit itself to minor and patch; without that, ` +
+				'a major lands inside a grouped pull request and stops being reviewable',
+		);
+		assert.doesNotMatch(
+			text,
+			/^\s+- major$/m,
+			`the ${ecosystem} group must not list major among its update types`,
+		);
+	}
+});
+
+test('a security fix never waits for the monthly batch', () => {
+	for (const { ecosystem, text } of ecosystemBlocks()) {
+		// Without this, Dependabot folds security updates into the grouped pull
+		// request, and an advisory published on the 2nd waits until the 1st.
+		assert.match(
+			text,
+			/applies-to: version-updates/,
+			`the ${ecosystem} group must apply to version updates only`,
+		);
+	}
+});
+
+test('the schedule is the cadence the header comment promises', () => {
+	// Two copies of one fact: the prose that argues for a quiet bot, and the
+	// `interval:` that implements it. Asserting `interval: monthly` on its own
+	// would be a constant checking itself — the header could be edited to
+	// promise a weekly bot and nothing would notice. So the expected value is
+	// read out of the promise.
+	const promised = /one grouped pull request a (day|week|month)\b/.exec(header);
+	assert.ok(
+		promised,
+		'the header comment must still state the cadence it is asking a maintainer to accept',
+	);
+	const interval = { day: 'daily', week: 'weekly', month: 'monthly' }[promised[1]];
+	for (const { ecosystem, text } of ecosystemBlocks()) {
+		assert.match(
+			text,
+			new RegExp(`interval: ${interval}\\b`),
+			`the header comment promises one grouped pull request a ${promised[1]}, so ${ecosystem} ` +
+				`must be on \`interval: ${interval}\``,
+		);
+	}
+});
+
+test('the open pull request limit leaves room for majors to queue', () => {
+	for (const { ecosystem, text } of ecosystemBlocks()) {
+		const limit = /open-pull-requests-limit: (\d+)/.exec(text);
+		assert.ok(limit, `${ecosystem} must state an open-pull-requests-limit`);
+		// One slot is spent on the grouped minor/patch pull request. A limit of 2
+		// leaves exactly one for majors, which is what made the backlog invisible.
+		assert.ok(
+			Number(limit[1]) >= 3,
+			`${ecosystem} has a limit of ${limit[1]}; majors open one pull request each, ` +
+				'so anything under 3 hides the queue rather than shortening it',
+		);
+	}
+});


### PR DESCRIPTION
`.github/dependabot.yml` groups each ecosystem with `patterns: ['*']` and no `update-types` filter, so a major version bump lands *inside* the monthly grouped pull request. The first run showed what that covers:

| PR | contents | crossed |
|---|---|---|
| #476 | 4 actions | major tags v4 → v7 — merged |
| #477 | 11 npm packages | TypeScript 5.6 → 7.0, Vite 6 → 8 |
| #478 | 17 crates | `tauri-plugin-prevent-default` 2 → 5, `notify` 6 → 8 |

Nothing failed — Dependabot's schema check accepts the config. It just produced a `chore(deps)` title wrapped around a toolchain migration, in a shape that cannot be split, bisected, or reverted per dependency.

Each group now takes `update-types: [minor, patch]`, and `open-pull-requests-limit` goes 2 → 4.

## Does this make majors individual, or does it drop them?

That distinction decides whether this fixes the problem or buries it, so I checked it rather than assuming.

**Documentation.** GitHub's [Optimizing the creation of pull requests for Dependabot version updates](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates) carries two adjacent examples:

- *"Example: Individual pull requests for major updates and grouped for minor/patch updates"* — a group with `patterns` + `update-types: [minor, patch]`, i.e. this config's exact shape. Its stated result: **"All major updates will continue to be raised as individual pull requests."**
- *"Example: Grouped pull requests for minor/patch updates and no pull requests for major updates"* — the same group **plus** an `ignore` condition on `version-update:semver-major`.

Suppressing majors takes that extra `ignore`. `update-types` alone does not, and no `ignore` is added here.

**Implementation**, read in `dependabot-core` at `main`, because the docs and the behaviour have been reported to diverge:

- `DependencyGroup#contains?` (`common/lib/dependabot/dependency_group.rb`) checks `patterns`, `exclude-patterns` and `dependency-type` — **not** `update_types`.
- `GroupUpdateCreation#compile_updates_for` calls `semver_rules_allow_grouping?`, which returns `false` for a major when `update_types` is `[minor, patch]`, and then returns early via `mark_handled_for_group_by_name`, which is a **no-op unless the group uses `group-by: dependency-name`**. We don't. So the dependency is never added to `handled_dependencies`.
- `DependencySnapshot#ungrouped_dependencies` is `allowed_dependencies` minus `handled_dependencies`, and `GroupUpdateAllVersions#perform` runs `run_ungrouped_dependency_updates` after the grouped pass, delegating to `UpdateAllVersions` — one pull request per dependency.

Majors are excluded from the group and opened individually. The change is right.

## What I could not verify

- **I did not run Dependabot.** This is a bot config; it only executes on GitHub's schedule. Everything above is documentation plus source reading, not observed behaviour. The real proof is the next run.
- **I read `dependabot-core` at `main`, not the revision GitHub's hosted Dependabot runs.** That revision isn't publicly pinned.
- **A known divergence, which I have written into the config comment.** [dependabot-core#14202](https://github.com/dependabot/dependabot-core/issues/14202) (open, filed 2026-02-17) reports majors being suppressed entirely under this config shape. I traced the mechanism: when a grouped pull request is *already open*, `GroupUpdateAllVersions` calls `mark_group_handled`, which does `add_handled_dependencies(group.dependencies.map(&:name))` — and `group.dependencies` was populated by `contains?`, which ignores `update-types`. So on such a run, no individual major pull requests open at all; they appear on the first run after the grouped PR is merged or closed. **Majors are deferred by an unreviewed batch, not dropped by it — but they are deferred.** The reporter's own job log shows exactly this path. I could not reproduce it, only trace it.
- **`open-pull-requests-limit: 4` is a judgement, not a measurement.** One slot for the grouped PR, three for majors. I have not observed how many majors a real run opens at once.

## Also found, and recorded in the config comment

#477 and #478 are both red, and one cause is a coupling Dependabot structurally cannot see. The Tauri plugins ship as coupled crate+npm pairs, and `tauri build` refuses to run when the halves disagree — from #478's Linux and macOS legs:

```
Found version mismatched Tauri packages. Make sure the NPM package and Rust
crate versions are on the same major/minor releases:
tauri-plugin-dialog (v2.7.2) : @tauri-apps/plugin-dialog (v2.6.0)
```

The crate half is in #478, the npm half in #477; neither is green alone. **The guard compares major *and minor*, so this change does not avoid it** — a minor-only grouped batch can split a plugin pair the same way. That is why it is written into `dependabot.yml` rather than left to be rediscovered.

## One thing I deliberately did not do

#478's Windows leg fails differently, and it is not a grouping problem:

```
error[E0599]: no method named `cast` found for struct ...ICoreWebView2
note: there are multiple different versions of crate `windows_core` in the dependency graph
```

`src-tauri/src/lib.rs:1966` and `:1972`. `windows-core` 0.61.2 (via tauri → `webview2-com`) and 0.62.2 (via our own `windows` bump) are both in the graph. I checked crates.io: **tauri 2.11.5, the current latest, still requires `windows ^0.61` and `webview2-com ^0.38`.** So bumping our `windows = "0.61.3"` to 0.62 is unmergeable at *any* published tauri 2.x, and it will come back every month.

An `ignore` entry would silence it, and I did not add one — that is a compatibility call, and a config `ignore` with no expiry goes stale silently the moment tauri moves. Three options, for you rather than for me:

1. **Do nothing.** It reappears monthly and gets closed monthly. Honest, noisy.
2. **`ignore` `windows` and `webview2-com` with a comment naming the unblocking condition** (tauri requiring `windows ^0.62`). Quiet, but needs a human to notice when it expires.
3. **Pin them to tauri's requirement in `Cargo.toml`** (`windows = "0.61"`, `webview2-com = "0.38"`) so Dependabot stops proposing an incompatible bump. Puts the constraint where the constraint actually lives.

## Tests

`scripts/dependabotConfig.test.ts` locks the properties that are invisible from reading the file: no group lists or admits `major`, every group stays `applies-to: version-updates`, the `interval` matches the cadence the header comment promises, and the limit stays above the point where the queue becomes invisible.

Each was verified by breaking the property it protects and confirming *that* test goes red:

| broken | test that failed | message |
|---|---|---|
| removed the github-actions ecosystem | every ecosystem the repository has is configured | `Expected values to be strictly deep-equal: - 'github-actions'` |
| npm group loses `update-types` | no group may batch a major version | `the npm group must limit itself to minor and patch; without that, a major lands inside a grouped pull request and stops being reviewable` |
| npm group gains `- major` | no group may batch a major version | `the npm group must not list major among its update types` |
| cargo group loses `applies-to` | a security fix never waits for the monthly batch | `the cargo group must apply to version updates only` |
| npm schedule → weekly | the schedule is the cadence the header comment promises | `the header comment promises one grouped pull request a month, so npm must be on \`interval: monthly\`` |
| header comment → "a week" | the schedule is the cadence the header comment promises | `the header comment promises one grouped pull request a week, so npm must be on \`interval: weekly\`` |
| npm limit back to 2 | the open pull request limit leaves room for majors to queue | `npm has a limit of 2; majors open one pull request each, so anything under 3 hides the queue rather than shortening it` |

Two of those tests changed as a result of running this:

- The cadence test asserted the literal `interval: monthly` while being *named* for the header comment. Editing the comment to promise a weekly bot left it green — the name was a claim the test did not make. It now reads the cadence out of the comment, which is what makes it a contract between two copies of one fact rather than a constant checking itself.
- Adding one space to each `- package-ecosystem:` line made `ecosystemBlocks()` return `[]`, and **four of the five checks passed on the empty list** — every one of them is a `for` over that result. `ecosystemBlocks()` now asserts it found something, so the detector states its own precondition instead of relying on a sibling test to notice.

`npm run check` — 0 errors. `npm test` — 733/733 locally. Those numbers are from before this
branch was rebased onto current `master`; the run on this PR is the one to trust.

---

## Second commit: cadence split, two held crates, and one change left out

### Cadence

`npm` and `cargo` → `quarterly`; `github-actions` stays `monthly`.

Security advisories never use this schedule, so version updates exist only to stop drift — and drift costs what *someone else's* deadline costs. On Actions somebody else always sets it: runner images retire toolchains on their own timetable, which is exactly how `build.yml` came to build releases on a Node pulled from the toolcache (#485). An Actions bump is also usually a one-line tag move. Nothing external forces a TypeScript or serde upgrade.

`quarterly` verified as a documented `schedule.interval` value — "run on the first day of each quarter (January, April, July, and October)". (It is `fpt`/GHEC plus GHES ≥ 3.19; this repo is on github.com.)

### Two crates held, and the shape the obvious version would have got wrong

`tauri` requires `windows ^0.61` and `webview2-com ^0.38` — still true at **2.11.5**, the current latest. #478's bumps are `windows 0.61.3 → 0.62.2` and `webview2-com 0.38.2 → 0.39.1`, which collide two `windows-core` versions and fail at `src-tauri/src/lib.rs:1966`.

**An `ignore` on `version-update:semver-major` would have been a no-op here, and I nearly wrote one.** These are 0.x crates. `IgnoreCondition#versions_by_type` delegates to `Version#ignored_major_versions`, which for `0.61.3` builds `[">= 1.a"]` — 0.62.2 passes straight through. The bump Dependabot needs to skip is classified **minor** (`new_minor > current_minor`). So the entries use bounded `versions:` ranges instead:

```yaml
ignore:
  - dependency-name: windows
    versions: ['0.62.*']
  - dependency-name: webview2-com
    versions: ['0.39.*']
```

That also gives the lapse property: `windows` 0.63 and `webview2-com` 0.40 do not exist yet, so on the day they ship Dependabot proposes them and the question gets asked again.

**One hazard worth naming:** `ignore` is the only option here that also filters **security** updates — `ignored_versions` does `return versions if security_updates_only`, so a `versions:` entry applies to advisories while an `update-types:` entry does not. The exposure is nil in practice because `Cargo.toml` pins `windows = "0.61.3"` (`^0.61.3` = `>=0.61.3, <0.62.0`), so 0.62.x is already outside what Cargo will resolve; advisories against the 0.61.x we actually build are untouched. It is in the config comment regardless.

The Tauri packages are **not** ignored, and the file now says why: the lockfile is on tauri 2.10.2 while 2.11.5 shipped 2026-07-01, and the red PR is the only notification that exists.

### The cooldown is not in this PR

The mechanism checks out. `cooldown` is valid alongside `groups`; dependabot-core passes `job.cooldown` on the grouped path (`group_update_creation.rb:404`) *and* the individual path (`update_all_versions.rb:249`) — so it would reach the individual major PRs, the case that matters; and it cannot delay a security update, both by `update_cooldown: job.security_updates_only? ? nil : job.cooldown` on both paths and by the docs ("only available for _version_ updates, not _security_ updates").

What does not hold is the premise. None of the current red PRs is red because its target is fresh:

| red item | actual cause | age of target |
|---|---|---|
| typescript 7.0.2 vs svelte-check | svelte-check **4.7.4** (2026‑07‑27, *19 days after* TS 7.0.2) narrowed its peer range to `^5.0.0 \|\| ^6.0.0` — a deliberate exclusion | 29 days |
| `windows` 0.62.2 | tauri requires `^0.61` | **10 months** (2025‑10‑06) |
| `webview2-com` 0.39.1 | tauri requires `^0.38` | **5 months** (2026‑03‑11) |
| tauri plugin pair | cross-ecosystem parity guard, not age | n/a |

And the cadence change makes a cooldown actively costly: on a quarterly schedule a major caught by an N-day window is not delayed N days, it is delayed to the **next quarter**. `quarterly` already means a proposed major is typically weeks old.

Also worth recording: **GitHub Actions does not support `semver-major-days`** at all (docs table: `default-days` only), so a cooldown could never have applied to the one ecosystem staying monthly.

Happy to add it if you'd rather — `semver-major-days: 7` on npm and cargo is the shape — but I'd be shipping something I can't show a benefit for.

### Falsification for every test touched

Per-ecosystem, as asked — each cadence mutation names the block it broke:

| broken | message |
|---|---|
| npm block → `monthly` | `the header comment promises npm runs quarterly, but its block says monthly` |
| cargo block → `monthly` | `the header comment promises cargo runs quarterly, but its block says monthly` |
| github-actions block → `quarterly` | `the header comment promises github-actions runs monthly, but its block says quarterly` |
| header row for npm → `monthly` | `the header comment promises npm runs monthly, but its block says quarterly` |
| header row for github-actions deleted | `the header comment must state a cadence for every ecosystem and no others` |
| ignore entry loses `versions:` | `every ignore entry under cargo must carry a versions: list; an entry without one silences the dependency permanently, including its security updates` |
| ignore range → `'>= 0.62'` | `ignoring windows at '>= 0.62' does not name a bounded version series, so nothing will ever reopen the question` |
| ignore range → `'0.*'` | `ignoring windows at '0.*' does not name a bounded version series, so nothing will ever reopen the question` |
| blank line inside `ignore:` | `cargo has an \`ignore:\` key this test cannot parse, so it cannot vouch for it` |

The four earlier properties were re-falsified after the rewrite and still fail correctly, and re-indenting `- package-ecosystem:` still turns **all six** red rather than passing vacuously.

The ignore test had the same vacuity hole as the first round — it `continue`d when its parser found nothing. It now asks "does this block ignore anything" separately from "can I read it", which is what the last mutation above exercises.

`npm run check` — 0 errors, 652 files. `npm test` — 752/752.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
