### PR TITLE
chore(build): add signing key to AppImage and update snapcraft workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -284,8 +284,8 @@ jobs:
       - name: Strip host-coupled libraries from AppImage
         if: matrix.platform == 'ubuntu-24.04'
         env:
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
           set -euo pipefail
 
@@ -329,7 +329,7 @@ jobs:
           # which no longer matches. signer sign reads the key/password from the
           # env above and writes <APPIMAGE>.sig, which the upload and the
           # latest.json job below both consume.
-          npm run tauri signer sign -- "$APPIMAGE" -k "$TAURI_SIGNING_PRIVATE_KEY" -p "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD"
+          npm run tauri signer sign -- "$APPIMAGE" -k
           if [ ! -f "$APPIMAGE.sig" ]; then
             echo "::error::signer sign did not produce $APPIMAGE.sig" >&2
             exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -329,7 +329,7 @@ jobs:
           # which no longer matches. signer sign reads the key/password from the
           # env above and writes <APPIMAGE>.sig, which the upload and the
           # latest.json job below both consume.
-          npm run tauri signer sign -- "$APPIMAGE"
+          npm run tauri signer sign -- "$APPIMAGE" -k "$TAURI_SIGNING_PRIVATE_KEY" -p "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD"
           if [ ! -f "$APPIMAGE.sig" ]; then
             echo "::error::signer sign did not produce $APPIMAGE.sig" >&2
             exit 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "markpad",
-	"version": "2.7.1",
+	"version": "2.7.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "markpad",
-			"version": "2.7.1",
+			"version": "2.7.2",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@tauri-apps/api": "^2",
@@ -678,9 +678,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -695,9 +692,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -712,9 +706,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -729,9 +720,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -746,9 +734,6 @@
 				"loong64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -763,9 +748,6 @@
 				"loong64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -780,9 +762,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -797,9 +776,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -814,9 +790,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -831,9 +804,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -848,9 +818,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -865,9 +832,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -882,9 +846,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -64,6 +64,7 @@ parts:
       - libjavascriptcoregtk-4.1-0
     build-snaps:
       - node/20/stable
+      - rustup/latest/stable
     override-build: |
       set -e
       craftctl set version="$(node -p "require('./package.json').version")"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Markpad"
-version = "2.7.1"
+version = "2.7.2"
 dependencies = [
  "arboard",
  "base64 0.22.1",


### PR DESCRIPTION
## Changes

1. `Strip host-coupled libraries from AppImage` fails during build due to no signing key. Added keys to build step explicitly

2. Snapcraft build failed due to `rustup` dep missing. 

## Verification

All tests in `scripts/releaseWorkflow.test.ts` passed (8/8).