### PR TITLE
refactor(rust): introduce lightweight Error type for internal functions

### DIFF
--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -1,0 +1,52 @@
+/// A lightweight error type that avoids the `Result<_, String>` boilerplate.
+///
+/// Internal functions use this so that `?` on `std::io::Error` and
+/// `serde_json::Error` converts automatically.  Tauri commands keep their
+/// `Result<T, String>` signatures — the frontend consumes those strings
+/// directly, and changing them would be a breaking API change.
+#[derive(Debug)]
+pub struct Error(String);
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<&str> for Error {
+    fn from(s: &str) -> Self {
+        Error(s.to_string())
+    }
+}
+
+impl From<String> for Error {
+    fn from(s: String) -> Self {
+        Error(s)
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Error(e.to_string())
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(e: serde_json::Error) -> Self {
+        Error(e.to_string())
+    }
+}
+
+impl From<notify::Error> for Error {
+    fn from(e: notify::Error) -> Self {
+        Error(e.to_string())
+    }
+}
+
+impl From<Error> for String {
+    fn from(e: Error) -> Self {
+        e.0
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -544,6 +544,7 @@ fn validate_vsix_archive_limits<R: std::io::Read + std::io::Seek>(
 }
 
 mod asset_protocol;
+mod error;
 mod tab_transfer;
 mod window_runtime;
 use window_runtime::{AppState, WatcherState};

--- a/src-tauri/src/window_runtime.rs
+++ b/src-tauri/src/window_runtime.rs
@@ -85,7 +85,7 @@ pub struct PinnedTag {
 }
 
 fn pinned_tags_path(app: &AppHandle) -> Result<std::path::PathBuf, crate::error::Error> {
-    let dir = app.path().app_config_dir()?;
+    let dir = app.path().app_config_dir().map_err(|e| e.to_string())?;
     fs::create_dir_all(&dir)?;
     Ok(dir.join("pinned-tags.json"))
 }
@@ -348,7 +348,7 @@ pub async fn show_window(window: tauri::Window) {
 }
 
 fn window_state_path(app: &AppHandle) -> Result<std::path::PathBuf, crate::error::Error> {
-    let dir = app.path().app_config_dir()?;
+    let dir = app.path().app_config_dir().map_err(|e| e.to_string())?;
     fs::create_dir_all(&dir)?;
     Ok(dir.join("window-state-v2.json"))
 }
@@ -382,7 +382,7 @@ pub fn clear_window_state(app: AppHandle) -> Result<(), String> {
 }
 
 fn restore_progress_path(app: &AppHandle) -> Result<std::path::PathBuf, crate::error::Error> {
-    let dir = app.path().app_config_dir()?;
+    let dir = app.path().app_config_dir().map_err(|e| e.to_string())?;
     fs::create_dir_all(&dir)?;
     Ok(dir.join("restore-progress-v1.json"))
 }

--- a/src-tauri/src/window_runtime.rs
+++ b/src-tauri/src/window_runtime.rs
@@ -84,12 +84,9 @@ pub struct PinnedTag {
     pub files: Vec<String>,
 }
 
-fn pinned_tags_path(app: &AppHandle) -> Result<std::path::PathBuf, String> {
-    let dir = app
-        .path()
-        .app_config_dir()
-        .map_err(|error| error.to_string())?;
-    fs::create_dir_all(&dir).map_err(|error| error.to_string())?;
+fn pinned_tags_path(app: &AppHandle) -> Result<std::path::PathBuf, crate::error::Error> {
+    let dir = app.path().app_config_dir()?;
+    fs::create_dir_all(&dir)?;
     Ok(dir.join("pinned-tags.json"))
 }
 
@@ -187,12 +184,13 @@ fn update_pinned_tags(
     lock: &Mutex<()>,
     path: &Path,
     edit: impl FnOnce(&mut Vec<PinnedTag>),
-) -> Result<(), String> {
+) -> Result<(), crate::error::Error> {
     let _guard = lock_recover(lock);
     let mut tags = read_pinned_tags_at(path);
     edit(&mut tags);
-    let json = serde_json::to_string(&tags).map_err(|error| error.to_string())?;
-    crate::atomic_write(path, json.as_bytes()).map_err(|error| error.to_string())
+    let json = serde_json::to_string(&tags)?;
+    crate::atomic_write(path, json.as_bytes())?;
+    Ok(())
 }
 
 fn save_pinned_tag_at(
@@ -201,7 +199,7 @@ fn save_pinned_tag_at(
     name: String,
     color: String,
     files: Vec<String>,
-) -> Result<(), String> {
+) -> Result<(), crate::error::Error> {
     update_pinned_tags(lock, path, move |tags| {
         if let Some(tag) = tags.iter_mut().find(|tag| tag.name == name) {
             tag.color = color;
@@ -212,7 +210,7 @@ fn save_pinned_tag_at(
     })
 }
 
-fn remove_pinned_tag_at(lock: &Mutex<()>, path: &Path, name: String) -> Result<(), String> {
+fn remove_pinned_tag_at(lock: &Mutex<()>, path: &Path, name: String) -> Result<(), crate::error::Error> {
     update_pinned_tags(lock, path, move |tags| {
         tags.retain(|tag| tag.name != name);
     })
@@ -232,14 +230,14 @@ pub fn save_pinned_tag(
 ) -> Result<(), String> {
     let path = pinned_tags_path(&app)?;
     let state = app.state::<AppState>();
-    save_pinned_tag_at(&state.pinned_tags, &path, name, color, files)
+    save_pinned_tag_at(&state.pinned_tags, &path, name, color, files).map_err(String::from)
 }
 
 #[tauri::command]
 pub fn remove_pinned_tag(app: AppHandle, name: String) -> Result<(), String> {
     let path = pinned_tags_path(&app)?;
     let state = app.state::<AppState>();
-    remove_pinned_tag_at(&state.pinned_tags, &path, name)
+    remove_pinned_tag_at(&state.pinned_tags, &path, name).map_err(String::from)
 }
 
 #[tauri::command]
@@ -349,9 +347,9 @@ pub async fn show_window(window: tauri::Window) {
     let _ = window.set_focus();
 }
 
-fn window_state_path(app: &AppHandle) -> Result<std::path::PathBuf, String> {
-    let dir = app.path().app_config_dir().map_err(|e| e.to_string())?;
-    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+fn window_state_path(app: &AppHandle) -> Result<std::path::PathBuf, crate::error::Error> {
+    let dir = app.path().app_config_dir()?;
+    fs::create_dir_all(&dir)?;
     Ok(dir.join("window-state-v2.json"))
 }
 
@@ -383,9 +381,9 @@ pub fn clear_window_state(app: AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-fn restore_progress_path(app: &AppHandle) -> Result<std::path::PathBuf, String> {
-    let dir = app.path().app_config_dir().map_err(|e| e.to_string())?;
-    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+fn restore_progress_path(app: &AppHandle) -> Result<std::path::PathBuf, crate::error::Error> {
+    let dir = app.path().app_config_dir()?;
+    fs::create_dir_all(&dir)?;
     Ok(dir.join("restore-progress-v1.json"))
 }
 


### PR DESCRIPTION
## Problem

Internal Rust functions return `Result<T, String>`, which forces
`.map_err(|e| e.to_string())` on every filesystem or serialization
call.  39 call sites in the codebase do this boilerplate.

## Change

Add `src-tauri/src/error.rs` with a simple `Error(String)` type:

- `From<std::io::Error>`, `From<serde_json::Error>`,
  `From<notify::Error>`, `From<&str>`, `From<String>`
- `From<Error> for String` — lets tauri commands keep their
  `Result<T, String>` signatures

Six internal helpers migrated away from `Result<_, String>`:

- `pinned_tags_path`, `update_pinned_tags`,
  `save_pinned_tag_at`, `remove_pinned_tag_at`,
  `window_state_path`, `restore_progress_path`

These now use `?` directly on `std::io::Error` and
`serde_json::Error` — the `From` impls do the conversion.

Tauri commands stay on `Result<T, String>` with a one-line
`.map_err(String::from)` at the boundary (2 call sites).

## Verification

`npm test` — 784 pass / 0 fail