### PR TITLE
ci(deps): split the cadence, hold two crates, and stop batching pre-1.0 npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,26 @@
 # Deliberately quiet. Three ecosystems on a weekly cadence would put roughly a
 # dozen pull requests a month in front of one maintainer, which is how a
 # dependency bot stops being read. Each ecosystem instead gets one grouped pull
-# request a month.
+# request per run, and the runs are spaced by what it costs to be late:
+#
+#   github-actions  monthly    -- someone else's deadline
+#   npm             quarterly  -- our own deadline
+#   cargo           quarterly  -- our own deadline
+#
+# Security advisories do not use this schedule at all (see the note at the foot
+# of this comment), so version updates exist only to stop drift, and drift costs
+# what somebody else's deadline costs. On GitHub Actions somebody else always
+# sets it: runner images retire toolchains on their own timetable, which is how
+# `build.yml` came to build releases on a `node-version: '20'` that had been
+# pulled from the image toolcache. Nobody chose that date. An Actions bump is
+# also nearly always a one-line tag move, so monthly review costs almost
+# nothing.
+#
+# Application dependencies are the other way round. Nothing external forces a
+# TypeScript or a serde upgrade, the diffs are real, and a quarter of them in
+# one grouped pull request is both less interrupting and more reviewable than
+# three monthly ones. `quarterly` runs on the first day of January, April, July
+# and October.
 #
 # That grouping is only safe for updates that promise to be compatible, so each
 # group is limited to `minor` and `patch`. Majors fall outside every group and
@@ -12,13 +31,35 @@
 # updates and grouped for minor/patch updates" in GitHub's guide to optimizing
 # pull request creation. Note that it is `update-types` alone that does this:
 # suppressing majors outright takes an additional `ignore` condition on
-# `version-update:semver-major`, which is deliberately not written here.
+# `version-update:semver-major`, which is deliberately not written here. The
+# `ignore` entries that do exist, under cargo, name two specific version ranges
+# and no semver level -- they exclude two known-unbuildable bumps, not a class.
 #
 # The first run without that limit produced an eleven-package npm batch that
 # crossed TypeScript 5 -> 7 and Vite 6 -> 8 (#477), and a seventeen-crate cargo
 # batch that crossed tauri-plugin-prevent-default 2 -> 5 (#478) -- toolchain
 # migrations under a `chore(deps)` title, which is not a thing anyone can review
 # as a batch.
+#
+# `minor` does not mean compatible below 1.0, and the two ecosystems disagree
+# about that. Dependabot decides npm's update type from the literal position of
+# the number, so katex 0.16.47 -> 0.18.1 is a `minor` bump and goes in the
+# batch -- while npm's own caret rule makes `^0.16.47` stop before 0.17, i.e.
+# exactly the range that says this is breaking. It is: KaTeX 0.18.0 renamed
+# every internal CSS class, and 0.17.0 changed `__defineFunction`. Both sat
+# inside the "reviewable at a glance" npm batch (#487).
+#
+# Cargo does not have this problem. `Dependabot::Cargo::Version` implements the
+# pre-1.0 rule properly, so windows 0.61.3 -> 0.62.2 counts as a major, falls
+# out of the group, and the rebuilt cargo batch (#489) came back without it.
+# The npm side has no such subclass.
+#
+# There is no `update-types` value for "pre-1.0 minor", and `patterns` match on
+# name, not version, so this cannot be expressed as a rule. What it can be is a
+# list: the pre-1.0 npm dependencies are named in `exclude-patterns` below and
+# get individual pull requests for everything. `scripts/dependabotConfig.test.ts`
+# derives that list from package.json, so a new 0.x dependency -- or an existing
+# one reaching 1.0 -- fails the suite instead of quietly rejoining the batch.
 #
 # One caveat, because it is invisible from the config: on a run where a grouped
 # pull request is already open, Dependabot marks every dependency matching the
@@ -43,11 +84,22 @@
 # rebase and merge the other, and treat the red build on the first as expected
 # rather than as a reason to close it.
 #
+# The Tauri packages are deliberately NOT ignored, even though that red build is
+# a recurring nuisance. Ignoring them means never being told that tauri itself
+# has moved: the lockfile is on 2.10.2 (February) while 2.11.5 has been out
+# since 2026-07-01. The red pull request is the notification, and there is no
+# other one.
+#
 # Security updates are not configured here -- they are a repository setting
 # (Settings -> Advanced Security -> Dependabot security updates) and they open
 # their own pull requests as advisories land, independent of the schedule below.
 # `applies-to: version-updates` on each group is what keeps them out of the
-# monthly batch, so a security fix still arrives on its own and immediately.
+# batch, so a security fix still arrives on its own and immediately. That is
+# what makes a quarterly cadence safe to choose: the slow schedule only ever
+# carries updates nobody is waiting on. The `ignore` entries below are the one
+# thing on this page that does reach security updates -- an ignored version
+# range is filtered out of those too -- which is why they are bounded to two
+# minor series that tauri's own requirement puts out of reach anyway.
 
 version: 2
 
@@ -56,7 +108,7 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: monthly
+      interval: quarterly
     # One slot for the grouped minor/patch pull request, three for the majors
     # that now open individually alongside it. At the old limit of 2 a single
     # major filled the file and the rest were invisible. Anything past the limit
@@ -68,6 +120,15 @@ updates:
         applies-to: version-updates
         patterns:
           - '*'
+        # Pre-1.0, where a minor bump is a breaking change that Dependabot
+        # still labels `minor` (see the header). Excluded from the group, so
+        # each gets its own pull request and its own changelog -- the
+        # documented behaviour of `exclude-patterns`. Kept in step with
+        # package.json by scripts/dependabotConfig.test.ts.
+        exclude-patterns:
+          - 'katex'
+          - 'monaco-editor'
+          - 'monaco-vim'
         update-types:
           - minor
           - patch
@@ -80,7 +141,7 @@ updates:
   - package-ecosystem: cargo
     directory: /src-tauri
     schedule:
-      interval: monthly
+      interval: quarterly
     open-pull-requests-limit: 4
     groups:
       cargo:
@@ -90,6 +151,39 @@ updates:
         update-types:
           - minor
           - patch
+    # Two crates whose next version cannot build here, whatever we do to them.
+    #
+    # `tauri` depends on `windows ^0.61` and `webview2-com ^0.38`, and still
+    # does at 2.11.5, the current latest. Taking `windows` 0.62 or
+    # `webview2-com` 0.39 puts two incompatible `windows-core` versions in one
+    # graph, and the build stops in our own WebView2 call:
+    #
+    #   error[E0599]: no method named `cast` found for struct ...ICoreWebView2
+    #   note: there are multiple different versions of crate `windows_core` in
+    #   the dependency graph
+    #
+    # The grouping change already keeps them out of the batch -- Cargo counts a
+    # pre-1.0 minor as a major -- so what is left is an individual pull request,
+    # every quarter, that cannot be merged at any published tauri 2.x. That is a
+    # decision, and it belongs in the file rather than in a quarterly reflex to
+    # close the same pull request.
+    #
+    # Bounded to one minor series each, rather than written as
+    # `update-types: [version-update:semver-major]`, so that the entries lapse.
+    # (The semver-level form would work here -- `Cargo::Version` overrides
+    # `ignored_major_versions` so that >= 0.62 is what "major" means for a 0.61
+    # crate -- but it would also swallow 0.63 and 0.64 in silence.) `windows`
+    # 0.63 and `webview2-com` 0.40 do not exist yet; on the day they do,
+    # Dependabot proposes them and we find out whether tauri has moved.
+    #
+    # Remove an entry once tauri's own requirement covers the newer series --
+    # `cargo tree -i windows-core` showing a single version is the check.
+    # Patches within the series we are on are unaffected and still arrive.
+    ignore:
+      - dependency-name: windows
+        versions: ['0.62.*']
+      - dependency-name: webview2-com
+        versions: ['0.39.*']
     commit-message:
       prefix: chore
       include: scope

--- a/scripts/dependabotConfig.test.ts
+++ b/scripts/dependabotConfig.test.ts
@@ -25,19 +25,35 @@ import { readSource } from './sourceTree.js';
 
 const config = readSource('.github/dependabot.yml');
 
+/** The prose above `version: 2` — the argument that justifies the settings below it. */
+const headerLines = config.slice(0, config.indexOf('version: 2')).split('\n');
+
+const manifest = JSON.parse(readSource('package.json')) as {
+	dependencies: Record<string, string>;
+	devDependencies: Record<string, string>;
+};
+
 /**
- * The prose above `version: 2` — the argument that justifies the settings below
- * it — as one line, with the `#` markers and the wrapping removed.
+ * The cadence the header comment promises for each ecosystem, read out of the
+ * table it opens with:
  *
- * Unwrapped because a sentence in a YAML comment is broken across lines at
- * whatever column it reaches, so `/one grouped pull request a month/` against
- * the raw text is a claim about where the author happened to press enter. It
- * did not match: the phrase is split after "pull".
+ *   github-actions  monthly    -- someone else's deadline
+ *   npm             quarterly  -- our own deadline
+ *
+ * Per ecosystem rather than one global cadence. The previous version of this
+ * file read a single promised cadence and applied it to every block, which was
+ * only right because every block agreed; with two cadences that shape passes as
+ * long as *some* ecosystem matches, which is a test going green for the wrong
+ * reason.
  */
-const header = config
-	.slice(0, config.indexOf('version: 2'))
-	.replace(/^#[ \t]?/gm, '')
-	.replace(/\s+/g, ' ');
+const promisedCadence = new Map(
+	headerLines
+		.map((line) =>
+			/^#\s{2,}([a-z-]+)\s{2,}(daily|weekly|monthly|quarterly|semiannually|yearly)\b/.exec(line),
+		)
+		.filter((m): m is RegExpExecArray => m !== null)
+		.map((m) => [m[1], m[2]]),
+);
 
 type EcosystemBlock = { ecosystem: string; text: string };
 
@@ -86,7 +102,7 @@ test('no group may batch a major version', () => {
 	}
 });
 
-test('a security fix never waits for the monthly batch', () => {
+test('a security fix never waits for the grouped batch', () => {
 	for (const { ecosystem, text } of ecosystemBlocks()) {
 		// Without this, Dependabot folds security updates into the grouped pull
 		// request, and an advisory published on the 2nd waits until the 1st.
@@ -98,25 +114,112 @@ test('a security fix never waits for the monthly batch', () => {
 	}
 });
 
-test('the schedule is the cadence the header comment promises', () => {
-	// Two copies of one fact: the prose that argues for a quiet bot, and the
-	// `interval:` that implements it. Asserting `interval: monthly` on its own
-	// would be a constant checking itself — the header could be edited to
-	// promise a weekly bot and nothing would notice. So the expected value is
-	// read out of the promise.
-	const promised = /one grouped pull request a (day|week|month)\b/.exec(header);
-	assert.ok(
-		promised,
-		'the header comment must still state the cadence it is asking a maintainer to accept',
+test('each ecosystem runs on the cadence the header comment promises for it', () => {
+	// Two copies of one fact: the table that argues for each cadence, and the
+	// `interval:` that implements it. Checked per ecosystem, so that changing one
+	// block's interval fails and names that block, rather than passing because
+	// its two siblings still agree with the comment.
+	const blocks = ecosystemBlocks();
+	assert.deepEqual(
+		[...promisedCadence.keys()].sort(),
+		blocks.map((b) => b.ecosystem).sort(),
+		'the header comment must state a cadence for every ecosystem and no others',
 	);
-	const interval = { day: 'daily', week: 'weekly', month: 'monthly' }[promised[1]];
-	for (const { ecosystem, text } of ecosystemBlocks()) {
-		assert.match(
-			text,
-			new RegExp(`interval: ${interval}\\b`),
-			`the header comment promises one grouped pull request a ${promised[1]}, so ${ecosystem} ` +
-				`must be on \`interval: ${interval}\``,
+	for (const { ecosystem, text } of blocks) {
+		const promised = promisedCadence.get(ecosystem);
+		const actual = /interval:\s*(\S+)/.exec(text)?.[1];
+		assert.equal(
+			actual,
+			promised,
+			`the header comment promises ${ecosystem} runs ${promised}, but its block says ${actual}`,
 		);
+	}
+});
+
+test('every pre-1.0 npm dependency is kept out of the grouped batch', () => {
+	// Dependabot types an npm update by the literal position of the number, so
+	// katex 0.16.47 -> 0.18.1 is a `minor` and lands in the batch — while npm's
+	// own caret rule stops `^0.16.47` before 0.17, because below 1.0 a minor
+	// bump is the breaking one. KaTeX 0.18.0 renamed every internal CSS class;
+	// it arrived inside the batch that is supposed to be safe to skim (#487).
+	//
+	// Cargo gets this right on its own (`Cargo::Version` implements the pre-1.0
+	// rule), so this is an npm-only exclusion, and `patterns` cannot express it
+	// — they match names, not versions. So it is a hand-written list, and this
+	// is what keeps the list honest: the expectation is derived from
+	// package.json, so adding a 0.x dependency, or an existing one reaching 1.0,
+	// fails here rather than silently changing what the batch contains.
+	const ranges = { ...manifest.dependencies, ...manifest.devDependencies };
+	const preRelease = Object.entries(ranges)
+		.filter(([, range]) => /^[\^~]?0\./.test(range))
+		.map(([name]) => name)
+		.sort();
+	assert.ok(
+		preRelease.length > 0,
+		'expected package.json to declare at least one pre-1.0 dependency; if that is no longer ' +
+			'true this test and the exclude-patterns it guards should both go',
+	);
+
+	const npm = ecosystemBlocks().find((b) => b.ecosystem === 'npm');
+	assert.ok(npm, 'the npm ecosystem block must exist');
+	const excluded = /exclude-patterns:\n((?:\s+- '[^']+'\n)+)/.exec(npm.text);
+	assert.ok(
+		excluded,
+		`the npm group must exclude its pre-1.0 dependencies (${preRelease.join(', ')}); without ` +
+			'that they ride along in the grouped pull request as ordinary minor bumps',
+	);
+	const listed = [...excluded[1].matchAll(/- '([^']+)'/g)].map((m) => m[1]).sort();
+	assert.deepEqual(
+		listed,
+		preRelease,
+		'the npm group\'s exclude-patterns must name exactly the pre-1.0 dependencies in package.json',
+	);
+});
+
+test('every ignored range names a version series, so the entry lapses', () => {
+	// An `ignore` is the one thing in this file that also filters *security*
+	// updates, and the one thing with no expiry. A bare `dependency-name`, or a
+	// semver level, silences a dependency until somebody deletes the line —
+	// and nothing will ever prompt them to.
+	//
+	// A bounded series does prompt them: `windows` is held at `0.62.*` because
+	// tauri requires `^0.61`, and the day `windows` 0.63 ships, Dependabot
+	// proposes it and the question gets asked again.
+	//
+	// This does not assert *which* dependencies are ignored — that is a decision
+	// the file may change. It asserts that whatever is ignored is ignored in a
+	// way that ends.
+	for (const { ecosystem, text } of ecosystemBlocks()) {
+		// Two steps, not one: "does this block ignore anything" is asked
+		// separately from "can this test read what it ignores", so a spelling the
+		// parser below does not understand fails here instead of skipping the
+		// block and reporting success.
+		if (!/^ {4}ignore:$/m.test(text)) continue;
+		const ignores = /^ {4}ignore:\n((?: {6}[-\s].*\n)+)/m.exec(text);
+		assert.ok(
+			ignores,
+			`${ecosystem} has an \`ignore:\` key this test cannot parse, so it cannot vouch for it`,
+		);
+		const entries = [
+			...ignores[1].matchAll(/- dependency-name:\s*(\S+)\n\s+versions:\s*\[([^\]]*)\]/g),
+		];
+		const names = [...ignores[1].matchAll(/- dependency-name:/g)];
+		assert.equal(
+			entries.length,
+			names.length,
+			`every ignore entry under ${ecosystem} must carry a \`versions:\` list; an entry without ` +
+				'one silences the dependency permanently, including its security updates',
+		);
+		for (const [, name, versions] of entries) {
+			for (const range of versions.split(',')) {
+				assert.match(
+					range.trim(),
+					/^'\d+\.\d+\.\*'$/,
+					`ignoring ${name} at ${range.trim()} does not name a bounded version series, so ` +
+						'nothing will ever reopen the question',
+				);
+			}
+		}
 	}
 });
 


### PR DESCRIPTION
Tuning for the bot #484 just landed. That change is working — the recreated cargo batch (**#489**) came back with **7 minor/patch crates instead of 16 with majors inside**, and `tauri-plugin-prevent-default 2→5` / `notify 6→8` are gone from it. This is the next layer: when to run, what "minor" is worth below 1.0, and two crates that cannot be merged at all.

## 1. Cadence split

`npm` and `cargo` → `quarterly`; `github-actions` stays `monthly`.

Security advisories never use this schedule, so version updates exist only to stop drift — and drift costs what *someone else's* deadline costs. On Actions somebody else always sets it: runner images retire toolchains on their own timetable, which is exactly how `build.yml` came to build releases on a Node pulled from the toolcache (#485). An Actions bump is also usually a one-line tag move. Nothing external forces a TypeScript or serde upgrade.

`quarterly` verified as a documented `schedule.interval` value — "run on the first day of each quarter (January, April, July, and October)". Available on github.com; GHES needs ≥ 3.19.

## 2. `minor` does not mean compatible below 1.0 — and npm and cargo disagree about it

This is the one worth reading.

**Verified in source.** `semver_rules_allow_grouping?` compares `semver_segments`, so for npm `katex 0.16.47 → 0.18.1` has `major 0 == 0`, then `minor 18 > 16` → returns `update_types.include?("minor")` → **true, it goes in the batch**. npm's own caret rule says the opposite: `^0.16.47` stops before `0.17`, because below 1.0 the minor *is* the breaking position.

**Verified in the wild.** #487 — the batch whose premise is that it can be skimmed — contains:

| package | from | to |
|---|---|---|
| katex | `0.16.47` | `0.18.1` |
| monaco-editor | `0.55.1` | `0.56.0` |

and it rewrites the manifest `^0.16.27` → `^0.18.1`. KaTeX's own release notes:

- **0.18.0** — `BREAKING CHANGES: users who apply custom styles or have allowlists targeting KaTeX's internal classes must update their selectors.` (CSS class prefixing, ~20 classes)
- **0.17.0** — `BREAKING CHANGES: The internal API for __defineFunction changed.`

Two breaking releases inside a `chore(deps)` batch labelled minor/patch.

**Cargo does not have this bug.** `Dependabot::Cargo::Version` overrides the pre-1.0 rule, so `windows 0.61.3 → 0.62.2` counts as a **major**, falls out of the group — and you can see it in #489, where `windows` and `webview2-com` are simply absent from the batch. `NpmAndYarn::Version` has no equivalent override; I checked, it defines `major`/`minor`/`patch` and nothing else.

**The fix, and why it is a list.** There is no `update-types` value for "pre-1.0 minor", and `patterns` match on **name**, not version (`WildcardMatcher.match?(rule, dependency_name)`), so this cannot be expressed as a rule. So `exclude-patterns` names them:

```yaml
exclude-patterns:
  - 'katex'
  - 'monaco-editor'
  - 'monaco-vim'
```

`exclude-patterns` is the mechanism with a *documented* outcome — Example 2 in GitHub's grouping guide: excluded dependencies are ones "Dependabot continues to raise single pull requests for". I considered leaning on the `PatternSpecificityCalculator` instead (exact match scores 1000, `*` scores 1) but rejected it: it's an implementation detail I'd only have read on `main`, whereas `exclude-patterns` is checked directly in `DependencyGroup#contains?`.

A hand-written list rots, so the test **derives the expected list from `package.json`** and asserts set equality. Adding a 0.x dependency, or an existing one reaching 1.0, fails the suite.

## 3. Two crates held

`tauri` requires `windows ^0.61` and `webview2-com ^0.38` — still true at **2.11.5**. Taking 0.62 / 0.39 collides two `windows-core` versions and fails at `src-tauri/src/lib.rs:1966` with `E0599`. Grouping already keeps them out of the batch (see above), so what remains is an individual PR every quarter that cannot be merged at any published tauri 2.x.

```yaml
ignore:
  - dependency-name: windows
    versions: ['0.62.*']
  - dependency-name: webview2-com
    versions: ['0.39.*']
```

Bounded series rather than a semver level, so the entries **lapse**: `windows` 0.63 does not exist yet, and the day it does Dependabot proposes it and we learn whether tauri has moved. A semver-level ignore would swallow 0.63 and 0.64 silently.

> **Correction to something I wrote in #484.** That PR's description claimed `version-update:semver-major` would be a *no-op* on these crates because Dependabot reads 0.61→0.62 as minor. That is true of the generic `Dependabot::Version`, which is what I read — but `Cargo::Version` **overrides** `ignored_major_versions`, and for a 0.61 crate "major" means `>= 0.62`. So the semver form would have worked; I rejected it for the wrong reason. The bounded range is still the better choice, for the lapse property, but the justification in the merged comment was wrong and is corrected in this diff.

The Tauri packages are **not** ignored, and the file now says why: the lockfile is on tauri 2.10.2 while 2.11.5 shipped 2026-07-01, and the red PR is the only notification that exists.

## 4. The cooldown is not in this PR

The mechanism checks out — `cooldown` is valid alongside `groups`; dependabot-core passes `job.cooldown` on the grouped path (`group_update_creation.rb:404`) *and* the individual path (`update_all_versions.rb:249`), so it would reach the individual major PRs; and it cannot delay a security update, both by `update_cooldown: job.security_updates_only? ? nil : job.cooldown` on both paths and by the docs ("only available for _version_ updates, not _security_ updates").

The premise is what fails. Nothing currently red is red because its target is fresh:

| red item | cause | age of target |
|---|---|---|
| typescript 7.0.2 | svelte-check **4.7.4** (2026‑07‑27, *19 days after* TS 7.0.2) narrowed its peer range to `^5.0.0 \|\| ^6.0.0` — deliberate | 29 days |
| `windows` 0.62.2 | tauri requires `^0.61` | **10 months** |
| `webview2-com` 0.39.1 | tauri requires `^0.38` | **5 months** |
| katex 0.18.1 | breaking at any age | 3 weeks |
| tauri plugin pair | cross-ecosystem parity guard | n/a |

And a cooldown now costs more than it did: on a **quarterly** schedule a major caught by an N-day window is not delayed N days, it is delayed a quarter. Also: **GitHub Actions does not support `semver-major-days`** (docs table — `default-days` only), so a cooldown could never have applied to the one ecosystem staying monthly.

Say the word and I'll add `semver-major-days: 7` to npm and cargo, but I'd be shipping something I can't show a benefit for.

## Falsification

Per-ecosystem on the cadence test, as asked — each mutation names the block it broke.

| broken | failing message |
|---|---|
| npm block → `monthly` | `the header comment promises npm runs quarterly, but its block says monthly` |
| cargo block → `monthly` | `the header comment promises cargo runs quarterly, but its block says monthly` |
| actions block → `quarterly` | `the header comment promises github-actions runs monthly, but its block says quarterly` |
| header row for npm → `monthly` | `the header comment promises npm runs monthly, but its block says quarterly` |
| header row for actions deleted | `the header comment must state a cadence for every ecosystem and no others` |
| `katex` dropped from exclude-patterns | `the npm group's exclude-patterns must name exactly the pre-1.0 dependencies in package.json` |
| all exclude-patterns dropped | `the npm group must exclude its pre-1.0 dependencies (katex, monaco-editor, monaco-vim); without that they ride along in the grouped pull request as ordinary minor bumps` |
| `mermaid` (a 11.x dep) added to exclude-patterns | `the npm group's exclude-patterns must name exactly the pre-1.0 dependencies in package.json` |
| **a new `^0.3.1` dependency added to package.json** | same — the drift direction that matters |
| ignore entry loses `versions:` | `every ignore entry under cargo must carry a versions: list; an entry without one silences the dependency permanently, including its security updates` |
| ignore range → `'>= 0.62'` | `ignoring windows at '>= 0.62' does not name a bounded version series, so nothing will ever reopen the question` |
| ignore range → `'0.*'` | `ignoring windows at '0.*' does not name a bounded version series` |
| blank line inside `ignore:` | `cargo has an \`ignore:\` key this test cannot parse, so it cannot vouch for it` |

The four properties from #484 were re-falsified after the rewrite and still fail correctly. Re-indenting `- package-ecosystem:` turns **all seven** red rather than passing vacuously.

`npm run check` — 0 errors, 650 files. `npm test` — 756/756.

## What I could not verify

- **I have not run Dependabot.** This is a bot config; the proof is the next run. What I can point at is #489 vs #478, which is #484's effect observed rather than predicted.
- **`quarterly` and the `ignore` version syntax are unvalidated against Dependabot's own parser.** There is no public validator. `0.62.*` follows the documented "standard pattern for the package manager" and Cargo accepts it as a requirement; if Dependabot rejects it the config fails loudly on the next run rather than silently.
- **I could not demonstrate a concrete Markpad breakage from KaTeX 0.18.** `src/lib/utils/exportFonts.ts` is the one place that reads KaTeX class names, and it is deliberately written to read them out of the shipped stylesheet at runtime — so a *consistent* rename is absorbed. The argument for excluding it is that a documented breaking change should not arrive inside a batch labelled minor/patch, not that I proved this one breaks us.
- **The `dependabot-core` reading is from `main`**, not the revision GitHub's hosted Dependabot runs.
- **`exclude-patterns` means 0.x *patch* bumps also get individual PRs.** Three dependencies on a quarterly cadence, so a handful of extra PRs a year. That is the cost and I have not tried to avoid it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
