### PR TITLE
chore: remove debug leftovers, bump prevent-default to stable

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ tauri-plugin-window-state = ">=2.2.2, <3"
 serde = { version = "1", features = ["derive"] }
 comrak = "0.54"
 serde_json = "1"
-tauri-plugin-prevent-default = "2.0.0-rc.1"
+tauri-plugin-prevent-default = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 notify = "6"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2607,7 +2607,6 @@ pub fn run() {
         )
         .setup(|app| {
             let args: Vec<String> = std::env::args().collect();
-            println!("Setup Args: {:?}", args);
 
             let label = "main";
 

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -2800,7 +2800,6 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			);
 			unlisteners.push(
 				await appWindow.listen('menu-tab-undo', () => {
-					console.log('Received menu-tab-undo event');
 					handleUndoCloseTab();
 				}),
 			);
@@ -2870,7 +2869,6 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			unlisteners.push(await appWindow.listen('menu-app-quit',         () => appExit()));
 			unlisteners.push(
 				await appWindow.onCloseRequested(async (event) => {
-					console.log('onCloseRequested triggered');
 					if (isForceExiting) return;
 
 					// The red button is a native control, so it is NOT blocked


### PR DESCRIPTION
## Changes

1. Remove `println!("Setup Args: {:?}", args)` from `lib.rs` — printed
   every CLI argument to stdout on every launch.

2. Remove 2 `console.log` calls from `MarkdownViewer.svelte`:
   - `'Received menu-tab-undo event'`
   - `'onCloseRequested triggered'`

   The remaining 66 console calls are all `console.error` (error handlers)
   and `console.warn` (intentional warnings).

3. Bump `tauri-plugin-prevent-default` from `2.0.0-rc.1` to stable `2`.

## Verification

`npm test` — 784 pass / 0 fail