### PR TITLE
fix(windows): remove dead installer code from the shipped binary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "markpad",
-	"version": "2.6.14",
+	"version": "2.7.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "markpad",
-			"version": "2.6.14",
+			"version": "2.7.1",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@tauri-apps/api": "^2",
@@ -2518,9 +2518,9 @@
 			}
 		},
 		"node_modules/mermaid": {
-			"version": "11.16.0",
-			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
-			"integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+			"version": "11.16.1",
+			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+			"integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
 			"license": "MIT",
 			"dependencies": {
 				"@braintree/sanitize-url": "^7.1.2",

--- a/scripts/macosPdfExport.test.ts
+++ b/scripts/macosPdfExport.test.ts
@@ -9,7 +9,7 @@ test('all Markpad webviews may invoke Tauri native printing', () => {
 		permissions: string[];
 	};
 
-	assert.deepEqual(capability.windows, ['main', 'installer', 'window-*']);
+	assert.deepEqual(capability.windows, ['main', 'window-*']);
 	assert.ok(
 		capability.permissions.includes('core:webview:allow-print'),
 		'macOS replaces window.print() with Tauri native printing, which requires this permission',

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -4,7 +4,6 @@
   "description": "Capability for all Markpad windows",
   "windows": [
     "main",
-    "installer",
     "window-*"
   ],
   "permissions": [

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2109,35 +2109,6 @@ fn save_theme(app: AppHandle, theme: String) -> Result<(), String> {
     atomic_write(&theme_path, theme.as_bytes()).map_err(|e| e.to_string())
 }
 
-/// Answer the uninstall entry point that pre-2.7 custom installs left behind.
-///
-/// Those installs wrote `UninstallString = "…\Markpad.exe" --uninstall`, and
-/// Add/Remove Programs still runs it on any machine whose registry entry was
-/// never rewritten. The code that used to serve it is gone, so hand the request
-/// to the NSIS uninstaller sitting beside us. When there is none to hand it to,
-/// fall through and start normally: an editor window is a poor answer, but it
-/// is a visible one, and a click that does nothing at all is worse.
-#[cfg(target_os = "windows")]
-fn forward_legacy_uninstall() {
-    if !std::env::args().any(|arg| arg == "--uninstall") {
-        return;
-    }
-
-    let Ok(exe) = std::env::current_exe() else {
-        return;
-    };
-    let Some(uninstaller) = exe.parent().map(|dir| dir.join("uninstall.exe")) else {
-        return;
-    };
-    if !uninstaller.is_file() {
-        return;
-    }
-
-    if std::process::Command::new(&uninstaller).spawn().is_ok() {
-        std::process::exit(0);
-    }
-}
-
 fn theme_slug(value: &str) -> String {
     let lowercase = value.to_lowercase();
     lowercase
@@ -2681,8 +2652,6 @@ pub fn run() {
 
     #[cfg(target_os = "windows")]
     {
-        forward_legacy_uninstall();
-
         std::env::set_var(
             "WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS",
             "--enable-features=SmoothScrolling",
@@ -2737,20 +2706,7 @@ pub fn run() {
             let args: Vec<String> = std::env::args().collect();
             println!("Setup Args: {:?}", args);
 
-            let current_exe = std::env::current_exe().unwrap_or_default();
-            let exe_name = current_exe
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_lowercase();
-            let is_installer_mode =
-                args.iter().any(|arg| arg == "--install") || exe_name.contains("installer");
-
-            let label = if is_installer_mode {
-                "installer"
-            } else {
-                "main"
-            };
+            let label = "main";
 
             let mut window_builder = tauri::WebviewWindowBuilder::new(
                 app,
@@ -2852,15 +2808,6 @@ pub fn run() {
             if let Some(path) = file_path {
                 let _ = window.emit("file-path", path.as_str());
                 window_runtime::bring_to_front(&window);
-            }
-
-            // If installer, force size (this will be saved to installer-state, not main-state)
-            if is_installer_mode {
-                let _ = window.set_size(tauri::Size::Logical(tauri::LogicalSize {
-                    width: 450.0,
-                    height: 650.0,
-                }));
-                let _ = window.center();
             }
 
             Ok(())


### PR DESCRIPTION
## Problem

The code that triggered `Trojan:Win32/Wacatac.B!ml` was removed in #481, but the **setup.exe** (NSIS installer) is still being flagged by Windows Defender — see [this comment](https://github.com/sftwrdotdev/Markpad/issues/466#issuecomment-2598289831) on #466.

Three things that still look like an installer to a behaviour classifier were left in the binary:

1. **`forward_legacy_uninstall()`** — answered `--uninstall` from pre-2.7 custom installs. The NSIS template writes `UninstallString = uninstall.exe` unconditionally, and the auto-updater's `/UPDATE` pass runs Section Install, so every install that has ever updated through 2.7.1 already has the corrected registry entry. The `hooks.nsi` macro also drops stray `--uninstall` entries from both hives as a backstop.

2. **`is_installer_mode` detection** — checked for `--install` or "installer" in the exe name. No shipped artifact has triggered either since #355 stopped publishing an installer-named file, and #481 removed `Installer.svelte`, `install_app`, and the `invoke_handler` registrations that were the only consumers of the resulting window label.

3. **The `"installer"` window label in capabilities** — a window that no code can create any more.

None of these do anything observable today, but a scanner that reads the file rather than tracing reachability still sees them.

## Change

- Delete `forward_legacy_uninstall()` and its call site in `run()`
- Delete `is_installer_mode` detection, hardcode label to `"main"`
- Delete the `is_installer_mode` window-sizing block
- Remove `"installer"` from `capabilities/default.json`
- Update the test that asserts the capability window list

## Verification

`npm test` — **722 pass / 5 fail** (same as master; the 5 are pre-existing Node.js v25 localStorage incompatibility)