### PR TITLE
fix(macos): give the menu back the commands the web side cannot bind

### DIFF
--- a/scripts/issue281MinimalMacosMenu.test.ts
+++ b/scripts/issue281MinimalMacosMenu.test.ts
@@ -18,8 +18,25 @@ test('macOS native menu keeps only application-level actions', () => {
 	assert.match(menuSetup, /PredefinedMenuItem::services\(app, None\)/);
 	assert.match(menuSetup, /PredefinedMenuItem::hide\(app, None\)/);
 	assert.doesNotMatch(menuSetup, /PredefinedMenuItem::(?:hide_others|show_all)/);
-	assert.match(menuSetup, /\.items\(&\[&app_submenu\]\)/);
-	assert.doesNotMatch(menuSetup, /SubmenuBuilder::new\(app, "(?:File|Edit|Window)"\)/);
+	assert.match(menuSetup, /\.items\(&\[&app_submenu, &edit_submenu\]\)/);
+	assert.doesNotMatch(menuSetup, /SubmenuBuilder::new\(app, "(?:File|Window)"\)/);
+});
+
+// Document actions stay in the in-window controls (#281), but Edit is not a
+// document menu: macOS routes ⌘X/⌘C/⌘V/⌘A through the main menu to the
+// first responder, so dropping it left every native input unable to paste
+// (#526).
+test('macOS menu keeps the standard Edit items so text fields can paste', () => {
+	const menuSetup = sliceBetween(
+		tauriLib,
+		'#[cfg(target_os = "macos")]\n            {\n                use tauri::menu',
+		'\n            let config_dir',
+	);
+
+	assert.match(menuSetup, /SubmenuBuilder::new\(app, "Edit"\)/);
+	for (const item of ['undo', 'redo', 'cut', 'copy', 'paste', 'select_all']) {
+		assert.match(menuSetup, new RegExp(`PredefinedMenuItem::${item}\\(app, None\\)`));
+	}
 });
 
 test('native Settings opens only the focused window settings modal', () => {

--- a/scripts/issue281MinimalMacosMenu.test.ts
+++ b/scripts/issue281MinimalMacosMenu.test.ts
@@ -6,37 +6,40 @@ import { readSource, sliceBetween } from './sourceTree.js';
 const tauriLib = readSource('src-tauri/src/lib.rs');
 const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
-test('macOS native menu keeps only application-level actions', () => {
-	const menuSetup = sliceBetween(
-		tauriLib,
-		'#[cfg(target_os = "macos")]\n            {\n                use tauri::menu',
-		'\n            let config_dir',
-	);
+const menuSetup = sliceBetween(
+	tauriLib,
+	'#[cfg(target_os = "macos")]\n            {\n                use tauri::menu',
+	'\n            let config_dir',
+);
 
+test('macOS native menu keeps document actions out', () => {
 	assert.match(menuSetup, /MenuItemBuilder::with_id\("menu-app-settings", "Settings…"\)\s*\.accelerator\("CmdOrCtrl\+,"\)/);
 	assert.match(menuSetup, /MenuItemBuilder::with_id\("check-updates", "Check for Updates…"\)/);
 	assert.match(menuSetup, /PredefinedMenuItem::services\(app, None\)/);
 	assert.match(menuSetup, /PredefinedMenuItem::hide\(app, None\)/);
 	assert.doesNotMatch(menuSetup, /PredefinedMenuItem::(?:hide_others|show_all)/);
-	assert.match(menuSetup, /\.items\(&\[&app_submenu, &edit_submenu\]\)/);
-	assert.doesNotMatch(menuSetup, /SubmenuBuilder::new\(app, "(?:File|Window)"\)/);
+	assert.match(menuSetup, /\.items\(&\[&app_submenu, &edit_submenu, &window_submenu\]\)/);
+	assert.doesNotMatch(menuSetup, /SubmenuBuilder::new\(app, "File"\)/);
+	// New/Open/Save/Close, zoom, preview width and tab cycling are all bound in
+	// `MarkdownViewer.handleKeyDown`, which is web-side and needs no menu item.
+	assert.doesNotMatch(menuSetup, /PredefinedMenuItem::close_window/);
 });
 
-// Document actions stay in the in-window controls (#281), but Edit is not a
-// document menu: macOS routes ⌘X/⌘C/⌘V/⌘A through the main menu to the
-// first responder, so dropping it left every native input unable to paste
-// (#526).
+// Document actions stay in the in-window controls (#281). What the menu still
+// owes macOS is the commands the web side cannot bind at all: text editing,
+// which AppKit routes through the main menu to the first responder (#526), and
+// the two window-server actions below.
 test('macOS menu keeps the standard Edit items so text fields can paste', () => {
-	const menuSetup = sliceBetween(
-		tauriLib,
-		'#[cfg(target_os = "macos")]\n            {\n                use tauri::menu',
-		'\n            let config_dir',
-	);
-
 	assert.match(menuSetup, /SubmenuBuilder::new\(app, "Edit"\)/);
 	for (const item of ['undo', 'redo', 'cut', 'copy', 'paste', 'select_all']) {
 		assert.match(menuSetup, new RegExp(`PredefinedMenuItem::${item}\\(app, None\\)`));
 	}
+});
+
+test('macOS menu carries ⌘M and ⌃⌘F, which have no web-side equivalent', () => {
+	assert.match(menuSetup, /SubmenuBuilder::new\(app, "Window"\)/);
+	assert.match(menuSetup, /PredefinedMenuItem::minimize\(app, None\)/);
+	assert.match(menuSetup, /PredefinedMenuItem::fullscreen\(app, None\)/);
 });
 
 test('native Settings opens only the focused window settings modal', () => {

--- a/scripts/menuModalGuards.test.ts
+++ b/scripts/menuModalGuards.test.ts
@@ -19,6 +19,16 @@ test('titlebar menus close before a document context menu opens', () => {
 	assert.match(titleBar, /window\.addEventListener\('blur', handleGlobalDismiss\)/);
 });
 
-test('modal backdrop consumes context-menu events', () => {
-	assert.match(modal, /oncontextmenu=\{\(e\) => \{ e\.preventDefault\(\); e\.stopPropagation\(\); \}\}/);
+test('modal backdrop consumes context-menu events outside text fields', () => {
+	assert.match(
+		modal,
+		/if \(\(e\.target as HTMLElement\)\.closest\('input, textarea'\)\) return;\n\t\t\te\.preventDefault\(\);\n\t\t\te\.stopPropagation\(\);/,
+	);
+});
+
+test('text fields keep the webview edit menu so paste stays reachable', () => {
+	assert.match(
+		viewer,
+		/if \(\(e\.target as HTMLElement\)\.closest\('input, textarea, \[contenteditable="true"\]'\)\) return;\n\t\te\.preventDefault\(\);/,
+	);
 });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2836,8 +2836,20 @@ pub fn run() {
                     .item(&PredefinedMenuItem::select_all(app, None)?)
                     .build()?;
 
+                // ⌘M and ⌃⌘F are window-server actions, not document actions:
+                // there is no web API the in-window controls could bind them
+                // to, so they only exist as long as a menu item carries them.
+                // Full Screen belongs in a View menu by convention, but View
+                // would hold that one item and nothing else — Markpad's view
+                // actions are all in-window (#281) — so it rides here instead.
+                let window_submenu = SubmenuBuilder::new(app, "Window")
+                    .item(&PredefinedMenuItem::minimize(app, None)?)
+                    .separator()
+                    .item(&PredefinedMenuItem::fullscreen(app, None)?)
+                    .build()?;
+
                 let menu = MenuBuilder::new(app)
-                    .items(&[&app_submenu, &edit_submenu])
+                    .items(&[&app_submenu, &edit_submenu, &window_submenu])
                     .build()?;
 
                 app.set_menu(menu)?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2821,8 +2821,23 @@ pub fn run() {
                     )
                     .build()?;
 
+                // WKWebView declines ⌘X/⌘C/⌘V/⌘A/⌘Z in plain inputs and hands
+                // them to the main menu, so without an Edit submenu those keys
+                // are dead in every native field (settings, modals). Monaco is
+                // unaffected either way: it preventDefault()s the key first, so
+                // the menu never sees it and its own paste handler still runs.
+                let edit_submenu = SubmenuBuilder::new(app, "Edit")
+                    .item(&PredefinedMenuItem::undo(app, None)?)
+                    .item(&PredefinedMenuItem::redo(app, None)?)
+                    .separator()
+                    .item(&PredefinedMenuItem::cut(app, None)?)
+                    .item(&PredefinedMenuItem::copy(app, None)?)
+                    .item(&PredefinedMenuItem::paste(app, None)?)
+                    .item(&PredefinedMenuItem::select_all(app, None)?)
+                    .build()?;
+
                 let menu = MenuBuilder::new(app)
-                    .items(&[&app_submenu])
+                    .items(&[&app_submenu, &edit_submenu])
                     .build()?;
 
                 app.set_menu(menu)?;

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -2117,6 +2117,10 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		if (mode !== 'app') return;
 		const isInsideEditor = (e.target as HTMLElement).closest('.editor-container');
 		if (isInsideEditor) return;
+		// Text fields keep the webview's own editing menu (Cut/Copy/Paste);
+		// the document menu below is about the rendered preview and has no
+		// edit items, so swallowing the native one leaves no way to paste.
+		if ((e.target as HTMLElement).closest('input, textarea, [contenteditable="true"]')) return;
 		e.preventDefault();
 
 		const selection = window.getSelection();

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -114,7 +114,12 @@
 		class="modal-backdrop"
 		transition:fade={{ duration: 150 }}
 		onclick={handleBackdropClick}
-		oncontextmenu={(e) => { e.preventDefault(); e.stopPropagation(); }}
+		oncontextmenu={(e) => {
+			// The prompt input needs the webview's Cut/Copy/Paste menu.
+			if ((e.target as HTMLElement).closest('input, textarea')) return;
+			e.preventDefault();
+			e.stopPropagation();
+		}}
 		role="presentation">
 		<div
 			class="modal-content {kind}"


### PR DESCRIPTION
Fixes #526.

Stacked on #528 (dompurify pin) so CI can run — merge that one first.

## What happens

On macOS nothing can be pasted into a plain input — the theme-import field in Settings, the rename prompt — by keyboard or by right-click. ⌘M and ⌃⌘F do nothing either. All of it broke in 2.6.10 with #339.

## Why

#339 reduced the native menu to app-level actions and dropped File/Edit/Window, on the grounds that Markpad keeps its document actions in the in-window controls. That holds for document actions — `MarkdownViewer.handleKeyDown` really does bind ⌘N/⌘O/⌘S/⌘W/⌘±/⌘0/⌘Tab web-side, and those still work. It does not hold for commands the web side has no way to bind:

1. **Text editing.** macOS routes ⌘X/⌘C/⌘V/⌘A and undo through the main menu to the first responder — WKWebView declines them precisely so the menu can. With no Edit menu they go nowhere. Monaco was unaffected only because `Editor.svelte` implements its own ⌘V against the Rust clipboard commands, which is why this looked field-specific rather than app-wide.
2. **Window-server actions.** Minimize and full screen have no web API to bind at all. No menu item, no key equivalent, no shortcut.

Plus one that is not AppKit's doing: `handleContextMenu` `preventDefault()`s across the whole document and opens Markpad's preview menu, which has no edit items — so right-clicking a text field offers no Paste either. The modal backdrop does the same to the rename prompt.

## Changes

- **Edit menu**: Undo, Redo, Cut, Copy, Paste, Select All.
- **Window menu**: Minimize, Toggle Full Screen. Full Screen belongs in a View menu by convention; View would hold that one item and nothing else, so it rides in Window — a deliberate deviation, not an oversight.
- Text fields keep the webview's own editing menu, in the document handler and behind modals.

File stays out, and so do Hide Others / Show All — #281's intent is otherwise untouched.

Monaco keeps its ⌘V: it calls `preventDefault()`, WebKit reports the key as handled, and the menu never fires. Image paste and URL linkify still go through `Editor.svelte`.

## Validation

- `npm run check` 0 errors · `npm test` 843 pass · `cargo test` 141 pass
- Paste into the theme-import field by ⌘V and by right-click → Paste: confirmed by hand on macOS 26.
- ⌘M and ⌃⌘F measured on a dev build, before and after, by window size — `AXFullScreen` is unreliable for this window's overlay title bar:

  | | ⌃⌘F | ⌘M |
  |---|---|---|
  | without Window menu | 708x923 → 708x923 | not minimized |
  | with it | 708x923 → 1470x33 | minimized |

  Control for "did the keystroke arrive at all": ⇧⌘M, which is bound web-side, took the window count 1 → 2 in the same session.

- ⌘\` still cycles windows either way — it is a system binding, not a menu key equivalent — so no menu item is owed for it.
- Tests updated to state the new intent: `issue281MinimalMacosMenu.test.ts` still keeps File and the document shortcuts out, and now requires Edit and Window; `menuModalGuards.test.ts` asserts the backdrop consumes context menus *outside* text fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)