### PR TITLE
fix(drag-drop): answer every file dropped on the editor pane

### DIFF
--- a/scripts/fileDropRouting.test.ts
+++ b/scripts/fileDropRouting.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Where a dropped file goes, per pane.
+ *
+ * The app answers a drop in three ways, and the branch for the editor pane
+ * knew only one of them: it looked for an image extension and **silently
+ * discarded everything else**. So dragging a `.md` onto the editor did
+ * nothing at all — no tab, no toast, no clue — while the identical drop two
+ * inches to the right opened it. #175 asked for "drag multiple files, for each
+ * file open a new tab" and got it, as long as the pointer stayed off the
+ * editor.
+ *
+ * The decision now lives in `routeDroppedFile`, away from the window event
+ * this suite cannot emit, which is what makes the table below a test rather
+ * than a reading of the source. It was written the other way first: source
+ * assertions that still passed with the markdown branch disabled by a
+ * `false &&`. A check that cannot fail is worse than none, because it is
+ * counted.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readSource, sliceBetween } from './sourceTree.js';
+
+import {
+	DROPPABLE_IMAGE_EXTENSIONS,
+	routeDroppedFile,
+	type DropAction,
+	type DropPane,
+} from '../src/lib/utils/fileDrop.js';
+
+const viewerSource = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
+
+/** file, pane, what must happen. */
+const ROUTES: ReadonlyArray<[path: string, pane: DropPane, action: DropAction]> = [
+	// The report: a document opens, whichever pane is under the pointer.
+	['/notes/spec.md', 'editor', 'open'],
+	['/notes/spec.md', 'preview', 'open'],
+	['/notes/spec.markdown', 'editor', 'open'],
+	['/notes/spec.txt', 'editor', 'open'],
+	['C:\\notes\\spec.MD', 'editor', 'open'],
+
+	// An image goes into the text, and only where there is text.
+	['/notes/img/figure.png', 'editor', 'insert'],
+	['/notes/img/figure.SVG', 'editor', 'insert'],
+	['/notes/img/figure.png', 'preview', 'unsupported'],
+
+	// Everything else is reported rather than dropped on the floor.
+	['/notes/archive.zip', 'editor', 'unsupported'],
+	['/notes/archive.zip', 'preview', 'unsupported'],
+	['/notes/report.pdf', 'editor', 'unsupported'],
+	['/notes/no-extension', 'editor', 'unsupported'],
+];
+
+test('every file has an answer on both panes', () => {
+	for (const [path, pane, action] of ROUTES) {
+		assert.equal(routeDroppedFile(path, pane), action, `${path} on the ${pane}`);
+	}
+});
+
+test('nothing routes to silence', () => {
+	// The defect in one sentence: a path that matched no branch produced no
+	// action at all. There is no fourth answer to return now, and this is the
+	// assertion that says so.
+	const answers: DropAction[] = ['insert', 'open', 'unsupported'];
+	for (const pane of ['editor', 'preview'] as DropPane[]) {
+		for (const path of ['/a.md', '/a.png', '/a.zip', '/a', '/a.md.zip', '']) {
+			assert.ok(answers.includes(routeDroppedFile(path, pane)), `${path} on the ${pane}`);
+		}
+	}
+});
+
+test('the image list and the document list cannot overlap', () => {
+	// They are asked in order, so an extension in both would take whichever
+	// branch runs first rather than the one that suits it.
+	for (const extension of DROPPABLE_IMAGE_EXTENSIONS) {
+		assert.equal(routeDroppedFile(`/notes/figure.${extension}`, 'editor'), 'insert', extension);
+	}
+});
+
+test('the viewer routes both panes through it, and acts on all three answers', () => {
+	const dropHandler = sliceBetween(
+		viewerSource,
+		"} else if (event.payload.type === 'drop') {",
+		'isDragging = false;',
+	);
+
+	assert.match(dropHandler, /switch \(routeDroppedFile\(path, pane\)\)/);
+	assert.match(dropHandler, /case 'insert':[\s\S]{0,120}?handleDroppedFile\(path, x, y\)/);
+	assert.match(dropHandler, /case 'open':[\s\S]{0,80}?loadMarkdown\(path\)/);
+	assert.match(dropHandler, /case 'unsupported':[\s\S]{0,80}?reportUnsupportedDrop\(path\)/);
+	// One toast helper for both panes: the message used to be built inline in
+	// the preview branch, which is part of why the editor branch had nothing
+	// to say.
+	assert.match(
+		viewerSource,
+		/function reportUnsupportedDrop\(path: string\)[\s\S]{0,300}?t\('toast\.unsupportedFile'\)/,
+	);
+});

--- a/scripts/openShortcutInPreview.test.ts
+++ b/scripts/openShortcutInPreview.test.ts
@@ -1,0 +1,68 @@
+/**
+ * #153: "While in Preview Mode - Ctrl+O doesn't work on windows."
+ *
+ * It works now — the branch is in `handleKeyDown`, which is attached to
+ * `<svelte:document>` rather than to the editor, and it carries no mode
+ * condition. What it never had is anything holding it there. The comment on
+ * the fix cited a test file that does not exist, and grepping the suite for
+ * `selectFile` returned nothing, so the report's own scenario was resting on
+ * the absence of a guard nobody had written down.
+ *
+ * That is the failure mode this file exists for: a shortcut that lives in two
+ * layers. `Ctrl+T` already went wrong that way (#392) — Monaco answered it
+ * inside the editor and the document handler answered it outside, and the two
+ * meant different things. Ctrl+O is answered by both layers as well; what
+ * makes it correct rather than a second #392 is that both call the same
+ * function, and that is what the second test holds.
+ *
+ * `documentKeymap` fires real chords at the real transpiled handler with
+ * `isEditing: false` — the reporter's preview mode — and reports what ran.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { documentKeymap, editorKeymap, PLATFORMS } from './keymapHarness.js';
+import { readSource } from './sourceTree.js';
+
+const editorSource = readSource(new URL('../src/lib/components/Editor.svelte', import.meta.url));
+const viewerSource = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
+
+test('Ctrl/Cmd+O opens the file dialog while reading, on every platform', () => {
+	for (const platform of PLATFORMS) {
+		const chord = platform.mac ? 'Meta+O' : 'Ctrl+O';
+		assert.deepEqual(
+			documentKeymap(platform.osType).get(chord),
+			['selectFile'],
+			`${platform.name}: ${chord} must open a file from preview mode`,
+		);
+	}
+});
+
+test('the editor claims it too, and both layers do the same thing', () => {
+	// Monaco calls `stopPropagation()` on a keystroke it consumes, so inside
+	// the editor its own `file-open` answers and the document handler never
+	// runs. That is fine — and is the shape #392 got WRONG — only because the
+	// two answers are the same function: `file-open` runs `onopen`, and the
+	// viewer passes `selectFile` to it, which is what the document branch calls.
+	for (const platform of PLATFORMS) {
+		const chord = platform.mac ? 'Meta+O' : 'Ctrl+O';
+		const claimed = [...editorKeymap(platform.mac, platform.os)]
+			.filter(([, chords]) => chords.includes(chord))
+			.map(([actionId]) => actionId);
+
+		assert.deepEqual(claimed, ['file-open'], `${platform.name}: ${chord}`);
+	}
+
+	assert.match(editorSource, /id: "file-open",[\s\S]{0,200}?run: \(\) => onopen\?\.\(\)/);
+	assert.match(viewerSource, /onopen=\{selectFile\}/);
+});
+
+test('Shift and Alt do not reach it', () => {
+	// The branch tests `!e.shiftKey && !e.altKey`. Without that, chords the app
+	// has not defined would silently open a file dialog on top of whatever the
+	// user was actually doing.
+	for (const chord of ['Ctrl+Shift+O', 'Alt+Ctrl+O']) {
+		assert.equal(documentKeymap('windows').get(chord), undefined, chord);
+	}
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -36,6 +36,7 @@ import {
 	type RichContentLibraries,
 } from './utils/richContent.js';
 import { observeFoldLayout } from './utils/foldLayout.js';
+import { routeDroppedFile, type DropPane } from './utils/fileDrop.js';
 import {
 	findAnchorElement,
 	getAnchorScrollTop,
@@ -164,6 +165,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 
 	let isDragging = $state(false);
 	let dragTarget = $state<'editor' | 'preview' | null>(null);
+
+	function reportUnsupportedDrop(path: string) {
+		const filename = path.split(/[/\\]/).pop() || 'File';
+		addToast(t('toast.unsupportedFile').replace('{{filename}}', filename), 'error');
+	}
 	let editorPaneEl = $state<HTMLElement>();
 	let viewerPaneEl = $state<HTMLElement>();
 	let isProgrammaticScroll = false;
@@ -3006,20 +3012,29 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 						const paths = event.payload.paths;
 						const currentEditor = editorPane;
 						if (currentEditor) currentEditor.hideDragCaret();
-						if (dragTarget === 'editor' && currentEditor) {
+						// Both panes route through `routeDroppedFile`. The editor's
+						// branch used to look for an image and silently discard
+						// everything else, so a `.md` dropped there did nothing at
+						// all while the same drop on the preview opened it.
+						const pane: DropPane | null =
+							dragTarget === 'editor' && currentEditor
+								? 'editor'
+								: dragTarget === 'preview' || (!isSplit && !isEditing)
+									? 'preview'
+									: null;
+
+						if (pane) {
 							paths.forEach(path => {
-								const ext = path.split('.').pop()?.toLowerCase();
-								if (ext && ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg'].includes(ext)) {
-									currentEditor.handleDroppedFile(path, x, y);
-								}
-							});
-						} else if (dragTarget === 'preview' || (!isSplit && !isEditing)) {
-							paths.forEach(path => {
-								if (hasMarkdownLinkExtension(path)) {
-									loadMarkdown(path);
-								} else {
-									const filename = path.split(/[\/\\]/).pop() || 'File';
-									addToast(t('toast.unsupportedFile').replace('{{filename}}', filename), 'error');
+								switch (routeDroppedFile(path, pane)) {
+									case 'insert':
+										currentEditor?.handleDroppedFile(path, x, y);
+										break;
+									case 'open':
+										loadMarkdown(path);
+										break;
+									case 'unsupported':
+										reportUnsupportedDrop(path);
+										break;
 								}
 							});
 						}

--- a/src/lib/utils/fileDrop.ts
+++ b/src/lib/utils/fileDrop.ts
@@ -1,0 +1,49 @@
+/**
+ * What to do with a file dropped on a pane.
+ *
+ * The two panes used to decide this in two `if` chains inside the window-level
+ * drag-drop callback, and only one of them was complete: the editor's looked
+ * for an image extension and silently discarded everything else, so dropping a
+ * `.md` there did nothing at all while the identical drop on the preview
+ * opened it.
+ *
+ * A decision, extracted, is a decision that can be driven — the callback it
+ * came from is fed by a Tauri window event this suite cannot emit, so as long
+ * as the routing lived inside it, the only available check was reading the
+ * source and hoping.
+ */
+import { hasMarkdownLinkExtension } from './markdownLinks.js';
+
+/** The pane under the pointer, as the drag handler tracks it. */
+export type DropPane = 'editor' | 'preview';
+
+export type DropAction =
+	/** Insert a reference at the caret — the editor pane's own answer. */
+	| 'insert'
+	/** Open it, in a tab. What a document does wherever it lands. */
+	| 'open'
+	/** Nothing here can hold it; say so instead of dropping it on the floor. */
+	| 'unsupported';
+
+/**
+ * What `Editor.handleDroppedFile` can turn into a reference. Deliberately not
+ * "anything an `<img>` can display": each of these has a Markdown spelling the
+ * editor writes, and a file the editor cannot write is a file the reader
+ * should be told about rather than one that vanishes.
+ */
+export const DROPPABLE_IMAGE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg'];
+
+function isDroppableImage(path: string): boolean {
+	const extension = path.split('.').pop()?.toLowerCase();
+	return extension !== undefined && DROPPABLE_IMAGE_EXTENSIONS.includes(extension);
+}
+
+export function routeDroppedFile(path: string, pane: DropPane): DropAction {
+	// An image goes INTO the text, and only where there is text to go into.
+	// On the preview there is no caret, so it is reported rather than inserted.
+	if (pane === 'editor' && isDroppableImage(path)) return 'insert';
+
+	if (hasMarkdownLinkExtension(path)) return 'open';
+
+	return 'unsupported';
+}


### PR DESCRIPTION
Closes #153. Two small things found while sweeping the open issues, both of the same kind: behaviour nobody had written down, in one case working and in one case not.

### Dropping a `.md` on the editor did nothing

No tab, no toast, no clue. The branch for that pane looked for an image extension and silently discarded everything else, so the app's own drag-and-drop stopped working as soon as the pointer crossed into the editor — the identical drop two inches to the right opened the file. #175 asked for "drag multiple files, for each file open a new tab", and got it, as long as you avoided that pane.

| dropped | on the editor | on the preview |
|---|---|---|
| image | a reference at the caret (unchanged) | unsupported-file toast |
| `.md` / `.markdown` / `.txt` | **opens in a tab** | opens in a tab |
| anything else | **the toast** | the toast |

The decision moved into `routeDroppedFile` rather than staying as two `if` chains in the drop callback. That is not tidiness: the callback is fed by a Tauri window-level event this suite cannot emit, so **the first version of this fix asserted the source text — and those assertions still passed with the markdown branch disabled by a `false &&`.** A check that cannot fail is worse than none, because it gets counted. Now the table above is driven directly, and disabling that branch fails it.

### #153 — Ctrl+O in preview mode

It works, and has since v2.6.12. What it never had is anything holding it: the comment on that fix cites a test file which does not exist, and the suite had no occurrence of `selectFile` at all. So the reporter's own scenario rested on the absence of a guard nobody had written down.

`documentKeymap` fires the real chord at the real transpiled handler with `isEditing: false` — the reporter's mode — on all three platforms.

Writing it turned up something better than the guard I expected. Monaco binds Ctrl/Cmd+O as well, through its own `file-open` action, so **both layers answer this chord**. That is exactly the shape #392 got wrong, where Monaco and the document handler answered Ctrl+T with two different things. It is correct here only because both call `selectFile` — so that equality is what the test holds, rather than the absence of the second binding.

@luanfernandes, if you are still on this: it should work in preview mode on Windows. If it does not on your build, that is a different bug from the one this closes and I would like the details.

### Verification

`npm run check` (0 errors), `npm test` (821 passing). Both new files falsified — disable the branch each covers and it fails with the real difference.
