### PR TITLE
fix(session): keep the snapshot when exit is used during startup

### DIFF
--- a/scripts/windowStateRestore.test.ts
+++ b/scripts/windowStateRestore.test.ts
@@ -107,6 +107,20 @@ test('v2 snapshots are invisible to legacy builds (Rust file, localStorage keys 
 	assert.match(exitScope, /await discardPersistedWindowState\(\)/);
 });
 
+test('exit discards the snapshot only once startup has finished', () => {
+	const exitScope = sliceBetween(viewer, 'async function appExit', '\n\t}');
+	// Until `init` flips `mode` to 'app', the file on disk is the only complete
+	// record of the session: restore has rebuilt the tab list but is still
+	// reading those files back. An unreachable restored path stretches that
+	// window to one share timeout per tab, and the loading screen renders the
+	// ☰ menu while every keyboard shortcut is inert — so Exit is the control
+	// the user reaches for, and discarding there costs them the session.
+	assert.match(exitScope, /restoreStateOnReopen && mode === 'app'/);
+	const gate = offsetOf(exitScope, "mode === 'app'");
+	const discard = offsetOf(exitScope, 'discardPersistedWindowState()');
+	assert.ok(gate < discard, 'the discard must sit behind the startup gate');
+});
+
 test('with restore enabled resolved titled tabs stay open for the snapshot', () => {
 	const handler = closeHandler();
 	// tabs are closed one-by-one only when restore is off (or untitled)

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -639,9 +639,20 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		await windowSession.persistState();
 	}
 
+	// Exit discards the snapshot on purpose — it is how "quit" differs from
+	// closing the window — but only once startup is over. Until `init` sets
+	// `mode` to 'app', the file on disk is still the only complete record of
+	// the session: `restore()` has rebuilt the tab list but is partway through
+	// reading those files back. That window is short unless a restored path is
+	// unreachable, and then it is the share timeout, once per tab, serially —
+	// which is exactly when the user starts looking for a way out. The loading
+	// screen renders the ☰ menu while every keyboard shortcut is inert
+	// (`handleKeyDown` returns on `mode !== 'app'`), so Exit is the control
+	// they reach. Discarding there costs them the session they were waiting
+	// for; falling through to a plain close writes it back instead.
 	async function appExit() {
 		await savePinnedTagIfNeeded();
-		if (settings.restoreStateOnReopen) {
+		if (settings.restoreStateOnReopen && mode === 'app') {
 			const hasUnsaved = tabManager.tabs.some((t) => t.isDirty || (t.path === '' && t.rawContent.trim() !== ''));
 			if (hasUnsaved) {
 				const response = await askCustom(t('modal.areYouSureYouWantToExit', settings.language), {


### PR DESCRIPTION
## What this is

`appExit` deletes the session snapshot, by design — it is what makes "quit"
different from closing the window. This gates that discard on `mode === 'app'`,
so it does not happen while the app is still starting up.

One line of behaviour change, plus a test. During startup, Exit now falls
through to the same plain `appWindow.close()` the ✕ button uses, which writes
the session back instead of deleting it.

Found while reading #153, **but it is not what happened to that reporter** —
they quit with the ✕, which saves, and their missing tabs turned out to have a
different cause (they were launching a pre-2.6.12 copy of the app, whose
session lives in a different store entirely). The defect below stands on its
own: it is reachable, it destroys data, and nothing about it depends on that
report.

## Mechanism

Three things line up badly during startup:

1. **`mode` is `'loading'` for the whole of restore.** `init()` awaits
   `windowSession.restore()` and only then sets `mode = 'app'`. `restore()`
   rebuilds the tab list from the snapshot first and *then* reads each file
   back, one at a time. So for the length of that loop the in-memory session is
   incomplete and the file on disk is the only full record of it.
2. **That loop is serial, and an unreachable path costs the share timeout.**
   One `\\wsl$\…` path with the distro stopped is ~30–60s; several are that
   many, end to end. The reads themselves are correctly off the UI thread, but
   the loading gate is not — the user sees a spinner and nothing else.
3. **The loading screen renders the ☰ menu, and every shortcut is inert.**
   `handleKeyDown` returns on `mode !== 'app'`, so Ctrl+Q does nothing there,
   while the title bar in the loading branch is a full `TitleBar` with
   `onexit={appExit}` wired up.

So the one control that answers during a slow restore is the one that deletes
the session being restored, and it deletes it *before* the close handler could
write it back: `appExit` also sets `isForceExiting`, which makes
`onCloseRequested` return early.

To be clear about how much of this is observed: the freeze and the loading
gate are read from the code, and no user has reported losing a session this
way. The reporter in #153 lost one, but has since confirmed they quit with the
✕ — so this is a defect found next to that report, not the explanation of it.

The ✕ in the same title bar takes the other path and saves. Both are reachable
in the same state, three pixels apart.

## Scope

This narrows the window; it does not settle the design question underneath it,
which I'd rather raise than quietly answer in a patch:

- **Should Exit discard at all?** On macOS the native menu's Quit (⌘Q,
  `menu-app-quit` → `appExit`) is the standard way to leave an app, and
  `handleKeyDown` deliberately steps aside for it — so on that platform the
  discarding path is the *default* one, while ✕ saves. On Windows and Linux the
  split is between the ☰ menu item and the ✕ next to it. Either way two exits
  that look equivalent do opposite things, and the ☰ item is labelled `Ctrl+Q`
  while the real `Ctrl+Q` keystroke saves. Unifying them, or renaming the menu
  item, is a bigger call than this PR makes.
- **Closing in the first instant of startup still writes an empty snapshot.**
  If the window closes before `restoreState(savedData)` has run, the tab list
  is empty and `persistState` serialises that. This is pre-existing, shared
  with the ✕ button, and much narrower than the window this PR closes (it ends
  when the snapshot is parsed, not when the files finish loading). Fixing it
  belongs with the question of whether persist should ever replace a snapshot
  with fewer tabs than it read.
- **The freeze itself is untouched.** Restore's per-tab reads stay serial and
  the UI stays gated behind them. #201 is in that area, so this PR keeps out
  of it.

## Tests

`scripts/windowStateRestore.test.ts` gains `exit discards the snapshot only
once startup has finished`, next to the existing test that pins the opposite
half of the contract ("Only explicit exit uses it"). It asserts the gate is
there and that it sits ahead of the discard.

Reverted the one-line change with the test in place: **it goes red** (`8 pass,
1 fail`). The existing `v2 snapshots are invisible to legacy builds` test,
which asserts `appExit` still calls `discardPersistedWindowState()`, stays
green — the call is unchanged, only its condition is narrower.

## Verification

Everything CI runs, on macOS (arm64):

```
npm audit      # found 0 vulnerabilities
npm run check  # 653 files, 0 errors, 0 warnings
npm test       # 779 pass, 0 fail  (778 before, +1 here)
cargo test     # 125 pass, 0 fail  (untouched by this change)
```

Not verified: the scenario itself. I have no Windows machine and no WSL distro,
so the 30–60s restore stall was reasoned about from the code, not reproduced.
The reporter has since answered the question this PR was originally chasing —
they quit with the ✕ — so nobody is known to have lost a session this way. The
gate is still right to have: the menu item is labelled with the same `Ctrl+Q`
whose keystroke saves, and during startup it deletes a snapshot that has not
yet been read back into memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
