### PR TITLE
chore(i18n): drop tabs.home, the home tab's own title key

### DIFF
--- a/scripts/homeTabRender.test.ts
+++ b/scripts/homeTabRender.test.ts
@@ -24,7 +24,8 @@ import { readSource } from './sourceTree.js';
  * halves became permanently true. From then on the home tab fell into the
  * markdown container and rendered an empty document. The later i18n pass
  * turned the title into `t('tabs.home', lang)`, which merely made the dead
- * half unrecoverable in 26 languages instead of one.
+ * half unrecoverable in 26 languages instead of one. (That key no longer
+ * exists — it was the home tab's title and outlived the tab by one release.)
  *
  * Nothing could see that coupling: a template string compared against a
  * localised title is invisible to the compiler, to `npm run check`, and to
@@ -240,8 +241,13 @@ test('the home screen is reached by tab kind, never by the tab title', () => {
 	openHomeTab();
 	const home = tabManager.activeTab!;
 
+	// `menu.home` rather than `tabs.home`: the latter was the home tab's own
+	// title key and went with the tab, since nothing was left to title. What
+	// the loop needs is only what each locale calls Home, and the menu item
+	// says that in all 26 — the claim being tested is about the title being
+	// ignored, not about which key it came from.
 	for (const { code } of getSupportedLanguages()) {
-		home.title = t('tabs.home', code);
+		home.title = t('menu.home', code);
 		assert.equal(showsDocumentContainer(), false, `the home screen disappears in locale ${code}`);
 	}
 

--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -420,8 +420,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Removing Markpad...'
         },
         tabs: {
-            untitled: 'Untitled',
-            home: 'Home'
+            untitled: 'Untitled'
         },
         common: {
             close: 'Close',
@@ -780,8 +779,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: '正在移除 Markpad...'
         },
         tabs: {
-            untitled: '无标题',
-            home: '主页'
+            untitled: '无标题'
         },
         common: {
             close: '关闭',
@@ -1056,8 +1054,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Markpad を削除中...'
         },
         tabs: {
-            untitled: '名前なし',
-            home: 'ホーム'
+            untitled: '名前なし'
         },
         common: {
             close: '閉じる',
@@ -1423,8 +1420,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: '正在移除 Markpad...'
         },
         tabs: {
-            untitled: '未命名',
-            home: '首頁'
+            untitled: '未命名'
         },
         common: {
             close: '關閉',
@@ -1765,8 +1761,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Markpad 제거 중...'
         },
         tabs: {
-            untitled: '제목 없음',
-            home: '홈'
+            untitled: '제목 없음'
         },
         common: {
             close: '닫기',
@@ -1994,8 +1989,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Удаление Markpad...'
         },
         tabs: {
-            untitled: 'Без названия',
-            home: 'Главная'
+            untitled: 'Без названия'
         },
         common: {
             close: 'Закрыть',
@@ -2221,8 +2215,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Eliminando Markpad...'
         },
         tabs: {
-            untitled: 'Sin título',
-            home: 'Inicio'
+            untitled: 'Sin título'
         },
         common: {
             close: 'Cerrar',
@@ -2448,8 +2441,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Suppression de Markpad...'
         },
         tabs: {
-            untitled: 'Sans titre',
-            home: 'Accueil'
+            untitled: 'Sans titre'
         },
         common: {
             close: 'Fermer',
@@ -2675,8 +2667,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Markpad wird entfernt...'
         },
         tabs: {
-            untitled: 'Unbenannt',
-            home: 'Startseite'
+            untitled: 'Unbenannt'
         },
         common: {
             close: 'Schließen',
@@ -2902,8 +2893,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Removendo Markpad...'
         },
         tabs: {
-            untitled: 'Sem título',
-            home: 'Início'
+            untitled: 'Sem título'
         },
         common: {
             close: 'Fechar',
@@ -3129,8 +3119,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Rimozione Markpad...'
         },
         tabs: {
-            untitled: 'Senza titolo',
-            home: 'Home'
+            untitled: 'Senza titolo'
         },
         common: {
             close: 'Chiudi',
@@ -3378,8 +3367,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Usuwanie Markpad...'
         },
         tabs: {
-            untitled: 'Bez tytułu',
-            home: 'Strona główna'
+            untitled: 'Bez tytułu'
         },
         common: {
             close: 'Zamknij',
@@ -3605,8 +3593,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Markpad verwijderen...'
         },
         tabs: {
-            untitled: 'Naamloos',
-            home: 'Startpagina'
+            untitled: 'Naamloos'
         },
         common: {
             close: 'Sluiten',
@@ -3832,8 +3819,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Tar bort Markpad...'
         },
         tabs: {
-            untitled: 'Namnlös',
-            home: 'Hem'
+            untitled: 'Namnlös'
         },
         common: {
             close: 'Stäng',
@@ -4059,8 +4045,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Đang gỡ cài đặt Markpad...'
         },
         tabs: {
-            untitled: 'Chưa đặt tên',
-            home: 'Trang chủ'
+            untitled: 'Chưa đặt tên'
         },
         common: {
             close: 'Đóng',
@@ -4286,8 +4271,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'A remover Markpad...'
         },
         tabs: {
-            untitled: 'Sem título',
-            home: 'Início'
+            untitled: 'Sem título'
         },
         common: {
             close: 'Fechar',
@@ -4513,8 +4497,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Se elimină Markpad...'
         },
         tabs: {
-            untitled: 'Fără titlu',
-            home: 'Acasă'
+            untitled: 'Fără titlu'
         },
         common: {
             close: 'Închidere',
@@ -4740,8 +4723,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Markpad eltávolítása...'
         },
         tabs: {
-            untitled: 'Névtelen',
-            home: 'Kezdőlap'
+            untitled: 'Névtelen'
         },
         common: {
             close: 'Bezárás',
@@ -4970,8 +4952,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Odstraňování Markpadu...'
         },
         tabs: {
-            untitled: 'Bez názvu',
-            home: 'Domů'
+            untitled: 'Bez názvu'
         },
         common: {
             close: 'Zavřít',
@@ -5200,8 +5181,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Odstraňovanie Markpadu...'
         },
         tabs: {
-            untitled: 'Bez názvu',
-            home: 'Domov'
+            untitled: 'Bez názvu'
         },
         common: {
             close: 'Zatvoriť',
@@ -5427,8 +5407,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Κατάργηση Markpad...'
         },
         tabs: {
-            untitled: 'Χωρίς τίτλο',
-            home: 'Αρχική'
+            untitled: 'Χωρίς τίτλο'
         },
         common: {
             close: 'Κλείσιμο',
@@ -5654,8 +5633,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Poistetaan Markpadia...'
         },
         tabs: {
-            untitled: 'Nimetön',
-            home: 'Koti'
+            untitled: 'Nimetön'
         },
         common: {
             close: 'Sulje',
@@ -5881,8 +5859,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Fjerner Markpad...'
         },
         tabs: {
-            untitled: 'Unavngivet',
-            home: 'Hjem'
+            untitled: 'Unavngivet'
         },
         common: {
             close: 'Luk',
@@ -6108,8 +6085,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Fjerner Markpad...'
         },
         tabs: {
-            untitled: 'Uten tittel',
-            home: 'Hjem'
+            untitled: 'Uten tittel'
         },
         common: {
             close: 'Lukk',
@@ -6335,8 +6311,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Mencopot Markpad...'
         },
         tabs: {
-            untitled: 'Tidak Berjudul',
-            home: 'Beranda'
+            untitled: 'Tidak Berjudul'
         },
         common: {
             close: 'Tutup',
@@ -6562,8 +6537,7 @@ export const translations: Record<LanguageCode, Translation> = {
             removingMarkpad: 'Markpad kaldırılıyor...'
         },
         tabs: {
-            untitled: 'Başlıksız',
-            home: 'Ana Sayfa'
+            untitled: 'Başlıksız'
         },
         common: {
             close: 'Kapat',


### PR DESCRIPTION
## Prerequisite

Third in a chain — **merge #480, then #482, then this**:

```
master ← #480 (Ctrl+T means new file)
           ← #482 (remove addHomeTab, keep the sentinel)
                ← this PR (remove tabs.home, the title that tab carried)
```

Branched on and targeting `chore/drop-dead-home-tab-constructor`, so the diff
above is this change alone. GitHub retargets each base automatically as the one
below it lands.

This is the follow-up #482's Scope section offered.

## What this is

`tabs.home` was the home tab's own title key: `addHomeTab` set
`title: t('tabs.home', settings.language)`, and that was its only consumer in
`src/`. #482 removed the method, so the key now titles nothing.

26 locales, one leaf each, always the second entry of a `tabs` block that keeps
`untitled`:

```diff
         tabs: {
-            untitled: 'Untitled',
-            home: 'Home'
+            untitled: 'Untitled'
         },
```

## Scope

**The home screen is not affected.** There are three `home` keys per locale and
this touches one:

| key | what it is | here |
| --- | --- | --- |
| `menu.home` | the Home menu item / titlebar button label | **kept** |
| `home.*` | the HomePage section (welcome, recent files, …) | **kept** |
| `tabs.home` | the title of the tab that held the home screen | **removed** |

The home screen keeps both of its live routes — the titlebar button and the
`showHome` toggle. What went is the title of a tab that can no longer exist.

`78 → 52` occurrences of `home:` in the dictionary, which is 26 × 3 → 26 × 2.

## Tests

`homeTabRender.test.ts` read the key to prove the render gate ignores the tab
title in every language — the dead half of the #392 gate compared against the
English literal `'Recents'`. It now reads `menu.home`, which every locale also
defines. The claim under test is that the title cannot affect which branch runs,
not which key the title came from; the following `'Recents'` assertion is
unchanged.

## Verification

Nothing type-checks a `t()` key — `Translation` is an index signature
(`[key: string]: string | Translation`), so `svelte-check` has no opinion here
and a half-finished sweep across 26 locales would compile fine. The safety net
is `i18nCoverage.test.ts`, and rather than assume it covers this I broke it both
ways and watched it fail:

**A locale left behind.** Restored `home: 'ホーム'` to `ja` only:

```
✖ no language defines a key English does not have
    tabs.home  [1] ja
```

**A call site missed.** Put `t('tabs.home', settings.language)` back into
`tabs.svelte.ts`:

```
✖ every key the source asks for exists in English
✖ t() never echoes a key back for a reachable string
```

Both directions of that file's interlock hold, so neither failure mode can reach
`master`. Probes reverted; the diff is the 26 deletions and the one test line.

Full suite, macOS (darwin 25.5.0), on top of #482:

```
npm audit        found 0 vulnerabilities
npm run check    649 FILES 0 ERRORS 0 WARNINGS
npm test         737 tests, 737 pass, 0 fail
cargo test       157 passed; 0 failed   (unchanged from #482 — no Rust here)
```

**Not verified:** no running app. This is a dictionary deletion whose safety
rests on the two probes above plus the caller census (`grep -rn 'tabs\.home' src
scripts` returns only the comment explaining the substitution), not on switching
the UI through 26 languages by hand.
