### PR TITLE
feat(editor): offer this document's headings as link targets

### DIFF
--- a/scripts/headingLinkCompletion.test.ts
+++ b/scripts/headingLinkCompletion.test.ts
@@ -1,0 +1,106 @@
+/**
+ * #200: "implement some function which slugify titles and purpose those as
+ * #targets for URL of link".
+ *
+ * Half of it already worked — comrak renders an `id` onto every heading and
+ * `[…](#that-id)` jumps to it — but nothing offered the ids, so writing one
+ * meant doing comrak's anchorizer by hand: lowercase, drop the punctuation it
+ * drops, hyphenate the spaces, and remember that a repeated heading is
+ * numbered. Getting it wrong produces a link that looks right and lands
+ * nowhere.
+ *
+ * The list comes from Rust, from the renderer's own parse and anchorizer
+ * (`heading_anchors`, pinned against the rendered `id=` attributes in
+ * `lib.rs`). What is asserted here is the other half: WHERE a heading is the
+ * answer, and what gets written when it is — the two link syntaxes take
+ * different text, which is the part that is easy to get backwards.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readSource } from './sourceTree.js';
+
+import { headingLinkContext, headingQueryStart } from '../src/lib/utils/headingCompletion.js';
+
+const editorSource = readSource(new URL('../src/lib/components/Editor.svelte', import.meta.url));
+const rustSource = readSource(new URL('../src-tauri/src/lib.rs', import.meta.url));
+
+test('an inline link destination after # wants the slug', () => {
+	assert.equal(headingLinkContext('See [the diagrams](#'), 'slug');
+	assert.equal(headingLinkContext('See [the diagrams](#mer'), 'slug');
+	assert.equal(headingLinkContext('![alt](#'), 'slug');
+});
+
+test('a wikilink to this document wants the heading as it reads', () => {
+	assert.equal(headingLinkContext('[[#'), 'wikilink');
+	assert.equal(headingLinkContext('[[#11. Mer'), 'wikilink');
+});
+
+test('a wikilink into another file is not this document\'s question', () => {
+	// Those are that file's headings, and this buffer does not have them.
+	// Offering these would be worse than offering nothing.
+	assert.equal(headingLinkContext('[[notes#'), null);
+	assert.equal(headingLinkContext('[[notes.md#Setup'), null);
+	// Past the pipe is the alias, which is prose.
+	assert.equal(headingLinkContext('[[#Setup|jump to '), null);
+});
+
+test('a finished destination, and prose that merely contains #, are not contexts', () => {
+	assert.equal(headingLinkContext('[the diagrams](#mermaid) and then'), null);
+	assert.equal(headingLinkContext('[the diagrams](#mermaid diagrams'), null, 'a space ends it');
+	assert.equal(headingLinkContext('issue #200 is about'), null);
+	assert.equal(headingLinkContext('# A heading being typed'), null);
+	assert.equal(headingLinkContext('[a file link](./notes'), null, 'that is the path completion');
+});
+
+test('the suggestion replaces what was typed after the #, not the # itself', () => {
+	const prefix = 'See [the diagrams](#mer';
+	assert.equal(headingQueryStart(prefix), prefix.indexOf('#') + 1);
+	assert.equal(prefix.slice(headingQueryStart(prefix)), 'mer');
+});
+
+/* ---------------------------------------------------------------- wiring */
+
+test('the heading context is asked before the path context, which shares its prefix', () => {
+	// `](#` also satisfies the embed test — `/!?\[.*\]\($/` matches everything
+	// up to the paren. Asking for files first would answer a `#` with a list of
+	// filenames.
+	const heading = editorSource.indexOf('const headingContext = headingLinkContext(prefix)');
+	const embed = editorSource.indexOf('const isEmbedContext =');
+	assert.ok(heading > 0 && embed > 0);
+	assert.ok(heading < embed);
+	// And `#` has to open the dropdown, or the reader types it and nothing
+	// happens until the next character.
+	assert.match(editorSource, /triggerCharacters: \["\(", "\/", "\\\\", '"', "#"\]/);
+});
+
+test('each context writes the text its own syntax resolves', () => {
+	assert.match(
+		editorSource,
+		/insertText:\s*\n?\s*headingContext === "slug" \? anchor\.slug : anchor\.text/,
+	);
+	// Labelled by the heading, so typing a word of it finds the entry whatever
+	// the slug turned that word into.
+	assert.match(editorSource, /label: anchor\.text/);
+	assert.match(editorSource, /detail: `#\$\{anchor\.slug\}`/);
+});
+
+test('the list is read from Rust, and re-read only when the buffer changes', () => {
+	// A second anchorizer written in TypeScript would drift from comrak's
+	// without anything failing — the links would simply stop landing.
+	assert.match(editorSource, /invoke\("list_heading_anchors", \{\s*\n?\s*markdown: model\.getValue\(\),/);
+	assert.match(rustSource, /async fn list_heading_anchors\(markdown: String\)/);
+	// Completion fires per keystroke while the dropdown is open; the headings
+	// cannot have moved between two keystrokes of one edit.
+	assert.match(editorSource, /if \(anchorCache\?\.version === version\) return anchorCache\.anchors;/);
+});
+
+test('the Rust side numbers repeated headings the way the renderer does', () => {
+	// One anchorizer for the document, not one per heading: a second
+	// "Objectives" is `objectives-1`, and offering the bare slug for it would
+	// link to the first section. `heading_anchor_id` stays fresh per lookup on
+	// purpose — that one answers a wikilink, which names a heading by text.
+	assert.match(rustSource, /let mut anchorizer = Anchorizer::new\(\);[\s\S]{0,900}?anchorizer\.anchorize\(text\.trim\(\)\)/);
+	assert.match(rustSource, /fn heading_anchor_id\(target: &str\) -> String \{\s*\n\s*Anchorizer::new\(\)/);
+});

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
-use comrak::{markdown_to_html, Anchorizer, Options};
+use comrak::nodes::NodeValue;
+use comrak::{markdown_to_html, parse_document, Anchorizer, Arena, Options};
 use regex::{Captures, Regex};
 use std::borrow::Cow;
 use std::fs;
@@ -372,6 +373,31 @@ fn escape_html_attribute(value: &str) -> String {
         }
     }
     escaped
+}
+
+/// The comrak configuration the preview is rendered with.
+///
+/// Extracted because a second reader of the document — `heading_anchors`, for
+/// the editor's link completion — has to parse it the same way the renderer
+/// does, or it reports ids for headings the renderer never made and misses the
+/// ones it did.
+fn markdown_options<'a>() -> Options<'a> {
+    let mut options = Options::default();
+    options.extension.strikethrough = true;
+    options.extension.table = true;
+    options.extension.autolink = true;
+    options.extension.tasklist = true;
+    options.extension.superscript = false;
+    options.extension.footnotes = true;
+    options.extension.description_lists = true;
+    // `header_ids` in 0.18; the option only ever set the *prefix* prepended to
+    // the anchorized heading text, and 0.52 renamed it to say so. `Some("")`
+    // means "ids on, no prefix" in both spellings.
+    options.extension.header_id_prefix = Some(String::new());
+    options.render.r#unsafe = true;
+    options.render.hardbreaks = true;
+    options.render.sourcepos = true;
+    options
 }
 
 /// The anchor id comrak assigns to a heading with this text. We call comrak's
@@ -1584,21 +1610,7 @@ fn convert_markdown(content: &str) -> String {
     let processed_links = process_wikilinks(&processed_embeds);
     let masked_math = mask_math_spans(&processed_links);
 
-    let mut options = Options::default();
-    options.extension.strikethrough = true;
-    options.extension.table = true;
-    options.extension.autolink = true;
-    options.extension.tasklist = true;
-    options.extension.superscript = false;
-    options.extension.footnotes = true;
-    options.extension.description_lists = true;
-    // `header_ids` in 0.18; the option only ever set the *prefix* prepended to
-    // the anchorized heading text, and 0.52 renamed it to say so. `Some("")`
-    // means "ids on, no prefix" in both spellings.
-    options.extension.header_id_prefix = Some(String::new());
-    options.render.r#unsafe = true;
-    options.render.hardbreaks = true;
-    options.render.sourcepos = true;
+    let options = markdown_options();
 
     let html = markdown_to_html(&masked_math.text, &options);
     annotate_task_checkboxes(restore_math_spans(&html, &masked_math), raw_buffer)
@@ -1753,6 +1765,144 @@ async fn open_markdown_preview(
     })
     .await
     .unwrap_or_else(|e| Err(e.to_string()))
+}
+
+/// A heading, and the id a link has to name to reach it.
+#[derive(serde::Serialize)]
+struct HeadingAnchor {
+    /// 1-based line in the buffer the caller passed, for ordering the list.
+    line: u32,
+    level: u8,
+    /// What the heading reads as — the completion's label, and what a
+    /// `[[#…]]` wikilink is written with.
+    text: String,
+    /// What `[…](#…)` has to say. This is the id comrak renders, duplicates
+    /// included: a second "Objectives" is `objectives-1`, and offering the
+    /// bare slug for it would link to the first one.
+    slug: String,
+}
+
+/// Every heading in `markdown`, with the anchor comrak gives it.
+///
+/// Parsed rather than scanned for `#`, because a `# comment` inside a fenced
+/// code block is not a heading and this document is full of shell examples.
+/// The parse uses `markdown_options()` — the renderer's own configuration —
+/// so what comes back is what is actually on screen.
+///
+/// ONE anchorizer for the whole document, not one per heading. comrak numbers
+/// repeated headings (`objectives`, `objectives-1`, …) and this list has to
+/// carry the same numbering or completion hands the reader a link to the wrong
+/// section. That is the opposite of `heading_anchor_id`, which is deliberately
+/// fresh per lookup: a wikilink names a heading by TEXT, and text can only
+/// ever address the first heading that reads that way.
+///
+/// The SAME preprocessing the renderer runs, for the same reason: comrak never
+/// sees the buffer. `[[note#Setup]]` is a link by the time it is parsed, so the
+/// heading reads "note > Setup" and is anchorized as such; parsing the raw
+/// buffer instead reports an id for a heading that was never rendered. The
+/// steps are line-preserving (`line_preserving_transforms`), so the sourcepos
+/// numbers still address the caller's buffer.
+///
+/// Math is masked before the parse and comes back after it. Its token is put
+/// back as the source it stands for, which is what the renderer's own
+/// `restore_math_spans` writes into an anchor — and the two agree because
+/// anchorizing is a per-character map with no collapsing, so doing it to the
+/// pieces and doing it to the whole give the same string.
+fn heading_anchors(markdown: &str) -> Vec<HeadingAnchor> {
+    let autolinks = process_parenthesized_autolinks(markdown);
+    let embeds = process_internal_embeds(&autolinks);
+    let preprocessed = process_wikilinks(&embeds);
+    let masked = mask_math_spans(&preprocessed);
+
+    let arena = Arena::new();
+    let options = markdown_options();
+    let root = parse_document(&arena, &masked.text, &options);
+    let mut anchorizer = Anchorizer::new();
+    let mut anchors = Vec::new();
+
+    for node in root.descendants() {
+        let (level, line) = {
+            let data = node.data.borrow();
+            match data.value {
+                NodeValue::Heading(heading) => (heading.level, data.sourcepos.start.line),
+                _ => continue,
+            }
+        };
+
+        let text = unmask_math_text(&collect_inline_text(node), &masked);
+        if text.trim().is_empty() {
+            continue;
+        }
+
+        anchors.push(HeadingAnchor {
+            line: line as u32,
+            level,
+            slug: anchorizer.anchorize(text.trim()),
+            text: text.trim().to_owned(),
+        });
+    }
+
+    anchors
+}
+
+/// The text a heading reads as, which is what comrak anchorizes: the literals
+/// of its inline children, with the emphasis and link markup dropped.
+fn collect_inline_text<'a>(node: &'a comrak::nodes::AstNode<'a>) -> String {
+    let mut text = String::new();
+    for descendant in node.descendants() {
+        match &descendant.data.borrow().value {
+            NodeValue::Text(literal) => text.push_str(literal),
+            NodeValue::Code(code) => text.push_str(&code.literal),
+            _ => {}
+        }
+    }
+    text
+}
+
+/// Puts masked math back into a piece of *text*, which is the spelling a text
+/// node gets. The rendered anchor is built from the same source
+/// (`restore_math_spans`, its `anchored` branch), so anchorizing this gives
+/// the id that is on the heading.
+fn unmask_math_text(text: &str, masked: &MaskedMath) -> String {
+    if masked.spans.is_empty() {
+        return text.to_owned();
+    }
+
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(at) = rest.find(masked.prefix.as_str()) {
+        out.push_str(&rest[..at]);
+        let after = &rest[at + masked.prefix.len()..];
+        let digits = after
+            .as_bytes()
+            .iter()
+            .take_while(|byte| byte.is_ascii_digit())
+            .count();
+        let index = if digits > 0 && after[digits..].starts_with(MATH_MASK_SUFFIX) {
+            after[..digits].parse::<usize>().ok()
+        } else {
+            None
+        };
+        match index.and_then(|index| masked.spans.get(index)) {
+            Some(span) => {
+                out.push_str(&span.text);
+                rest = &after[digits + MATH_MASK_SUFFIX.len_utf8()..];
+            }
+            None => {
+                out.push_str(&rest[at..at + masked.prefix.len()]);
+                rest = after;
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+#[tauri::command]
+async fn list_heading_anchors(markdown: String) -> Result<Vec<HeadingAnchor>, String> {
+    tauri::async_runtime::spawn_blocking(move || Ok(heading_anchors(&markdown)))
+        .await
+        .unwrap_or_else(|e| Err(e.to_string()))
 }
 
 #[tauri::command]
@@ -2722,6 +2872,7 @@ pub fn run() {
             open_markdown,
             open_markdown_preview,
             render_markdown,
+            list_heading_anchors,
             window_runtime::send_markdown_path,
             read_file_content_checked,
             canonicalize_path,
@@ -4073,6 +4224,122 @@ mod tests {
         }
     }
 
+    /// The list the editor completes from has to name the ids that are on
+    /// screen. Rendering the same document and reading its `id=` attributes
+    /// back is the only check that cannot drift from comrak with it.
+    #[test]
+    fn heading_anchors_are_the_ids_the_renderer_writes() {
+        let markdown = concat!(
+            "# 11. Mermaid Diagrams\n\n",
+            "Prose.\n\n",
+            "## Objectives\n\n",
+            "Prose.\n\n",
+            "## Objectives\n\n",
+            "Setext heading\n",
+            "---\n\n",
+            "## A **bold** word and `code`\n\n",
+            "## 1. 概述\n\n",
+            "```bash\n",
+            "# not a heading, a shell comment\n",
+            "```\n",
+        );
+
+        let anchors = heading_anchors(markdown);
+        let texts: Vec<&str> = anchors.iter().map(|a| a.text.as_str()).collect();
+        assert_eq!(
+            texts,
+            vec![
+                "11. Mermaid Diagrams",
+                "Objectives",
+                "Objectives",
+                "Setext heading",
+                "A bold word and code",
+                "1. 概述",
+            ],
+            "a fenced `#` line is not a heading, and setext headings are",
+        );
+
+        let html = convert_markdown(markdown);
+        for anchor in &anchors {
+            assert!(
+                html.contains(&format!("id=\"{}\"", anchor.slug)),
+                "id {:?} for heading {:?} is not in the rendered document: {html}",
+                anchor.slug,
+                anchor.text,
+            );
+        }
+
+        // The repeated heading is numbered, or completion would offer one link
+        // for two sections and silently reach only the first.
+        let objectives: Vec<&str> = anchors
+            .iter()
+            .filter(|a| a.text == "Objectives")
+            .map(|a| a.slug.as_str())
+            .collect();
+        assert_eq!(objectives, vec!["objectives", "objectives-1"]);
+
+        // And the line numbers are the buffer's, so the list can be ordered
+        // and a completion can say where it points.
+        assert_eq!(anchors[0].line, 1);
+        assert_eq!(anchors[0].level, 1);
+        assert_eq!(anchors[1].level, 2);
+    }
+
+    /// comrak never sees the buffer: four preprocessing steps run first, and
+    /// two of them rewrite what a heading READS as. A completion list built
+    /// from the raw text reports ids for headings that were never rendered.
+    /// Measured, before this was fixed:
+    ///
+    ///     ## Wiki [[note#Setup]] here   rendered wiki-note--setup-here
+    ///                                   raw      wiki-notesetup-here
+    ///     ## See $[a](b)$ inline        rendered see-ab-inline
+    ///                                   raw      see-a-inline
+    ///
+    /// Every case is checked against the id the renderer actually wrote, so
+    /// this cannot drift with a change to the preprocessing chain.
+    #[test]
+    fn heading_anchors_match_the_renderer_through_every_preprocessing_step() {
+        for markdown in [
+            // Math: masked before the parse, restored after it.
+            "## A heading with $x_1$\n",
+            "## 关于 $x_1$ 的说明\n",
+            "## Solve $x + 1 = 2$ now\n",
+            "## $$E = mc^2$$\n",
+            "## Escaped \\$5 and $y_2$\n",
+            // Math whose source looks like markup. The renderer anchorizes the
+            // source; parsing the buffer would see a link and take its text.
+            "## See $[a](b)$ inline\n",
+            "## Math $a*b*c$ here\n",
+            // A wikilink is a LINK by the time comrak parses it, and its text
+            // is the "Note > Heading" spelling `process_wikilinks` chose.
+            "## Wiki [[note#Setup]] here\n",
+            "## Wiki [[#Setup|jump]] here\n",
+            // Ordinary inline markup, which comrak strips for the id.
+            "## A [real link](https://x.dev) here\n",
+            "## Code `let x = 1;` here\n",
+            "## A **bold** and *italic* heading\n",
+        ] {
+            let html = convert_markdown(markdown);
+            let rendered = html
+                .split("id=\"")
+                .nth(1)
+                .and_then(|rest| rest.split('"').next())
+                .unwrap_or_default()
+                .to_owned();
+            let ours = heading_anchors(markdown)
+                .first()
+                .map(|anchor| anchor.slug.clone())
+                .unwrap_or_default();
+
+            assert!(!rendered.is_empty(), "no id rendered for {markdown:?}");
+            assert_eq!(
+                ours, rendered,
+                "completion would offer {ours:?} for {markdown:?}, but the \
+                 renderer wrote {rendered:?}",
+            );
+        }
+    }
+
     #[test]
     fn wikilink_targets_survive_punctuation_in_the_heading() {
         // "1. 概述" used to become "1.-概述" while comrak rendered "1-概述",
@@ -4623,10 +4890,14 @@ mod tests {
         // rather than a participant in it. `restore_math_spans` also runs on
         // the rendered HTML — it is the second half of `mask_math_spans`,
         // which *is* registered, and it never sees the source buffer.
+        // `markdown_options` returns the parser configuration and never
+        // touches the text at all; it is shared with `heading_anchors`, which
+        // has to parse the document the way the renderer does.
         let not_a_transform = [
             "markdown_to_html",
             "annotate_task_checkboxes",
             "restore_math_spans",
+            "markdown_options",
         ];
 
         let mut found: Vec<String> = call

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -8,6 +8,11 @@
 	import { getTabModel, tabModelUri } from '../utils/tabModels.js';
 	import { installVimScrollCommands } from '../utils/vimScrollCommands.js';
 	import {
+		headingLinkContext,
+		headingQueryStart,
+		type HeadingAnchor,
+	} from '../utils/headingCompletion.js';
+	import {
 		getLineAtVerticalOffset,
 		getScrollSyncPositionFromPixels,
 		getScrollTopForSyncPosition,
@@ -479,13 +484,75 @@
 
 		container.addEventListener("wheel", wheelListener, { capture: true });
 
-		const completionProvider = monaco.languages.registerCompletionItemProvider(
+		/**
+	 * This document's headings, from the Rust side that renders them.
+	 *
+	 * Cached on the model's version, which changes on every edit: a completion
+	 * fires per keystroke once the dropdown is open, and re-parsing a
+	 * 3,000-line document for each of them would be paid for nothing — the
+	 * headings cannot have moved between two keystrokes of the same edit.
+	 *
+	 * Asked of Rust rather than derived here: the ids come out of comrak's
+	 * anchorizer, and a second implementation in TypeScript would drift from
+	 * it silently, producing links that look right and land nowhere.
+	 */
+	let anchorCache: { version: number; anchors: HeadingAnchor[] } | null = null;
+
+	async function headingAnchors(model: Monaco.editor.ITextModel): Promise<HeadingAnchor[]> {
+		const version = model.getVersionId();
+		if (anchorCache?.version === version) return anchorCache.anchors;
+
+		try {
+			const anchors = (await invoke("list_heading_anchors", {
+				markdown: model.getValue(),
+			})) as HeadingAnchor[];
+			anchorCache = { version, anchors };
+			return anchors;
+		} catch {
+			return [];
+		}
+	}
+
+	const completionProvider = monaco.languages.registerCompletionItemProvider(
 			"markdown",
 			{
-				triggerCharacters: ["(", "/", "\\", '"'],
+				triggerCharacters: ["(", "/", "\\", '"', "#"],
 				provideCompletionItems: async (model, position) => {
 					const lineContent = model.getLineContent(position.lineNumber);
 					const prefix = lineContent.substring(0, position.column - 1);
+
+					// #200: this document's headings, as link targets. Asked
+					// first because `](#` is also the tail of the embed context
+					// below — once a `#` is typed the answer is headings, not
+					// files.
+					const headingContext = headingLinkContext(prefix);
+					if (headingContext) {
+						const anchors = await headingAnchors(model);
+						const range = new monaco.Range(
+							position.lineNumber,
+							headingQueryStart(prefix) + 1,
+							position.lineNumber,
+							position.column,
+						);
+
+						return {
+							suggestions: anchors.map((anchor, index) => ({
+								// Labelled by what it reads as, inserted as
+								// whatever that context needs. Monaco filters on
+								// the label, so typing "mermaid" finds
+								// "11. Mermaid Diagrams" and writes the slug.
+								label: anchor.text,
+								detail: `#${anchor.slug}`,
+								kind: monaco.languages.CompletionItemKind.Reference,
+								insertText:
+									headingContext === "slug" ? anchor.slug : anchor.text,
+								// Document order, not alphabetical: a heading's
+								// neighbours are what the writer is thinking in.
+								sortText: String(index).padStart(5, "0"),
+								range,
+							})),
+						};
+					}
 
 					const isEmbedContext = /(!?\[.*\]\(|<img.*src=["']|src=["'])$/.test(
 						prefix,

--- a/src/lib/utils/headingCompletion.ts
+++ b/src/lib/utils/headingCompletion.ts
@@ -1,0 +1,56 @@
+/**
+ * Where the editor should offer this document's headings as a link target.
+ *
+ * #200: "implement some function which slugify titles and purpose those as
+ * #targets for URL of link". The slugs exist — comrak renders an `id` onto
+ * every heading and `[…](#that-id)` already jumps to it — but nothing offered
+ * them, so writing one meant reading the heading, lowercasing it, dropping the
+ * punctuation comrak drops and hyphenating the spaces, by hand.
+ *
+ * Two syntaxes take a heading in this app, and they take DIFFERENT text:
+ *
+ *   [text](#11-mermaid-diagrams)     the slug — what the renderer wrote
+ *   [[#11. Mermaid Diagrams]]        the heading, which Rust anchorizes at
+ *                                    render time (`process_wikilinks`)
+ *
+ * So the context decides what a completion inserts, not just whether to offer
+ * one. Both are worth having: the wikilink spelling is what `Copy Reference`
+ * produces, so a reader who pastes one and then wants another writes it in
+ * that form.
+ */
+export type HeadingLinkContext = 'slug' | 'wikilink';
+
+/** One row of `list_heading_anchors`. Mirrors `HeadingAnchor` in `lib.rs`. */
+export type HeadingAnchor = {
+	line: number;
+	level: number;
+	text: string;
+	slug: string;
+};
+
+/**
+ * The text before the cursor, or `null` where headings are not the answer.
+ *
+ * `[[note#`, with a path before the `#`, is deliberately not a context: those
+ * are another file's headings and this buffer does not have them. Offering
+ * this document's would be worse than offering nothing.
+ */
+export function headingLinkContext(prefix: string): HeadingLinkContext | null {
+	// `](#…` — an inline link's destination, still being typed. A closing
+	// paren or whitespace means the destination is finished.
+	if (/\]\(#[^)\s]*$/.test(prefix)) return 'slug';
+
+	// `[[#…` — a wikilink to a heading of this document. `|` starts the alias
+	// half, which is prose, not a target.
+	if (/\[\[#[^\]|]*$/.test(prefix)) return 'wikilink';
+
+	return null;
+}
+
+/**
+ * What the user has typed since the `#`, which is what a suggestion replaces.
+ * `-1` when there is none to replace, which cannot happen for a context above.
+ */
+export function headingQueryStart(prefix: string): number {
+	return prefix.lastIndexOf('#') + 1;
+}


### PR DESCRIPTION
Closes #200 — @lolalalol asked for "some function which slugify titles and purpose those as #targets for URL of link".

Half of it already worked: comrak renders an `id` onto every heading, and `[…](#that-id)` jumps to it. What was missing is that nothing ever *offered* those ids, so writing one meant doing comrak's anchorizer by hand — lowercase it, drop the punctuation comrak drops, hyphenate the spaces, and remember that a repeated heading is numbered. Get it wrong and you have a link that looks right and lands nowhere.

### Two syntaxes, two different insertions

```
[text](#      →  suggestions insert the SLUG            11-mermaid-diagrams
[[#           →  suggestions insert the HEADING          11. Mermaid Diagrams
[[note#       →  nothing: those are another file's headings
```

Both are worth having — the wikilink spelling is what `Copy Reference` produces, so a reader who pastes one and then wants another writes it in that form. Entries are labelled by the heading and detailed with the slug, so typing "mermaid" finds `11. Mermaid Diagrams` whatever the slug turned that into, and they are sorted in document order rather than alphabetically: a heading's neighbours are what the writer is thinking in.

### The list comes from Rust, and that is the whole design

A second anchorizer written in TypeScript would drift from comrak's without anything failing — the links would simply stop landing. `list_heading_anchors` parses with `markdown_options()`, the renderer's own configuration, and anchorizes with comrak's `Anchorizer`.

Parsed, not scanned for `#`: `samples/stress-test-hard.md` is full of shell examples whose comments start with one.

Two consequences of taking the list from where the renderer takes it:

**One anchorizer for the document**, unlike `heading_anchor_id`, which is deliberately fresh per lookup. comrak numbers repeated headings, and the stress document has sixty `### Objectives` — offering the bare slug for the second would quietly link to the first. (A `[[#…]]` wikilink still cannot address the second; it names a heading by text. Pre-existing, not introduced here.)

**The same preprocessing chain.** comrak never sees the buffer — four steps run first, and two of them rewrite what a heading *reads* as. This is the part I got wrong first and only found by measuring: I had written a comment claiming inline math was the gap. Math was fine. These were not:

| heading | renderer wrote | parsing the raw buffer gives |
|---|---|---|
| `## Wiki [[note#Setup]] here` | `wiki-note--setup-here` | `wiki-notesetup-here` |
| `## See $[a](b)$ inline` | `see-ab-inline` | `see-a-inline` |

A wikilink is a *link* by the time comrak parses it, so the heading reads "note > Setup". Running the same chain fixes both, and the steps are line-preserving (`line_preserving_transforms`), so sourcepos still addresses the caller's buffer.

Math is masked before the parse and put back after it. That works for the id because anchorizing is a per-character map with no collapsing — `$x + 1 = 2$` becomes `x--1--2`, the double hyphens intact — so doing it to the pieces and doing it to the whole give the same string.

### Tests

`heading_anchors_match_the_renderer_through_every_preprocessing_step` renders each of twelve headings and asserts the slug against the `id=` the renderer actually wrote, rather than against a hand-written expectation. It cannot drift with a change to the chain. Falsified — parse the raw buffer instead and it fails with the real numbers:

```
✖ completion would offer "see-a-inline" for "## See $[a](b)$ inline",
  but the renderer wrote "see-ab-inline"
```

`scripts/headingLinkCompletion.test.ts` covers the other half: where a heading is the answer (and where it is not — a finished destination, an alias after `|`, prose that merely contains `#`), and that each context writes the text its own syntax resolves.

One guard test also fired during this work and was right to: `markdown_options()` is a new call inside `convert_markdown`, and the line-contract registry demands every call there be classified. It is registered as not-a-transform, with the reason.

### Cost

Completion fires per keystroke while the dropdown is open, so the anchor list is cached on the model's version id — the headings cannot have moved between two keystrokes of one edit.

### Verification

`npm run check` (0 errors), `npm test` (823 passing), `cargo test` (137 passing). Driven by hand over `samples/stress-test-hard.md` in both syntaxes.
