### PR TITLE
fix(preview): media players inherit the source range they replaced

### DIFF
--- a/scripts/renderProtocol.test.ts
+++ b/scripts/renderProtocol.test.ts
@@ -9,11 +9,12 @@
  * statement must not turn these red, and changing what the preview actually
  * produces must.
  *
- * The four protocols covered are the ones that have already regressed:
+ * The five protocols covered are the ones that have already regressed:
  *   1. task-list markers and source positions (checkbox click → source line)
  *   2. `$$…$$` underscore protection (issue #174)
  *   3. heading ids and fold anchors (#371)
  *   4. raw HTML checkboxes are not markdown tasks (#319)
+ *   5. media substitutions keep the source range of the markup they replaced
  */
 
 import assert from 'node:assert/strict';
@@ -536,4 +537,62 @@ test('a checkbox outside a list item is left alone by the task pass', () => {
 	assert.equal(checkbox.closest('li'), null);
 	assert.equal(checkbox.hasAttribute('data-task-checkbox'), false);
 	assert.equal(checkbox.closest('p')?.textContent.trim(), 'A paragraph with  inline.');
+});
+
+// --- protocol 5: media substitutions keep their source range -------------
+
+/**
+ * `processMarkdownHtml` does not restyle a media `<img>`, it *replaces* it: an
+ * `.mp4`/`.mp3` src becomes a freshly created `<video>`/`<audio>`, a YouTube
+ * src becomes a thumbnail `<a>`. A fresh element starts with no attributes, so
+ * unless the source range is carried across, the tallest thing in the preview
+ * is the one element that maps to no source line — the same defect
+ * `carrySourcepos` was written for on Mermaid diagrams. Both halves of scroll
+ * sync then attribute the player's pixels to whichever neighbouring block is
+ * nearest, and the panes disagree by its height for as long as it is on
+ * screen; "edit what I right-clicked" degrades to the enclosing paragraph.
+ */
+/**
+ * A local media src is rewritten through Tauri's asset protocol, which lives
+ * on `window`. Without it the rewrite throws into `processMarkdownHtml`'s own
+ * catch and these fixtures would exercise the fallback path instead of the
+ * one the preview takes. Set after the imports above so DOMPurify's module
+ * init still sees no window.
+ */
+(globalThis as unknown as Record<string, unknown>).window = {
+	__TAURI_INTERNALS__: { convertFileSrc: (path: string) => `asset://localhost/${path}` },
+};
+
+const MEDIA_FIXTURES = [
+	{ name: 'videoImage', selector: 'video' },
+	{ name: 'audioImage', selector: 'audio' },
+	{ name: 'youtubeImage', selector: 'a.youtube-link' },
+	{ name: 'youtubeLink', selector: 'a.youtube-link' },
+] as const satisfies readonly { name: FixtureName; selector: string }[];
+
+/** The range comrak put on the element the substitution consumed. */
+function rendererSourcepos(name: FixtureName): string {
+	const source = parseHtml(renderFixtures[name].html).body.querySelector('img, p a');
+	return source?.getAttribute('data-sourcepos') ?? '';
+}
+
+test('a media element inherits the source range of the markup it replaced', () => {
+	for (const { name, selector } of MEDIA_FIXTURES) {
+		const [media] = render(name).querySelectorAll(selector);
+		assert.ok(media, `${name}: no ${selector} was produced`);
+
+		const expected = rendererSourcepos(name);
+		assert.match(expected, /^\d+:\d+-\d+:\d+$/, `${name}: fixture lost its source range`);
+		assert.equal(
+			media.getAttribute('data-sourcepos'),
+			expected,
+			`${name}: the replacement maps to no source line, so scroll sync has to guess`,
+		);
+	}
+});
+
+test('a replaced video reports the line it was written on, not the first one', () => {
+	const [video] = render('videoImageSurrounded').querySelectorAll('video');
+
+	assert.equal(video.getAttribute('data-sourcepos'), '3:1-3:17');
 });

--- a/scripts/renderProtocolFixtures.ts
+++ b/scripts/renderProtocolFixtures.ts
@@ -149,4 +149,26 @@ export const renderFixtures = {
 		markdown: "A paragraph with <input type=\"checkbox\" /> inline.\n",
 		html: "<p data-sourcepos=\"1:1-1:50\">A paragraph with <input type=\"checkbox\" /> inline.</p>\n",
 	},
+
+	// --- protocol 5 — media substitutions keep their source range ---
+	videoImage: {
+		markdown: "![clip](clip.mp4)\n",
+		html: "<p data-sourcepos=\"1:1-1:17\"><img data-sourcepos=\"1:1-1:17\" src=\"clip.mp4\" alt=\"clip\" /></p>\n",
+	},
+	videoImageSurrounded: {
+		markdown: "Intro paragraph.\n\n![clip](clip.mp4)\n\nTrailing prose.\n",
+		html: "<p data-sourcepos=\"1:1-1:16\">Intro paragraph.</p>\n<p data-sourcepos=\"3:1-3:17\"><img data-sourcepos=\"3:1-3:17\" src=\"clip.mp4\" alt=\"clip\" /></p>\n<p data-sourcepos=\"5:1-5:15\">Trailing prose.</p>\n",
+	},
+	audioImage: {
+		markdown: "![take](take.mp3)\n",
+		html: "<p data-sourcepos=\"1:1-1:17\"><img data-sourcepos=\"1:1-1:17\" src=\"take.mp3\" alt=\"take\" /></p>\n",
+	},
+	youtubeImage: {
+		markdown: "![demo](https://youtu.be/dQw4w9WgXcQ)\n",
+		html: "<p data-sourcepos=\"1:1-1:37\"><img data-sourcepos=\"1:1-1:37\" src=\"https://youtu.be/dQw4w9WgXcQ\" alt=\"demo\" /></p>\n",
+	},
+	youtubeLink: {
+		markdown: "[demo](https://youtu.be/dQw4w9WgXcQ)\n",
+		html: "<p data-sourcepos=\"1:1-1:36\"><a data-sourcepos=\"1:1-1:36\" href=\"https://youtu.be/dQw4w9WgXcQ\">demo</a></p>\n",
+	},
 } as const satisfies Record<string, RenderFixture>;

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -1,4 +1,5 @@
 import { convertFileSrc } from "@tauri-apps/api/core";
+import { carrySourcepos } from "./richContent.js";
 
 const alertIcons: Record<string, string> = {
 	note: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-pencil"><path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/><path d="m15 5 4 4"/></svg>',
@@ -46,6 +47,7 @@ function getYoutubeId(url: string): string | null {
 function replaceWithYoutubeLink(element: Element, videoId: string, href: string) {
 	const link = element.ownerDocument.createElement("a");
 	link.className = "youtube-link";
+	carrySourcepos(element, link);
 	link.href = href;
 	link.setAttribute("aria-label", "Open YouTube video in browser");
 
@@ -478,6 +480,7 @@ export function processMarkdownHtml(
 				media.setAttribute("controls", "");
 				media.setAttribute("src", finalSrc || "");
 				media.style.maxWidth = "100%";
+				carrySourcepos(img, media);
 
 				if (img.hasAttribute("width"))
 					media.setAttribute("width", img.getAttribute("width")!);

--- a/src/lib/utils/richContent.ts
+++ b/src/lib/utils/richContent.ts
@@ -170,8 +170,13 @@ function defaultIdFactory(index: number): string {
  * replaced by Mermaid's SVG. Both halves of scroll sync then treat several
  * hundred pixels of preview as belonging to whatever block is nearest, and the
  * panes disagree by the height of the diagram for as long as it is on screen.
+ *
+ * Exported because `processMarkdownHtml` replaces elements the same way — an
+ * `<img>` whose src is a video or audio file becomes a fresh `<video>` /
+ * `<audio>`, a YouTube `<img>`/`<a>` becomes a thumbnail link — and the same
+ * gap costs the same thing there.
  */
-function carrySourcepos(from: Element, to: Element) {
+export function carrySourcepos(from: Element, to: Element) {
 	const sourcepos = from.getAttribute('data-sourcepos');
 	if (sourcepos) to.setAttribute('data-sourcepos', sourcepos);
 }


### PR DESCRIPTION
## What

`processMarkdownHtml` replaces an `<img>` whose src is a video/audio file with a freshly created `<video>` / `<audio>`, and a YouTube src with a thumbnail `<a>`. A fresh element starts with no attributes, and the copy carried `width`, `height`, `alt` and `title` — never `data-sourcepos`.

## Why it matters

That made the tallest element in the preview the one element mapping to no source line:

```
source                     preview DOM                     maps to
──────────────────────────────────────────────────────────────────
1: Intro paragraph.   →   <p data-sourcepos="1:1-1:16">    line 1
3: ![clip](clip.mp4)  →   <video>            (no attrs)    nothing
5: Trailing prose.    →   <p data-sourcepos="5:1-5:15">    line 5
```

Both halves of scroll sync attribute the player's pixels to whichever neighbouring block is nearest, so the panes disagree by the height of the media for as long as it is on screen. It also degrades #90's "edit jumps to what you right-clicked" from media-precise to paragraph-precise.

## Fix

This is the defect `carrySourcepos` in `src/lib/utils/richContent.ts` was already written and documented for on Mermaid diagrams. It is exported rather than reimplemented, and called at both replacement sites in `markdown.ts`.

## Tests

Render protocol 5 in `scripts/renderProtocol.test.ts` — the render-protocol DOM shim over real `processMarkdownHtml` output, asserting a media substitution keeps the range comrak put on the markup it consumed (video, audio, YouTube image, YouTube link), plus one case where the media is not on line 1.

The new fixtures were captured by running comrak 0.54 under `lib.rs`'s own `markdown_options`, per the provenance rule in `renderProtocolFixtures.ts` — not hand-written.

The test file stubs `window.__TAURI_INTERNALS__` after its imports: local media srcs go through `convertFileSrc`, which would otherwise throw into `processMarkdownHtml`'s catch and leave these fixtures exercising the fallback path instead of the one the preview takes.

## Verification

- Removing both `carrySourcepos(...)` calls turns the two new tests red; restoring them turns them green.
- `npm test` — 845/845 pass (includes `exportRichContent`, `renderProtocol*`, since `processMarkdownHtml` is shared with the HTML/PDF export path).
- `npm run check` — 666 files, 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)