### PR TITLE
chore: delete the code nothing reaches, and narrow the exports nothing imports

### DIFF
--- a/scripts/frontMatter.test.ts
+++ b/scripts/frontMatter.test.ts
@@ -2,7 +2,6 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
-	addFrontMatterListItem,
 	addFrontMatterListItems,
 	getMarkdownBodyWithoutFrontMatter,
 	getFrontMatterListItems,
@@ -104,8 +103,8 @@ test('getFrontMatterListItems returns string tag values for YAML lists', () => {
 test('front matter tag helpers add, edit, and remove tags predictably', () => {
 	const original = ['logger', 'synlog'];
 
-	assert.deepEqual(addFrontMatterListItem(original, ' appconfig '), ['logger', 'synlog', 'appconfig']);
-	assert.deepEqual(addFrontMatterListItem(original, 'logger'), ['logger', 'synlog']);
+	assert.deepEqual(addFrontMatterListItems(original, [' appconfig ']), ['logger', 'synlog', 'appconfig']);
+	assert.deepEqual(addFrontMatterListItems(original, ['logger']), ['logger', 'synlog']);
 	assert.deepEqual(addFrontMatterListItems(original, [' ', 'synlog', 'codesite, onoff']), ['logger', 'synlog', 'codesite', 'onoff']);
 	assert.deepEqual(updateFrontMatterListItem(original, 1, ' syslog '), ['logger', 'syslog']);
 	assert.deepEqual(updateFrontMatterListItem(original, 1, 'logger'), ['logger', 'synlog']);

--- a/scripts/keymapHarness.ts
+++ b/scripts/keymapHarness.ts
@@ -45,7 +45,7 @@ export type Chord = string;
  */
 export const OperatingSystem = { Windows: 1, Macintosh: 2, Linux: 3 } as const;
 
-export type OperatingSystemValue = (typeof OperatingSystem)[keyof typeof OperatingSystem];
+type OperatingSystemValue = (typeof OperatingSystem)[keyof typeof OperatingSystem];
 
 const MODIFIER_ORDER = ['Ctrl', 'Shift', 'Alt', 'Meta'] as const;
 
@@ -66,7 +66,7 @@ export function label(parts: {
 }
 
 /** A Monaco keybinding number, as the chord (or chord sequence) Monaco resolves it to. */
-export function chordOf(binding: number, os: OperatingSystemValue): Chord {
+function chordOf(binding: number, os: OperatingSystemValue): Chord {
 	const decoded = decodeKeybinding(binding, os);
 	assert.ok(decoded, `Monaco could not decode keybinding ${binding}`);
 	return decoded.chords.map((chord) => label(chord as KeyCodeChord)).join(' ');
@@ -80,7 +80,7 @@ export const PLATFORMS = [
 
 // ------------------------------------------------- the editor (Monaco) layer
 
-export type ActionDescriptor = {
+type ActionDescriptor = {
 	id: string;
 	label: string;
 	keybindings?: number[];
@@ -180,7 +180,7 @@ export function editorKeymap(mac: boolean, os: OperatingSystemValue): Map<string
  * `key` is the unshifted character and `code` the physical key, which is what a
  * US layout reports and what every layout reports for letters and digits.
  */
-export const FUZZ_KEYS: Array<{ keyCode: number; key: string; code: string }> = [
+const FUZZ_KEYS: Array<{ keyCode: number; key: string; code: string }> = [
 	...'abcdefghijklmnopqrstuvwxyz'.split('').map((c) => ({
 		keyCode: KeyCode.KeyA + (c.charCodeAt(0) - 97),
 		key: c,

--- a/scripts/renderProtocolDom.ts
+++ b/scripts/renderProtocolDom.ts
@@ -61,7 +61,7 @@ function escapeAttribute(value: string): string {
 
 export const NODE_ELEMENT = 1;
 export const NODE_TEXT = 3;
-export const NODE_COMMENT = 8;
+const NODE_COMMENT = 8;
 
 export class ShimNode {
 	nodeType: number;
@@ -213,7 +213,7 @@ export class ShimText extends ShimNode {
 	}
 }
 
-export class ShimComment extends ShimNode {
+class ShimComment extends ShimNode {
 	nodeValue: string;
 
 	constructor(value: string) {
@@ -411,7 +411,7 @@ export class ShimElement extends ShimNode {
 	}
 }
 
-export class ShimDocument extends ShimNode {
+class ShimDocument extends ShimNode {
 	documentElement: ShimElement;
 	body: ShimElement;
 
@@ -537,7 +537,7 @@ function parseFragment(html: string, doc: ShimDocument | null): ShimNode[] {
 	});
 }
 
-export class ShimDOMParser {
+class ShimDOMParser {
 	parseFromString(html: string, _type: string): ShimDocument {
 		const doc = new ShimDocument();
 		parseInto(html, doc.body, doc);

--- a/scripts/renderProtocolFixtures.ts
+++ b/scripts/renderProtocolFixtures.ts
@@ -21,7 +21,7 @@
  * here a lie.
  */
 
-export type RenderFixture = {
+type RenderFixture = {
 	/** Markdown handed to `convert_markdown`. */
 	markdown: string;
 	/** Exactly what `convert_markdown` returned. */
@@ -150,5 +150,3 @@ export const renderFixtures = {
 		html: "<p data-sourcepos=\"1:1-1:50\">A paragraph with <input type=\"checkbox\" /> inline.</p>\n",
 	},
 } as const satisfies Record<string, RenderFixture>;
-
-export type RenderFixtureName = keyof typeof renderFixtures;

--- a/scripts/scrollSyncBlockMapping.test.ts
+++ b/scripts/scrollSyncBlockMapping.test.ts
@@ -253,7 +253,7 @@ function isAnnotated(element: ShimElement): boolean {
 	return elementChildren(element).some(isAnnotated);
 }
 
-export type Box = { top: number; height: number };
+type Box = { top: number; height: number };
 
 /**
  * Assign every annotated block a top and a height, laying children out in

--- a/scripts/windowTagEditor.ts
+++ b/scripts/windowTagEditor.ts
@@ -185,7 +185,7 @@ function handlerSourceIn(text: string, node: Node, name: string): string {
 	return soleExpression(text, attribute?.value) ?? '(() => {})';
 }
 
-export function handlerSource(node: Node, name: string): string {
+function handlerSource(node: Node, name: string): string {
 	return handlerSourceIn(source, node, name);
 }
 
@@ -198,7 +198,7 @@ export function handlerSource(node: Node, name: string): string {
  * on its own claim ("the strip carried no scope line while a tag was set")
  * rather than on a missing attribute name.
  */
-export function directiveSource(node: Node, type: 'ClassDirective' | 'StyleDirective', name: string): string {
+function directiveSource(node: Node, type: 'ClassDirective' | 'StyleDirective', name: string): string {
 	const directive = node.attributes?.find((a: Node) => a.type === type && a.name === name);
 	if (!directive) return type === 'ClassDirective' ? 'false' : 'undefined';
 	if (type === 'ClassDirective') return stripTypes(source.slice(directive.expression.start, directive.expression.end));
@@ -210,7 +210,7 @@ export function directiveSource(node: Node, type: 'ClassDirective' | 'StyleDirec
 }
 
 /** The one `<name>` element under `root`. */
-export function elementByTag(root: Node, name: string): Node {
+function elementByTag(root: Node, name: string): Node {
 	const found: Node[] = [];
 	collect(root, (node) => {
 		if (node.type === 'RegularElement' && node.name === name) found.push(node);
@@ -225,7 +225,7 @@ export function elementByTag(root: Node, name: string): Node {
  * nothing when it is clicked and renders under no condition, which is what the
  * stand-in models. Same reasoning as `handlerSourceIn`.
  */
-export function elementByHandler(root: Node, marker: string): Node {
+function elementByHandler(root: Node, marker: string): Node {
 	const found: Node[] = [];
 	collect(root, (node) => {
 		if (node.type !== 'RegularElement' || node === root) return;
@@ -240,7 +240,7 @@ export function elementByHandler(root: Node, marker: string): Node {
  * element to be on screen at all — or `false` for an element that is not in the
  * markup.
  */
-export function enclosingIfTest(node: Node): string {
+function enclosingIfTest(node: Node): string {
 	if (typeof node.start !== 'number') return 'false';
 	let innermost: Node | null = null;
 	collect(fragment, (candidate) => {
@@ -253,14 +253,14 @@ export function enclosingIfTest(node: Node): string {
 }
 
 /** The one `{…}` an element renders as its whole content, if that is all it has. */
-export function textExpression(node: Node): string {
+function textExpression(node: Node): string {
 	const tags = (node.fragment?.nodes ?? []).filter((child: Node) => child.type === 'ExpressionTag');
 	if (tags.length !== 1) return "''";
 	return stripTypes(source.slice(tags[0].expression.start, tags[0].expression.end));
 }
 
 /** The initialiser of a top-level `const`, evaluated. */
-export function constantValue(name: string): unknown {
+function constantValue(name: string): unknown {
 	const found: Node[] = [];
 	collect(parse(source, { modern: true, filename: TITLE_BAR }).instance, (node) => {
 		if (node.type === 'VariableDeclarator' && node.id?.type === 'Identifier' && node.id.name === name && node.init) {
@@ -295,20 +295,20 @@ const dismissEffectBody = (() => {
 
 // ------------------------------------------------------------------- harness
 
-export type WindowStub = {
+type WindowStub = {
 	listeners: Map<string, () => void>;
 	addEventListener: (type: string, fn: () => void) => void;
 	removeEventListener: (type: string, fn: () => void) => void;
 };
 
-export type ClickHandler = (event: { stopPropagation: () => void }) => void;
+type ClickHandler = (event: { stopPropagation: () => void }) => void;
 
-export type MouseEventStub = {
+type MouseEventStub = {
 	preventDefault: () => void;
 	stopPropagation: () => void;
 };
 
-export type InvokeCall = { cmd: string; args: any };
+type InvokeCall = { cmd: string; args: any };
 
 export type TitleBar = {
 	state: () => {
@@ -402,7 +402,7 @@ function createTitleBar(windowStub: WindowStub, invoke: (cmd: string, args: any)
 
 export const COLORS = constantValue('tagColors') as string[];
 
-export type SetupOptions = {
+type SetupOptions = {
 	/** Answers `is_window_tag_taken`; every other command resolves to null. */
 	tagTakenElsewhere?: boolean | (() => boolean | Promise<boolean>);
 	/** Fails every `invoke`, to drive the "backend cannot answer" path. */

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -697,119 +697,6 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		}
 	});
 
-	function processHighlights(root: Element) {
-		const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
-			acceptNode(node) {
-				let curr = node.parentElement;
-				while (curr && curr !== root) {
-					if (['CODE', 'PRE', 'SCRIPT', 'STYLE'].includes(curr.tagName)) return NodeFilter.FILTER_REJECT;
-					curr = curr.parentElement;
-				}
-				return NodeFilter.FILTER_ACCEPT;
-			},
-		});
-
-		const toReplace: { node: Text; replaced: string }[] = [];
-		let node: Node | null;
-		while ((node = walker.nextNode())) {
-			const text = (node as Text).nodeValue || '';
-			if (text.includes('==')) {
-				const replaced = text.replace(/==([^=\n]+)==/g, '<mark>$1</mark>');
-				if (replaced !== text) toReplace.push({ node: node as Text, replaced });
-			}
-		}
-		for (const { node, replaced } of toReplace) {
-			const span = root.ownerDocument!.createElement('span');
-			span.innerHTML = replaced;
-			node.parentNode?.replaceChild(span, node);
-		}
-	}
-
-	function processBlockIds(root: Element, doc: Document) {
-		// handle pre-emitted block-id spans from rust parser
-		for (const el of Array.from(root.querySelectorAll('.block-id, [data-block-id]'))) {
-			const rawId = el.getAttribute('data-block-id') || (el as HTMLElement).textContent?.replace(/^\^/, '').trim() || '';
-			if (!rawId) continue;
-			const anchor = doc.createElement('a');
-			anchor.id = rawId;
-			anchor.className = 'block-id-anchor';
-			anchor.setAttribute('data-label', rawId);
-			anchor.setAttribute('aria-hidden', 'true');
-			el.replaceWith(anchor);
-		}
-
-		// scan text nodes for trailing ^id pattern (text ^blockid at end of block)
-		const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
-			acceptNode(node) {
-				const parent = node.parentElement;
-				if (!parent) return NodeFilter.FILTER_REJECT;
-				if (['CODE', 'PRE', 'SCRIPT', 'STYLE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6'].includes(parent.tagName)) return NodeFilter.FILTER_REJECT;
-				return NodeFilter.FILTER_ACCEPT;
-			},
-		});
-
-		const blockIdPattern = / \^([a-zA-Z0-9_-]+)\s*$/;
-		const nodes: { node: Text; id: string }[] = [];
-		let textNode: Node | null;
-		while ((textNode = walker.nextNode())) {
-			const text = (textNode as Text).nodeValue || '';
-			const match = text.match(blockIdPattern);
-			if (match) nodes.push({ node: textNode as Text, id: match[1] });
-		}
-
-		for (const { node, id } of nodes) {
-			const text = node.nodeValue || '';
-			const cleanText = text.replace(blockIdPattern, '');
-			const anchor = doc.createElement('a');
-			anchor.id = id;
-			anchor.className = 'block-id-anchor';
-			anchor.setAttribute('data-label', id);
-			anchor.setAttribute('aria-hidden', 'true');
-			const parent = node.parentNode;
-			if (parent) {
-				const textBefore = doc.createTextNode(cleanText);
-				parent.replaceChild(anchor, node);
-				parent.insertBefore(textBefore, anchor);
-			}
-		}
-	}
-
-	function processTaskItems(root: Element) {
-		for (const input of Array.from(root.querySelectorAll('li input[type="checkbox"]'))) {
-			input.setAttribute('data-task-checkbox', '');
-			input.removeAttribute('disabled');
-			(input as HTMLInputElement).style.cursor = 'pointer';
-
-			const li = input.closest('li');
-			if (!li) continue;
-
-			// wrap bare text/inline nodes after checkbox in a span for CSS targeting
-			const nodes = Array.from(li.childNodes);
-			const inputIdx = nodes.indexOf(input);
-			const afterInput = nodes.slice(inputIdx + 1);
-
-			// we loop until we hit a block child (like a nested UL)
-			const inlineNodes = [];
-			for (const n of afterInput) {
-				if (n.nodeType === 1 && ['P', 'DIV', 'UL', 'OL'].includes((n as Element).tagName)) break;
-				inlineNodes.push(n);
-			}
-
-			if (inlineNodes.length > 0) {
-				const wrapper = root.ownerDocument!.createElement('span');
-				wrapper.className = 'task-text';
-				for (const n of inlineNodes) wrapper.appendChild(n);
-				
-				// insert the newly wrapped span after the checkbox
-				li.insertBefore(wrapper, afterInput[inlineNodes.length] || null);
-			}
-
-			if ((input as HTMLInputElement).checked) {
-				li.classList.add('task-done');
-			}
-		}
-	}
-
 	// The preview and the export run the same filter in opposite orders, on
 	// purpose. The export sanitizes the renderer output first and processes
 	// afterwards, because the bytes it writes are read by another program and
@@ -2790,28 +2677,6 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		window.addEventListener('pointercancel', onUp);
 	}
 
-	function getSplitTransition(node: Element, { isEditing, side }: { isEditing: boolean; side: 'left' | 'right' }) {
-		let shouldAnimate = false;
-		let x = 0;
-
-		if (side === 'left') {
-			if (!isEditing) {
-				shouldAnimate = true;
-				x = -50;
-			}
-		} else {
-			if (isEditing) {
-				shouldAnimate = true;
-				x = 50;
-			}
-		}
-
-		if (shouldAnimate) {
-			return fly(node, { x, duration: 250 });
-		}
-		return { duration: 0 };
-	}
-
 	onMount(() => {
 		loadRecentFiles();
 		isDisposed = false;
@@ -3452,7 +3317,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 																	<input
 																		id={frontMatterFieldId(field.key)}
 																		type={field.kind === 'number' ? 'number' : 'text'}
-																		value={field.editableValue}
+																		value={field.displayValue}
 																		onchange={(e) => handleFrontMatterEdit(field, (e.currentTarget as HTMLInputElement).value)} />
 																{/if}
 															{:else}

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -32,7 +32,7 @@ export type LoadMarkdownOptions = {
  * `conflict` means the owning tab has unsaved edits, so the choice belongs
  * to the user rather than to a background reload.
  */
-export type ExternalChangeOutcome =
+type ExternalChangeOutcome =
 	| { action: 'ignore' }
 	| { action: 'reload'; tabId: string; path: string }
 	| { action: 'conflict'; tabId: string; path: string };

--- a/src/lib/utils/editorToolbar.ts
+++ b/src/lib/utils/editorToolbar.ts
@@ -10,7 +10,7 @@ export type EditorToolbarTool = {
 	group: EditorToolbarGroup;
 };
 
-export type EditorToolbarMove = {
+type EditorToolbarMove = {
 	fromIndex: number;
 	toIndex: number;
 };

--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -3,7 +3,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { getMarkdownBodyWithoutFrontMatter, parseFrontMatter } from './frontMatter.js';
 import { processMarkdownHtml } from './markdown.js';
 import {
-	escapeHtmlText,
+	escapeHtml,
 	renderStaticFrontMatterPanel,
 	resolveExportImagePath,
 	rewriteMarkdownHrefForExport,
@@ -53,7 +53,7 @@ interface ExportContext {
 	libraries: RichContentLibraries | null;
 }
 
-export type ExportHtmlResult = {
+type ExportHtmlResult = {
 	path: string;
 	embeddedImages: number;
 	missingImages: number;
@@ -176,7 +176,7 @@ export function buildExportDocument(input: ExportDocumentInput): string {
 <meta charset="UTF-8">
 <meta http-equiv="Content-Security-Policy" content="${EXPORT_CSP}">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>${escapeHtmlText(input.title || 'Export')}</title>
+<title>${escapeHtml(input.title || 'Export')}</title>
 <style>
 ${input.styles}
 html, body {

--- a/src/lib/utils/exportHtml.ts
+++ b/src/lib/utils/exportHtml.ts
@@ -4,7 +4,7 @@ import { resolvePath } from './markdown.js';
 const localMarkdownExtensionPattern = /\.(?:md|markdown|mdown|mkd|txt)$/i;
 const windowsDrivePathPattern = /^[a-zA-Z]:[\\/]/;
 
-function escapeHtml(value: string): string {
+export function escapeHtml(value: string): string {
 	return value
 		.replace(/&/g, '&amp;')
 		.replace(/</g, '&lt;')
@@ -144,8 +144,4 @@ export function renderStaticFrontMatterPanel(frontMatter: FrontMatterParseResult
 </summary>
 <div class="frontmatter-grid">${rows}</div>
 </details>`;
-}
-
-export function escapeHtmlText(value: string): string {
-	return escapeHtml(value);
 }

--- a/src/lib/utils/frontMatter.ts
+++ b/src/lib/utils/frontMatter.ts
@@ -7,7 +7,6 @@ export type FrontMatterField = {
 	value: unknown;
 	kind: FrontMatterValueKind;
 	displayValue: string;
-	editableValue: string;
 	editable: boolean;
 };
 
@@ -25,7 +24,6 @@ export type FrontMatterParseResult = {
 type FrontMatterRange = {
 	raw: string;
 	body: string;
-	lineEnding: '\n' | '\r\n';
 };
 
 function detectLineEnding(content: string): '\n' | '\r\n' {
@@ -33,7 +31,6 @@ function detectLineEnding(content: string): '\n' | '\r\n' {
 }
 
 function findFrontMatterRange(content: string): FrontMatterRange | null {
-	const lineEnding = detectLineEnding(content);
 	const firstLineMatch = content.match(/^(?:\uFEFF)?---[ \t]*(?:\r?\n|$)/);
 	if (!firstLineMatch) return null;
 
@@ -54,7 +51,6 @@ function findFrontMatterRange(content: string): FrontMatterRange | null {
 			return {
 				raw,
 				body: content.slice(bodyStart),
-				lineEnding,
 			};
 		}
 
@@ -84,11 +80,6 @@ function stringifyDisplayValue(value: unknown): string {
 	return String(value);
 }
 
-function toPlainRecord(value: unknown): Record<string, unknown> {
-	if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
-	return value as Record<string, unknown>;
-}
-
 // Front matter is metadata, so the block has to parse as a YAML mapping. Jekyll
 // rejects anything else outright (`validate_data!` raises unless the parsed
 // value `is_a?(Hash)`) and Hugo fails to unmarshal it into its map type; when a
@@ -107,14 +98,13 @@ function toField([key, value]: [string, unknown]): FrontMatterField {
 		value,
 		kind,
 		displayValue: stringifyDisplayValue(value),
-		editableValue: Array.isArray(value) ? value.map((item) => stringifyDisplayValue(item)).join(', ') : stringifyDisplayValue(value),
 		editable: kind !== 'object',
 	};
 }
 
 export function parseFrontMatter(content: string): FrontMatterParseResult {
+	const lineEnding = detectLineEnding(content);
 	const range = findFrontMatterRange(content);
-	const lineEnding = range?.lineEnding ?? detectLineEnding(content);
 	const notFrontMatter: FrontMatterParseResult = {
 		exists: false,
 		valid: true,
@@ -148,7 +138,7 @@ export function parseFrontMatter(content: string): FrontMatterParseResult {
 	const parsed = doc.toJSON();
 	if (!isFrontMatterMapping(parsed)) return notFrontMatter;
 
-	const data = toPlainRecord(parsed);
+	const data = (parsed ?? {}) as Record<string, unknown>;
 	return {
 		exists: true,
 		valid: true,
@@ -213,15 +203,7 @@ export function getFrontMatterListItems(field: FrontMatterField): string[] {
 }
 
 export function addFrontMatterListItems(items: string[], values: string[]): string[] {
-	const next = [...items];
-	for (const value of values.flatMap(parseFrontMatterTagInput)) {
-		if (!next.includes(value)) next.push(value);
-	}
-	return next;
-}
-
-export function addFrontMatterListItem(items: string[], value: string): string[] {
-	return addFrontMatterListItems(items, [value]);
+	return [...new Set([...items, ...values.flatMap(parseFrontMatterTagInput)])];
 }
 
 export function removeFrontMatterListItem(items: string[], index: number): string[] {

--- a/src/lib/utils/openExportedFile.ts
+++ b/src/lib/utils/openExportedFile.ts
@@ -1,12 +1,12 @@
-export type ExportedFileFormat = 'HTML' | 'PDF';
-export type OpenExportedFileResult = 'opened' | 'declined' | 'failed';
+type ExportedFileFormat = 'HTML' | 'PDF';
+type OpenExportedFileResult = 'opened' | 'declined' | 'failed';
 
 type OpenExportedFileLabels = {
 	title?: string;
 	message?: string;
 };
 
-export type OpenExportedFileDeps = {
+type OpenExportedFileDeps = {
 	ask: (message: string, options?: { title: string; kind: 'info' }) => Promise<boolean>;
 	openPath: (path: string) => Promise<void>;
 	labels?: OpenExportedFileLabels;

--- a/src/lib/utils/pasteContext.ts
+++ b/src/lib/utils/pasteContext.ts
@@ -126,7 +126,7 @@ export function buildPasteProbe(
 	return { text: lines.join('\n'), lineIndex, offset };
 }
 
-export type PasteCaretContext = {
+type PasteCaretContext = {
 	/** Language id of the model the caret is in. */
 	languageId: string;
 	/** Full document text, needed to locate front matter. */

--- a/src/lib/utils/previewAnchor.ts
+++ b/src/lib/utils/previewAnchor.ts
@@ -29,7 +29,7 @@
  */
 
 /** Inclusive source line range, as written in `data-sourcepos`. */
-export type LineRange = {
+type LineRange = {
 	startLine: number;
 	endLine: number;
 };
@@ -47,7 +47,7 @@ export type AnchorNode = {
 	readonly classList?: { contains(token: string): boolean };
 };
 
-export type AnchorMatch = LineRange & {
+type AnchorMatch = LineRange & {
 	element: AnchorNode;
 };
 
@@ -61,7 +61,7 @@ export type AnchorBox = {
 	height: number;
 };
 
-export type MeasureAnchorBox = (node: AnchorNode) => AnchorBox;
+type MeasureAnchorBox = (node: AnchorNode) => AnchorBox;
 
 const ELEMENT_NODE = 1;
 
@@ -294,7 +294,7 @@ export function findAnchorElement(root: AnchorNode, line: number): AnchorMatch |
  * back to the proportional mapping on every one of them would make the paired
  * pane jump back and forth as the reader scrolled.
  */
-export function findNearestAnchorElement(root: AnchorNode, line: number): AnchorMatch | null {
+function findNearestAnchorElement(root: AnchorNode, line: number): AnchorMatch | null {
 	if (!Number.isFinite(line) || line <= 0) return null;
 	return descend(root, null, (span) => lineDistance(span, line), false);
 }
@@ -309,7 +309,7 @@ export function findNearestAnchorElement(root: AnchorNode, line: number): Anchor
  * the render-protocol DOM shim, and that shim has no layout at all; injecting
  * one is what lets the mapping be tested over real pipeline output.
  */
-export function findAnchorElementAtOffset(
+function findAnchorElementAtOffset(
 	root: AnchorNode,
 	offset: number,
 	measure: MeasureAnchorBox,

--- a/src/lib/utils/scrollSync.ts
+++ b/src/lib/utils/scrollSync.ts
@@ -103,7 +103,7 @@ export function getScrollTopForSyncPosition(position: ScrollSyncPosition, scroll
  * end of the document — the part #205 is about — the one place the round trip
  * did not close.
  */
-export type LineTopLookup = (line: number) => number;
+type LineTopLookup = (line: number) => number;
 
 /** Fractional line number rendered at `offset`. Inverse of the function below. */
 export function getLineAtVerticalOffset(offset: number, lineCount: number, topForLine: LineTopLookup): number {

--- a/src/lib/utils/shortcuts.ts
+++ b/src/lib/utils/shortcuts.ts
@@ -28,7 +28,7 @@
  * Which menu the command would live under. The four labels are the existing
  * menu-bar categories, so grouping the panel costs no new translations.
  */
-export type ShortcutGroup = 'file' | 'edit' | 'view' | 'window';
+type ShortcutGroup = 'file' | 'edit' | 'view' | 'window';
 
 /** Display order of the groups, and the i18n key that titles each one. */
 export const SHORTCUT_GROUPS: ReadonlyArray<{ group: ShortcutGroup; labelKey: string }> = [
@@ -39,7 +39,7 @@ export const SHORTCUT_GROUPS: ReadonlyArray<{ group: ShortcutGroup; labelKey: st
 ];
 
 /** The platforms the app distinguishes, spelled the way `settings.osType` does. */
-export type ShortcutPlatform = 'macos' | 'windows' | 'linux';
+type ShortcutPlatform = 'macos' | 'windows' | 'linux';
 
 export type ShortcutEntry = {
 	/**
@@ -311,7 +311,7 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 ];
 
 /** The modifier word each platform spells `Mod` with. */
-export function modifierFor(platform: ShortcutPlatform): 'Cmd' | 'Ctrl' {
+function modifierFor(platform: ShortcutPlatform): 'Cmd' | 'Ctrl' {
 	return platform === 'macos' ? 'Cmd' : 'Ctrl';
 }
 
@@ -327,10 +327,6 @@ export function formatChord(chord: string, modifier: 'Cmd' | 'Ctrl'): string {
 
 const byId = new Map(SHORTCUTS.map((entry) => [entry.id, entry]));
 
-export function getShortcut(id: string): ShortcutEntry | undefined {
-	return byId.get(id);
-}
-
 /**
  * The single chord a one-line consumer shows for `id`, or `undefined` when the
  * command has no shortcut. This is what the app menu and the toolbar tooltip
@@ -341,7 +337,7 @@ export function shortcutLabel(id: string, modifier: 'Cmd' | 'Ctrl'): string | un
 	return entry ? formatChord(entry.chords[0], modifier) : undefined;
 }
 
-export type ShortcutSection = {
+type ShortcutSection = {
 	group: ShortcutGroup;
 	labelKey: string;
 	entries: ReadonlyArray<{ id: string; labelKey: string; chords: string[] }>;

--- a/src/lib/utils/tabFileActions.ts
+++ b/src/lib/utils/tabFileActions.ts
@@ -2,7 +2,7 @@ import { isHomePath } from './homeTab.js';
 
 type TabFileActionId = 'copy-path' | 'open-location';
 
-export type TabFileAction = {
+type TabFileAction = {
 	id: TabFileActionId;
 	labelKey: string;
 	disabled: boolean;

--- a/src/lib/utils/tabHistory.ts
+++ b/src/lib/utils/tabHistory.ts
@@ -1,13 +1,13 @@
-export type FileHistoryState = {
+type FileHistoryState = {
 	history: string[];
 	historyIndex: number;
 };
 
-export type FileHistoryNavigationState = FileHistoryState & {
+type FileHistoryNavigationState = FileHistoryState & {
 	currentPath: string;
 };
 
-export type FileHistoryNavigationResult = FileHistoryState & {
+type FileHistoryNavigationResult = FileHistoryState & {
 	path: string | null;
 };
 

--- a/src/lib/utils/titlebarToolbar.ts
+++ b/src/lib/utils/titlebarToolbar.ts
@@ -1,6 +1,6 @@
 export type TitlebarToolbarPlacement = 'bar' | 'menu';
 
-export type TitlebarToolbarAction = {
+type TitlebarToolbarAction = {
 	id: string;
 	labelKey: string;
 	fallbackName: string;
@@ -9,12 +9,12 @@ export type TitlebarToolbarAction = {
 	required?: boolean;
 };
 
-export type TitlebarToolbarMove = {
+type TitlebarToolbarMove = {
 	fromIndex: number;
 	toIndex: number;
 };
 
-export type ConfiguredTitlebarToolbarIds = {
+type ConfiguredTitlebarToolbarIds = {
 	visibleIds: string[];
 	barIds: string[];
 	menuIds: string[];


### PR DESCRIPTION
## What this is

Deletions only, no behaviour change: four functions in `MarkdownViewer.svelte` that nothing calls, 24 exports nothing outside their own file imports, one alias that only forwards, one wrapper with no production caller, and one `FrontMatterField` property that is a duplicate of the property beside it. Net -162 lines, no dependency change.

Three of the four dead functions are what makes this worth a PR rather than a tidy-up — they are *stale copies* of render steps that still run somewhere else:

| dead copy in `MarkdownViewer.svelte` | live implementation | what the live one has that the copy doesn't |
|---|---|---|
| `processTaskItems` | `src/lib/utils/markdown.ts:368` | the `data-task-checkbox` guard, paragraph re-parenting, whitespace-node handling, the `inputIdx === -1` guard |
| `processBlockIds` | `src/lib/utils/markdown.ts:252` | — same logic, just a second copy |
| `processHighlights` | Rust, `src-tauri/src/lib.rs:967` | code-span and fence protection (#228, #371); the copy is a bare `text.replace(/==([^=\n]+)==/g, …)` |

`getSplitTransition` is simply unreachable.

## Mechanism

`b46a283` (2026-03-20) added the three `process*` steps to `MarkdownViewer.svelte`. `09fa88f` (2026-03-27) moved the two DOM ones into `markdown.ts`, and the `==highlight==` rewrite moved into the Rust renderer. Each migration re-pointed the call site and left the old function body in place.

Nothing was ever going to complain. A module-level function in a `.svelte` `<script>` that nobody calls is legal TypeScript; `svelte-check` reports it as neither error nor warning, and `cargo`'s `dead_code` lint doesn't reach across the language boundary. So the copies have sat there since March looking like helpers.

That is also the gap in `scripts/singleImplementationConvention.test.ts`: its rules ask whether a marker appears in more than one *allowed* file, which an unreachable second copy passes. The bug class that suite describes — *"it looks like a reusable shared helper, so the next person to reuse or sync it silently reverts a merged fix"* — is live here. Reusing `processTaskItems` from `MarkdownViewer.svelte` would reintroduce the pre-`data-task-checkbox` behaviour.

The rest is smaller. `editableValue` is worth one line: it computes the identical string as `displayValue` in every branch (the array branch is the same expression spelled twice), and nothing type-checks that they stay equal, so it is a copy waiting to drift. The one consumer now reads `displayValue`.

## Scope

Found and deliberately left alone:

- **A guard rule for the deleted copies.** Cleanup without a gate can regress, but the obvious markers don't qualify: `processTaskItems` and `processBlockIds` are private in `markdown.ts`, and that suite states a marker "must never be a private identifier". The one that could be pinned by defect shape is the highlight rewrite — `marker: /replace\([^)]*<mark>/g` with `allowed: []`, matching the three existing empty-`allowed` rules. Say the word and I'll add it here so cleanup and gate land together.
- **13 copy-on-write updates on `$state` records** in `MarkdownViewer.svelte` (`x = { ...x, [k]: v }`, and copy-then-`delete`). Svelte 5's `$state` proxy already makes plain mutation reactive, so these are Svelte-4-era habit, but no test covers that component's front-matter tag editor and neither `svelte-check` nor the suite verifies reactivity. Not a change to make blind.
- **The 22 near-identical checkbox blocks in `Settings.svelte`** and the `toggleX()` methods behind them. The methods are not boilerplate: most have 2–3 call sites and several map a boolean onto `'on'`/`'off'` or run real logic (`toggleZenMode` is 29 lines). Deleting them would copy that logic outward, not remove it.
- **93 `en` i18n keys with no static reference.** The native macOS menu is built in Rust and `titlebarToolbar.ts` resolves keys indirectly through `labelKey`, so a static scan can't separate genuinely dead keys from indirectly referenced ones. Acting on it would be a ~2400-line diff across 26 locales on a guess; it needs runtime evidence first.

## Tests

None added, and the honest reason is that no test applies. Every deletion here is either unreachable code or a name nothing imports, so there is no behaviour to pin — a test written for any of it would pass identically with and without the change. The falsification check the template asks for degenerates for the same reason: putting the four functions back leaves the suite green, which is exactly the claim.

`scripts/frontMatter.test.ts` changed for a different reason: `addFrontMatterListItem` had no production caller, only that test, so the three assertions now call `addFrontMatterListItems` with a one-element array. Same inputs, same expectations.

What actually verifies this change is the reachability evidence, not a test: every deleted symbol has zero references across `src/` and `scripts/` (the four functions have exactly one occurrence each — their own definition), checked over `.ts`, `.svelte` and the Svelte markup, and `svelte-check` compiles the tree afterwards.

## Verification

```
npm audit      → found 0 vulnerabilities
npm run check  → 653 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS
npm test       → tests 778, pass 778, fail 0
cargo test     → 125 passed; 0 failed
```

Not verified: I did not run this on Windows or Linux, and I did not launch the app. The deletions contain no platform branch (`#[cfg]`, `osType`, or otherwise) and no deleted symbol has a caller, so there is no runtime path left to exercise — but that reasoning is what I'm offering, not an observation.
