### PR TITLE
fix(editor): honour Highlight Occurrences, and drop the U+2028 dialog

### DIFF
--- a/scripts/editorOptionWiring.test.ts
+++ b/scripts/editorOptionWiring.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { containsUnusualLineTerminators } from 'monaco-editor/esm/vs/base/common/strings.js';
 import {
 	EditorOptions,
 	inUntrustedWorkspace,
@@ -188,44 +189,65 @@ test('Show Whitespace renders every whitespace run, not just trailing', () => {
 // the shipped defaults, and `UnicodeTextModelHighlighter` to decide what gets a
 // box. A regression has to survive Monaco's own code to reach the assertions.
 
-/** The options object Editor.svelte hands to `monaco.editor.create`, evaluated. */
-function createdEditorOptions(): Record<string, unknown> {
+/**
+ * The one option literal Editor.svelte passes to `callee`, evaluated against a
+ * given settings store.
+ *
+ * `settings` is a plain object rather than a fixture of the real store: an
+ * absent key reads as `undefined`, which is what a falsy setting does to every
+ * ternary in these literals anyway, so naming only the keys a test cares about
+ * keeps that test readable. It is a parameter at all because a settings-driven
+ * option cannot be judged from one evaluation — wiring that is right for one
+ * value of a setting and wrong for the other is the defect shape this whole
+ * file exists for.
+ */
+function optionsPassedTo(callee: string, settings: Record<string, unknown> = {}): Record<string, unknown> {
 	const script = sliceBetween(editor, '<script lang="ts">', '</script>');
 	const source = ts.createSourceFile('Editor.ts', script, ts.ScriptTarget.Latest, true);
 
 	const literals: ts.Expression[] = [];
 	const visit = (node: ts.Node): void => {
-		if (ts.isCallExpression(node) && node.expression.getText(source) === 'monaco.editor.create') {
-			assert.equal(node.arguments.length, 2, 'monaco.editor.create(container, options)');
-			literals.push(node.arguments[1]);
+		if (ts.isCallExpression(node) && node.expression.getText(source) === callee) {
+			assert.equal(
+				node.arguments.length,
+				callee === 'monaco.editor.create' ? 2 : 1,
+				`${callee} takes the options object last`,
+			);
+			literals.push(node.arguments[node.arguments.length - 1]);
 		}
 		ts.forEachChild(node, visit);
 	};
 	visit(source);
 
 	// Also the check that this file is looking at the only editor in the app: a
-	// second `create` call would need the same option and would not be covered
-	// by anything below.
-	assert.equal(literals.length, 1, 'exactly one Monaco editor is constructed in Editor.svelte');
+	// second `create` call would need the same options and would not be covered
+	// by anything below. The same holds for a second `updateOptions`, which is
+	// the effect race #369 removed.
+	assert.equal(literals.length, 1, `exactly one ${callee} call site in Editor.svelte`);
 
 	const js = ts.transpileModule(`(${literals[0].getText(source)})`, {
 		compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ESNext },
 	}).outputText;
 
-	// The literal closes over five locals. None of them can reach
-	// `unicodeHighlight`, which is a constant, so they are stubbed rather than
-	// reconstructed — the settings proxy answers undefined for every key, which
-	// is enough to let the object build. `documentOptions` is the spread that
-	// hands the editor the active tab's model (or `value`/`language` when there
-	// is no tab); an empty object is the right stub because nothing it can
-	// contain is an option this file asserts on.
-	return new Function('settings', 'value', 'language', 'getTheme', 'documentOptions', `return ${js};`)(
-		new Proxy({}, { get: () => undefined }),
-		'',
-		'markdown',
-		() => 'app-theme-dark',
-		{},
-	) as Record<string, unknown>;
+	// The literals close over six locals, stubbed rather than reconstructed.
+	// `documentOptions` is the spread that hands the editor the active tab's
+	// model (or `value`/`language` when there is no tab); an empty object is the
+	// right stub because nothing it can contain is an option this file asserts
+	// on. `zoomLevel` is 100, the neutral factor, for the same reason.
+	return new Function(
+		'settings',
+		'value',
+		'language',
+		'getTheme',
+		'documentOptions',
+		'zoomLevel',
+		`return ${js};`,
+	)(settings, '', 'markdown', () => 'app-theme-dark', {}, 100) as Record<string, unknown>;
+}
+
+/** The options object Editor.svelte hands to `monaco.editor.create`, evaluated. */
+function createdEditorOptions(): Record<string, unknown> {
+	return optionsPassedTo('monaco.editor.create');
 }
 
 /**
@@ -338,4 +360,123 @@ test('the invisible-character warning survives the fix', () => {
 
 	const found = outlined(['a b', 'x​z'], effective);
 	assert.equal(found.invisibleCharacterCount, 2, 'NBSP and zero-width space are still flagged');
+});
+
+// ------------------------------------------------- the defaults left in force
+//
+// Everything above is an option Editor.svelte was passing wrongly. The two
+// below are options it was not passing at all, so `monaco.editor.create`'s
+// default was deciding — and deciding against something the app states
+// elsewhere.
+//
+// Both are read through the option's own `validate`, the function the real
+// `create` runs over what it is handed. That is not ceremony: `validate`
+// silently returns the option's *default* for anything outside its accepted
+// set, so `"Off"`, `0`, or an enum member renamed in a Monaco upgrade would
+// leave the editor exactly as it is today while an `assert.equal` on the
+// literal stayed green.
+
+/**
+ * What both occurrence-highlighting options resolve to, for one value of the
+ * one setting that is supposed to drive them.
+ */
+function occurrenceHighlighting(
+	callee: string,
+	occurrencesHighlight: boolean,
+): { occurrencesHighlight: string; selectionHighlight: boolean } {
+	const options = optionsPassedTo(callee, { occurrencesHighlight });
+	return {
+		occurrencesHighlight: EditorOptions.occurrencesHighlight.validate(options.occurrencesHighlight),
+		selectionHighlight: EditorOptions.selectionHighlight.validate(options.selectionHighlight),
+	};
+}
+
+test('"Highlight Occurrences" off leaves nothing highlighting occurrences', () => {
+	// The setting (`settings.occurrencesHighlight`, default false, labelled
+	// "Highlight Occurrences" / 高亮匹配项 / 一致箇所の強調) drove Monaco's
+	// `occurrencesHighlight` alone. Monaco splits the feature in two:
+	// `SelectionHighlighter` gates itself on `selectionHighlight` and consults
+	// `occurrencesHighlight` only to choose which decoration style to draw with.
+	// So at the setting's own default, selecting a word still highlighted every
+	// other copy of it — the promise the label makes was kept by half the
+	// editor.
+	//
+	// Both call sites, because they can disagree: two effects writing one option
+	// with different values is what #369 found in `fontSize`, and an option set
+	// only at construction stops tracking the setting the moment a user toggles
+	// it.
+	for (const callee of ['monaco.editor.create', 'editor.updateOptions']) {
+		assert.deepEqual(
+			occurrenceHighlighting(callee, false),
+			{ occurrencesHighlight: 'off', selectionHighlight: false },
+			`${callee}: with the setting off both occurrence highlighters must be off — ` +
+				'selectionHighlight is the one SelectionHighlighter actually gates on',
+		);
+		assert.deepEqual(
+			occurrenceHighlighting(callee, true),
+			{ occurrencesHighlight: 'singleFile', selectionHighlight: true },
+			`${callee}: with the setting on the same one switch must turn both on`,
+		);
+	}
+});
+
+test('an unset selectionHighlight still means "highlight the selection"', () => {
+	// The other half of the test above, for the same reason the CJK fixtures are
+	// re-checked against Monaco's defaults: without this, dropping
+	// `selectionHighlight` from Editor.svelte would pass if Monaco ever flipped
+	// that default, and the test would be asserting nothing. It fails on Monaco
+	// instead, rather than on the fix.
+	assert.equal(
+		EditorOptions.selectionHighlight.validate(undefined),
+		true,
+		"Monaco still highlights the selection's occurrences when the option is not passed",
+	);
+	assert.notEqual(
+		EditorOptions.occurrencesHighlight.validate(undefined),
+		'off',
+		'…and still runs the other highlighter, so neither is covered by leaving it out',
+	);
+});
+
+test('the editor does not offer to rewrite a document containing U+2028', () => {
+	// `unusualLineTerminators` defaults to 'prompt'. On 'prompt',
+	// UnusualLineTerminatorsDetector calls IDialogService.confirm, which in a
+	// standalone build is StandaloneDialogService — `mainWindow.confirm(...)`,
+	// an unstyled browser dialog carrying Monaco's English string, inside an app
+	// whose own UI ships 26 locales, offering to delete characters out of the
+	// user's file. The guard exists to protect JavaScript string literals, which
+	// U+2028 and U+2029 terminate; Markdown has no such hazard.
+	//
+	// 'auto' is not the alternative: it makes the same edit with no dialog.
+	assert.equal(
+		EditorOptions.unusualLineTerminators.validate(createdEditorOptions().unusualLineTerminators),
+		'off',
+		'the detector must return early instead of reaching the dialog',
+	);
+
+	// The default this moves away from, and the reason the assertion above is
+	// not spelled against the literal: anything Monaco does not recognise
+	// resolves straight back to the dialog.
+	assert.equal(EditorOptions.unusualLineTerminators.validate(undefined), 'prompt');
+	assert.equal(EditorOptions.unusualLineTerminators.validate('never'), 'prompt');
+	assert.equal(EditorOptions.unusualLineTerminators.validate('Off'), 'prompt');
+});
+
+test('the character that opens that dialog is one prose really carries', () => {
+	// Not hypothetical: U+2028 is what several word processors and PDF text
+	// extractors emit for a soft line break, so it arrives by pasting. This is
+	// Monaco's own predicate — its result is what the piece-tree buffer stores
+	// as `mightContainUnusualLineTerminators`, the flag the detector reads
+	// before it prompts.
+	//
+	// Spelled as escapes rather than as the characters themselves: the value
+	// Monaco sees is identical, and a reviewer can tell which character each
+	// fixture is about instead of staring at an invisible one.
+	assert.equal(containsUnusualLineTerminators('A pasted paragraph with a soft\u2028break.'), true);
+	assert.equal(containsUnusualLineTerminators('Two paragraphs,\u2029joined.'), true);
+	assert.equal(
+		containsUnusualLineTerminators('# Heading\n\nOrdinary markdown\r\nwith both line endings.\n'),
+		false,
+		'ordinary line endings are not what this is about',
+	);
 });

--- a/scripts/monacoInternals.d.ts
+++ b/scripts/monacoInternals.d.ts
@@ -30,7 +30,26 @@ declare module 'monaco-editor/esm/vs/editor/common/config/editorOptions.js' {
 		allowedLocales: Record<string, boolean>;
 	}
 
+	/**
+	 * One entry of the option registry.
+	 *
+	 * `validate` is the function `monaco.editor.create` runs over the value it
+	 * was handed: it returns `defaultValue` for `undefined`, and for anything
+	 * outside the option's accepted set. Driving an assertion through it rather
+	 * than comparing the literal is what makes `"Off"` or a renamed enum member
+	 * fail in the test instead of silently reverting at runtime.
+	 */
+	export interface SimpleEditorOption<T> {
+		readonly id: number;
+		readonly name: string;
+		readonly defaultValue: T;
+		validate(input: unknown): T;
+	}
+
 	export const EditorOptions: {
+		occurrencesHighlight: SimpleEditorOption<'off' | 'singleFile' | 'multiFile'>;
+		selectionHighlight: SimpleEditorOption<boolean>;
+		unusualLineTerminators: SimpleEditorOption<'auto' | 'off' | 'prompt'>;
 		unicodeHighlight: {
 			readonly defaultValue: UnicodeHighlightOptions;
 			/** Merges a partial option object over `value`, as `editor.create` does. */
@@ -40,6 +59,15 @@ declare module 'monaco-editor/esm/vs/editor/common/config/editorOptions.js' {
 			): { newValue: UnicodeHighlightOptions };
 		};
 	};
+}
+
+declare module 'monaco-editor/esm/vs/base/common/strings.js' {
+	/**
+	 * Monaco's own predicate for U+2028 / U+2029 — the one whose result the
+	 * piece-tree buffer stores as `mightContainUnusualLineTerminators`, which is
+	 * the gate `UnusualLineTerminatorsDetector` checks before it opens a dialog.
+	 */
+	export function containsUnusualLineTerminators(str: string): boolean;
 }
 
 declare module 'monaco-editor/esm/vs/editor/common/services/unicodeTextModelHighlighter.js' {

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -331,6 +331,16 @@
 			occurrencesHighlight: settings.occurrencesHighlight
 				? "singleFile"
 				: "off",
+			// The other half of "Highlight Occurrences". Monaco splits the
+			// feature across two options, and `SelectionHighlighter` gates
+			// itself on `selectionHighlight` — it reads `occurrencesHighlight`
+			// only to choose which decoration style to draw with. Left unset,
+			// `selectionHighlight` defaults to true, so with the setting off —
+			// which is its default — selecting a word still highlighted every
+			// other copy of it, from a switch the app never exposed. Same shape
+			// as the defects #369 fixed: a setting that does not control the
+			// thing its label names.
+			selectionHighlight: settings.occurrencesHighlight,
 			fontSize: settings.editorFontSize,
 			fontFamily: settings.editorFont,
 			wordBasedSuggestions: "off",
@@ -356,6 +366,24 @@
 			// service returns true unconditionally, so it is already off; were it
 			// on, every ideograph would be boxed rather than the punctuation.
 			unicodeHighlight: { ambiguousCharacters: false },
+			// The same argument one option over. U+2028 (LINE SEPARATOR) and
+			// U+2029 (PARAGRAPH SEPARATOR) break a JavaScript string literal,
+			// which is what Monaco's guard is for; in Markdown they are just
+			// characters, and they arrive by ordinary means — several word
+			// processors and PDF text extractors emit U+2028 for a soft line
+			// break, so pasting one in is normal here.
+			//
+			// The default is 'prompt', and in standalone Monaco that prompt is
+			// `StandaloneDialogService.doConfirm`, i.e. a bare
+			// `mainWindow.confirm()`: an unstyled browser dialog inside a Tauri
+			// window, carrying Monaco's English string in an app translated
+			// into 26 locales, offering to rewrite the user's bytes. 'auto'
+			// would rewrite them without asking, which is worse.
+			//
+			// 'off' loses no visibility: the line renderer substitutes U+FFFD
+			// for LINE_SEPARATOR and PARAGRAPH_SEPARATOR unconditionally, so
+			// they stay as visible as they ever were. Only the dialog goes.
+			unusualLineTerminators: "off",
 			renderWhitespace: settings.showWhitespace ? "all" : "none",
 			padding: { top: 20 },
 			scrollbar: {
@@ -1451,6 +1479,7 @@
 				occurrencesHighlight: settings.occurrencesHighlight
 					? "singleFile"
 					: "off",
+				selectionHighlight: settings.occurrencesHighlight,
 				fontSize: settings.editorFontSize * (zoomLevel / 100),
 				fontFamily: settings.editorFont,
 				renderWhitespace: settings.showWhitespace ? "all" : "none",


### PR DESCRIPTION
## What this is

Two options `monaco.editor.create` was deciding for us, where the default it
picked contradicts something the app states elsewhere. Everything below was
read against **monaco-editor 0.55.1** — the version in `package-lock.json` and
the copy in `node_modules` — this session.

**`selectionHighlight`** is the real one, and the reason this exists. The
setting labelled "Highlight Occurrences" (`settings.occurrencesHighlight`,
default `false`, translated into all 26 locales) drove Monaco's
`occurrencesHighlight` and nothing else. Monaco splits that feature across two
options, and `occurrencesHighlight` is not the one that decides whether it
runs. So at the setting's own default a user still got occurrence
highlighting — from a switch the app never exposed, in an editor whose own UI
says the feature is off. Both options now come off the one setting, at both
call sites.

**`unusualLineTerminators`** now says `'off'`. Left at its default, a Markdown
document containing U+2028 or U+2029 pops a browser `confirm()` offering to
rewrite it.

## Mechanism

**`selectionHighlight`.** `SelectionHighlighter` reads
`EditorOption.selectionHighlight` (id 122) for whether to run at all — it is
the `_isEnabled` that early-returns out of `onDidChangeCursorSelection` — and
consults `EditorOption.occurrencesHighlight` (id 90) only at the end of
`_update`, to pick which decoration style to draw with:

```js
const occurrenceHighlighting = this.editor.getOption(90 /* occurrencesHighlight */) !== 'off';
const hasSemanticHighlights = this._languageFeaturesService.documentHighlightProvider.has(model) && occurrenceHighlighting;
```

(`contrib/multicursor/browser/multicursor.js`; `editor.all.js` imports that
module, so the contribution is in this build.) `selectionHighlight` defaults to
`true`. Setting `occurrencesHighlight: "off"` therefore changed the *style* of
a highlight it did not stop. Same class as the defects #369 fixed: a setting
that does not control the thing its label names.

The fix drives both from the one setting rather than pinning
`selectionHighlight: false` and renaming the setting. Renaming would break the
feature for whoever deliberately turned it on, and would leave the app holding
a control whose two halves still disagree; #369's principle was to make the
setting mean its label, so that is what this does.

**`unusualLineTerminators`.** Registered as
`EditorStringEnumOption(143, 'unusualLineTerminators', 'prompt', ['auto', 'off', 'prompt'])`
— confirmed by reading the registration, and by running `validate` over each
value. `UnusualLineTerminatorsDetector` returns early only on `'off'`; on
`'auto'` it calls `model.removeUnusualLineTerminators(...)` outright, and on
`'prompt'` it calls `IDialogService.confirm(...)` and then makes the same edit
if confirmed. In a standalone build that service is `StandaloneDialogService`,
whose `doConfirm` is:

```js
doConfirm(message, detail) {
    let messageText = message;
    if (detail) { messageText = messageText + '\n\n' + detail; }
    return mainWindow.confirm(messageText);
}
```

So inside a Tauri window it is a bare browser dialog: unstyled, modal, nothing
like the app's chrome. Its strings come from `localize(1558..1562, "…")`, which
falls back to the English literal unless `globalThis._VSCODE_NLS_MESSAGES` is
set — nothing in `src/` or `vite.config.js` sets it, so English is what shows,
in an app that ships 26 UI languages.

The guard exists because U+2028 and U+2029 terminate a JavaScript string
literal. Markdown has no such hazard, and those characters reach a prose editor
by ordinary means: several word processors and PDF text extractors emit U+2028
for a soft line break, so pasting one in is a normal thing to do here.

`'off'` costs no visibility. `renderLine` in `viewLineRenderer.js` substitutes
U+FFFD for `LINE_SEPARATOR` and `PARAGRAPH_SEPARATOR` in a `switch` arm that
sits *outside* the `renderControlCharacters` branches, so it happens either
way. Only the dialog goes.

## Scope

**`bracketPairColorization.enabled` was proposed alongside these two and is
deliberately not here.** The defect it names is real, and I verified both
halves of it by running Monaco's own code:

- `LanguageBracketsConfiguration('markdown', conf)` over the shipped Markdown
  language configuration yields opening brackets `{ [ (`, and
  `')'.closesColorized('(')` is true — when `colorizedBracketPairs` is unset
  Monaco excludes only `<`…`>`.
- Driving the shipped Markdown Monarch grammar through `MonarchTokenizer` with
  a real `TokenTheme` and reading the encoded metadata: `Markpad (a Markdown
  editor) is not an IDE.` is one token with `StandardTokenType.Other` and the
  balanced-brackets bit set, which is exactly the pair of conditions
  `NonPeekableTextBufferTokenizer.read()` requires before it will treat a
  character as a bracket. In `See [the docs](https://example.com/a) for more.`
  the substring `](https://example.com/a)` is `StandardTokenType.String`, which
  that same gate skips. So prose parentheses would be colorized and link syntax
  would not, as claimed.

What is not true is that the option turns it off. **Nothing in the bundle reads
`EditorOption.bracketPairColorization`** (id 21) — no `getOption(21)`, no
`hasChanged(21)`. The model's `bracketPairColorizationOptions` is produced only
by `ModelService._readModelOptions`, from `config.editor.bracketPairColorization`
out of the *configuration service*. The one bridge from create-options to that
service is `updateConfigurationService`, which forwards a key only if
`isEditorConfigurationKey(key)`; that returns **false** for
`bracketPairColorization`, because `BracketPairColorization`'s schema is a
multi-property object, so `editorConfigurationSchema.js` registers
`editor.bracketPairColorization.enabled` and `…independentColorPoolPerBracketType`
and no bare `editor.bracketPairColorization`. I checked that by running it:

```
bracketPairColorization  -> false
unusualLineTerminators   -> true
selectionHighlight       -> true
occurrencesHighlight     -> true
```

Turning it off in this app therefore means
`model.updateOptions({ bracketColorizationOptions: { enabled: false, … } })` on
every model `tabModels.ts` creates, plus the editor-owned fallback model — a
different change, a different surface, and on top of that a taste call about
prose. It does not belong in a pull request about two one-line defaults, so it
is left for you.

Also examined and left alone: `autoDetectHighContrast` (turning it off leaves
the editor on stock `vs`/`vs-dark` rather than the app's themes when the OS
switches back, so it needs a behaviour decision first) and
`wordSegmenterLocales` (word-wise motion in CJK — the right value depends on
the *document's* language, which the app does not track).

## Tests

Four tests, in `scripts/editorOptionWiring.test.ts`, which already holds the
`Editor.svelte` → Monaco option-wiring contracts.

Both option values are read back out of the real `monaco.editor.create` and
`editor.updateOptions` literals and pushed through the option's own
`validate` — the function the running editor applies to what it is handed.
That is load-bearing rather than decorative: `validate` silently returns the
*default* for anything outside the accepted set, so `"Off"`, `0`, or an enum
member renamed in a future Monaco would fail here instead of quietly restoring
today's behaviour at runtime.

The occurrence-highlighting test evaluates both literals twice, once per value
of the setting, because wiring that is right for one value and wrong for the
other is precisely what was wrong.

**Reverted the fix, kept the tests.** With `git show 8674be8:…/Editor.svelte`
in place and this branch's tests: **13 pass, 2 fail**, and both failures are
the new ones.

```
✖ "Highlight Occurrences" off leaves nothing highlighting occurrences
  AssertionError: monaco.editor.create: with the setting off both occurrence
  highlighters must be off — selectionHighlight is the one SelectionHighlighter
  actually gates on
  + actual - expected
      occurrencesHighlight: 'off',
  +   selectionHighlight: true
  -   selectionHighlight: false

✖ the editor does not offer to rewrite a document containing U+2028
  AssertionError: the detector must return early instead of reaching the dialog
    actual: 'prompt', expected: 'off'
```

Six more one-at-a-time mutations, each restored from a file copy afterwards,
to check the assertions discriminate rather than merely fail:

| mutation | result |
|---|---|
| `selectionHighlight` dropped from `updateOptions` only | red, message names `editor.updateOptions` |
| `selectionHighlight: true` (i.e. rename the setting instead) | red on the setting-off case |
| `selectionHighlight: false` (ignore the setting) | red on the setting-on case, `expected: true` |
| `unusualLineTerminators` deleted | red, `actual: 'prompt'` |
| `unusualLineTerminators: "auto"` | red, `actual: 'auto'` |
| `unusualLineTerminators: "Off"` | red, `actual: 'prompt'` — `validate` is doing the work |

And the U+2028 fixture itself: replacing the `\u2028` / `\u2029` escapes
with an ordinary space turns `the character that opens that dialog is one prose really carries`
red. Without that it would be a test that cannot fail.

Two of the four tests are there for the same reason the CJK fixtures in this
file are re-checked against Monaco's defaults: they assert that
`selectionHighlight` unset still resolves to `true`, and that
`unusualLineTerminators` unset still resolves to `'prompt'`. If a Monaco
upgrade ever flips either default, that fails loudly instead of leaving the
tests above asserting nothing.

One refactor was needed to make that possible: `createdEditorOptions()` becomes
`optionsPassedTo(callee, settings)` — the same AST extraction and evaluation,
now able to name a call site and a settings store. `createdEditorOptions()`
remains as the no-argument form the `unicodeHighlight` tests already use, so
those are untouched.

## Verification

Run in a worktree at `8674be8`, both before and after:

| | `master` (8674be8) | this branch |
|---|---|---|
| `npm audit` | — | 0 vulnerabilities |
| `npm run check` | 650 files, 0 errors, 0 warnings | 650 files, 0 errors, 0 warnings |
| `npm test` | 754 pass, 0 fail | **758** pass, 0 fail |
| `cargo test` | — | 125 pass, 0 fail |

`cargo test` was run on this branch only; no Rust file is touched.

**What I did not verify.** I could not run the app, so **none of the
user-visible behaviour here is observed — all of it is argued from the option
semantics and the Monaco source read above.** Specifically:

- I never saw the selection highlight appear or disappear in a running editor;
  the argument is that `SelectionHighlighter._isEnabled` is `getOption(122)`
  and that option is now false when the setting is off.
- I never saw the `confirm()` dialog. I confirmed that `containsUnusualLineTerminators`
  — the predicate whose result the piece-tree buffer stores as
  `mightContainUnusualLineTerminators`, the flag the detector checks — returns
  true for a paragraph containing U+2028, and read the path from there to
  `mainWindow.confirm`. I did not observe the dialog, and I have no data on how
  many users have such a character in a file.
- The U+FFFD substitution claim about `renderControlCharacters` is read from
  `viewLineRenderer.js`, not seen on screen.
- Only macOS (darwin 25.5.0, Node 24) was exercised. Nothing here is
  platform-conditional, but the suite was not run on Windows or Linux.
- The bracket-pair findings in **Scope** come from driving Monaco's tokenizer
  and bracket configuration directly in Node with stubbed services, not from a
  real `TextModel` in a browser. The stubs cover only what those two code paths
  touch.
- `scripts/editorOptionWiring.test.ts` and `scripts/monacoInternals.d.ts` are
  files another change of mine is also touching this week; if it lands first
  this will need a rebase, and the conflict is mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
