### PR TITLE
feat(markdown): accept ++inserted++, and copy a reference in the document's own spelling

### DIFF
--- a/scripts/copyReferenceStyle.test.ts
+++ b/scripts/copyReferenceStyle.test.ts
@@ -1,0 +1,137 @@
+/**
+ * "Copy Reference" writes the spelling the document is already written in.
+ *
+ * Markpad understands two ways to link a heading — `[[note#Setup]]`, which it
+ * rewrites before the parse, and `[Setup](note.md#setup)`, which every reader
+ * resolves — and this menu always produced the first. Which one is right
+ * depends on the person, not on the app: a vault full of `[[…]]` wants
+ * another one; a document written for GitHub wants a link that survives
+ * leaving Markpad.
+ *
+ * The document is the evidence, because a person's habit is already written
+ * down in the file they are working in. The inference has a floor: says
+ * nothing, or says both, and the answer is what the menu always produced. So
+ * it can be better than the old behaviour and never worse — which is the only
+ * reason inferring is defensible here at all.
+ *
+ * Known and accepted: a reference is usually pasted into a DIFFERENT document,
+ * so following this one is a guess about that one.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readSource } from './sourceTree.js';
+
+import {
+	DEFAULT_REFERENCE_STYLE,
+	headingReference,
+	preferredReferenceStyle,
+} from '../src/lib/utils/headingReference.js';
+
+const viewerSource = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
+
+/* ------------------------------------------------------ reading the document */
+
+test('a document that links one way gets another of the same', () => {
+	assert.equal(
+		preferredReferenceStyle('See [[Setup#Install]] for details.\n'),
+		'wikilink',
+	);
+	assert.equal(
+		preferredReferenceStyle('See [Install](setup.md#install) for details.\n'),
+		'inline',
+	);
+	// A same-document anchor counts as well — it is the same spelling.
+	assert.equal(preferredReferenceStyle('Back to [the top](#introduction).\n'), 'inline');
+	// And a bare note link, which the renderer leaves literal, still says what
+	// the writer's habit is.
+	assert.equal(preferredReferenceStyle('See [[Setup]].\n'), 'wikilink');
+});
+
+test('silence and disagreement both fall back to what the menu always did', () => {
+	assert.equal(DEFAULT_REFERENCE_STYLE, 'wikilink');
+	assert.equal(preferredReferenceStyle(''), DEFAULT_REFERENCE_STYLE);
+	assert.equal(preferredReferenceStyle('# A document\n\nWith no links at all.\n'), DEFAULT_REFERENCE_STYLE);
+	assert.equal(
+		preferredReferenceStyle('Both [[Setup#Install]] and [Install](setup.md#install).\n'),
+		DEFAULT_REFERENCE_STYLE,
+		'a document using both is not evidence of either',
+	);
+	// An ordinary link with no anchor is not evidence: every document has those.
+	assert.equal(preferredReferenceStyle('See [the site](https://example.com).\n'), DEFAULT_REFERENCE_STYLE);
+});
+
+test('a document ABOUT markdown does not vote with its examples', () => {
+	// `samples/stress-test-hard.md` and this project's own notes are full of
+	// both spellings inside fences. Counting those would make the syntax
+	// documentation the loudest voice in every vault.
+	const teaching = [
+		'# Linking',
+		'',
+		'```markdown',
+		'[[Setup#Install]]',
+		'```',
+		'',
+		'Prose with [an anchor](setup.md#install) in it.',
+		'',
+	].join('\n');
+
+	assert.equal(preferredReferenceStyle(teaching), 'inline', 'the fenced example must not count');
+
+	const tildeFenced = '~~~md\n[[Setup#Install]]\n~~~\n\nSee [x](a.md#b).\n';
+	assert.equal(preferredReferenceStyle(tildeFenced), 'inline', 'tilde fences too');
+});
+
+/* ------------------------------------------------------------ writing it out */
+
+test('each style is written the way its own resolver reads it', () => {
+	const heading = { text: 'Setup', slug: 'setup', fileName: 'notes.md' as string | null };
+
+	// The wikilink drops the extension — `process_wikilinks` appends `.md`
+	// itself — and names the heading by its TEXT.
+	assert.equal(headingReference({ ...heading, style: 'wikilink' }), '[[notes#Setup]]');
+	// The CommonMark form keeps it, because that is how the frontend claims a
+	// link for local navigation, and names the heading by its rendered id.
+	assert.equal(headingReference({ ...heading, style: 'inline' }), '[Setup](notes.md#setup)');
+});
+
+test('an unsaved document has no file to name', () => {
+	const heading = { text: 'Setup', slug: 'setup', fileName: null };
+	assert.equal(headingReference({ ...heading, style: 'wikilink' }), '#Setup');
+	assert.equal(headingReference({ ...heading, style: 'inline' }), '[Setup](#setup)');
+});
+
+test('the CommonMark form survives a filename with a space and a bracketed heading', () => {
+	// `[Setup](my notes.md#setup)` stops at the space; `[Notes [draft](…)` ends
+	// its label early. Neither can happen in the wikilink form, which is part
+	// of why this only applies to one of them.
+	assert.equal(
+		headingReference({ text: 'Setup', slug: 'setup', fileName: 'my notes.md', style: 'inline' }),
+		'[Setup](<my notes.md#setup>)',
+	);
+	assert.equal(
+		headingReference({ text: 'Notes [draft', slug: 'notes-draft', fileName: null, style: 'inline' }),
+		'[Notes \\[draft](#notes-draft)',
+	);
+});
+
+test('a repeated heading is addressable, because the slug comes from the render', () => {
+	// comrak numbers them; recomputing the id here would drift from that.
+	assert.equal(
+		headingReference({ text: 'Objectives', slug: 'objectives-1', fileName: 'n.md', style: 'inline' }),
+		'[Objectives](n.md#objectives-1)',
+	);
+});
+
+/* ---------------------------------------------------------------- the wiring */
+
+test('all three entries go through one helper, which reads the buffer', () => {
+	// The preview's heading menu, the outline's right-click, and the outline's
+	// context menu. All three built the string inline before, which is how they
+	// came to disagree about the filename in the first place.
+	assert.equal((viewerSource.match(/copyHeadingReference\(/g) ?? []).length, 4, 'one helper, three callers');
+	assert.match(viewerSource, /style: preferredReferenceStyle\(tab\?\.rawContent \?\? ''\)/);
+	// The id is taken off the rendered element rather than recomputed.
+	assert.match(viewerSource, /heading\.id \|\| heading\.querySelector\('a\.anchor'\)\?\.id/);
+});

--- a/scripts/wikilinkFileTargets.test.ts
+++ b/scripts/wikilinkFileTargets.test.ts
@@ -28,6 +28,7 @@ import {
 
 const rustSource = readSource(new URL('../src-tauri/src/lib.rs', import.meta.url));
 const viewerSource = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
+const referenceSource = readSource(new URL('../src/lib/utils/headingReference.ts', import.meta.url));
 
 // href values as produced by process_wikilinks() in src-tauri/src/lib.rs.
 // Only the heading-bearing forms appear: a wikilink with no `#` is
@@ -92,7 +93,19 @@ test('every wikilink Copy Reference builds carries the heading the rewriter need
 	// the basename — renaming `fn` broke it — and the count, so adding a fourth
 	// correct Copy Reference entry failed while replacing one of the three with a
 	// broken bare form still left three matches and passed.
-	const emitted = [...viewerSource.matchAll(/`\[\[[^`]*\]\]`/g)].map((match) => match[0]);
+	// The string moved: all three entries build it through `headingReference`,
+	// which picks the spelling the document is already written in (see
+	// `copyReferenceStyle.test.ts`). The contract this test exists for is
+	// unchanged — a wikilink Copy Reference writes always carries a `#`,
+	// because the rewriter leaves a bare `[[Notes]]` as literal text — so it
+	// is asserted where the string is now built.
+	// Code lines only: the doc comment above the function spells `[[…]]` out
+	// in prose, and prose is not something Copy Reference writes.
+	const code = referenceSource
+		.split('\n')
+		.filter((line) => !/^\s*(\*|\/\/)/.test(line))
+		.join('\n');
+	const emitted = [...code.matchAll(/`\[\[[^`]*\]\]`/g)].map((match) => match[0]);
 	assert.ok(emitted.length > 0, 'Copy Reference no longer builds a wikilink — has the format moved?');
 	for (const wikilink of emitted) {
 		assert.match(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -387,7 +387,33 @@ fn markdown_options<'a>() -> Options<'a> {
     options.extension.table = true;
     options.extension.autolink = true;
     options.extension.tasklist = true;
-    options.extension.superscript = false;
+    // `++ins++` — Pandoc's and CriticMarkup's spelling for inserted text, and
+    // plain characters here until now. It is the only one of its group worth
+    // taking, and the rule that decided the others is worth stating, because
+    // it is not "is this syntax popular":
+    //
+    //     Accept a dialect only where it cannot misread ORDINARY TEXT.
+    //
+    // Measured against this renderer, three failed that:
+    //
+    //   `subscript` (`~sub~`). GFM defines strikethrough as "one or two
+    //   tildes", so `~x~` is struck-through on GitHub and here. Subscripts
+    //   take that spelling away, and a valid GFM document starts rendering
+    //   differently in this app. `<sub>2</sub>` works in both places.
+    //
+    //   `superscript` (`^sup^`). Worse than taking a spelling — it takes
+    //   PROSE. Two carets in a paragraph pair up, so `a^2 + b^2 = c^2`, which
+    //   renders as written today both here and on GitHub, would become
+    //   `a<sup>2 + b</sup>2 = c^2`.
+    //
+    //   `spoiler` (`||text||`). `||` is also an empty table cell: with
+    //   spoilers on, `| 1 || 3 |` collapses into one cell reading "1 || 3".
+    //
+    // `++` passed: nothing else claims it, and `i++ then j++`, `C++ and C++`
+    // and a `+` list all come through untouched. See `syntax_coexistence`,
+    // `the_syntaxes_that_would_misread_ordinary_text` and
+    // `an_empty_table_cell_is_not_a_spoiler`.
+    options.extension.insert = true;
     options.extension.footnotes = true;
     options.extension.description_lists = true;
     // `header_ids` in 0.18; the option only ever set the *prefix* prepended to
@@ -4338,6 +4364,71 @@ mod tests {
                  renderer wrote {rendered:?}",
             );
         }
+    }
+
+    /// The spellings people actually write, and the ones they collide with.
+    ///
+    /// Every extension added here takes a character some other feature already
+    /// uses, so the question is never "does it work" but "what did it take
+    /// from". Each row was measured before being enabled; the `||` row is the
+    /// one that failed, which is why spoilers are off.
+    /// The three that were measured and left off, and the ordinary text each
+    /// would have misread. A test rather than a comment, so that turning one
+    /// on shows what it costs before the pull request is opened.
+    #[test]
+    fn the_syntaxes_that_would_misread_ordinary_text() {
+        // `~x~` is GFM strikethrough — one or two tildes — so a subscript
+        // extension takes a spelling GitHub already renders.
+        assert!(convert_markdown("H~2~O\n").contains("<del"));
+        assert!(convert_markdown("~struck~\n").contains("<del"));
+
+        // Two carets in a paragraph pair up. This sentence renders as written
+        // today, here and on GitHub, and a superscript extension would eat it.
+        let prose = convert_markdown("a^2 + b^2 = c^2\n");
+        assert!(prose.contains("a^2 + b^2 = c^2"), "got: {prose}");
+        assert!(!prose.contains("<sup"), "got: {prose}");
+
+        // `||` is an empty table cell — see the dedicated test for the row it
+        // would break.
+        assert!(!convert_markdown("||spoiler||\n").contains("class=\"spoiler\""));
+    }
+
+    #[test]
+    fn syntax_coexistence() {
+        let cases: &[(&str, &str, &str)] = &[
+            // The characters this group did NOT take, still meaning what they
+            // meant. See `markdown_options` for why.
+            ("~~gone~~", "<del", "strikethrough, unchanged"),
+            ("H~2~O", "<del", "a lone tilde is still GFM strikethrough"),
+            ("text^[a note]", "footnote-ref", "the inline footnote still owns `^[`"),
+            ("A paragraph. ^abc123", "block-id-anchor", "and a block id its own shape"),
+            // Inserted text against the `+` that starts a list.
+            ("++added++", "<ins", "inserted text"),
+            ("+ item one\n+ item two", "<ul", "a `+` list is still a list"),
+            // The false positives that would make prose unreadable.
+            ("I know C++ and also C++ well", "C++ and also C++", "C++ in prose is not inserted text"),
+            ("see ~/notes and ~/tmp", "~/notes and ~/tmp", "home paths are not subscripts"),
+            ("`H~2~O ^2^ ++y++`", "<code", "and none of it applies inside code"),
+        ];
+
+        for (markdown, expected, why) in cases {
+            let html = convert_markdown(&format!("{markdown}\n"));
+            assert!(html.contains(expected), "{why}: {markdown:?} produced {html}");
+        }
+    }
+
+    /// Why `options.extension.spoiler` is off.
+    ///
+    /// `||text||` is the spoiler spelling, and `| 1 || 3 |` is how an empty
+    /// table cell is written. With spoilers on, the row collapses into one cell
+    /// reading "1 || 3" — measured, which is why this is a test and not a
+    /// comment. Tables are core; spoilers are a Discord convention.
+    #[test]
+    fn an_empty_table_cell_is_not_a_spoiler() {
+        let html = convert_markdown("| a | b |\n|---|---|\n| 1 || 3 |\n");
+        assert!(html.contains("<td data-sourcepos=\"3:2-3:4\">1</td>"), "{html}");
+        assert!(!html.contains("1 || 3"), "the `||` was swallowed: {html}");
+        assert!(!html.contains("class=\"spoiler\""), "{html}");
     }
 
     #[test]

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -37,6 +37,7 @@ import {
 } from './utils/richContent.js';
 import { observeFoldLayout } from './utils/foldLayout.js';
 import { routeDroppedFile, type DropPane } from './utils/fileDrop.js';
+import { headingReference, preferredReferenceStyle } from './utils/headingReference.js';
 import {
 	findAnchorElement,
 	getAnchorScrollTop,
@@ -165,6 +166,23 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 
 	let isDragging = $state(false);
 	let dragTarget = $state<'editor' | 'preview' | null>(null);
+
+	/**
+	 * The reference for a heading of THIS document, in the spelling this
+	 * document is written in. See `headingReference.ts` — the inference falls
+	 * back to what the menu has always produced.
+	 */
+	function copyHeadingReference(text: string, slug: string) {
+		const tab = tabManager.activeTab;
+		const fileName = tab?.path ? tab.path.split(/[/\\]/).pop() || null : null;
+		const reference = headingReference({
+			text,
+			slug,
+			fileName,
+			style: preferredReferenceStyle(tab?.rawContent ?? ''),
+		});
+		invoke('clipboard_write_text', { text: reference });
+	}
 
 	function reportUnsupportedDrop(path: string) {
 		const filename = path.split(/[/\\]/).pop() || 'File';
@@ -2118,11 +2136,12 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		let copyRefItem: any[] = [];
 		if (heading) {
 			const text = heading.textContent?.trim() || '';
-			const tab = tabManager.activeTab;
-			const filename = tab?.path ? tab.path.split(/[/\\]/).pop()?.replace(/\.[^.]+$/, '') || '' : '';
-			const ref = filename ? `[[${filename}#${text}]]` : `#${text}`;
+			// The rendered id, straight off the element: comrak wrote it, and
+			// the outline reads it the same way — it can be on an anchor comrak
+			// nests inside the heading rather than on the heading itself.
+			const slug = heading.id || heading.querySelector('a.anchor')?.id || '';
 			copyRefItem = [
-				{ label: t('menu.copyReference', uiLanguage), onClick: () => invoke('clipboard_write_text', { text: ref }) },
+				{ label: t('menu.copyReference', uiLanguage), onClick: () => copyHeadingReference(text, slug) },
 				{ separator: true },
 			];
 		}
@@ -3464,7 +3483,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 										onBeforeJump={pushScrollHistory} 
 										{collapsedHeaders} 
 										ontoggleFold={toggleFold} 
-										oncopyref={(text: string) => { const tab = tabManager.activeTab; const fn = tab?.path ? tab.path.split(/[/\\]/).pop()?.replace(/\.[^.]+$/, '') || '' : ''; invoke('clipboard_write_text', { text: fn ? `[[${fn}#${text}]]` : `#${text}` }); }}
+										oncopyref={(text: string, slug: string) => copyHeadingReference(text, slug)}
 										onjump={(id: string, text: string, sourceLine: number | null) => {
 											if (isEditing && editorPane) {
 												editorPane.revealHeader(sourceLine, text);
@@ -3479,9 +3498,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 													{ 
 														label: t('menu.copyReference', uiLanguage),
 														onClick: () => {
-															const tab = tabManager.activeTab;
-															const fn = tab?.path ? tab.path.split(/[/\\]/).pop()?.replace(/\.[^.]+$/, '') || '' : '';
-															invoke('clipboard_write_text', { text: fn ? `[[${fn}#${item.text}]]` : `#${item.text}` });
+															copyHeadingReference(item.text, item.id);
 															docContextMenu.show = false;
 														} 
 													}

--- a/src/lib/components/Toc.svelte
+++ b/src/lib/components/Toc.svelte
@@ -17,7 +17,7 @@
 		onBeforeJump?: () => void;
 		collapsedHeaders?: Set<string>;
 		ontoggleFold?: (id: string) => void;
-		oncopyref?: (text: string) => void;
+		oncopyref?: (text: string, slug: string) => void;
 		oncontext?: (e: MouseEvent, item: TocItem) => void;
 		onjump?: (id: string, text: string, sourceLine: number | null) => void;
 		onshowTooltip?: (e: MouseEvent, text: string, shortcut?: string, align?: 'top' | 'right' | 'left' | 'below') => void;
@@ -308,7 +308,7 @@
 								class="toc-link {activeId === item.id ? 'active' : ''}"
 								data-id={item.id}
 								onclick={() => jumpTo(item.id)}
-								oncontextmenu={(e) => { e.preventDefault(); e.stopPropagation(); oncontext ? oncontext(e, item) : oncopyref?.(item.text); }}
+								oncontextmenu={(e) => { e.preventDefault(); e.stopPropagation(); oncontext ? oncontext(e, item) : oncopyref?.(item.text, item.id); }}
 								use:checkTruncation>
 								{item.text}
 							</button>

--- a/src/lib/utils/headingReference.ts
+++ b/src/lib/utils/headingReference.ts
@@ -1,0 +1,89 @@
+/**
+ * The link "Copy Reference" puts on the clipboard, in the spelling the
+ * document is already written in.
+ *
+ * Markpad understands two:
+ *
+ *     [[note#Setup]]              Obsidian's, rewritten before the parse
+ *     [Setup](note.md#setup)      CommonMark's, which every reader resolves
+ *
+ * It used to always write the first. Which is right depends on the reader, not
+ * on the app: someone whose vault is full of `[[…]]` wants another one, and
+ * someone writing documents for GitHub wants a link that survives leaving this
+ * app. Neither answer is right for both, and the document itself is the one
+ * piece of evidence available — a person's habit is already written down in
+ * the file they are working in.
+ *
+ * So the style is inferred, and the inference has a floor: where the document
+ * says nothing, or says both, the answer is what this menu has always
+ * produced. It can be better than the old behaviour and never worse.
+ *
+ * The caveat worth knowing: a reference is usually pasted into a DIFFERENT
+ * document, so following this one is a guess about that one. In practice a
+ * person writes one way throughout, which is what makes the guess worth
+ * making — but it is a guess.
+ */
+
+export type ReferenceStyle = 'wikilink' | 'inline';
+
+/** What the menu produced before it looked at anything, and the fallback. */
+export const DEFAULT_REFERENCE_STYLE: ReferenceStyle = 'wikilink';
+
+/**
+ * Fenced code is where a document ABOUT Markdown keeps its examples, and this
+ * app's own samples contain both spellings inside fences. Counting those would
+ * make the syntax documentation the loudest voice in every vault.
+ */
+function withoutFencedCode(document: string): string {
+	return document.replace(/^ {0,3}(```+|~~~+)[\s\S]*?^ {0,3}\1[^\n]*$/gm, '');
+}
+
+export function preferredReferenceStyle(document: string): ReferenceStyle {
+	const prose = withoutFencedCode(document);
+
+	const hasWikilink = /\[\[[^\]\n]*\]\]/.test(prose);
+	// A link whose destination carries a `#` — `](#setup)` in this document,
+	// or `](notes.md#setup)` into another.
+	const hasInlineAnchor = /\]\([^)\n]*#[^)\n]*\)/.test(prose);
+
+	if (hasWikilink === hasInlineAnchor) return DEFAULT_REFERENCE_STYLE;
+	return hasWikilink ? 'wikilink' : 'inline';
+}
+
+/**
+ * A link destination may not contain spaces or parentheses unless it is
+ * wrapped in angle brackets — `[x](my note.md#a)` stops at the space and the
+ * rest becomes text. Filenames with spaces are ordinary.
+ */
+function linkDestination(target: string): string {
+	return /[\s()<>]/.test(target) ? `<${target}>` : target;
+}
+
+/** Link text is delimited by brackets, so a heading containing one escapes it. */
+function linkLabel(text: string): string {
+	return text.replace(/([[\]])/g, '\\$1');
+}
+
+export type HeadingReference = {
+	/** The heading as it reads. Both spellings show this to the reader. */
+	text: string;
+	/** The rendered `id`, which only the CommonMark spelling names. */
+	slug: string;
+	/**
+	 * The document's file name **with** its extension, or `null` for one that
+	 * has never been saved. The wikilink spelling drops the extension, the
+	 * CommonMark one needs it — that is how each is resolved.
+	 */
+	fileName: string | null;
+	style: ReferenceStyle;
+};
+
+export function headingReference({ text, slug, fileName, style }: HeadingReference): string {
+	if (style === 'wikilink') {
+		const note = fileName ? fileName.replace(/\.[^.]+$/, '') : '';
+		return note ? `[[${note}#${text}]]` : `#${text}`;
+	}
+
+	const destination = fileName ? `${fileName}#${slug}` : `#${slug}`;
+	return `[${linkLabel(text)}](${linkDestination(destination)})`;
+}


### PR DESCRIPTION
Two changes, one rule apiece. Both rules came out of measuring this renderer rather than reading a spec.

## `++inserted++`

Pandoc's and CriticMarkup's spelling, plain characters here until now. It is the only one of its group worth taking, and **the rule that rejected the others is the actual content of this PR**:

> accept a dialect only where it cannot misread **ordinary text**

Three failed it:

| extension | what it would take |
|---|---|
| `~sub~` | GFM defines strikethrough as **one or two** tildes, so `~x~` is struck through on GitHub *and here*. A subscript extension takes a spelling GitHub already renders — and `H~2~O` looks struck through on GitHub too, so we would diverge on both. |
| `^sup^` | Worse: it takes **prose**. Two carets in a paragraph pair up, so `a^2 + b^2 = c^2` — which renders as written today, here and on GitHub — becomes `a<sup>2 + b</sup>2 = c^2`. |
| `\|\|x\|\|` | `\|\|` is also an empty table cell. `\| 1 \|\| 3 \|` collapses into one cell reading `1 \|\| 3`. |

`++` passed: nothing else claims it, and `i++ then j++`, `C++ and C++` and a `+` list all come through untouched. Every rejection is a **test**, not a comment, so turning one on shows what it costs before a pull request is opened.

Both earlier drafts of this PR had `subscript` and then `superscript` enabled. They came out after measurement, which is why the tests naming them exist.

## Copy Reference follows the document

It always wrote `[[note#Setup]]` — the Obsidian spelling, which Markpad has understood since v2.6.2. Which spelling is *right* depends on the reader, not on the app: a vault full of `[[…]]` wants another one; a document written for GitHub wants a link that survives leaving Markpad.

The document is the evidence available. A person's habit is already written down in the file they are working in.

```
only [[…]] in the document     →  [[notes#Setup]]
only ](…#…)                    →  [Setup](notes.md#setup)
both, or neither               →  [[notes#Setup]]   ← what it always did
```

That floor is what makes inferring defensible at all: **it can be better than the old behaviour and never worse.** Fenced code is excluded from the vote, or a document *about* Markdown — this repo's own samples, for one — would be the loudest voice in every vault.

Known and accepted: a reference is usually pasted into a **different** document, so following this one is a guess about that one. In practice a person writes one way throughout.

Two spellings the CommonMark form has to handle and the wikilink never did are tested: a filename with a space (`[Setup](<my notes.md#setup>)`) and a bracket in the heading. Its slug is read off the rendered element rather than recomputed, so a repeated heading keeps the `-1` comrak gave it — a second `### Objectives` is addressable.

`wikilinkFileTargets.test.ts` moves its contract to where the string is now built. The property is unchanged: every wikilink Copy Reference writes carries a `#`, because the rewriter leaves a bare `[[Notes]]` literal.

## Verification

`npm run check` (0 errors), `npm test` (840 passing), `cargo test` (140 passing).
