### PR TITLE
chore(deps): move the dompurify pin to 3.4.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@tauri-apps/plugin-opener": "^2",
 				"@tauri-apps/plugin-process": "^2.3.1",
 				"@tauri-apps/plugin-updater": "^2.10.1",
-				"dompurify": "3.4.12",
+				"dompurify": "3.4.13",
 				"highlight.js": "^11.11.1",
 				"highlightjs-svelte": "^1.0.6",
 				"katex": "^0.16.27",
@@ -2275,9 +2275,9 @@
 			"license": "MIT"
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.12",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-			"integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+			"version": "3.4.13",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+			"integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"@tauri-apps/plugin-opener": "^2",
 		"@tauri-apps/plugin-process": "^2.3.1",
 		"@tauri-apps/plugin-updater": "^2.10.1",
-		"dompurify": "3.4.12",
+		"dompurify": "3.4.13",
 		"highlight.js": "^11.11.1",
 		"highlightjs-svelte": "^1.0.6",
 		"katex": "^0.16.27",
@@ -46,6 +46,6 @@
 	},
 	"overrides": {
 		"cookie": "0.7.2",
-		"dompurify": "3.4.12"
+		"dompurify": "3.4.13"
 	}
 }


### PR DESCRIPTION
## Why

[GHSA-55q2-fjhq-7xh7](https://github.com/advisories/GHSA-55q2-fjhq-7xh7) (moderate, dompurify `<= 3.4.12`) was published after master's last green run. Both the direct dependency and the `overrides` entry pinned 3.4.12 exactly, so `npm audit` — a required check — now fails on **every open PR**, including ones that touch nothing related. This unblocks them.

## What

`3.4.12` → `3.4.13` in `dependencies` and `overrides`, plus the lockfile. That is the patch release for the advisory; no major or minor moves, and mermaid's copy still dedupes to the same version.

The advisory is about `IN_PLACE` sanitization leaving a detached subtree executable after hook removal. Markpad calls neither `IN_PLACE` nor `addHook`, so the fixed path is one it never took.

The `dompurify 3.4.12` mentions in `previewSanitize.test.ts` and `mermaidDiagramLabels.test.ts` are left alone on purpose: they record which build the browser-side measurements were taken against, and nothing was re-measured here.

## Validation

- `npm audit` — 0 vulnerabilities (was 3 moderate)
- `npm test` — 840 pass, including the sanitizer suites that exercise DOMPurify directly
- `npm run check` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)