### PR TITLE
refactor(tauri): move #[tauri::command] to window_runtime, delete 17 wrapper functions

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -548,93 +548,6 @@ mod tab_transfer;
 mod window_runtime;
 use window_runtime::{AppState, WatcherState};
 
-#[tauri::command]
-async fn show_window(window: tauri::Window) {
-    window_runtime::show_window(window).await;
-}
-
-#[tauri::command]
-fn save_window_state(app: AppHandle, json: String) -> Result<(), String> {
-    window_runtime::save_window_state(app, json)
-}
-
-#[tauri::command]
-fn load_window_state(app: AppHandle) -> Option<String> {
-    window_runtime::load_window_state(app)
-}
-
-#[tauri::command]
-fn clear_window_state(app: AppHandle) -> Result<(), String> {
-    window_runtime::clear_window_state(app)
-}
-
-#[tauri::command]
-fn save_restore_progress(app: AppHandle, json: String) -> Result<(), String> {
-    window_runtime::save_restore_progress(app, json)
-}
-
-#[tauri::command]
-fn load_restore_progress(app: AppHandle) -> Option<String> {
-    window_runtime::load_restore_progress(app)
-}
-
-#[tauri::command]
-fn clear_restore_progress(app: AppHandle) -> Result<(), String> {
-    window_runtime::clear_restore_progress(app)
-}
-
-#[tauri::command]
-fn set_window_meta(
-    window: tauri::Window,
-    state: State<'_, AppState>,
-    tag_name: Option<String>,
-    tag_color: Option<String>,
-    active_tab_title: String,
-    tab_count: usize,
-) {
-    window_runtime::set_window_meta(window, state, tag_name, tag_color, active_tab_title, tab_count)
-}
-
-#[tauri::command]
-fn list_viewer_windows(state: State<'_, AppState>) -> Vec<window_runtime::WindowListEntry> {
-    window_runtime::list_viewer_windows(state)
-}
-
-#[tauri::command]
-fn is_window_tag_taken(window: tauri::Window, state: State<'_, AppState>, name: String) -> bool {
-    window_runtime::is_window_tag_taken(window, state, name)
-}
-
-#[tauri::command]
-fn offer_tab_to_window(
-    app: AppHandle,
-    state: State<'_, tab_transfer::TabTransferBroker>,
-    target_label: String,
-    token: String,
-) -> Result<(), String> {
-    window_runtime::offer_tab_to_window(app, state, target_label, token)
-}
-
-#[tauri::command]
-fn focus_window(app: AppHandle, label: String) -> Result<(), String> {
-    window_runtime::focus_window(app, label)
-}
-
-#[tauri::command]
-fn list_pinned_tags(app: AppHandle) -> Vec<window_runtime::PinnedTag> {
-    window_runtime::list_pinned_tags(app)
-}
-
-#[tauri::command]
-fn save_pinned_tag(app: AppHandle, name: String, color: String, files: Vec<String>) -> Result<(), String> {
-    window_runtime::save_pinned_tag(app, name, color, files)
-}
-
-#[tauri::command]
-fn remove_pinned_tag(app: AppHandle, name: String) -> Result<(), String> {
-    window_runtime::remove_pinned_tag(app, name)
-}
-
 /// Byte ranges of code regions — fenced code blocks and inline code spans —
 /// paired with CommonMark's rules. The regex alternation previously used for
 /// protection (```` ```.*?```|`.*?` ````) cannot express them: a fence closes
@@ -2092,16 +2005,6 @@ async fn watch_file(window: tauri::Window, handle: AppHandle, path: String) -> R
 }
 
 #[tauri::command]
-fn unwatch_file(window: tauri::Window, state: State<'_, WatcherState>) -> Result<(), String> {
-    window_runtime::unwatch_file(window, state)
-}
-
-#[tauri::command]
-fn send_markdown_path(state: State<'_, AppState>) -> Vec<String> {
-    window_runtime::send_markdown_path(state)
-}
-
-#[tauri::command]
 fn save_theme(app: AppHandle, theme: String) -> Result<(), String> {
     let config_dir = app.path().app_config_dir().map_err(|e| e.to_string())?;
     fs::create_dir_all(&config_dir).map_err(|e| e.to_string())?;
@@ -2872,7 +2775,7 @@ pub fn run() {
             open_markdown,
             open_markdown_preview,
             render_markdown,
-            send_markdown_path,
+            window_runtime::send_markdown_path,
             read_file_content_checked,
             canonicalize_path,
             read_file_as_data_url,
@@ -2884,8 +2787,8 @@ pub fn run() {
             open_file_folder,
             rename_file,
             watch_file,
-            unwatch_file,
-            show_window,
+            window_runtime::unwatch_file,
+            window_runtime::show_window,
             save_theme,
             get_system_fonts,
             get_os_type,
@@ -2902,20 +2805,20 @@ pub fn run() {
             tab_transfer::complete_detached_tab,
             tab_transfer::cancel_detached_tab,
             create_transfer_window,
-            set_window_meta,
-            list_viewer_windows,
-            is_window_tag_taken,
-            offer_tab_to_window,
-            focus_window,
-            list_pinned_tags,
-            save_pinned_tag,
-            remove_pinned_tag,
-            save_window_state,
-            load_window_state,
-            clear_window_state,
-            save_restore_progress,
-            load_restore_progress,
-            clear_restore_progress
+            window_runtime::set_window_meta,
+            window_runtime::list_viewer_windows,
+            window_runtime::is_window_tag_taken,
+            window_runtime::offer_tab_to_window,
+            window_runtime::focus_window,
+            window_runtime::list_pinned_tags,
+            window_runtime::save_pinned_tag,
+            window_runtime::remove_pinned_tag,
+            window_runtime::save_window_state,
+            window_runtime::load_window_state,
+            window_runtime::clear_window_state,
+            window_runtime::save_restore_progress,
+            window_runtime::load_restore_progress,
+            window_runtime::clear_restore_progress
         ])
         .on_window_event(window_runtime::handle_window_event)
         .on_menu_event(|app, event| {

--- a/src-tauri/src/window_runtime.rs
+++ b/src-tauri/src/window_runtime.rs
@@ -218,10 +218,12 @@ fn remove_pinned_tag_at(lock: &Mutex<()>, path: &Path, name: String) -> Result<(
     })
 }
 
+#[tauri::command]
 pub fn list_pinned_tags(app: AppHandle) -> Vec<PinnedTag> {
     read_pinned_tags(&app)
 }
 
+#[tauri::command]
 pub fn save_pinned_tag(
     app: AppHandle,
     name: String,
@@ -233,12 +235,14 @@ pub fn save_pinned_tag(
     save_pinned_tag_at(&state.pinned_tags, &path, name, color, files)
 }
 
+#[tauri::command]
 pub fn remove_pinned_tag(app: AppHandle, name: String) -> Result<(), String> {
     let path = pinned_tags_path(&app)?;
     let state = app.state::<AppState>();
     remove_pinned_tag_at(&state.pinned_tags, &path, name)
 }
 
+#[tauri::command]
 pub fn set_window_meta(
     window: tauri::Window,
     state: State<'_, AppState>,
@@ -294,11 +298,13 @@ fn tag_held_by_another_window(
         .any(|(other, meta)| other != label && meta.tag_name.as_deref() == Some(name))
 }
 
+#[tauri::command]
 pub fn is_window_tag_taken(window: tauri::Window, state: State<'_, AppState>, name: String) -> bool {
     let registry = lock_recover(&state.window_registry);
     tag_held_by_another_window(&registry, window.label(), &name)
 }
 
+#[tauri::command]
 pub fn list_viewer_windows(state: State<'_, AppState>) -> Vec<WindowListEntry> {
     let registry = lock_recover(&state.window_registry);
     let mut list: Vec<WindowListEntry> = registry
@@ -312,6 +318,7 @@ pub fn list_viewer_windows(state: State<'_, AppState>) -> Vec<WindowListEntry> {
     list
 }
 
+#[tauri::command]
 pub fn offer_tab_to_window(
     app: AppHandle,
     broker: State<'_, crate::tab_transfer::TabTransferBroker>,
@@ -326,6 +333,7 @@ pub fn offer_tab_to_window(
         .map_err(|error| error.to_string())
 }
 
+#[tauri::command]
 pub fn focus_window(app: AppHandle, label: String) -> Result<(), String> {
     let window = app
         .get_webview_window(&label)
@@ -334,6 +342,7 @@ pub fn focus_window(app: AppHandle, label: String) -> Result<(), String> {
     Ok(())
 }
 
+#[tauri::command]
 pub async fn show_window(window: tauri::Window) {
     let _ = window.show();
     let _ = window.unminimize();
@@ -355,14 +364,17 @@ fn window_state_path(app: &AppHandle) -> Result<std::path::PathBuf, String> {
 /// next launch restores no tabs at all. `atomic_write` publishes the new
 /// snapshot with a rename: the file on disk is either entirely the old
 /// session or entirely the new one.
+#[tauri::command]
 pub fn save_window_state(app: AppHandle, json: String) -> Result<(), String> {
     crate::atomic_write(&window_state_path(&app)?, json.as_bytes()).map_err(|e| e.to_string())
 }
 
+#[tauri::command]
 pub fn load_window_state(app: AppHandle) -> Option<String> {
     fs::read_to_string(window_state_path(&app).ok()?).ok()
 }
 
+#[tauri::command]
 pub fn clear_window_state(app: AppHandle) -> Result<(), String> {
     let path = window_state_path(&app)?;
     if path.exists() {
@@ -421,14 +433,17 @@ fn write_restore_progress(path: &Path, json: &str) -> std::io::Result<()> {
     Ok(())
 }
 
+#[tauri::command]
 pub fn save_restore_progress(app: AppHandle, json: String) -> Result<(), String> {
     write_restore_progress(&restore_progress_path(&app)?, &json).map_err(|e| e.to_string())
 }
 
+#[tauri::command]
 pub fn load_restore_progress(app: AppHandle) -> Option<String> {
     fs::read_to_string(restore_progress_path(&app).ok()?).ok()
 }
 
+#[tauri::command]
 pub fn clear_restore_progress(app: AppHandle) -> Result<(), String> {
     let path = restore_progress_path(&app)?;
     if path.exists() {
@@ -552,11 +567,13 @@ pub fn watch_file(
     Ok(())
 }
 
+#[tauri::command]
 pub fn unwatch_file(window: tauri::Window, state: State<'_, WatcherState>) -> Result<(), String> {
     lock_recover(&state.watchers).remove(window.label());
     Ok(())
 }
 
+#[tauri::command]
 pub fn send_markdown_path(state: State<'_, AppState>) -> Vec<String> {
     let mut files: Vec<String> = std::env::args()
         .skip(1)


### PR DESCRIPTION
## Problem

`lib.rs` had 17 one-line wrapper functions whose only job was to carry
`#[tauri::command]` so `invoke_handler!` could register them.  Each one
just delegates to `window_runtime::same_name(...)`.

The `tab_transfer` module already proved the better pattern: put
`#[tauri::command]` on the module's own functions and reference them by
module path in the invoke handler.

## Change

- Add `#[tauri::command]` to 17 functions in `window_runtime.rs`
- Delete the 17 wrapper bodies from `lib.rs` (`-114` lines)
- Update `invoke_handler` to reference the moved commands as
  `window_runtime::function_name`

Two commands are deliberately left in `lib.rs` because their wrappers
are **not** one-liners:

| Command | Why it stays |
|---|---|
| `watch_file` | wraps with `spawn_blocking` — notifying a watcher opens the watched path, which can block for seconds on a network volume |
| `create_transfer_window` | the async wrapper prevents a Windows deadlock — `WebviewWindowBuilder::build()` needs the main thread to pump WebView2 messages, which a sync command blocks |

## Verification

`npm test` — 722 pass / 5 fail (same as master)