### PR TITLE
fix(session): keep the restore breadcrumb where a kill cannot take it

### DIFF
--- a/scripts/sessionRestoreResilience.test.ts
+++ b/scripts/sessionRestoreResilience.test.ts
@@ -14,9 +14,10 @@ import test from 'node:test';
 //
 // These tests drive the real window session and the real TabManager against a
 // stubbed Tauri bridge and a stubbed localStorage, so they lock the behaviour
-// rather than the wording. What they cannot cover is the renderer actually
-// dying mid-restore; an interrupted launch is simulated by leaving behind
-// exactly the breadcrumb such a launch leaves.
+// rather than the wording. The tests in the first half simulate an interrupted
+// launch by leaving behind exactly the breadcrumb such a launch leaves; the
+// `launch()` harness at the bottom goes further and models the kill itself,
+// including what a kill takes with it.
 
 const g = globalThis as any;
 const runeEffect = (fn: () => void) => {
@@ -46,6 +47,8 @@ const RESTORE_IN_PROGRESS_KEY = 'markpad-window-restore-in-progress';
 let invokeCalls: Array<{ cmd: string; args: any }> = [];
 /** The window-state file the Rust side holds. */
 let storedSnapshot: string | null = null;
+/** The breadcrumb file the Rust side holds, beside the snapshot. */
+let storedProgress: string | null = null;
 /** Files the backend can read; anything else fails the way a real read does. */
 let disk = new Map<string, string>();
 /** Paths whose read should fail even though the file "exists". */
@@ -53,10 +56,24 @@ let unreadable = new Set<string>();
 /** Called just before each read, to observe the breadcrumb mid-restore. */
 let onRead: (path: string) => void = () => {};
 
+/**
+ * When this says yes, the process is gone: the call never answers and nothing
+ * after it runs. See `launch()` for what that models and what it costs.
+ */
+let killsTheLaunch: (call: { cmd: string; args: any }) => boolean = () => false;
+let died = false;
+
 g.window.__TAURI_INTERNALS__ = {
 	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (cmd: string, args: any) => {
 		invokeCalls.push({ cmd, args });
+		if (!died && killsTheLaunch({ cmd, args })) {
+			died = true;
+			// A process that has been killed does not return an error — it does
+			// not return. A rejection here would be caught and handled, which is
+			// the one thing a real kill never lets the code do.
+			return new Promise(() => {});
+		}
 		switch (cmd) {
 			case 'get_os_type':
 				return Promise.resolve('macos');
@@ -67,6 +84,14 @@ g.window.__TAURI_INTERNALS__ = {
 				return Promise.resolve(null);
 			case 'clear_window_state':
 				storedSnapshot = null;
+				return Promise.resolve(null);
+			case 'load_restore_progress':
+				return Promise.resolve(storedProgress);
+			case 'save_restore_progress':
+				storedProgress = args.json;
+				return Promise.resolve(null);
+			case 'clear_restore_progress':
+				storedProgress = null;
 				return Promise.resolve(null);
 			case 'read_file_content_checked': {
 				onRead(args.path);
@@ -86,6 +111,8 @@ const { createWindowSession } = await import('../src/lib/sessions/windowSession.
 
 const warnings: string[] = [];
 const errors: string[] = [];
+/** What the session asked the UI to tell the user, before any wording. */
+const notices: Array<{ deferredPath: string | null }> = [];
 
 function makeSession() {
 	return createWindowSession({
@@ -112,6 +139,7 @@ function makeSession() {
 		acceptTransferredTab: async () => true,
 		onError: (message) => errors.push(message),
 		onWarning: (message) => warnings.push(message),
+		onInterrupted: (interruption) => notices.push(interruption),
 	});
 }
 
@@ -130,15 +158,24 @@ function reset(paths: string[], contents: Record<string, string> = {}) {
 	invokeCalls = [];
 	warnings.length = 0;
 	errors.length = 0;
+	notices.length = 0;
 	unreadable = new Set();
 	onRead = () => {};
+	killsTheLaunch = () => false;
+	died = false;
 	disk = new Map(paths.map((path) => [path, contents[path] ?? `# ${path}`]));
 	storedSnapshot = snapshotOf(paths);
+	storedProgress = null;
 }
 
+/**
+ * The breadcrumb as the next launch would find it. It is read from the Rust
+ * side because that is where it lives now: the tests below seed the
+ * localStorage key instead where they mean "a breadcrumb an older build left",
+ * and the session honours that as a migration.
+ */
 function breadcrumb(): any {
-	const raw = localStore.get(RESTORE_IN_PROGRESS_KEY);
-	return raw === undefined ? null : JSON.parse(raw);
+	return storedProgress === null ? null : JSON.parse(storedProgress);
 }
 
 function persistedPaths(): string[] {
@@ -340,6 +377,163 @@ test('a snapshot of nothing but HOME does not cost the window its session', asyn
 		invokeCalls.some((call) => call.cmd === 'read_file_content_checked'),
 		false,
 	);
+});
+
+// --- a launch killed at any point costs at most one repeat ---
+//
+// The tests above all begin from a breadcrumb that a dead launch is ASSUMED to
+// have left. That assumption is the thing #201 disproves: the breadcrumb lived
+// in localStorage, `setItem` is an async message to the WebKit storage process,
+// and the kill this record exists to survive is exactly the event that loses
+// messages in flight. A test that seeds the breadcrumb by hand cannot see that
+// — it will pass whatever store the record is kept in, which is why the
+// mechanism could be complete, tested, and still leave the reporter relaunching
+// into the same hang.
+//
+// So these run the kill instead of assuming its result. `launch()` models three
+// things about a killed process, and the second is the one that bites:
+//
+//   1. the call it died in never answers, and nothing after it runs;
+//   2. whatever the launch had put in localStorage is gone with it;
+//   3. whatever reached the backend is still there when the next one starts.
+//
+// (2) is the pessimistic reading — a real kill sometimes loses the write and
+// sometimes does not — and it is the right one for a resilience contract: the
+// guarantee worth having is the one that holds when the flush does not happen.
+// It is also what the repository already concluded about this exact store, in
+// the comment above `persistWindowState`.
+
+/** Lets every already-queued microtask run, then returns. */
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+/**
+ * One launch of Markpad against the world the previous launches left behind.
+ *
+ * Returns 'died' if `dies` fired, 'restored' if the pass ran to completion.
+ * A killed launch never resolves — that is what being killed means — so this
+ * cannot simply await `restore()`.
+ */
+async function launch(dies: (call: { cmd: string; args: any }) => boolean = () => false) {
+	// A new process: no tabs on screen, and nothing left of the store the last
+	// kill took down with it.
+	tabManager.closeAll();
+	localStore.clear();
+	died = false;
+	killsTheLaunch = dies;
+
+	let settled = false;
+	void makeSession()
+		.restore()
+		.then(
+			() => (settled = true),
+			() => (settled = true),
+		);
+	for (let turn = 0; turn < 200 && !settled && !died; turn++) await flush();
+	killsTheLaunch = () => false;
+
+	// Without this the harness could report 'restored' for a launch that merely
+	// ran out of turns, and every assertion below would be measuring the loop
+	// bound instead of the mechanism.
+	assert.ok(settled || died, 'the simulated launch neither finished nor died');
+	return died ? 'died' : 'restored';
+}
+
+const readsOfPath = (path: string) => readsOf().filter((read) => read === path).length;
+
+test('a document that kills the launch reading it is read by exactly one more launch', async () => {
+	reset(['/a.md', '/poison.md', '/c.md']);
+	// The #201 shape: one document takes the process down, every time, before
+	// the window is usable. The user's only move is to launch it again.
+	const poison = ({ cmd, args }: { cmd: string; args: any }) =>
+		cmd === 'read_file_content_checked' && args.path === '/poison.md';
+
+	const outcomes: string[] = [];
+	for (let attempt = 0; attempt < 6; attempt++) {
+		outcomes.push(await launch(poison));
+		if (outcomes[outcomes.length - 1] === 'restored') break;
+	}
+
+	assert.deepEqual(
+		outcomes,
+		['died', 'restored'],
+		`recovery took ${outcomes.length} launches; /poison.md was read ${readsOfPath('/poison.md')} times, ` +
+			'so the launch that died on it left nothing the next one could find',
+	);
+	assert.equal(readsOfPath('/poison.md'), 1, 'the document that killed a launch is not read again');
+	assert.deepEqual(
+		tabManager.tabs.map((tab) => tab.path),
+		['/a.md', '/poison.md', '/c.md'],
+		'and the session comes back whole, minus the content of the one suspect',
+	);
+	assert.deepEqual(readsOf().slice(-2), ['/a.md', '/c.md'], 'the other documents are read normally');
+});
+
+test('launches killed before the snapshot arrives still count, so startup can give up by itself', async () => {
+	reset(['/a.md', '/b.md', '/c.md']);
+	// Nothing here blames a document — the process is gone before the snapshot
+	// that names one has even been loaded. A launch that leaves no trace of
+	// itself cannot advance the give-up counter, and startup that cannot give
+	// up walks into the same wall for as long as the user keeps launching it.
+	const duringTheLoad = ({ cmd }: { cmd: string }) => cmd === 'load_window_state';
+
+	for (let attempt = 0; attempt < 3; attempt++) {
+		assert.equal(await launch(duringTheLoad), 'died', `launch ${attempt + 1} was supposed to die`);
+	}
+	invokeCalls = [];
+	assert.equal(await launch(), 'restored');
+
+	assert.deepEqual(
+		readsOf(),
+		[],
+		'after three launches died before they could name a suspect, startup stops opening documents at all',
+	);
+	assert.deepEqual(
+		tabManager.tabs.map((tab) => tab.path),
+		['/a.md', '/b.md', '/c.md'],
+		'and still hands back every tab',
+	);
+	assert.deepEqual(persistedPaths(), ['/a.md', '/b.md', '/c.md']);
+});
+
+test('claiming the launch early does not strand a window that had nothing to restore', async () => {
+	// Claiming before the snapshot is loaded means a launch with no snapshot at
+	// all leaves a breadcrumb describing nothing. If that phantom stuck, three
+	// ordinary launches of an empty window would be enough to make the fourth
+	// refuse to open documents.
+	reset([]);
+	storedSnapshot = null;
+	assert.equal(await launch(), 'restored');
+	assert.equal(breadcrumb(), null, 'a launch with nothing to restore leaves no claim behind');
+
+	assert.equal(await launch(({ cmd }) => cmd === 'load_window_state'), 'died');
+	assert.notEqual(breadcrumb(), null, 'the launch that died during the load is on the record');
+	assert.equal(await launch(), 'restored');
+	assert.equal(breadcrumb(), null, 'and the record retires itself once there is nothing to describe');
+
+	// The phantom cost nothing: a later launch reads every document.
+	disk = new Map([['/a.md', '# a'], ['/b.md', '# b']]);
+	storedSnapshot = snapshotOf(['/a.md', '/b.md']);
+	invokeCalls = [];
+	assert.equal(await launch(), 'restored');
+	assert.deepEqual(readsOf(), ['/a.md', '/b.md']);
+});
+
+test('the launch that follows an interruption tells the user which document it skipped', async () => {
+	reset(['/a.md', '/poison.md']);
+	await launch(({ cmd, args }) => cmd === 'read_file_content_checked' && args.path === '/poison.md');
+	notices.length = 0;
+
+	assert.equal(await launch(), 'restored');
+
+	// Not a sentence: the session has no language and the app ships 26 locales,
+	// so the mechanism reports the fact and MarkdownViewer picks the wording.
+	assert.deepEqual(notices, [{ deferredPath: '/poison.md' }]);
+});
+
+test('a launch that was not interrupted tells the user nothing', async () => {
+	reset(['/a.md']);
+	assert.equal(await launch(), 'restored');
+	assert.deepEqual(notices, [], 'the ordinary case is silent');
 });
 
 test('a deferred document is released once Markpad has read it', async () => {

--- a/scripts/sessionRestoreResilience.test.ts
+++ b/scripts/sessionRestoreResilience.test.ts
@@ -447,17 +447,30 @@ test('a document that kills the launch reading it is read by exactly one more la
 	const poison = ({ cmd, args }: { cmd: string; args: any }) =>
 		cmd === 'read_file_content_checked' && args.path === '/poison.md';
 
+	// A stopping bound, not an expected count: the design promises two, and a
+	// broken mechanism never recovers at all, so anything comfortably above two
+	// does the job. Read the failure message, not this number.
+	const GIVE_UP_AFTER = 5;
 	const outcomes: string[] = [];
-	for (let attempt = 0; attempt < 6; attempt++) {
+	for (let attempt = 0; attempt < GIVE_UP_AFTER; attempt++) {
 		outcomes.push(await launch(poison));
 		if (outcomes[outcomes.length - 1] === 'restored') break;
 	}
+	const recovered = outcomes[outcomes.length - 1] === 'restored';
 
 	assert.deepEqual(
 		outcomes,
 		['died', 'restored'],
-		`recovery took ${outcomes.length} launches; /poison.md was read ${readsOfPath('/poison.md')} times, ` +
-			'so the launch that died on it left nothing the next one could find',
+		// Says what happened rather than how long the loop ran. `outcomes.length`
+		// is this test's own bound when nothing recovers, and a message that
+		// reports it as a launch count reads as a result — which is how a reader
+		// ends up believing the suite reproduced a number from a bug report.
+		recovered
+			? `recovery took ${outcomes.length} launches, not the two the design promises; ` +
+				`/poison.md was read ${readsOfPath('/poison.md')} times`
+			: `never recovered: ${outcomes.length} launches all died and the loop gave up, ` +
+				`with /poison.md read ${readsOfPath('/poison.md')} times — ` +
+				'the launch that died on it left nothing the next one could find',
 	);
 	assert.equal(readsOfPath('/poison.md'), 1, 'the document that killed a launch is not read again');
 	assert.deepEqual(

--- a/scripts/windowStateRestore.test.ts
+++ b/scripts/windowStateRestore.test.ts
@@ -98,7 +98,7 @@ test('v2 snapshots are invisible to legacy builds (Rust file, localStorage keys 
 	// The shared helper clears the Rust snapshot and both localStorage keys.
 	// Only explicit exit uses it: a restore that goes wrong must never delete
 	// the record of which documents were open (interruptedSessionRestore.test.ts).
-	const discardScope = sliceBetween(session, 'async function discardPersistedState', '\n\t}\n\n\tfunction readProgress');
+	const discardScope = sliceBetween(session, 'async function discardPersistedState', 'async function readProgress');
 	assert.match(discardScope, /clear_window_state/);
 	assert.match(discardScope, /removeItem\(options\.windowStateKey\)/);
 	assert.match(discardScope, /removeItem\(options\.legacyStateKey\)/);

--- a/scripts/windowTagPerWindow.test.ts
+++ b/scripts/windowTagPerWindow.test.ts
@@ -138,6 +138,7 @@ function makeSession(isMainWindow: boolean) {
 		},
 		onError: () => {},
 		onWarning: () => {},
+		onInterrupted: () => {},
 	});
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -568,6 +568,21 @@ fn clear_window_state(app: AppHandle) -> Result<(), String> {
 }
 
 #[tauri::command]
+fn save_restore_progress(app: AppHandle, json: String) -> Result<(), String> {
+    window_runtime::save_restore_progress(app, json)
+}
+
+#[tauri::command]
+fn load_restore_progress(app: AppHandle) -> Option<String> {
+    window_runtime::load_restore_progress(app)
+}
+
+#[tauri::command]
+fn clear_restore_progress(app: AppHandle) -> Result<(), String> {
+    window_runtime::clear_restore_progress(app)
+}
+
+#[tauri::command]
 fn set_window_meta(
     window: tauri::Window,
     state: State<'_, AppState>,
@@ -2852,7 +2867,10 @@ pub fn run() {
             remove_pinned_tag,
             save_window_state,
             load_window_state,
-            clear_window_state
+            clear_window_state,
+            save_restore_progress,
+            load_restore_progress,
+            clear_restore_progress
         ])
         .on_window_event(window_runtime::handle_window_event)
         .on_menu_event(|app, event| {

--- a/src-tauri/src/window_runtime.rs
+++ b/src-tauri/src/window_runtime.rs
@@ -371,6 +371,72 @@ pub fn clear_window_state(app: AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+fn restore_progress_path(app: &AppHandle) -> Result<std::path::PathBuf, String> {
+    let dir = app.path().app_config_dir().map_err(|e| e.to_string())?;
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    Ok(dir.join("restore-progress-v1.json"))
+}
+
+/// Publishes the restore breadcrumb by rename, but without `atomic_write`'s
+/// fsyncs.
+///
+/// The breadcrumb is the record a launch leaves before it reads a document, so
+/// that the launch after it knows which document killed it. It lives here for
+/// the reason the snapshot does: `localStorage.setItem` is an async message to
+/// the WebKit storage process, and the abnormal termination this record exists
+/// to survive is exactly the event that loses messages in flight. Keeping the
+/// one piece of state whose whole job is to outlive a kill in the store this
+/// codebase had already proved does not survive one is what left #201's
+/// reporter relaunching into the same hang.
+///
+/// The rename is not decoration: `fs::write` truncates before it writes, so a
+/// process killed mid-call leaves an empty file — and an empty breadcrumb
+/// reads as "nothing was interrupted", the one direction this record must
+/// never fail in. What it does *not* need is durability past a power cut. The
+/// event it survives is the process dying, and a rename the kernel has
+/// accepted is visible to every later process whether or not it reached the
+/// platter; after a power cut the breadcrumb is simply absent and startup
+/// behaves as it did before this file existed. That is worth separating from
+/// `atomic_write`, which runs on the user's documents and must survive the
+/// stronger event, because this one runs once per document on every launch:
+/// measured on macOS/APFS with a 122-byte payload, `atomic_write`'s two fsyncs
+/// cost ~8 ms per call against ~0.2 ms for temp-file-plus-rename.
+fn write_restore_progress(path: &Path, json: &str) -> std::io::Result<()> {
+    // Two Markpad processes (Windows, Linux) would otherwise share a temp name
+    // and the loser would delete the winner's file out from under its rename.
+    let temp = path.with_file_name(format!(".restore-progress-{}.tmp", std::process::id()));
+    let write = (|| -> std::io::Result<()> {
+        let mut file = fs::File::create(&temp)?;
+        std::io::Write::write_all(&mut file, json.as_bytes())?;
+        // Closed before the rename: Windows tolerates renaming an open handle
+        // only because Rust opens with FILE_SHARE_DELETE, which is a detail of
+        // the standard library rather than a promise to this caller.
+        drop(file);
+        fs::rename(&temp, path)
+    })();
+    if let Err(error) = write {
+        let _ = fs::remove_file(&temp);
+        return Err(error);
+    }
+    Ok(())
+}
+
+pub fn save_restore_progress(app: AppHandle, json: String) -> Result<(), String> {
+    write_restore_progress(&restore_progress_path(&app)?, &json).map_err(|e| e.to_string())
+}
+
+pub fn load_restore_progress(app: AppHandle) -> Option<String> {
+    fs::read_to_string(restore_progress_path(&app).ok()?).ok()
+}
+
+pub fn clear_restore_progress(app: AppHandle) -> Result<(), String> {
+    let path = restore_progress_path(&app)?;
+    if path.exists() {
+        fs::remove_file(path).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
 pub fn bring_to_front(window: &tauri::WebviewWindow) {
     let _ = window.show();
     let _ = window.unminimize();
@@ -789,6 +855,82 @@ mod tests {
         .unwrap();
         let tags = read_pinned_tags_at(&path);
         assert_eq!(names(&tags), HashSet::from(["after".to_string()]));
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// The breadcrumb must never be readable half-written.
+    ///
+    /// Its two failure directions are not symmetric. A stale record costs one
+    /// spurious deferral: a document the user can reopen by hand. An empty or
+    /// truncated one parses as "no interruption", so the next launch walks
+    /// back into whatever killed the last one — the failure the record exists
+    /// to prevent. `fs::write` truncates before it writes, which puts an empty
+    /// file on disk for as long as the write takes, so the write goes through
+    /// a temp file and a rename instead.
+    ///
+    /// Asserts the property a reader can observe rather than the mechanism:
+    /// every read either fails (no file yet) or yields one of the payloads the
+    /// writer actually wrote, whole.
+    #[test]
+    fn a_reader_never_sees_a_half_written_breadcrumb() {
+        use std::sync::atomic::{AtomicBool, AtomicUsize};
+
+        let dir = temp_dir("restore-progress-torn");
+        let path = dir.join("restore-progress-v1.json");
+
+        // Long enough that a truncating writer is observable. A hundred bytes
+        // might reach the file in one step on some filesystems and make this
+        // test lie; eight kilobytes will not.
+        let payloads: Vec<String> = (0..4u8)
+            .map(|i| {
+                let pending = format!("/{}{}.md", (b'a' + i) as char, "x".repeat(8192));
+                format!("{{\"running\":true,\"pending\":\"{pending}\",\"deferred\":[],\"interruptions\":0}}")
+            })
+            .collect();
+
+        let writing = AtomicBool::new(true);
+        let whole_reads = AtomicUsize::new(0);
+
+        std::thread::scope(|scope| {
+            scope.spawn(|| {
+                for round in 0..300 {
+                    write_restore_progress(&path, &payloads[round % payloads.len()]).unwrap();
+                }
+                writing.store(false, Ordering::Relaxed);
+            });
+            scope.spawn(|| {
+                while writing.load(Ordering::Relaxed) {
+                    // A failed read is the file not existing yet, which is the
+                    // one state startup already handles correctly.
+                    if let Ok(text) = fs::read_to_string(&path) {
+                        assert!(
+                            payloads.contains(&text),
+                            "a launch read a breadcrumb of {} bytes that is not any record the writer wrote; \
+                             startup would parse it as 'nothing was interrupted'",
+                            text.len()
+                        );
+                        whole_reads.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            });
+        });
+
+        // Without this the assertion above is vacuous: a reader that never
+        // managed to open the file would sail through having checked nothing.
+        assert!(
+            whole_reads.load(Ordering::Relaxed) > 0,
+            "the reader never read the breadcrumb at all, so it proved nothing"
+        );
+
+        // The temp file is an implementation detail of the write and must not
+        // outlive it, or app_config_dir fills up one launch at a time.
+        let left_behind: Vec<String> = fs::read_dir(&dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .filter(|name| name != "restore-progress-v1.json")
+            .collect();
+        assert_eq!(left_behind, Vec::<String>::new());
 
         fs::remove_dir_all(&dir).unwrap();
     }

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -542,6 +542,17 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			addToast(`${message}: ${String(error)}`, 'error');
 		},
 		onWarning: (message, error) => console.warn(message, error),
+		// The console line above says the same thing in more detail, but in a
+		// packaged build nobody can open that console: the recovery mechanism
+		// was diagnosing itself and writing the answer where no one could read
+		// it. A document missing its content needs an explanation on screen.
+		onInterrupted: ({ deferredPath }) =>
+			addToast(
+				deferredPath
+					? t('toast.restoreInterruptedDeferred', settings.language).replace('{path}', deferredPath)
+					: t('toast.restoreInterrupted', settings.language),
+				'warning',
+			),
 	});
 
 	$effect(() => {

--- a/src/lib/sessions/windowSession.svelte.ts
+++ b/src/lib/sessions/windowSession.svelte.ts
@@ -29,6 +29,19 @@ type RestoreProgress = {
 	interruptions: number;
 };
 
+/**
+ * What an interrupted launch has to tell the user.
+ *
+ * Not a sentence: this module has no language, and Markpad ships 26 locales.
+ * It reports what happened and the UI decides how to say it — the same event
+ * also goes to `onWarning`, which stays detailed and English because its
+ * destination is a developer console.
+ */
+export type RestoreInterruption = {
+	/** The document the dead launch was reading, if it got far enough to name one. */
+	deferredPath: string | null;
+};
+
 /** Enough to keep the suspects, few enough to stay a breadcrumb. */
 const MAX_DEFERRED = 8;
 
@@ -61,6 +74,13 @@ type WindowSessionOptions = {
 	acceptTransferredTab: (tab: TransferableTab) => Promise<boolean>;
 	onError: (message: string, error: unknown) => void;
 	onWarning: (message: string, error?: unknown) => void;
+	/**
+	 * Called once, at startup, when the previous launch did not finish. This is
+	 * the mechanism's own diagnosis of "why did Markpad come back without my
+	 * documents"; routing it anywhere the user cannot see leaves the answer
+	 * written where nobody can read it.
+	 */
+	onInterrupted: (interruption: RestoreInterruption) => void;
 };
 
 export function createWindowSession(options: WindowSessionOptions) {
@@ -77,8 +97,23 @@ export function createWindowSession(options: WindowSessionOptions) {
 		}
 	}
 
-	function readProgress(): RestoreProgress | null {
-		const raw = localStorage.getItem(options.restoreInProgressKey);
+	/**
+	 * The breadcrumb is written through Rust, for the reason the snapshot is
+	 * (see `persistWindowState` in MarkdownViewer): `setItem` is an async
+	 * message to the WebKit storage process, and the abnormal termination this
+	 * record exists to survive is exactly the event that loses messages in
+	 * flight. It was the one piece of state whose whole job is to outlive a
+	 * kill, kept in the store this codebase had already proved does not.
+	 *
+	 * `restoreInProgressKey` stays as a read-once migration path: a breadcrumb
+	 * an older build left behind is still honoured, and dropped as soon as a
+	 * Rust write succeeds. The Rust file wins when both exist, so a downgrade
+	 * and re-upgrade cannot resurrect a stale localStorage record.
+	 */
+	async function readProgress(): Promise<RestoreProgress | null> {
+		const raw =
+			((await invoke('load_restore_progress').catch(() => null)) as string | null) ??
+			localStorage.getItem(options.restoreInProgressKey);
 		if (!raw) return null;
 		try {
 			const data = JSON.parse(raw) as Partial<RestoreProgress> | null;
@@ -100,14 +135,24 @@ export function createWindowSession(options: WindowSessionOptions) {
 		}
 	}
 
-	function writeProgress(progress: RestoreProgress) {
+	async function writeProgress(progress: RestoreProgress) {
 		// A finished pass with nothing deferred leaves no breadcrumb at all,
-		// which is what keeps the key absent in the ordinary case.
-		if (!progress.running && progress.deferred.length === 0) {
-			localStorage.removeItem(options.restoreInProgressKey);
+		// which is what keeps the record absent in the ordinary case.
+		const clearing = !progress.running && progress.deferred.length === 0;
+		try {
+			if (clearing) await invoke('clear_restore_progress');
+			else await invoke('save_restore_progress', { json: JSON.stringify(progress) });
+		} catch (error) {
+			// No localStorage fallback on purpose: two copies that can disagree
+			// is how a stale record gets preferred over a fresh one. A backend
+			// that cannot write this cannot write the snapshot either, and that
+			// failure is already reported at close.
+			options.onWarning('Failed to record session restore progress', error);
 			return;
 		}
-		localStorage.setItem(options.restoreInProgressKey, JSON.stringify(progress));
+		// Only once the durable copy is in place, so a build that cannot reach
+		// the backend keeps whatever the previous one left behind.
+		localStorage.removeItem(options.restoreInProgressKey);
 	}
 
 	/**
@@ -117,20 +162,20 @@ export function createWindowSession(options: WindowSessionOptions) {
 	 * one bad startup would cost the user automatic restore of that document
 	 * forever.
 	 */
-	function releaseReadableDeferrals() {
-		const progress = readProgress();
+	async function releaseReadableDeferrals() {
+		const progress = await readProgress();
 		if (!progress || progress.deferred.length === 0) return;
 		const readable = new Set(
 			tabManager.tabs.filter((tab) => tab.isTruncated !== true && tab.rawContent !== '').map((tab) => tab.path),
 		);
 		const deferred = progress.deferred.filter((path) => !readable.has(path));
 		if (deferred.length === progress.deferred.length) return;
-		writeProgress({ ...progress, deferred });
+		await writeProgress({ ...progress, deferred });
 	}
 
 	async function persistState() {
 		if (!options.isMainWindow) return;
-		releaseReadableDeferrals();
+		await releaseReadableDeferrals();
 		try {
 			await invoke('save_window_state', { json: options.serializeState() });
 			localStorage.removeItem(options.windowStateKey);
@@ -147,14 +192,10 @@ export function createWindowSession(options: WindowSessionOptions) {
 			localStorage.removeItem(options.legacyStateKey);
 			// Nothing will be restored, so there is nothing for a breadcrumb to
 			// say about the next launch.
-			localStorage.removeItem(options.restoreInProgressKey);
+			await writeProgress({ running: false, pending: null, deferred: [], interruptions: 0 });
 			return;
 		}
-		const savedData =
-			localStorage.getItem(options.windowStateKey) ??
-			localStorage.getItem(options.legacyStateKey) ??
-			((await invoke('load_window_state').catch(() => null)) as string | null);
-		const previous = readProgress();
+		const previous = await readProgress();
 		const deferred = previous ? [...previous.deferred] : [];
 		let interruptions = previous?.interruptions ?? 0;
 		if (previous?.running) {
@@ -170,14 +211,35 @@ export function createWindowSession(options: WindowSessionOptions) {
 					? `Markpad session restore was interrupted; deferring ${previous.pending}`
 					: 'Markpad session restore was interrupted with no document to blame',
 			);
+			options.onInterrupted({ deferredPath: previous.pending });
 		}
 		// Nothing here is allowed to delete the snapshot: a restore that goes
 		// wrong must cost the user at most the automatic reopening of a
 		// document, never the record of which documents were open.
 		const deferAll = interruptions >= MAX_INTERRUPTIONS;
+
+		// Claim the launch before the snapshot is loaded, not after.
+		//
+		// The snapshot lives on the Rust side — `persistState` moves it there
+		// and drops the localStorage copies — so reading it is an IPC round
+		// trip. Claiming afterwards left that round trip, and everything before
+		// it, outside the window this mechanism can see: a launch killed in
+		// there leaves no trace, so the next one starts from zero and walks
+		// into the same startup again, and the give-up counter that is supposed
+		// to end the loop never advances.
+		//
+		// Claiming early can leave a breadcrumb for a launch that turns out to
+		// have no snapshot at all. That costs one phantom interruption, and the
+		// `else` branch below clears it on the next launch; being wrong in that
+		// direction costs nothing, being wrong in the other costs a relaunch.
+		const progress: RestoreProgress = { running: true, pending: null, deferred, interruptions };
+		await writeProgress(progress);
+
+		const savedData =
+			localStorage.getItem(options.windowStateKey) ??
+			localStorage.getItem(options.legacyStateKey) ??
+			((await invoke('load_window_state').catch(() => null)) as string | null);
 		if (savedData) {
-			const progress: RestoreProgress = { running: true, pending: null, deferred, interruptions };
-			writeProgress(progress);
 			try {
 				options.restoreState(savedData);
 				for (const tab of options.restoredTabs()) {
@@ -194,7 +256,10 @@ export function createWindowSession(options: WindowSessionOptions) {
 						continue;
 					}
 					progress.pending = tab.path;
-					writeProgress(progress);
+					// Awaited: the record has to be on disk before the read it
+					// describes starts, or the launch this read kills is the one
+					// that leaves nothing behind.
+					await writeProgress(progress);
 					try {
 						// `_checked`, because restore fills an editable buffer: reads
 						// decode leniently, so a file in a legacy encoding comes back
@@ -216,7 +281,7 @@ export function createWindowSession(options: WindowSessionOptions) {
 						tabManager.markTabContentUnavailable(tab.id);
 					}
 					progress.pending = null;
-					writeProgress(progress);
+					await writeProgress(progress);
 				}
 				// The pass got to the end, so whatever interrupted the previous
 				// launches is behind us; only the deferrals stay.
@@ -224,13 +289,15 @@ export function createWindowSession(options: WindowSessionOptions) {
 			} catch (error) {
 				options.onError('Failed to restore Markpad session', error);
 			} finally {
-				writeProgress({ running: false, pending: null, deferred, interruptions });
+				await writeProgress({ running: false, pending: null, deferred, interruptions });
 			}
 		} else {
 			// No snapshot to read: a breadcrumb left by an earlier launch has
 			// nothing left to describe, and leaving it would count as another
-			// interruption next time.
-			writeProgress({ running: false, pending: null, deferred, interruptions: 0 });
+			// interruption next time. This is also what retires the claim the
+			// launch above staked before it knew whether there was anything to
+			// restore, so claiming early cannot accumulate phantom strikes.
+			await writeProgress({ running: false, pending: null, deferred, interruptions: 0 });
 		}
 		if (options.isDisposed()) return;
 		if (options.restoredTabs().length > 0) await persistState();

--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -272,7 +272,9 @@ export const translations: Record<LanguageCode, Translation> = {
             savedNewerEdits: 'Saved — staying in edit mode because you have newer edits',
             openExportedFileFailed: 'Could not open exported file',
             partialDocument: 'Cannot edit yet — this file is not fully loaded',
-            lossySaveBlocked: 'Not saved: this file is not UTF-8, so parts of it became "�" when it was opened. Saving would destroy the original — use "Save As" to write a copy'
+            lossySaveBlocked: 'Not saved: this file is not UTF-8, so parts of it became "�" when it was opened. Saving would destroy the original — use "Save As" to write a copy',
+            restoreInterrupted: 'Markpad did not finish restoring your session last time',
+            restoreInterruptedDeferred: 'Markpad did not finish opening {path} last time, so it was skipped. Open it yourself to try again'
         },
         externalChange: {
             message: 'This file changed on disk while you had unsaved changes.',


### PR DESCRIPTION
The session-restore recovery mechanism (#260, #401) does not survive the
abnormal termination it exists to handle. It is complete, it is tested, and the
record it depends on is kept in the one store this repository has already proved
does not outlive a kill.

## What the mechanism promises, and what #201 got

Before reading each document, `restore()` writes a breadcrumb naming it. A
launch that finds the breadcrumb still set knows the last launch died on that
document and defers it; after `MAX_INTERRUPTIONS` (3) consecutive interrupted
launches it stops reading documents entirely and hands back the tabs alone.

I traced that promise against `windowSession.svelte.ts` and it holds: **recovery
costs two launches.** Launch 1 claims the pass, writes `pending = P`, dies on
`read_file_content_checked(P)`. Launch 2 reads the breadcrumb, counts one
interruption, puts `P` in `deferred`, reads everything else, finishes. Two.
#201's reporter needed six.

That gap is not in the policy. It is in whether the breadcrumb is there at all
on launch 2.

## Three changes

### 1. Claim the launch before loading the snapshot

`savedData` was read first, normally via `await invoke('load_window_state')` —
an IPC round trip, because `persistState` moves the snapshot to the Rust side
and drops the localStorage copies. The breadcrumb was written only after that
returned. A launch killed during the round trip, or during anything before it,
left no trace, so the next one started from zero — and, more importantly, the
give-up counter that is supposed to terminate the loop never advanced. Startup
that cannot record that it failed cannot decide to stop trying.

The claim now goes in first. The case where there turns out to be no snapshot at
all is handled by the existing `else` branch, which writes
`{ running: false, …, interruptions: 0 }` and so retires the claim; I confirmed
that rather than assuming it, and there is a test for it below.

### 2. Route the diagnosis somewhere the user can read it

`restore()` already computed the answer to "why did Markpad come back without my
documents" — `interrupted; deferring <path>`, or `interrupted with no document to
blame` — and sent it to `onWarning`, which `MarkdownViewer` wires to
`console.warn`. In a packaged Tauri app nobody can open that console. The
mechanism was diagnosing itself and writing the answer where no one could read
it.

It now also reaches `addToast`. The seam: `windowSession` has no language, so it
reports the fact and the viewer picks the wording.

```ts
onInterrupted: (interruption: { deferredPath: string | null }) => void
```

`onWarning` is unchanged — the console line stays detailed and English, because
that is who reads it.

**This adds two English-only keys** (`toast.restoreInterrupted`,
`toast.restoreInterruptedDeferred`). `scripts/i18nCoverage.test.ts` requires
every key the source asks for to exist in English and reports per-locale
completeness without enforcing it, so the other 25 locales fall back to English
until someone translates them. Saying that here rather than leaving it to be
found.

### 3. Persist the breadcrumb the way the snapshot already is

The evidence is this repository's own comment at `MarkdownViewer.svelte:629`:

> `setItem` is an async message to the WebKit storage process that dies in
> transit when the last window's close ends the process (reproduced in QA as
> "close secondary first, then main → snapshot gone")

That was diagnosed here, reproduced here, and the snapshot was moved to a
Rust-written file because of it. The breadcrumb was left behind — the one piece
of state whose entire purpose is to survive an abnormal termination, in the store
this codebase had already shown does not survive one. It now takes the same path:
`save_restore_progress` / `load_restore_progress` / `clear_restore_progress`,
writing `restore-progress-v1.json` beside `window-state-v2.json`.

`restoreInProgressKey` stays as a read-once migration path: a breadcrumb an older
build left is still honoured, and dropped as soon as a Rust write succeeds. The
Rust file wins when both exist, so a downgrade and re-upgrade cannot resurrect a
stale localStorage record.

## The cost, honestly

This is the part worth arguing with numbers rather than asserting.

**Surface:** three Tauri commands and one file in `app_config_dir`, all
main-window-only (`restore()` returns early for secondary windows).

**Latency:** `2N + 4` added awaited round trips per launch, `N` = restorable file
tabs. Two per document (before the read, after it), plus the claim, the final
write, the `readProgress` at startup and the one in `releaseReadableDeferrals`.

**The write does not reuse `atomic_write`, deliberately.** It keeps the rename,
because `fs::write` truncates before it writes and an empty breadcrumb parses as
"nothing was interrupted" — the one direction this record must never fail in. It
drops the two fsyncs, because they buy durability past a *power cut*, and this
record does not need that: after a power cut the breadcrumb is simply absent and
startup behaves exactly as it did before the file existed. The snapshot does need
it, which is why `save_window_state` keeps `atomic_write` untouched — that file
is the only record of which documents the user had open.

Measured on this machine (macOS 15.5, APFS SSD, 122-byte payload, 200 iterations
after warm-up):

```
atomic_write            (temp + fsync + rename + fsync parent)   7.99 ms/call
temp + fsync + rename   (no parent-dir fsync)                    3.85 ms/call
temp + rename           (what this uses)                         0.20 ms/call
fs::write               (torn; rejected)                         0.09 ms/call
```

So a 10-tab launch pays ~5 ms of file I/O plus 24 IPC round trips, against ~190 ms
if it had reused `atomic_write`. That is what makes the per-document write
affordable at all; had it cost 8 ms I would have proposed writing the breadcrumb
only at the claim and blaming the whole pass rather than one document, which is
strictly worse recovery.

**One deliberate non-fallback:** if the Rust write fails, `writeProgress` reports
through `onWarning` and does *not* fall back to localStorage. Two copies that can
disagree is how a stale record gets preferred over a fresh one, and a backend that
cannot write this cannot write the snapshot either — a failure already surfaced at
close. The degraded behaviour is the current behaviour.

## Tests

`scripts/sessionRestoreResilience.test.ts` had 13 tests over this mechanism. All
13 start from a breadcrumb that a dead launch is **assumed** to have left — which
is exactly the assumption #201 disproves. They pass whatever store the record is
kept in, which is how the mechanism could be complete, tested, and still leave the
reporter relaunching into the same hang. A test that only asserts write order has
the same blind spot.

The five new tests run the kill. `launch()` models three things about a killed
process:

1. the call it died in never answers, and nothing after it runs (the stub returns
   a promise that never settles — a rejection would be *caught*, which is the one
   thing a real kill never allows);
2. whatever the launch had put in localStorage is gone with it;
3. whatever reached the backend is still there when the next one starts.

(2) is the pessimistic reading — a real kill sometimes loses the write and
sometimes does not — and it is the right one for a resilience contract: the
guarantee worth having is the one that holds when the flush does not happen. It is
also what this repository already concluded about this exact store.

The contract locked is **"a launch killed at any point costs at most one
repeat"**, expressed as launch counts and read counts rather than as writes:

| test | property |
|---|---|
| a document that kills the launch reading it is read by exactly one more launch | recovery in 2 launches, `/poison.md` read once |
| launches killed before the snapshot arrives still count, so startup can give up by itself | 3 pre-load deaths ⇒ the 4th reads nothing and still returns every tab |
| claiming the launch early does not strand a window that had nothing to restore | the phantom claim retires itself; a later launch reads everything |
| the launch that follows an interruption tells the user which document it skipped | `onInterrupted({ deferredPath })` fires once, naming the path |
| a launch that was not interrupted tells the user nothing | the ordinary case is silent |

Plus one Rust test, `a_reader_never_sees_a_half_written_breadcrumb`: a writer and
a reader thread race over the real file, and every read must be a whole record.
It carries its own anti-vacuity guard (`whole_reads > 0`) because a reader that
never opened the file would otherwise sail through having checked nothing.

## Falsification

Each assertion was broken on purpose, with the tests left intact, to confirm it
discriminates and names the real problem.

| broken | what failed |
|---|---|
| breadcrumb back in localStorage | `never recovered: 5 launches all died and the loop gave up, with /poison.md read 5 times — the launch that died on it left nothing the next one could find` |
| claim moved back after the load | `after three launches died before they could name a suspect, startup stops opening documents at all` (actual `['/a.md','/b.md','/c.md']`), and `the launch that died during the load is on the record` |
| `else` branch no longer retires the claim | `a launch with nothing to restore leaves no claim behind` |
| `onInterrupted` call removed | `actual [] / expected [{ deferredPath: '/poison.md' }]` |
| `onInterrupted` fired unconditionally | `the ordinary case is silent` (actual `[{ deferredPath: null }]`) |
| `write_restore_progress` → `fs::write` | `a launch read a breadcrumb of 256 bytes that is not any record the writer wrote; startup would parse it as 'nothing was interrupted'` |
| English key renamed out from under the call site | `t() references 1 key(s) English does not define … toast.restoreInterruptedDeferred <- src/lib/MarkdownViewer.svelte` |
| reader pointed at a path that does not exist | `the reader never read the breadcrumb at all, so it proved nothing` |

The `fs::write` row is worth reading twice: a reader really did observe a
256-byte partial file on APFS, so the truncation window is not theoretical.

The `5` in the first row is that test's stopping bound, not a launch count — with
the mechanism broken nothing recovers at all. It is spelled out because an
earlier wording of that message reported the bound as if it were a result, and a
reader reasonably took it for a reproduction of the number in #201's report. The
two are unrelated: his six ended in a working app.

## Verification

Against `origin/master` (`382ab8c`, which is the `v2.7.1` tag — the reporter is
running what this is written against):

```
                  baseline        this branch
npm run check     0 errors        0 errors, 653 files, 0 warnings
npm test          778 pass        783 pass, 0 fail
cargo test        125 passed      126 passed, 0 failed
npm run build     clean           clean
```

+5 frontend and +1 Rust are exactly the new tests. `cargo clippy` and
`cargo fmt --check` produce the same output as master (one pre-existing
`push_str` warning; 47 pre-existing fmt diffs, none in the new code).

## Not verified

- **I could not reproduce the original hang.** The reporter's file now opens
  fine and he no longer has a way to trigger it. This is a mechanism fix argued
  from the code and from the repository's own QA note, not a fix confirmed
  against the failure. What I can show is that the property holds under a
  simulated kill and fails without each change.
- **I did not reproduce the localStorage loss itself.** The QA reproduction in
  `MarkdownViewer.svelte:629` is for the snapshot at window close. That a
  force-quit mid-restore loses the breadcrumb the same way is the same mechanism
  applied to the same store, not a second observation. If it turns out
  `setItem` does survive a force-quit, change 3 is insurance and changes 1 and 2
  stand on their own.
- **No packaged build was run.** `restore-progress-v1.json` was never written by
  a real `AppHandle`; `restore_progress_path` is exercised only through the same
  `app_config_dir` call `window_state_path` already uses. The toast was never
  seen on screen.
- **macOS only.** The latency numbers are APFS on one machine. The rename is
  atomic on Windows too (`MoveFileExW`, per `atomic_write`'s own note) but the
  cost ratio there is unmeasured.
- The 26-locale wording is English for 25 of them until translated.

## Two things found in passing, both left alone

**The snapshot is still written once, at graceful close** (`MarkdownViewer.svelte:629-641`).
A freeze-and-kill therefore loses the tab list entirely — which is #153's third
symptom, and probably why #201's reporter got one tab back rather than all of
them. This PR makes that seam more visible (the breadcrumb now outlives a kill
that the snapshot does not) and deliberately does **not** touch it, because
changing it means revisiting a decision made in #214. Filed separately.

**The user is blind for the whole of restore, and this change does not fix
that.** `mode` is `'loading'` from mount until the very end of `init()` — after
`windowSession.restore()`, `claimTransferredTab()`, the `?file=` load and
`send_markdown_path` — and `handleKeyDown` returns early on `mode !== 'app'`.
So every document-level shortcut is inert for as long as restore runs, including
on a launch slowly working through a pathological document. From the user's side
that is indistinguishable from a freeze, and it is the window in which the
decision to reach for Task Manager actually gets made — the force-kill that
powers the whole #201 loop.

The toast this PR adds fires *after* restore. It answers "why did my documents
not come back"; it says nothing during the stretch where the user decides to
kill. Saying something during restore means rendering into the
`{#if mode === 'loading'}` branch, and the useful signal there is not this notice
(which is about the previous launch) but per-document progress — a different
feature on the same startup path. I left the mode gate alone: it may be
load-bearing for reasons I have not checked, and widening scope here is not worth
it. Noting it because it is the next thing someone should look at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
