### PR TITLE
feat(settings): the two preferences the panel was missing, and honest semantics for the ones it had

### DIFF
--- a/scripts/oneWritePerTabInFlight.test.ts
+++ b/scripts/oneWritePerTabInFlight.test.ts
@@ -250,7 +250,6 @@ test('closing a tab mid-write does not leave the older snapshot on disk', async 
 	// then renames on top, and there is no longer a tab to raise a flag on.
 	reset();
 	settings.autoSave = true;
-	settings.confirmBeforeSave = false;
 	const session = makeSession();
 	const tabId = await openDirtyTab(session, '/notes/e.md', 'A');
 	writeDurationsMs = [30, 5];

--- a/scripts/openFileMode.test.ts
+++ b/scripts/openFileMode.test.ts
@@ -1,0 +1,138 @@
+/**
+ * #183: "I'd like it to remember that I had the split screen option turned on
+ * when opening a new session."
+ *
+ * Half of it already worked — a session restore replays each tab's saved
+ * `isSplit` — but every newly opened document was created `isSplit: false`, so
+ * the reporter pressed the split button again for each file. There was a
+ * preference for the neighbouring case and none for this one.
+ *
+ * It is ONE preference with three answers rather than a second checkbox beside
+ * the first, because `isEditing` and `isSplit` are independent flags on the tab:
+ * two booleans can say "editor AND split", which is not a state the reader can
+ * be in. That made the checkbox that already existed part of this change, and
+ * an existing install must not notice — hence the migration below.
+ *
+ * The two implementation details pinned here are the ones that are quietly
+ * expensive to get wrong:
+ *
+ *   1. Split must go through `setSplitEnabled`, not a bare `tab.isSplit = true`.
+ *      A fresh tab is created `isScrollSynced: false`, and `setSplitEnabled` is
+ *      what applies the remembered scroll-sync preference — assigning the flag
+ *      directly opens split view with sync silently off.
+ *
+ *   2. Both must be applied BEFORE `initialIsSplit` is read. That variable is
+ *      what sends the load down the full-read branch: `open_markdown_preview`
+ *      returns only the first 50KB, and a split pane is an editor, so a document
+ *      that opened split on a partial buffer would be one keystroke away from
+ *      auto-saving the truncation back over the file.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readSource } from './sourceTree.js';
+
+import {
+	DEFAULT_OPEN_FILE_MODE,
+	isOpenFileMode,
+	resolveOpenFileMode,
+} from '../src/lib/utils/openFileMode.js';
+
+const sessionSource = readSource(new URL('../src/lib/sessions/documentSession.svelte.ts', import.meta.url));
+const settingsSource = readSource(new URL('../src/lib/stores/settings.svelte.ts', import.meta.url));
+const settingsComponentSource = readSource(new URL('../src/lib/components/Settings.svelte', import.meta.url));
+const tabsSource = readSource(new URL('../src/lib/stores/tabs.svelte.ts', import.meta.url));
+
+/* ------------------------------------------------- the stored preference */
+
+test('a stored choice is honoured, and anything else is not', () => {
+	assert.equal(resolveOpenFileMode('preview', null), 'preview');
+	assert.equal(resolveOpenFileMode('editor', null), 'editor');
+	assert.equal(resolveOpenFileMode('split', null), 'split');
+
+	// A value from a newer version, or a hand-edited one.
+	assert.equal(resolveOpenFileMode('wysiwyg', null), DEFAULT_OPEN_FILE_MODE);
+	assert.equal(resolveOpenFileMode('', null), DEFAULT_OPEN_FILE_MODE);
+	assert.ok(!isOpenFileMode('Editor'));
+});
+
+test('an install upgrading from the checkbox opens files exactly as it did', () => {
+	// The whole point of the migration: nobody who upgrades sees their app
+	// behave differently on the first launch.
+	assert.equal(resolveOpenFileMode(null, 'true'), 'editor');
+	assert.equal(resolveOpenFileMode(null, 'false'), 'preview');
+	// Never set it at all — the default, which is what that install did.
+	assert.equal(resolveOpenFileMode(null, null), 'preview');
+});
+
+test('the old boolean stops being consulted once a choice exists', () => {
+	// Otherwise a reader who upgrades, picks "preview", and relaunches gets
+	// "editor" back — the old key is still sitting in localStorage saying true.
+	assert.equal(resolveOpenFileMode('preview', 'true'), 'preview');
+	assert.equal(resolveOpenFileMode('split', 'true'), 'split');
+});
+
+test('the old key is read, never written — a rollback still finds its setting', () => {
+	assert.match(settingsSource, /const LEGACY_START_IN_EDITOR_KEY = 'editor\.startInEditor'/);
+	assert.match(settingsSource, /read: \(s\) => s\.openFileMode/);
+	assert.match(
+		settingsSource,
+		/resolveOpenFileMode\(raw, readStoredKey\(LEGACY_START_IN_EDITOR_KEY\)\)/,
+	);
+	// One `key:` per persisted entry, and this entry's is the new one: the
+	// legacy name must not appear as a key this store writes back.
+	assert.doesNotMatch(settingsSource, /key: 'editor\.startInEditor'/);
+});
+
+/* ------------------------------------------------------------- the wiring */
+
+test('opening a document applies the choice, split through the same door the toggle uses', () => {
+	assert.match(sessionSource, /tab\.isEditing = settings\.openFileMode === 'editor'/);
+	assert.match(
+		sessionSource,
+		/if \(settings\.openFileMode === 'split'\) tabManager\.setSplitEnabled\(tab\.id, true\)/,
+	);
+	// The premise of point 1 above: a fresh tab has sync off, and
+	// `setSplitEnabled` is the only place the preference is applied.
+	assert.match(tabsSource, /isScrollSynced: false/);
+	assert.match(
+		tabsSource,
+		/setSplitEnabled\(id: string, enabled: boolean\)[\s\S]{0,200}?tab\.isScrollSynced = this\.splitScrollSyncPreference/,
+	);
+});
+
+test('the choice is applied before the load decides how much of the file to read', () => {
+	const applied = sessionSource.indexOf("if (settings.openFileMode === 'split')");
+	const read = sessionSource.indexOf('const initialIsSplit = tab?.isSplit ?? false');
+	const fullRead = sessionSource.indexOf('if (initialIsEditing || initialIsSplit)');
+
+	assert.ok(applied > 0 && read > 0 && fullRead > 0);
+	assert.ok(
+		applied < read && read < fullRead,
+		'a document opening into an editable mode must take the full-read branch, ' +
+			'or the editor is bound to the 50KB preview slice',
+	);
+});
+
+test('it applies to a newly opened document only', () => {
+	// Not to a reload that is preserving the mode, and not to a file already
+	// open in a tab — reopening a document must not flip the mode the reader
+	// chose for it. The same guard the checkbox always had.
+	assert.match(sessionSource, /if \(tab && !loadOptions\.preserveEditState && !existing\) \{/);
+});
+
+test('a new empty document keeps its own preference', () => {
+	// `Ctrl+N` asks a different question — what an empty buffer opens as — and
+	// answers it with `newFileDefaultMode`. This change must not annex it.
+	assert.match(tabsSource, /isEditing: settings\.newFileDefaultMode/);
+});
+
+test('the setting is one control, defaulting to preview', () => {
+	assert.match(settingsSource, /openFileMode = \$state<OpenFileMode>\(DEFAULT_OPEN_FILE_MODE\)/);
+	assert.equal(DEFAULT_OPEN_FILE_MODE, 'preview');
+	assert.match(settingsComponentSource, /<select id="appearance-open-file-mode" bind:value=\{settings\.openFileMode\}>/);
+	for (const value of ['preview', 'editor', 'split']) {
+		assert.match(settingsComponentSource, new RegExp(`<option value="${value}">`));
+	}
+});

--- a/scripts/settingsSemantics.test.ts
+++ b/scripts/settingsSemantics.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Settings whose label did not describe what the code did.
+ *
+ * Three of them, found in one sweep of the panel, and all three are the same
+ * failure: a control whose effect depends on another control, with nothing in
+ * the UI saying so.
+ *
+ *   * "Auto-save edits" + "Ask for confirmation before saving" — four
+ *     combinations, two behaviours, and one of them turned auto-save off while
+ *     showing it on. Merged into the single switch every call site already
+ *     evaluated. `autoSaveSetting.ts` holds the migration.
+ *
+ *   * "Wrap Column" — fed to Monaco as `wordWrapColumn`, which Monaco reads
+ *     only in one of the three "Word Wrap" modes. It sat ABOVE that select and
+ *     was always editable, so the two settings' relationship was invisible.
+ *
+ *   * "Word Count" — rendered inside the status bar. With the status bar off,
+ *     turning it on shows nothing at all.
+ *
+ * The first is a behaviour change and is tested as one. The other two are the
+ * UI admitting a dependency that was always there, so what is pinned is the
+ * gate, plus the layout rule that the prerequisite is the row above.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readSource } from './sourceTree.js';
+
+import { DEFAULT_AUTO_SAVE, resolveAutoSave } from '../src/lib/utils/autoSaveSetting.js';
+
+const settingsSource = readSource(new URL('../src/lib/stores/settings.svelte.ts', import.meta.url));
+const settingsComponentSource = readSource(new URL('../src/lib/components/Settings.svelte', import.meta.url));
+const viewerSource = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
+const sessionSource = readSource(new URL('../src/lib/sessions/documentSession.svelte.ts', import.meta.url));
+
+/* ------------------------------------------------- A: one save preference */
+
+test('every old combination keeps the behaviour it already had', () => {
+	// The expression the whole app used to evaluate, one row per combination.
+	//        autoSave  confirmBeforeSave        silently saves?
+	assert.equal(resolveAutoSave(null, 'true', 'false'), true);
+	assert.equal(resolveAutoSave(null, 'true', 'true'), false); // the contradictory one
+	assert.equal(resolveAutoSave(null, 'false', 'false'), false);
+	assert.equal(resolveAutoSave(null, 'false', 'true'), false);
+});
+
+test('an install that never touched either switch keeps the default', () => {
+	assert.equal(resolveAutoSave(null, null, null), DEFAULT_AUTO_SAVE);
+	assert.equal(DEFAULT_AUTO_SAVE, true);
+	// Auto-save on by default, so an absent `confirmBeforeSave` must not read
+	// as "confirm" and silently turn saving off for everybody.
+	assert.equal(resolveAutoSave(null, null, 'false'), true);
+	assert.equal(resolveAutoSave(null, null, 'true'), false);
+});
+
+test('the old pair stops being consulted once the merged key exists', () => {
+	// Otherwise a reader who upgrades with both switches on, then turns
+	// auto-save back on, has the stale veto disable it again on next launch.
+	assert.equal(resolveAutoSave('true', 'true', 'true'), true);
+	assert.equal(resolveAutoSave('false', 'true', 'false'), false);
+});
+
+test('the merged preference is stored under its own key, and the old ones are read-only', () => {
+	assert.match(settingsSource, /key: 'editor\.autoSaveEdits'/);
+	assert.match(settingsSource, /const LEGACY_AUTO_SAVE_KEY = 'editor\.autoSave'/);
+	assert.match(settingsSource, /const LEGACY_CONFIRM_BEFORE_SAVE_KEY = 'editor\.confirmBeforeSave'/);
+	// A rollback finds both of the old keys where it left them.
+	assert.doesNotMatch(settingsSource, /key: 'editor\.autoSave'/);
+	assert.doesNotMatch(settingsSource, /key: 'editor\.confirmBeforeSave'/);
+});
+
+test('nothing evaluates the pair any more', () => {
+	// Four sites read `autoSave && !confirmBeforeSave`; a survivor would be a
+	// path that still consults a preference no UI can set.
+	for (const source of [viewerSource, sessionSource, settingsComponentSource, settingsSource]) {
+		assert.doesNotMatch(source, /settings\.confirmBeforeSave/);
+	}
+	// And the four decisions are still there, now reading the one switch.
+	assert.match(viewerSource, /if \(!settings\.autoSave\) return;/); // leaving an editable pane
+	assert.match(viewerSource, /if \(!settings\.autoSave\) \{/); // the debounce
+	assert.match(viewerSource, /if \(settings\.autoSave\) \{/); // the close-window walk
+	assert.match(sessionSource, /if \(settings\.autoSave && tab\.path !== ''\)/); // closing a tab
+});
+
+/* ---------------------------------------------- B & C: visible dependency */
+
+test('the wrap column sits under the wrap mode, and is inert without it', () => {
+	const wrapMode = settingsComponentSource.indexOf('<label for="editor-word-wrap">');
+	const wrapColumn = settingsComponentSource.indexOf('<label for="editor-max-width">');
+	assert.ok(wrapMode > 0 && wrapColumn > 0);
+	assert.ok(wrapMode < wrapColumn, 'the prerequisite must be the row above the setting it gates');
+
+	// Monaco reads `wordWrapColumn` only in this mode — `Editor.svelte` passes
+	// the value unconditionally, and Monaco ignores it in the other two.
+	const gate = /settings\.wordWrap !== 'wordWrapColumn'/g;
+	assert.equal((settingsComponentSource.match(gate) ?? []).length, 4, 'the row, its input and both steppers');
+});
+
+test('the word count is greyed out when there is no status bar to show it in', () => {
+	assert.match(settingsComponentSource, /class:inactive=\{!settings\.statusBar\}/);
+	assert.match(
+		settingsComponentSource,
+		/id="editor-word-count"[^>]*disabled=\{!settings\.statusBar\}/,
+	);
+	const statusBar = settingsComponentSource.indexOf('<label for="editor-status-bar">');
+	const wordCount = settingsComponentSource.indexOf('<label for="editor-word-count">');
+	assert.ok(statusBar > 0 && statusBar < wordCount, 'same rule: the prerequisite is the row above');
+});
+
+test('an inactive row is dimmed rather than hidden', () => {
+	// Hiding it would answer "where did that setting go?" with nothing.
+	assert.match(settingsComponentSource, /\.setting-item\.inactive[\s\S]{0,200}?opacity: 0\.45/);
+});
+
+/* ------------------------------------------------------------- D: the hint */
+
+test('the restore preference says that it also governs closing', () => {
+	// It decides whether resolved tabs stay open when a window closes, which
+	// "Restore State on Reopen" does not lead anyone to expect.
+	assert.match(settingsComponentSource, /t\('settings\.restoreStateOnReopenHint', settings\.language\)/);
+	assert.match(viewerSource, /!settings\.restoreStateOnReopen \|\| dirty\.path === ''/);
+});

--- a/scripts/tocFollowsEditor.test.ts
+++ b/scripts/tocFollowsEditor.test.ts
@@ -1,0 +1,118 @@
+/**
+ * #169, the half that was missing: the outline highlights the heading you are
+ * reading, but only ever answered to the PREVIEW.
+ *
+ * `Toc.svelte`'s `handleScroll` decides by rendered box — it asks each heading
+ * element where it is on screen. That question has no answer while the editor
+ * is the pane being scrolled: in editor-only mode the preview never scrolls,
+ * and in split view it moves only while scroll sync is on. So the outline sat
+ * still exactly where the reporter said it did.
+ *
+ * The editor's position is a source line, and every outline entry already has
+ * one (`data-sourcepos` on the rendered heading), so the same question is
+ * answered by comparison instead. What matters is that the two rules AGREE:
+ * both are live in split view with sync on, and a disagreement would show as
+ * the highlight flickering between two entries as the panes settle.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readSource } from './sourceTree.js';
+
+import { activeTocIdForLine, sourceLineOf } from '../src/lib/utils/tocFollow.js';
+
+const tocSource = readSource(new URL('../src/lib/components/Toc.svelte', import.meta.url));
+const viewerSource = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
+const settingsSource = readSource(new URL('../src/lib/stores/settings.svelte.ts', import.meta.url));
+const settingsComponentSource = readSource(new URL('../src/lib/components/Settings.svelte', import.meta.url));
+
+/** An outline of a document whose headings are 20 source lines apart. */
+const OUTLINE = [
+	{ id: 'intro', line: 1 },
+	{ id: 'setup', line: 21 },
+	{ id: 'a-block-anchor', line: null },
+	{ id: 'usage', line: 41 },
+	{ id: 'api', line: 61 },
+];
+
+test('the active entry is the last heading at or above the editor position', () => {
+	assert.equal(activeTocIdForLine(OUTLINE, 1), 'intro');
+	assert.equal(activeTocIdForLine(OUTLINE, 20), 'intro');
+	assert.equal(activeTocIdForLine(OUTLINE, 21), 'setup');
+	assert.equal(activeTocIdForLine(OUTLINE, 40.7), 'setup');
+	assert.equal(activeTocIdForLine(OUTLINE, 41), 'usage');
+	assert.equal(activeTocIdForLine(OUTLINE, 4000), 'api');
+});
+
+test('a position above every heading takes the first entry, as the preview does', () => {
+	// `handleScroll` seeds `currentActive` with `visibleItems[0]` before its
+	// loop, so front matter — or anything above the first heading — leaves the
+	// first entry highlighted. Answering `null` here instead would blank the
+	// outline on the way past the top of a document scrolled in the editor.
+	assert.equal(activeTocIdForLine([{ id: 'later', line: 12 }], 3), 'later');
+});
+
+test('an entry with no source range never becomes active, and never hides one that has', () => {
+	// Block anchors (`^id`) are in the outline and carry no range of their own.
+	// A `null` must not be read as line 0 and swallow every position after it.
+	assert.equal(activeTocIdForLine(OUTLINE, 45), 'usage');
+	assert.equal(activeTocIdForLine([{ id: 'block', line: null }], 900), 'block');
+});
+
+test('nothing to follow yields nothing, rather than a stale entry', () => {
+	assert.equal(activeTocIdForLine([], 12), null);
+	assert.equal(activeTocIdForLine(OUTLINE, Number.NaN), null);
+});
+
+test('the start line comes from the sourcepos comrak wrote, or nothing', () => {
+	assert.equal(sourceLineOf('42:1-44:9'), 42);
+	assert.equal(sourceLineOf('7:1-7:12'), 7);
+	assert.equal(sourceLineOf(undefined), null);
+	assert.equal(sourceLineOf(''), null);
+	assert.equal(sourceLineOf('0:1-0:1'), null);
+	assert.equal(sourceLineOf('nonsense'), null);
+});
+
+/* --------------------------------------------------------------- wiring */
+
+test('the outline carries a source line for every entry it builds', () => {
+	// Both kinds — headings and block anchors — or the mapping above is asked
+	// about entries it cannot place.
+	assert.match(tocSource, /isBlock: false, line: sourceLineOf\(h\.dataset\.sourcepos\)/);
+	assert.match(tocSource, /isBlock: true, line: sourceLineOf\(el\.dataset\.sourcepos\)/);
+	// The fingerprint decides whether a re-render replaces the items. An edit
+	// that only moves a heading changes nothing else about it, so without the
+	// line in there the outline would keep answering with the old positions.
+	assert.match(tocSource, /newFingerprint = result\.map\(i => `\$\{i\.id\}-\$\{i\.text\}-\$\{i\.level\}-\$\{i\.line\}`\)/);
+});
+
+test('a click still wins over the editor, as it does over the preview', () => {
+	// `clickLock` holds the entry the user picked until the jump's smooth scroll
+	// settles. The preview's handler returns early on it; so must this one, or
+	// clicking an entry would highlight it and then lose it to the scroll the
+	// click itself caused.
+	assert.match(tocSource, /const line = activeLine;\s*\n\s*if \(line === null \|\| clickLock\) return;/);
+});
+
+test('the editor position reaches the outline whether or not scroll sync is on', () => {
+	// The line is recorded before the sync check, not inside it: following the
+	// editor is not the same feature as moving the preview, and #169 asks for it
+	// in editor-only mode, where there is no preview to move.
+	assert.match(
+		viewerSource,
+		/function handleEditorScrollSync\(position: ScrollSyncPosition\) \{\s*\n\s*if \(position\.line !== undefined\) tocActiveLine = position\.line;/,
+	);
+	// And it is only handed over when the setting is on and an editor is on
+	// screen — a reading-only tab leaves the outline to the preview's handler.
+	assert.match(
+		viewerSource,
+		/activeLine=\{settings\.tocFollowsEditor && \(isEditing \|\| isSplit\) \? tocActiveLine : null\}/,
+	);
+});
+
+test('the preference is off by default, persisted, and reachable from settings', () => {
+	assert.match(settingsSource, /tocFollowsEditor = \$state\(false\)/);
+	assert.match(settingsSource, /booleanSetting\('editor\.tocFollowsEditor'/);
+	assert.match(settingsComponentSource, /settings\.toggleTocFollowsEditor\(\)/);
+});

--- a/scripts/viewModeWithoutSaving.test.ts
+++ b/scripts/viewModeWithoutSaving.test.ts
@@ -226,15 +226,21 @@ function dirtyTab(mode: 'edit' | 'split', path = '/notes/note.md') {
 	return { tab, fakes, harness: buildHarness(fakes, mode === 'edit') };
 }
 
-function setSettings(autoSave: boolean, confirmBeforeSave: boolean) {
+/**
+ * `autoSave` used to be half of a pair — the other, `confirmBeforeSave`, could
+ * veto it, and every decision in the app read `autoSave && !confirmBeforeSave`.
+ * The pair is now the one switch that expression always described, so the two
+ * old combinations that meant "do not write silently" are the single `false`
+ * here.
+ */
+function setSettings(autoSave: boolean) {
 	settings.autoSave = autoSave;
-	settings.confirmBeforeSave = confirmBeforeSave;
 }
 
 // ------------------------------------------------------- leaving edit mode
 
 test('a dirty file switches to reading mode without a modal and without writing', async () => {
-	setSettings(false, false);
+	setSettings(false);
 	const { tab, fakes, harness } = dirtyTab('edit');
 
 	await harness.toggleEdit();
@@ -248,7 +254,7 @@ test('a dirty file switches to reading mode without a modal and without writing'
 });
 
 test('reading mode shows the buffer, not the file', async () => {
-	setSettings(false, false);
+	setSettings(false);
 	const { tab, harness, fakes } = dirtyTab('edit');
 
 	await harness.toggleEdit();
@@ -263,22 +269,8 @@ test('reading mode shows the buffer, not the file', async () => {
 	assert.deepEqual(fakes.loadCalls, [], 'the file is not re-read to leave the editor');
 });
 
-test('confirm-before-save no longer turns a view toggle into a question', async () => {
-	// This setting promises confirmation before each WRITE. With no write left
-	// to do, it has nothing to confirm.
-	setSettings(true, true);
-	const { tab, fakes, harness } = dirtyTab('edit');
-
-	await harness.toggleEdit();
-
-	assert.deepEqual(fakes.askCustomCalls, []);
-	assert.deepEqual(fakes.saveCalls, []);
-	assert.equal(tab.isEditing, false);
-	assert.equal(tab.content, rendered(IN_BUFFER, tab.path));
-});
-
 test('an untitled buffer never reaches the Save dialog on a view toggle', async () => {
-	setSettings(true, false);
+	setSettings(true);
 	tabManager.closeAll();
 	const fakes = freshFakes();
 	tabManager.addTab('');
@@ -297,7 +289,7 @@ test('an untitled buffer never reaches the Save dialog on a view toggle', async 
 test('auto-save still flushes on the way out, because the debounce is about to be dropped', async () => {
 	// The auto-save effect requires `isEditing || isSplit`, so this is the last
 	// chance to honour "save automatically" for these edits.
-	setSettings(true, false);
+	setSettings(true);
 	const { tab, fakes, harness } = dirtyTab('edit');
 
 	await harness.toggleEdit();
@@ -314,7 +306,7 @@ test('a file that cannot be written no longer traps the user in the editor', asy
 	// Read-only path, or a buffer the lossy-decode guard refuses: saveContent
 	// returns false forever, and the old code returned early on that, so
 	// reading mode was unreachable for the life of the tab.
-	setSettings(true, false);
+	setSettings(true);
 	const { tab, fakes, harness } = dirtyTab('edit');
 	fakes.saveFails = true;
 
@@ -328,7 +320,7 @@ test('a file that cannot be written no longer traps the user in the editor', asy
 });
 
 test('edits typed during the flush are shown, and reported as not yet on disk', async () => {
-	setSettings(true, false);
+	setSettings(true);
 	const { tab, fakes, harness } = dirtyTab('edit');
 	fakes.typeDuringSave = 'typed while saving\n';
 
@@ -347,7 +339,7 @@ test('edits typed during the flush are shown, and reported as not yet on disk', 
 // --------------------------------------------------- closing the split view
 
 test('closing split view on a dirty file neither asks nor writes', async () => {
-	setSettings(false, false);
+	setSettings(false);
 	const { tab, fakes, harness } = dirtyTab('split');
 
 	await harness.toggleSplitView(tab.id);
@@ -362,7 +354,7 @@ test('closing split view on a dirty file neither asks nor writes', async () => {
 });
 
 test('closing split view honours auto-save the same way leaving edit mode does', async () => {
-	setSettings(true, false);
+	setSettings(true);
 	const { tab, fakes, harness } = dirtyTab('split');
 
 	await harness.toggleSplitView(tab.id);
@@ -402,7 +394,7 @@ function makeSession(askClose: (title: string) => Promise<'save' | 'discard' | '
 }
 
 test('closing a tab with unsaved edits still asks, and Cancel still keeps it open', async () => {
-	setSettings(false, false);
+	setSettings(false);
 	tabManager.closeAll();
 	tabManager.addTab('/notes/note.md');
 	const tab = tabManager.activeTab!;

--- a/scripts/windowStateRestore.test.ts
+++ b/scripts/windowStateRestore.test.ts
@@ -129,7 +129,7 @@ test('with restore enabled resolved titled tabs stay open for the snapshot', () 
 
 test('auto-save fast path silently saves titled tabs before the walk', () => {
 	const handler = closeHandler();
-	const fastPath = offsetOf(handler, 'settings.autoSave && !settings.confirmBeforeSave');
+	const fastPath = offsetOf(handler, 'if (settings.autoSave) {');
 	const walk = offsetOf(handler, 'canCloseTab(dirty.id)');
 	assert.ok(fastPath < walk, 'the silent save runs before the per-tab walk');
 });

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -1174,7 +1174,17 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		markdownBody.scrollTop = targetScroll;
 	}
 
+	/**
+	 * The source line at the top of the editor's viewport, for the outline to
+	 * follow (#169). Held here rather than read from the editor because this is
+	 * where that line already arrives — the same position scroll sync sends,
+	 * whether or not sync is on and whether or not the preview is even visible.
+	 */
+	let tocActiveLine = $state<number | null>(null);
+
 	function handleEditorScrollSync(position: ScrollSyncPosition) {
+		if (position.line !== undefined) tocActiveLine = position.line;
+
 		if (tabManager.activeTab?.isScrollSynced) {
 			scrollPreviewToSyncPosition(position);
 		}
@@ -1524,10 +1534,9 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	 */
 	async function flushBeforeLeavingEditableMode(tab: Tab) {
 		if (!tab.isDirty || tab.path === '') return;
-		// `confirmBeforeSave` disables the silent background save entirely
-		// (the Settings label promises confirmation before each write), so it
-		// disables this flush too.
-		if (!settings.autoSave || settings.confirmBeforeSave) return;
+		// Auto-save off means edits are kept until the user saves them, so
+		// leaving the pane must not write either — the close dialog asks.
+		if (!settings.autoSave) return;
 
 		const success = await saveContent(tab.id);
 		if (!success) {
@@ -1694,13 +1703,9 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	 * cancelled and a manual Cmd+S becomes the only path again.
 	 */
 	$effect(() => {
-		// Disable background auto-save in two cases:
-		//   1. The user turned `autoSave` off entirely.
-		//   2. The user enabled `confirmBeforeSave` — the Settings UI label
-		//      promises confirmation before each save, so silent debounced
-		//      writes contradict that contract. With this flag on, saves
-		//      happen only via Cmd+S or via the close/toggle modals.
-		if (!settings.autoSave || settings.confirmBeforeSave) {
+		// With auto-save off, saves happen only via Cmd+S or via the
+		// close/toggle modals, so every armed timer is dropped.
+		if (!settings.autoSave) {
 			untrack(() => {
 				for (const t of autoSaveTimers.values()) clearTimeout(t);
 				autoSaveTimers.clear();
@@ -2916,7 +2921,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 							// walk. `saveContent` cancels each tab's pending timer
 							// itself, so no writer here can be raced by its own
 							// debounce.
-							if (settings.autoSave && !settings.confirmBeforeSave) {
+							if (settings.autoSave) {
 								for (const tab of dirtyTabs.filter((t) => t.path !== '')) {
 									const ok = await saveContent(tab.id);
 									if (!ok) {
@@ -3428,7 +3433,8 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 									tabindex="0"
 									onpointerdown={startTocResize}
 									onkeydown={handleTocResizeKeyDown}></div>
-								<Toc 
+								<Toc
+									activeLine={settings.tocFollowsEditor && (isEditing || isSplit) ? tocActiveLine : null} 
 										{markdownBody} 
 										htmlContent={sanitizedHtml}
 										onBeforeJump={pushScrollHistory} 

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -940,11 +940,23 @@
 								</div>
 							</div>
 
-							<div class="setting-item" class:modified={modified.editorMaxWidth}>
+<div class="setting-item">
+								<label for="editor-word-wrap">{t('settings.wordWrap', settings.language)}</label>
+								<div class="select-wrapper">
+									<select id="editor-word-wrap" bind:value={settings.wordWrap}>
+										<option value="off">{t('menu.wordWrapOff', settings.language)}</option>
+										<option value="on">{t('menu.wordWrapOn', settings.language)}</option>
+										<option value="wordWrapColumn">{t('menu.wordWrapColumn', settings.language)}</option>
+									</select>
+									<svg class="select-arrow" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
+								</div>
+							</div>
+
+							<div class="setting-item" class:modified={modified.editorMaxWidth} class:inactive={settings.wordWrap !== 'wordWrapColumn'}>
 								<label for="editor-max-width">{t('settings.wrapColumn', settings.language)}</label>
 								<div class="slider-container">
 									<div class="number-input-wrapper horizontal">
-										<button class="spin-btn minus" onclick={() => stepSetting(settings.editorMaxWidth, -EDITOR_MAX_WIDTH_RANGE.step, EDITOR_MAX_WIDTH_RANGE, setEditorMaxWidth)} aria-label={t('common.decrease', settings.language)}>
+										<button class="spin-btn minus" disabled={settings.wordWrap !== 'wordWrapColumn'} onclick={() => stepSetting(settings.editorMaxWidth, -EDITOR_MAX_WIDTH_RANGE.step, EDITOR_MAX_WIDTH_RANGE, setEditorMaxWidth)} aria-label={t('common.decrease', settings.language)}>
 											<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
 												><line x1="5" y1="12" x2="19" y2="12"></line></svg>
 										</button>
@@ -960,8 +972,9 @@
 											onblur={(e) => commitNumberInput(e, EDITOR_MAX_WIDTH_RANGE, setEditorMaxWidth)}
 											onkeydown={(e) => handleNumberKeydown(e, EDITOR_MAX_WIDTH_RANGE, setEditorMaxWidth)}
 											class="number-input"
+											disabled={settings.wordWrap !== 'wordWrapColumn'}
 										/>
-										<button class="spin-btn plus" onclick={() => stepSetting(settings.editorMaxWidth, EDITOR_MAX_WIDTH_RANGE.step, EDITOR_MAX_WIDTH_RANGE, setEditorMaxWidth)} aria-label={t('common.increase', settings.language)}>
+										<button class="spin-btn plus" disabled={settings.wordWrap !== 'wordWrapColumn'} onclick={() => stepSetting(settings.editorMaxWidth, EDITOR_MAX_WIDTH_RANGE.step, EDITOR_MAX_WIDTH_RANGE, setEditorMaxWidth)} aria-label={t('common.increase', settings.language)}>
 											<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
 												><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
 										</button>
@@ -970,18 +983,7 @@
 								</div>
 							</div>
 
-							<div class="setting-item">
-								<label for="editor-word-wrap">{t('settings.wordWrap', settings.language)}</label>
-								<div class="select-wrapper">
-									<select id="editor-word-wrap" bind:value={settings.wordWrap}>
-										<option value="off">{t('menu.wordWrapOff', settings.language)}</option>
-										<option value="on">{t('menu.wordWrapOn', settings.language)}</option>
-										<option value="wordWrapColumn">{t('menu.wordWrapColumn', settings.language)}</option>
-									</select>
-									<svg class="select-arrow" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-								</div>
-							</div>
-
+							
 							<div class="setting-item">
 								<label for="editor-line-numbers">{t('settings.lineNumbers', settings.language)}</label>
 								<label class="toggle">
@@ -1022,10 +1024,10 @@
 								</label>
 							</div>
 
-							<div class="setting-item">
+							<div class="setting-item" class:inactive={!settings.statusBar}>
 								<label for="editor-word-count">{t('settings.wordCount', settings.language)}</label>
 								<label class="toggle">
-									<input id="editor-word-count" type="checkbox" checked={settings.wordCount} onchange={() => settings.toggleWordCount()} />
+									<input id="editor-word-count" type="checkbox" checked={settings.wordCount} disabled={!settings.statusBar} onchange={() => settings.toggleWordCount()} />
 									<span class="toggle-slider"></span>
 								</label>
 							</div>
@@ -1315,14 +1317,19 @@
 									<input id="appearance-restore-state" type="checkbox" checked={settings.restoreStateOnReopen} onchange={() => settings.toggleRestoreStateOnReopen()} />
 									<span class="toggle-slider"></span>
 								</label>
+								<span class="slider-value">{t('settings.restoreStateOnReopenHint', settings.language)}</span>
 							</div>
 
 							<div class="setting-item">
-								<label for="appearance-start-editor">{t('settings.startInEditor', settings.language)}</label>
-								<label class="toggle">
-									<input id="appearance-start-editor" type="checkbox" checked={settings.startInEditor} onchange={() => settings.toggleStartInEditor()} />
-									<span class="toggle-slider"></span>
-								</label>
+								<label for="appearance-open-file-mode">{t('settings.openFileMode', settings.language)}</label>
+								<div class="select-wrapper">
+									<select id="appearance-open-file-mode" bind:value={settings.openFileMode}>
+										<option value="preview">{t('settings.preview', settings.language)}</option>
+										<option value="editor">{t('settings.editor', settings.language)}</option>
+										<option value="split">{t('menu.splitView', settings.language)}</option>
+									</select>
+									<svg class="select-arrow" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
+								</div>
 							</div>
 							<div class="setting-item">
 								<label for="appearance-new-file-mode">{t('settings.newFileDefaultMode', settings.language)}</label>
@@ -1342,6 +1349,14 @@
 							<label for="appearance-toc">{t('settings.showTableOfContents', settings.language)}</label>
 							<label class="toggle">
 								<input id="appearance-toc" type="checkbox" checked={settings.showToc} onchange={() => settings.toggleToc()} />
+								<span class="toggle-slider"></span>
+							</label>
+						</div>
+
+						<div class="setting-item">
+							<label for="appearance-toc-follows-editor">{t('settings.tocFollowsEditor', settings.language)}</label>
+							<label class="toggle">
+								<input id="appearance-toc-follows-editor" type="checkbox" checked={settings.tocFollowsEditor} onchange={() => settings.toggleTocFollowsEditor()} />
 								<span class="toggle-slider"></span>
 							</label>
 						</div>
@@ -1564,14 +1579,6 @@
 							<label for="files-auto-save">{t('settings.autoSave', settings.language)}</label>
 							<label class="toggle">
 								<input id="files-auto-save" type="checkbox" checked={settings.autoSave} onchange={() => settings.toggleAutoSave()} />
-								<span class="toggle-slider"></span>
-							</label>
-						</div>
-
-						<div class="setting-item">
-							<label for="files-confirm-before-save">{t('settings.confirmBeforeSave', settings.language)}</label>
-							<label class="toggle">
-								<input id="files-confirm-before-save" type="checkbox" checked={settings.confirmBeforeSave} onchange={() => settings.toggleConfirmBeforeSave()} />
 								<span class="toggle-slider"></span>
 							</label>
 						</div>
@@ -2001,6 +2008,24 @@
 
 	.reset-text-btn:hover:not(.disabled) {
 		color: var(--color-accent-fg);
+	}
+
+	/*
+	 * A control whose prerequisite is off. It stays visible and readable — the
+	 * reader needs to see that the setting exists, and where it went — but says
+	 * plainly that nothing it does can take effect yet. The prerequisite is
+	 * always the row directly above it.
+	 */
+	.setting-item.inactive label:first-child,
+	.setting-item.inactive .slider-container,
+	.setting-item.inactive .toggle {
+		opacity: 0.45;
+	}
+
+	.setting-item.inactive .toggle,
+	.setting-item.inactive .number-input,
+	.setting-item.inactive .spin-btn {
+		cursor: default;
 	}
 
 	.reset-text-btn.disabled {

--- a/src/lib/components/Toc.svelte
+++ b/src/lib/components/Toc.svelte
@@ -1,10 +1,19 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
+
 	import { settings } from '../stores/settings.svelte.js';
 	import { t } from '../utils/i18n.js';
+	import { activeTocIdForLine, sourceLineOf } from '../utils/tocFollow.js';
 
-	let { markdownBody, htmlContent, onBeforeJump, collapsedHeaders, ontoggleFold, oncopyref, oncontext, onjump, onshowTooltip, onhideTooltip } = $props<{
+	let { markdownBody, htmlContent, activeLine = null, onBeforeJump, collapsedHeaders, ontoggleFold, oncopyref, oncontext, onjump, onshowTooltip, onhideTooltip } = $props<{
 		markdownBody: HTMLElement | null;
 		htmlContent: string;
+		/**
+		 * The source line at the top of the EDITOR's viewport, or `null` when the
+		 * outline should follow the preview alone (the setting is off, or nothing
+		 * is being edited). See `tocFollow.ts`.
+		 */
+		activeLine?: number | null;
 		onBeforeJump?: () => void;
 		collapsedHeaders?: Set<string>;
 		ontoggleFold?: (id: string) => void;
@@ -21,6 +30,8 @@
 		level: number;
 		isBlock: boolean;
 		hasChildren?: boolean;
+		/** Where this entry starts in the source, for following the editor. */
+		line: number | null;
 	}
 
 	let items = $state<TocItem[]>([]);
@@ -43,7 +54,7 @@
 				const anchor = h.querySelector('a.anchor') as HTMLElement | null;
 				const id = h.id || (anchor ? anchor.id : '');
 				if (id) {
-					result.push({ id, text: text.trim(), level: parseInt(h.tagName[1], 10), isBlock: false });
+					result.push({ id, text: text.trim(), level: parseInt(h.tagName[1], 10), isBlock: false, line: sourceLineOf(h.dataset.sourcepos) });
 				}
 			}
 
@@ -51,7 +62,7 @@
 			for (const el of Array.from(blockAnchors)) {
 				const id = el.id;
 				const label = el.getAttribute('data-label') || id;
-				result.push({ id, text: label, level: 0, isBlock: true });
+				result.push({ id, text: label, level: 0, isBlock: true, line: sourceLineOf(el.dataset.sourcepos) });
 			}
 
 			const allIds = new Map<string, number>();
@@ -75,8 +86,8 @@
 				}
 			}
 
-			const currentFingerprint = items.map(i => `${i.id}-${i.text}-${i.level}`).join('|');
-			const newFingerprint = result.map(i => `${i.id}-${i.text}-${i.level}`).join('|');
+			const currentFingerprint = items.map(i => `${i.id}-${i.text}-${i.level}-${i.line}`).join('|');
+			const newFingerprint = result.map(i => `${i.id}-${i.text}-${i.level}-${i.line}`).join('|');
 			
 			if (currentFingerprint !== newFingerprint) {
 				items = result;
@@ -168,6 +179,27 @@
 		}
 	}
 
+	/**
+	 * Following the EDITOR, when the setting asks for it (#169).
+	 *
+	 * `handleScroll` above cannot answer here: it reads rendered boxes, and the
+	 * pane being scrolled is the one with no boxes to read — in editor-only mode
+	 * the preview never scrolls at all, and in split view it follows only while
+	 * scroll sync is on. The position therefore arrives as a source line and is
+	 * resolved by comparison instead. A click still wins until its scroll
+	 * settles, exactly as it does against the preview's handler.
+	 */
+	$effect(() => {
+		const line = activeLine;
+		if (line === null || clickLock) return;
+
+		const next = activeTocIdForLine(visibleItems, line);
+		if (next === null || next === untrack(() => activeId)) return;
+
+		activeId = next;
+		untrack(scrollTocIntoView);
+	});
+
 	$effect(() => {
 		// Capture the element the listener was attached to: the cleanup must
 		// detach from that same node, not from whatever `markdownBody` points at
@@ -193,8 +225,7 @@
 			scrollTocIntoView();
 			
 			const item = items.find(i => i.id === id);
-			const sourceLine = Number(el.dataset.sourcepos?.match(/^(\d+):/)?.[1]);
-			if (item) onjump?.(id, item.text, Number.isInteger(sourceLine) ? sourceLine : null);
+			if (item) onjump?.(id, item.text, sourceLineOf(el.dataset.sourcepos));
 
 			// highlight element persistently until scroll
 			if (activeTargetEl) activeTargetEl.classList.remove('toc-target-active');

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -368,7 +368,24 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 			const tab = tabManager.tabs.find((item) => item.id === activeId);
 
 			if (isMarkdown) {
-				if (tab && !loadOptions.preserveEditState && !existing) tab.isEditing = settings.startInEditor;
+				if (tab && !loadOptions.preserveEditState && !existing) {
+					// #183: the reporter turns split view on for every file he
+					// opens, so what a picked file opens as is one preference with
+					// three answers (`openFileMode.ts`).
+					//
+					// Split goes through `setSplitEnabled` rather than assigning
+					// the flag, so the tab carries the scroll-sync preference the
+					// toggle would have given it — a fresh tab is created
+					// `isScrollSynced: false` and would otherwise silently drop it.
+					//
+					// And both are applied BEFORE `initialIsSplit` is read, so a
+					// document opening into either editable mode takes the
+					// full-read branch below: those panes can write, and an editor
+					// bound to the 50KB preview slice is one keystroke away from
+					// auto-saving it back over the whole file.
+					tab.isEditing = settings.openFileMode === 'editor';
+					if (settings.openFileMode === 'split') tabManager.setSplitEnabled(tab.id, true);
+				}
 				const initialIsEditing = tab?.isEditing ?? false;
 				const initialIsSplit = tab?.isSplit ?? false;
 				// `open_markdown_preview` returns only the first 50KB of a large
@@ -602,7 +619,7 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		const tab = tabManager.tabs.find((item) => item.id === tabId);
 		if (!tab || (!tab.isDirty && tab.path !== '')) return true;
 		if (!tab.isDirty) return true;
-		if (settings.autoSave && !settings.confirmBeforeSave && tab.path !== '') {
+		if (settings.autoSave && tab.path !== '') {
 			const success = await saveContent(tabId);
 			if (success && !tab.isDirty) return true;
 			if (success) options.onCloseSaveNewerEdits();

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -8,6 +8,15 @@ import {
 	normalizeEditorToolbarOrder,
 } from '../utils/editorToolbar.js';
 import {
+	DEFAULT_AUTO_SAVE,
+	resolveAutoSave,
+} from '../utils/autoSaveSetting.js';
+import {
+	DEFAULT_OPEN_FILE_MODE,
+	resolveOpenFileMode,
+	type OpenFileMode,
+} from '../utils/openFileMode.js';
+import {
 	DEFAULT_TITLEBAR_TOOLBAR_ORDER,
 	DEFAULT_TITLEBAR_TOOLBAR_PLACEMENT,
 	applyTitlebarToolbarMove,
@@ -196,6 +205,15 @@ export function stepWithinRange(current: unknown, delta: number, range: NumericS
 	return clampToRange(clampToRange(current, range) + delta, range);
 }
 
+const LEGACY_START_IN_EDITOR_KEY = 'editor.startInEditor';
+const LEGACY_AUTO_SAVE_KEY = 'editor.autoSave';
+const LEGACY_CONFIRM_BEFORE_SAVE_KEY = 'editor.confirmBeforeSave';
+
+function readStoredKey(key: string): string | null {
+	if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') return null;
+	return localStorage.getItem(key);
+}
+
 function parseStoredStringList(value: string | null): string[] | null {
 	if (value === null) return null;
 	try {
@@ -332,12 +350,13 @@ export class SettingsStore {
 	} | null>(null);
 	occurrencesHighlight = $state(false);
 	showWhitespace = $state(false);
-	startInEditor = $state(false);
+	openFileMode = $state<OpenFileMode>(DEFAULT_OPEN_FILE_MODE);
 	newFileDefaultMode = $state(true);
 	showRecentFiles = $state(true);
 	editorMaxWidth = $state(80);
 	previewMaxWidth = $state(DEFAULT_PREVIEW_MAX_WIDTH);
 	pinnedToc = $state(false);
+	tocFollowsEditor = $state(false);
 	tocSide = $state<'left' | 'right'>('left');
 	tocWidth = $state(240);
 	osType = $state<OSType>('unknown');
@@ -358,11 +377,11 @@ export class SettingsStore {
 	codeFont = $state('Consolas');
 	codeFontSize = $state(14);
 
-	// File-save behavior. autoSave = silently persist edits without Cmd+S.
-	// confirmBeforeSave = if true, keep the unsaved-changes modals on close/toggle
-	// (i.e. ask for confirmation) even when autoSave is on.
-	autoSave = $state(true);
-	confirmBeforeSave = $state(false);
+	// File-save behavior: on, edits are persisted without Cmd+S; off, they are
+	// kept until saved and closing asks. One switch, because that is the number
+	// of behaviours the app has — see `autoSaveSetting.ts` for the pair it
+	// replaced and why the two of them were never independent.
+	autoSave = $state(DEFAULT_AUTO_SAVE);
 
 	constructor() {
 		if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') return;
@@ -482,12 +501,12 @@ export class SettingsStore {
 		this.showWhitespace = !this.showWhitespace;
 	}
 
-	toggleStartInEditor() {
-		this.startInEditor = !this.startInEditor;
-	}
-
 	toggleNewFileDefaultMode() {
 		this.newFileDefaultMode = !this.newFileDefaultMode;
+	}
+
+	toggleTocFollowsEditor() {
+		this.tocFollowsEditor = !this.tocFollowsEditor;
 	}
 
 	togglePinnedToc() {
@@ -508,10 +527,6 @@ export class SettingsStore {
 
 	toggleAutoSave() {
 		this.autoSave = !this.autoSave;
-	}
-
-	toggleConfirmBeforeSave() {
-		this.confirmBeforeSave = !this.confirmBeforeSave;
 	}
 
 	setLanguage(lang: LanguageCode) {
@@ -680,7 +695,16 @@ export function createSettingsPersistence(): PersistedSetting<SettingsStore>[] {
 		booleanSetting('editor.showWhitespace', (s) => s.showWhitespace, (s, v) => { s.showWhitespace = v; }),
 		booleanSetting('editor.showToc', (s) => s.showToc, (s, v) => { s.showToc = v; }),
 		stringSetting('editor.highlightColor', (s) => s.highlightColor, (s, v) => { s.highlightColor = v; }),
-		booleanSetting('editor.startInEditor', (s) => s.startInEditor, (s, v) => { s.startInEditor = v; }),
+		{
+			key: 'editor.openFileMode',
+			read: (s) => s.openFileMode,
+			// The second key is read, never written: it is the boolean this
+			// setting replaced, and it is what an existing install still has on
+			// the first launch after the upgrade. See `resolveOpenFileMode`.
+			load: (s, raw) => {
+				s.openFileMode = resolveOpenFileMode(raw, readStoredKey(LEGACY_START_IN_EDITOR_KEY));
+			},
+		},
 		booleanSetting('editor.newFileDefaultMode', (s) => s.newFileDefaultMode, (s, v) => { s.newFileDefaultMode = v; }),
 		booleanSetting('editor.showRecentFiles', (s) => s.showRecentFiles, (s, v) => { s.showRecentFiles = v; }),
 		numberSetting('editor.maxWidth', EDITOR_MAX_WIDTH_RANGE, (s) => s.editorMaxWidth, (s, v) => { s.editorMaxWidth = v; }),
@@ -690,6 +714,7 @@ export function createSettingsPersistence(): PersistedSetting<SettingsStore>[] {
 			load: (s, savedPreviewMaxWidth) => { s.previewMaxWidth = normalizePreviewMaxWidth(savedPreviewMaxWidth); },
 		},
 		booleanSetting('editor.pinnedToc', (s) => s.pinnedToc, (s, v) => { s.pinnedToc = v; }),
+		booleanSetting('editor.tocFollowsEditor', (s) => s.tocFollowsEditor, (s, v) => { s.tocFollowsEditor = v; }),
 		{
 			key: 'editor.tocSide',
 			read: (s) => s.tocSide,
@@ -743,8 +768,20 @@ export function createSettingsPersistence(): PersistedSetting<SettingsStore>[] {
 		numberSetting('preview.fontSize', PREVIEW_FONT_SIZE_RANGE, (s) => s.previewFontSize, (s, v) => { s.previewFontSize = v; }),
 		stringSetting('preview.codeFont', (s) => s.codeFont, (s, v) => { s.codeFont = v; }),
 		numberSetting('preview.codeFontSize', CODE_FONT_SIZE_RANGE, (s) => s.codeFontSize, (s, v) => { s.codeFontSize = v; }),
-		booleanSetting('editor.autoSave', (s) => s.autoSave, (s, v) => { s.autoSave = v; }),
-		booleanSetting('editor.confirmBeforeSave', (s) => s.confirmBeforeSave, (s, v) => { s.confirmBeforeSave = v; }),
+		{
+			key: 'editor.autoSaveEdits',
+			read: (s) => String(s.autoSave),
+			// The two older keys are read, never written: they are what an
+			// existing install still has on the first launch after the upgrade.
+			// See `resolveAutoSave`.
+			load: (s, raw) => {
+				s.autoSave = resolveAutoSave(
+					raw,
+					readStoredKey(LEGACY_AUTO_SAVE_KEY),
+					readStoredKey(LEGACY_CONFIRM_BEFORE_SAVE_KEY),
+				);
+			},
+		},
 		{
 			key: 'editor.preZenState',
 			read: (s) => (s.preZenState ? JSON.stringify(s.preZenState) : null),

--- a/src/lib/utils/autoSaveSetting.ts
+++ b/src/lib/utils/autoSaveSetting.ts
@@ -1,0 +1,47 @@
+/**
+ * Whether edits are written without being asked for.
+ *
+ * This used to be two checkboxes — "Auto-save edits" and "Ask for confirmation
+ * before saving" — and every decision in the app read them as one expression:
+ *
+ *     settings.autoSave && !settings.confirmBeforeSave
+ *
+ * (`MarkdownViewer`'s debounce, its flush when leaving an editable pane, its
+ * close-the-window walk, and `documentSession.canCloseTab`. There was no fifth
+ * reading, and no site read `confirmBeforeSave` on its own.)
+ *
+ * So the four combinations were two behaviours, and one of them contradicted
+ * its own label: with both switches on, "Auto-save edits" was on and nothing
+ * was auto-saved. The second switch also never touched Cmd+S, which is the one
+ * thing "before saving" would lead a reader to expect — what it really governed
+ * was whether the unsaved-changes dialog still appears on close.
+ *
+ * One switch now, with the two states the code always had: on, edits are saved
+ * silently; off, they are kept until you save, and closing asks.
+ */
+export const DEFAULT_AUTO_SAVE = true;
+
+/**
+ * The stored preference, and what to do about the pair it replaced.
+ *
+ * `editor.autoSaveEdits` is the new key. An install that predates it is asked
+ * the old question instead, through the same expression the app used to
+ * evaluate — which is what makes the upgrade invisible: every one of the four
+ * old combinations maps to the behaviour it already produced.
+ *
+ * Both old keys are left where they are rather than migrated away. They cost
+ * nothing, they are never written again, and a user who rolls back finds the
+ * settings they had. Reading them is conditional on the new key being absent,
+ * so a reader who upgrades and then turns auto-save back on does not have the
+ * stale `confirmBeforeSave` veto it again on the next launch.
+ */
+export function resolveAutoSave(
+	stored: string | null,
+	legacyAutoSave: string | null,
+	legacyConfirmBeforeSave: string | null,
+): boolean {
+	if (stored !== null) return stored === 'true';
+
+	const autoSave = legacyAutoSave === null ? DEFAULT_AUTO_SAVE : legacyAutoSave === 'true';
+	return autoSave && legacyConfirmBeforeSave !== 'true';
+}

--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -77,7 +77,6 @@ export const translations: Record<LanguageCode, Translation> = {
             toolbarsSettings: 'Toolbar Settings',
             fileSettings: 'File Settings',
             autoSave: 'Auto-save edits',
-            confirmBeforeSave: 'Ask for confirmation before saving',
             resetEditorSettings: 'Reset editor settings',
             resetFontSettings: 'Reset font settings',
 			resetPreviewSettings: 'Reset preview settings',
@@ -100,7 +99,9 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Show Whitespace',
             showTabs: 'Show Tabs',
             restoreStateOnReopen: 'Restore State on Reopen',
-            startInEditor: 'Start in Editor',
+            restoreStateOnReopenHint: 'also keeps tabs open when a window closes',
+            openFileMode: 'Open existing files in',
+            tocFollowsEditor: 'Table of Contents Follows Editor Scrolling',
             newFileDefaultMode: 'New file opens in editor',
             showRecentFiles: 'Show Recent Files',
             showTableOfContents: 'Show Table of Contents',
@@ -435,8 +436,10 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: '显示空白',
             showTabs: '显示标签',
             restoreStateOnReopen: '重新打开时恢复状态',
-            startInEditor: '在编辑器中启动',
-            newFileDefaultMode: '新文件在编辑器中打开',
+            restoreStateOnReopenHint: '同时决定关闭窗口时是否保留标签页',
+            openFileMode: '打开已有文件时',
+            tocFollowsEditor: '目录跟随编辑器滚动',
+            newFileDefaultMode: '新建文件在编辑器中打开',
             showRecentFiles: '显示最近文件',
             showTableOfContents: '显示目录',
             zenMode: '禅模式',
@@ -467,7 +470,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: '文件',
             fileSettings: '文件设置',
             autoSave: '自动保存编辑',
-            confirmBeforeSave: '保存前进行确认'
         },
         colors: {
             default: '默认',
@@ -756,7 +758,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: '空白を表示',
             showTabs: 'タブを表示',
             restoreStateOnReopen: '再オープン時に状態を復元',
-            startInEditor: 'エディタで開始',
             newFileDefaultMode: '新しいファイルをエディタで開く',
             showRecentFiles: '最近のファイルを表示',
             showTableOfContents: '目次を表示',
@@ -784,7 +785,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'ファイル',
             fileSettings: 'ファイル設定',
             autoSave: '編集を自動保存',
-            confirmBeforeSave: '保存前に確認する'
         },
         colors: {
             default: 'デフォルト',
@@ -989,7 +989,6 @@ export const translations: Record<LanguageCode, Translation> = {
             toolbarsSettings: '工具列設定',
             fileSettings: '檔案設定',
             autoSave: '自動儲存編輯內容',
-            confirmBeforeSave: '儲存前先確認',
             resetEditorSettings: '重設編輯器設定',
             resetFontSettings: '重設字型設定',
             resetPreviewSettings: '重設預覽設定',
@@ -1012,8 +1011,10 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: '顯示空白字元',
             showTabs: '顯示分頁欄',
             restoreStateOnReopen: '重新開啟時還原狀態',
-            startInEditor: '以編輯器啟動',
-            newFileDefaultMode: '新檔案以編輯器開啟',
+            restoreStateOnReopenHint: '同時決定關閉視窗時是否保留分頁',
+            openFileMode: '開啟既有檔案時',
+            tocFollowsEditor: '目錄跟隨編輯器捲動',
+            newFileDefaultMode: '新建檔案以編輯器開啟',
             showRecentFiles: '顯示最近的檔案',
             showTableOfContents: '顯示目錄',
             zenMode: '專注模式',
@@ -1339,7 +1340,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: '공백 표시',
             showTabs: '탭 표시',
             restoreStateOnReopen: '다시 열 때 상태 복원',
-            startInEditor: '편집기에서 시작',
             newFileDefaultMode: '새 파일을 편집기에서 열기',
             showRecentFiles: '최근 파일 표시',
             showTableOfContents: '목차 표시',
@@ -1376,7 +1376,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: '파일',
             fileSettings: '파일 설정',
             autoSave: '편집 내용 자동 저장',
-            confirmBeforeSave: '저장 전 확인'
         },
         colors: {
             default: '기본',
@@ -1635,7 +1634,6 @@ export const translations: Record<LanguageCode, Translation> = {
             appearanceSettings: 'Настройки внешнего вида',
             fileSettings: 'Настройки файлов',
             autoSave: 'Автосохранение изменений',
-            confirmBeforeSave: 'Спрашивать подтверждение перед сохранением',
             resetEditorSettings: 'Сбросить настройки редактора',
             resetFontSettings: 'Сбросить настройки шрифта',
             font: 'Шрифт',
@@ -1652,7 +1650,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Показывать пробелы',
             showTabs: 'Показывать вкладки',
             restoreStateOnReopen: 'Восстановить состояние при повторном открытии',
-            startInEditor: 'Запускать в редакторе',
             newFileDefaultMode: 'Новый файл открывается в редакторе',
             showRecentFiles: 'Показывать недавние файлы',
             showTableOfContents: 'Показывать оглавление',
@@ -1869,7 +1866,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Mostrar espacios',
             showTabs: 'Mostrar pestañas',
             restoreStateOnReopen: 'Restaurar estado al reabrir',
-            startInEditor: 'Iniciar en editor',
             newFileDefaultMode: 'Nuevo archivo se abre en el editor',
             showRecentFiles: 'Mostrar archivos recientes',
             showTableOfContents: 'Mostrar tabla de contenidos',
@@ -1897,7 +1893,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'Archivos',
             fileSettings: 'Configuración de archivos',
             autoSave: 'Guardar cambios automáticamente',
-            confirmBeforeSave: 'Pedir confirmación antes de guardar'
         },
         colors: {
             default: 'Predeterminado',
@@ -2089,7 +2084,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Afficher les espaces',
             showTabs: 'Afficher les onglets',
             restoreStateOnReopen: 'Restaurer l\'état à la réouverture',
-            startInEditor: 'Démarrer dans l\'éditeur',
             newFileDefaultMode: 'Nouveau fichier s\'ouvre dans l\'éditeur',
             showRecentFiles: 'Afficher les fichiers récents',
             showTableOfContents: 'Afficher la table des matières',
@@ -2117,7 +2111,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'Fichiers',
             fileSettings: 'Paramètres des fichiers',
             autoSave: 'Enregistrement automatique des modifications',
-            confirmBeforeSave: 'Demander confirmation avant d\'enregistrer'
         },
         colors: {
             default: 'Par défaut',
@@ -2309,7 +2302,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Leerzeichen anzeigen',
             showTabs: 'Tabs anzeigen',
             restoreStateOnReopen: 'Zustand beim erneuten Öffnen wiederherstellen',
-            startInEditor: 'Im Editor starten',
             newFileDefaultMode: 'Neue Datei im Editor öffnen',
             showRecentFiles: 'Zuletzt geöffnete Dateien anzeigen',
             showTableOfContents: 'Inhaltsverzeichnis anzeigen',
@@ -2337,7 +2329,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'Dateien',
             fileSettings: 'Datei-Einstellungen',
             autoSave: 'Änderungen automatisch speichern',
-            confirmBeforeSave: 'Vor dem Speichern bestätigen'
         },
         colors: {
             default: 'Standard',
@@ -2529,7 +2520,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Mostrar espaços',
             showTabs: 'Mostrar abas',
             restoreStateOnReopen: 'Restaurar estado ao reabrir',
-            startInEditor: 'Iniciar no editor',
             newFileDefaultMode: 'Novo arquivo abre no editor',
             showRecentFiles: 'Mostrar arquivos recentes',
             showTableOfContents: 'Mostrar tabela de conteúdos',
@@ -2557,7 +2547,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'Arquivos',
             fileSettings: 'Configurações de arquivos',
             autoSave: 'Salvar edições automaticamente',
-            confirmBeforeSave: 'Pedir confirmação antes de salvar'
         },
         colors: {
             default: 'Padrão',
@@ -2749,7 +2738,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Mostra spazi',
             showTabs: 'Mostra schede',
             restoreStateOnReopen: 'Ripristina stato alla riapertura',
-            startInEditor: 'Avvia in editor',
             newFileDefaultMode: 'Nuovo file apre nell\'editor',
             showRecentFiles: 'Mostra file recenti',
             showTableOfContents: 'Mostra indice',
@@ -2777,7 +2765,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'File',
             fileSettings: 'Impostazioni file',
             autoSave: 'Salvataggio automatico delle modifiche',
-            confirmBeforeSave: 'Chiedi conferma prima di salvare'
         },
         colors: {
             default: 'Predefinito',
@@ -2971,7 +2958,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Pokaż białe znaki',
             showTabs: 'Pokaż karty',
             restoreStateOnReopen: 'Przywróć stan przy ponownym otwarciu',
-            startInEditor: 'Startuj w edytorze',
             newFileDefaultMode: 'Nowy plik otwiera się w edytorze',
             showRecentFiles: 'Pokaż ostatnie pliki',
             showTableOfContents: 'Pokaż spis treści',
@@ -3009,7 +2995,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'Pliki',
             fileSettings: 'Ustawienia plików',
             autoSave: 'Autozapis zmian',
-            confirmBeforeSave: 'Pytaj o potwierdzenie przed zapisem'
         },
         colors: {
             default: 'Domyślny',
@@ -3211,7 +3196,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Toon witruimte',
             showTabs: 'Toon tabbladen',
             restoreStateOnReopen: 'Herstel status bij heropenen',
-            startInEditor: 'Start in editor',
             newFileDefaultMode: 'Nieuw bestand opent in editor',
             showRecentFiles: 'Toon recente bestanden',
             showTableOfContents: 'Toon inhoudsopgave',
@@ -3239,7 +3223,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'Bestanden',
             fileSettings: 'Bestandsinstellingen',
             autoSave: 'Wijzigingen automatisch opslaan',
-            confirmBeforeSave: 'Bevestiging vragen voor opslaan'
         },
         colors: {
             default: 'Standaard',
@@ -3431,7 +3414,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Visa blanksteg',
             showTabs: 'Visa flikar',
             restoreStateOnReopen: 'Återställ tillstånd vid återöppning',
-            startInEditor: 'Starta i redigerare',
             newFileDefaultMode: 'Ny fil öppnas i redigeraren',
             showRecentFiles: 'Visa senaste filer',
             showTableOfContents: 'Visa innehållsförteckning',
@@ -3459,7 +3441,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'Filer',
             fileSettings: 'Filinställningar',
             autoSave: 'Spara ändringar automatiskt',
-            confirmBeforeSave: 'Fråga om bekräftelse innan sparande'
         },
         colors: {
             default: 'Standard',
@@ -3651,7 +3632,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Hiển thị khoảng trắng',
             showTabs: 'Hiển thị tab',
             restoreStateOnReopen: 'Khôi phục trạng thái khi mở lại',
-            startInEditor: 'Bắt đầu trong trình chỉnh sửa',
             newFileDefaultMode: 'Tệp mới mở trong trình chỉnh sửa',
             showRecentFiles: 'Hiển thị tệp gần đây',
             showTableOfContents: 'Hiển thị mục lục',
@@ -3679,7 +3659,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'Tệp',
             fileSettings: 'Cài đặt tệp',
             autoSave: 'Tự động lưu chỉnh sửa',
-            confirmBeforeSave: 'Hỏi xác nhận trước khi lưu'
         },
         colors: {
             default: 'Mặc định',
@@ -3871,7 +3850,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Mostrar espaços em branco',
             showTabs: 'Mostrar separadores',
             restoreStateOnReopen: 'Restaurar estado ao reabrir',
-            startInEditor: 'Iniciar no editor',
             newFileDefaultMode: 'Novo ficheiro abre no editor',
             showRecentFiles: 'Mostrar ficheiros recentes',
             showTableOfContents: 'Mostrar índice',
@@ -3899,7 +3877,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'Ficheiros',
             fileSettings: 'Definições de ficheiros',
             autoSave: 'Guardar edições automaticamente',
-            confirmBeforeSave: 'Pedir confirmação antes de guardar'
         },
         colors: {
             default: 'Predefinição',
@@ -4091,7 +4068,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Afișare spații',
             showTabs: 'Afișare file',
             restoreStateOnReopen: 'Restaurare stare la redeschidere',
-            startInEditor: 'Pornire în editor',
             newFileDefaultMode: 'Fișier nou se deschide în editor',
             showRecentFiles: 'Afișare fișiere recente',
             showTableOfContents: 'Afișare cuprins',
@@ -4119,7 +4095,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'Fișiere',
             fileSettings: 'Setări fișiere',
             autoSave: 'Salvare automată a modificărilor',
-            confirmBeforeSave: 'Solicită confirmare înainte de salvare'
         },
         colors: {
             default: 'Implicit',
@@ -4311,7 +4286,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Szóközök megjelenítése',
             showTabs: 'Lapok megjelenítése',
             restoreStateOnReopen: 'Állapot visszaállítása újranyitáskor',
-            startInEditor: 'Indítás szerkesztőben',
             newFileDefaultMode: 'Új fájl megnyílik a szerkesztőben',
             showRecentFiles: 'Legutóbbi fájlok megjelenítése',
             showTableOfContents: 'Tartalomjegyzék megjelenítése',
@@ -4339,7 +4313,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'Fájlok',
             fileSettings: 'Fájlbeállítások',
             autoSave: 'Módosítások automatikus mentése',
-            confirmBeforeSave: 'Mentés előtt kérjen megerősítést'
         },
         colors: {
             default: 'Alapértelmezett',
@@ -4531,7 +4504,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Zobrazit mezery',
             showTabs: 'Zobrazit karty',
             restoreStateOnReopen: 'Obnovit stav při opětovném otevření',
-            startInEditor: 'Spustit v editoru',
             newFileDefaultMode: 'Nový soubor se otevře v editoru',
             showRecentFiles: 'Zobrazit nedávné soubory',
             showTableOfContents: 'Zobrazit obsah',
@@ -4559,7 +4531,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'Soubory',
             fileSettings: 'Nastavení souborů',
             autoSave: 'Automaticky ukládat úpravy',
-            confirmBeforeSave: 'Před uložením se zeptat na potvrzení'
         },
         colors: {
             default: 'Výchozí',
@@ -4757,7 +4728,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Zobraziť medzery',
             showTabs: 'Zobraziť karty',
             restoreStateOnReopen: 'Obnoviť stav pri opätovnom otvorení',
-            startInEditor: 'Spustiť v editore',
             newFileDefaultMode: 'Nový súbor sa otvorí v editore',
             showRecentFiles: 'Zobraziť nedávne súbory',
             showTableOfContents: 'Zobraziť obsah',
@@ -4785,7 +4755,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'Súbory',
             fileSettings: 'Nastavenia súborov',
             autoSave: 'Automaticky ukladať úpravy',
-            confirmBeforeSave: 'Pred uložením sa opýtať na potvrdenie'
         },
         colors: {
             default: 'Predvolené',
@@ -4977,7 +4946,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Εμφάνιση κενών',
             showTabs: 'Εμφάνιση καρτελών',
             restoreStateOnReopen: 'Επαναφορά κατάστασης κατά την επανεκκίνηση',
-            startInEditor: 'Έναρξη στον επεξεργαστή',
             newFileDefaultMode: 'Νέο αρχείο ανοίγει στον επεξεργαστή',
             showRecentFiles: 'Εμφάνιση πρόσφατων αρχείων',
             showTableOfContents: 'Εμφάνιση περιεχομένων',
@@ -5005,7 +4973,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'Αρχεία',
             fileSettings: 'Ρυθμίσεις αρχείων',
             autoSave: 'Αυτόματη αποθήκευση αλλαγών',
-            confirmBeforeSave: 'Ζήτηση επιβεβαίωσης πριν την αποθήκευση'
         },
         colors: {
             default: 'Προεπιλογή',
@@ -5197,7 +5164,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Näytä välilyönnit',
             showTabs: 'Näytä välilehdet',
             restoreStateOnReopen: 'Palauta tila uudelleen avattaessa',
-            startInEditor: 'Aloita editorissa',
             newFileDefaultMode: 'Uusi tiedosto avautuu editorissa',
             showRecentFiles: 'Näytä viimeisimmät tiedostot',
             showTableOfContents: 'Näytä sisällysluettelo',
@@ -5225,7 +5191,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'Tiedostot',
             fileSettings: 'Tiedostoasetukset',
             autoSave: 'Tallenna muutokset automaattisesti',
-            confirmBeforeSave: 'Pyydä vahvistus ennen tallennusta'
         },
         colors: {
             default: 'Oletus',
@@ -5417,7 +5382,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Vis mellemrum',
             showTabs: 'Vis faner',
             restoreStateOnReopen: 'Gendan tilstand ved genåbning',
-            startInEditor: 'Start i editor',
             newFileDefaultMode: 'Ny fil åpnes i redigeringsprogram',
             showRecentFiles: 'Vis seneste filer',
             showTableOfContents: 'Vis indholdsfortegnelse',
@@ -5445,7 +5409,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'Filer',
             fileSettings: 'Filindstillinger',
             autoSave: 'Gem ændringer automatisk',
-            confirmBeforeSave: 'Bed om bekræftelse før der gemmes'
         },
         colors: {
             default: 'Standard',
@@ -5637,7 +5600,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Vis mellomrom',
             showTabs: 'Vis faner',
             restoreStateOnReopen: 'Gjenopprett tilstand ved gjenåpning',
-            startInEditor: 'Start i redigeringsprogram',
             newFileDefaultMode: 'Ny fil åbnes i editor',
             showRecentFiles: 'Vis nylige filer',
             showTableOfContents: 'Vis innholdsfortegnelse',
@@ -5665,7 +5627,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'Filer',
             fileSettings: 'Filinnstillinger',
             autoSave: 'Lagre endringer automatisk',
-            confirmBeforeSave: 'Be om bekreftelse før lagring'
         },
         colors: {
             default: 'Standard',
@@ -5857,7 +5818,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Tampilkan Spasi',
             showTabs: 'Tampilkan Tab',
             restoreStateOnReopen: 'Pulihkan Status saat Dibuka Kembali',
-            startInEditor: 'Mulai di Editor',
             newFileDefaultMode: 'File baru terbuka di editor',
             showRecentFiles: 'Tampilkan File Terbaru',
             showTableOfContents: 'Tampilkan Daftar Isi',
@@ -5885,7 +5845,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'Berkas',
             fileSettings: 'Pengaturan berkas',
             autoSave: 'Simpan otomatis perubahan',
-            confirmBeforeSave: 'Minta konfirmasi sebelum menyimpan'
         },
         colors: {
             default: 'Default',
@@ -6077,7 +6036,6 @@ export const translations: Record<LanguageCode, Translation> = {
             showWhitespace: 'Boşlukları Göster',
             showTabs: 'Sekmeleri Göster',
             restoreStateOnReopen: 'Yeniden Açıldığında Durumu Geri Yükle',
-            startInEditor: 'Editörde Başlat',
             newFileDefaultMode: 'Yeni dosya editörde açılır',
             showRecentFiles: 'Son Dosyaları Göster',
             showTableOfContents: 'İçindekileri Göster',
@@ -6105,7 +6063,6 @@ export const translations: Record<LanguageCode, Translation> = {
             files: 'Dosyalar',
             fileSettings: 'Dosya ayarları',
             autoSave: 'Düzenlemeleri otomatik kaydet',
-            confirmBeforeSave: 'Kaydetmeden önce onay iste'
         },
         colors: {
             default: 'Varsayılan',

--- a/src/lib/utils/openFileMode.ts
+++ b/src/lib/utils/openFileMode.ts
@@ -1,0 +1,41 @@
+/**
+ * What an already-open document opens AS — the preference behind #183.
+ *
+ * One choice rather than two switches. `isEditing` and `isSplit` are
+ * independent flags on the tab, so a preference expressed as two booleans can
+ * say "editor AND split", which is not a state the reader can be in: split view
+ * wins the layout (`MarkdownViewer`'s pane flex reads `isSplit` first) and the
+ * editor flag would only decide where closing the split lands. The question the
+ * reader is actually answering has three answers, so it is stored as three.
+ *
+ * This does NOT cover a new empty document — `Ctrl+N` has its own preference
+ * (`newFileDefaultMode`), because "what should an empty buffer open as" and
+ * "what should a file I picked open as" are not the same question.
+ */
+export type OpenFileMode = 'preview' | 'editor' | 'split';
+
+export const DEFAULT_OPEN_FILE_MODE: OpenFileMode = 'preview';
+
+export function isOpenFileMode(value: unknown): value is OpenFileMode {
+	return value === 'preview' || value === 'editor' || value === 'split';
+}
+
+/**
+ * The stored preference, and what to do about the boolean it replaced.
+ *
+ * Until split view became a third answer this was `editor.startInEditor`, a
+ * checkbox. An upgrade must not change what anybody's app does, so a machine
+ * with no `editor.openFileMode` yet is asked the old question instead — `true`
+ * meant "editor", and its `false`/absent meant "preview", which is the default
+ * here. The old key is left where it is rather than migrated away: it costs
+ * nothing, and a user who rolls back to the previous version finds their
+ * setting still there.
+ *
+ * Read once. The first write of the new key ends the fallback, so a reader who
+ * later picks "preview" does not get "editor" back on the next launch.
+ */
+export function resolveOpenFileMode(stored: string | null, legacyStartInEditor: string | null): OpenFileMode {
+	if (stored !== null) return isOpenFileMode(stored) ? stored : DEFAULT_OPEN_FILE_MODE;
+
+	return legacyStartInEditor === 'true' ? 'editor' : DEFAULT_OPEN_FILE_MODE;
+}

--- a/src/lib/utils/tocFollow.ts
+++ b/src/lib/utils/tocFollow.ts
@@ -1,0 +1,44 @@
+/**
+ * Which outline entry the EDITOR is inside.
+ *
+ * The outline already follows the preview: `Toc.svelte` listens to the
+ * preview's scroll event and picks the last heading whose rendered box is above
+ * the top of the viewport. That mechanism needs a rendered box, so it has
+ * nothing to say while the reader is in the editor — in split view the preview
+ * scrolls along only when scroll sync is on, and in editor-only mode there is
+ * no preview scrolling at all, which is the half of #169 the reporter asked
+ * for ("while scrolling through the editor or preview").
+ *
+ * The editor's answer is a SOURCE LINE, which every outline entry already
+ * carries: `data-sourcepos` is on the rendered heading, and the outline is
+ * built from those elements. So the same question is answered here by
+ * comparison instead of by layout.
+ *
+ * Deliberately the same shape as the preview's rule, so the two cannot
+ * disagree while both are live: the last entry at or above the position, and
+ * the first entry when the position is above all of them.
+ */
+export type TocLineEntry = {
+	id: string;
+	/** `null` for an entry the renderer gave no source range (a block anchor). */
+	line: number | null;
+};
+
+export function activeTocIdForLine(entries: readonly TocLineEntry[], line: number): string | null {
+	if (!Number.isFinite(line) || entries.length === 0) return null;
+
+	// Above the first heading the first entry is the active one — what the
+	// preview's handler does with `visibleItems[0]` before its loop.
+	let active: string | null = entries[0].id;
+	for (const entry of entries) {
+		if (entry.line !== null && entry.line <= line) active = entry.id;
+	}
+
+	return active;
+}
+
+/** The start line of a rendered block, from the `data-sourcepos` comrak wrote. */
+export function sourceLineOf(sourcepos: string | null | undefined): number | null {
+	const line = Number(sourcepos?.match(/^(\d+):/)?.[1]);
+	return Number.isInteger(line) && line > 0 ? line : null;
+}


### PR DESCRIPTION
Closes #169. Closes #183. Plus the three more instances of the same defect that looking for those two turned up.

### #169 — the outline follows the preview, and only the preview

`Toc.svelte` decides which heading is current by rendered box: it asks each heading element where it is on screen. That question has no answer while the **editor** is the pane being scrolled — in editor-only mode the preview never scrolls, and in split view it moves only while scroll sync is on — so the outline sat still, which is what the reporter described.

The editor's position is a source line, and every outline entry already has one (`data-sourcepos` on the rendered heading), so the same question is answered by comparison instead. Deliberately the same rule as the preview's — the last entry at or above the position, the first entry when above all of them — because both are live in split view with sync on, and a disagreement would show as the highlight flickering as the panes settle.

Behind **Table of Contents Follows Editor Scrolling**, off by default.

### #183 — one choice, not a second checkbox

Every newly opened document was created `isSplit: false`, so a reader who works in split view pressed the button again for every file. Session restore already replayed each tab's saved `isSplit`; what was missing was the preference.

It is **one** preference with three answers rather than a switch beside "Start in Editor", because `isEditing` and `isSplit` are independent flags on the tab: two booleans can say "editor AND split", which is not a state the reader can be in — split wins the layout and the editor flag would only decide where closing the split lands.

```
打开已有文件时 / Open existing files in   [ Preview | Editor | Split View ]
```

`editor.openFileMode` is a new key. An install without it is asked the old question — `editor.startInEditor === 'true'` → Editor — so **the upgrade changes nobody's behaviour**. The old key is read, never written, so a rollback finds it where it was, and it stops being consulted the moment the new key exists (otherwise picking "Preview" would be undone on the next launch).

Split is applied through `setSplitEnabled`, not by assigning the flag: a fresh tab is created `isScrollSynced: false`, and that function is where the remembered scroll-sync preference is applied. Both are applied *before* `initialIsSplit` is read, so a document opening into an editable mode takes the full-read branch — `open_markdown_preview` returns the first 50KB, a split pane is an editor, and an editor bound to a partial buffer is one keystroke from auto-saving the truncation back over the file.

### The same defect, three more times

Looking for the seam in #183 — a preference that can express a state the app cannot be in — found three more in the same panel.

**Auto-save.** Two switches, four combinations, two behaviours:

| Auto-save edits | Ask for confirmation before saving | What actually happened |
|---|---|---|
| ✓ | ✗ | saves silently (default) |
| ✓ | **✓** | **does not auto-save**; closing asks |
| ✗ | ✗ | does not auto-save; closing asks |
| ✗ | ✓ | identical to the row above |

Every decision in the app read `settings.autoSave && !settings.confirmBeforeSave` — the debounce, the flush when leaving an editable pane, the close-the-window walk, `canCloseTab`. There was no fifth reading and no site that read the second flag alone. So one row showed auto-save on while nothing was auto-saved, and the switch never touched Cmd+S, which is the one thing "before saving" leads a reader to expect.

One switch now. `editor.autoSaveEdits` resolves an install that predates it through that same expression, so each of the four old combinations keeps the behaviour it already produced.

**Wrap Column** is handed to Monaco as `wordWrapColumn`, which Monaco reads in one of the three Word Wrap modes and ignores in the other two. It sat *above* that select and was always editable. Moved under it, and inert without it.

**Word Count** renders inside the status bar. With the status bar off, turning it on shows nothing at all. Gated on it.

**Restore State on Reopen** also decides whether resolved tabs stay open when a window closes — not something its name leads anyone to expect. Said so, in a caption, without changing the behaviour.

An inactive control is **dimmed, not hidden**: hiding it answers "where did that setting go?" with nothing, and gives no clue which control switched it off. The rule the tests pin is that the prerequisite is always the row directly above.

### Labels

`Start in Editor` was the English for a preference about opening a file, not about starting the app, and its translations inherited that. It is now `Open existing files in`. Its neighbour `New file opens in editor` is about `Ctrl+N` and is untouched — the two were easy to confuse in Chinese, so that one's translation now says 新建 explicitly.

Option labels reuse `settings.preview` / `settings.editor` / `menu.splitView`, which all 26 locales already carry; only the row's own label is new. The two replaced keys are removed from every locale, which is what `i18nCoverage` requires.

### Tests

`scripts/openFileMode.test.ts`, `scripts/settingsSemantics.test.ts`, `scripts/tocFollowsEditor.test.ts` — 27 between them. The migrations are pure functions specifically so the table above can be asserted row by row rather than described.

`viewModeWithoutSaving.test.ts` loses one case: it covered `confirm-before-save no longer turns a view toggle into a question`, and with the setting gone it is the same assertion as the auto-save-off case directly above it.

### Verification

`npm run check` (0 errors), `npm test` (814 passing).

What the tests cannot reach is the part of #169 that is layout: whether the outline's highlight really tracks the editor on screen. `activeTocIdForLine` is asserted directly and the wiring by source, but the behaviour itself has been exercised only in a dev build by hand, not measured — the same limit `scrollSyncBlockMapping.test.ts` names for the mapping it covers.
