### PR TITLE
fix(ci): strip host-coupled libwayland from the AppImage so it starts on newer Mesa

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,6 +232,72 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run tauri build
 
+      # tauri/linuxdeploy bundles libwayland-client.so.0 (and other host-graphics
+      # libraries) from the ubuntu-24.04 runner into the AppImage. On a host whose
+      # Mesa is newer than the runner's, that older bundled libwayland-client
+      # shadows the system one and breaks host libEGL: WebKit's WebProcess aborts
+      # with "Could not create default EGL display: EGL_BAD_PARAMETER" and the
+      # window comes up blank. These libraries are on the AppImage excludelist
+      # precisely because they must come from the host. Strip them, repack, and
+      # re-sign so the updater signature still matches. See #498; #463 fixed the
+      # separate WebKitGTK version pin.
+      - name: Strip host-coupled libraries from AppImage
+        if: matrix.platform == 'ubuntu-24.04'
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          APPIMAGE=$(find src-tauri/target/release/bundle/appimage -maxdepth 1 -name '*.AppImage' | head -1)
+          if [ -z "$APPIMAGE" ]; then
+            echo "::error::No AppImage found to repackage" >&2
+            exit 1
+          fi
+          APPIMAGE=$(realpath "$APPIMAGE")
+          echo "Repackaging $APPIMAGE"
+
+          # appimagetool + a type2 runtime. --appimage-extract-and-run (below) and
+          # --appimage-extract both unpack without libfuse2, which the runner lacks.
+          tools=$(mktemp -d)
+          wget -q https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage -O "$tools/appimagetool"
+          wget -q https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64 -O "$tools/runtime-x86_64"
+          chmod +x "$tools/appimagetool"
+
+          work=$(mktemp -d)
+          ( cd "$work" && "$APPIMAGE" --appimage-extract >/dev/null )
+          libdir="$work/squashfs-root/usr/lib"
+
+          # Host-coupled graphics libraries (AppImageCommunity/pkg2appimage
+          # excludelist). libwayland-client.so.0 is the one that actually breaks
+          # EGL; the rest belong to the host graphics stack for the same reason.
+          for lib in libwayland-client.so.0 libwayland-cursor.so.0 libwayland-egl.so.1 \
+                     libwayland-server.so.0 libxcb-render.so.0 libxcb-shm.so.0; do
+            rm -fv "$libdir/$lib"
+          done
+          if [ -e "$libdir/libwayland-client.so.0" ]; then
+            echo "::error::libwayland-client.so.0 still bundled after strip" >&2
+            exit 1
+          fi
+
+          # Repack in place so the filename (and updater target) is unchanged.
+          ARCH=x86_64 "$tools/appimagetool" --appimage-extract-and-run \
+            --runtime-file "$tools/runtime-x86_64" \
+            "$work/squashfs-root" "$APPIMAGE"
+
+          # Re-sign: tauri build already produced a .sig for the pre-strip file,
+          # which no longer matches. signer sign reads the key/password from the
+          # env above and writes <APPIMAGE>.sig, which the upload and the
+          # latest.json job below both consume.
+          npm run tauri signer sign -- "$APPIMAGE"
+          if [ ! -f "$APPIMAGE.sig" ]; then
+            echo "::error::signer sign did not produce $APPIMAGE.sig" >&2
+            exit 1
+          fi
+
+          echo "Repacked and re-signed:"
+          ls -la "$APPIMAGE" "$APPIMAGE.sig"
+
       - name: Upload Linux Artifacts
         if: matrix.platform == 'ubuntu-24.04'
         shell: bash


### PR DESCRIPTION
## Problem

The Linux AppImage still fails to display on hosts whose Mesa is newer than the ubuntu-24.04 build runner (#498). The window opens but stays blank white and WebKit's WebProcess aborts:

```
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```

This is a second, independent cause behind #182, distinct from the WebKitGTK version pin fixed in #463. The published v2.7.1 AppImage bundles WebKitGTK 2.52.3 (confirmed by dlopening the bundled library and reading `webkit_get_*_version`), so #463 landed correctly.

## Root cause

The AppImage bundles `libwayland-client.so.0` from the ubuntu-24.04 runner. On a host with a newer libwayland/Mesa, that older bundled copy shadows the host one, and host `libEGL` then fails `eglGetPlatformDisplay` with `EGL_BAD_PARAMETER`.

Single-library isolation (extract the published AppImage, move one library out of the AppDir at a time, run): removing only `libwayland-client.so.0` is necessary and sufficient to make the full UI render. It is on the AppImageCommunity/pkg2appimage excludelist precisely because it must come from the host.

The failure is backend independent (the default forced `GDK_BACKEND=x11` and `GDK_BACKEND=wayland` both abort), and `WEBKIT_DISABLE_DMABUF_RENDERER`, `WEBKIT_DISABLE_COMPOSITING_MODE`, and `LIBGL_ALWAYS_SOFTWARE` do not help.

## Change

A step after "Build Linux" that extracts the AppImage, removes the six host-coupled graphics libraries (`libwayland-*`, `libxcb-render/shm`), repacks with appimagetool, and re-signs.

The re-sign is required: `tauri build` already signed the pre-strip file, and the updater verifies the downloaded AppImage against the signature in `latest.json`, so the repacked artifact must be signed again. Both the upload step and the `latest.json` job read the regenerated `.AppImage.sig`.

`--appimage-extract` and `appimagetool --appimage-extract-and-run` are used so no libfuse2 is needed on the runner.

## Validation

Validated locally on Arch (Intel, Mesa 26.1.6): extracting the published v2.7.1 AppImage, removing the libs, repacking, and launching the result renders the full UI with no EGL error (before/after screenshots on #498). The signer invocation and the no-FUSE extract/repack were exercised directly.

Not validated, and it cannot be before a release: the step running on the ubuntu-24.04 runner with the real signing secret. As with #463, the resulting AppImage is the first artifact that can be tested, so it is worth confirming the published file starts before announcing.

## Why the #463 verification did not catch this

My #463 check rebuilt on Arch, so linuxdeploy bundled Arch's `libwayland-client` (matching the host) and could not reproduce the mismatch. The ubuntu-24.04 release build bundles the older one. Two independent bugs: the version pin (#463) and this libwayland bundling.

Addresses #498 and the remaining AppImage failure in #182. Leaving both open so they can be closed after the published 2.7.x AppImage is confirmed to start.
