### PR TITLE
fix(preview): make task checkboxes work, and look like task checkboxes

### DIFF
--- a/samples/stress-test.md
+++ b/samples/stress-test.md
@@ -46,6 +46,10 @@ This is a normal paragraph. It includes **bold text**, *italic text*, ***bold it
 
 You can also test combinations such as **bold with `inline code`**, *italic with [a link](https://example.com)*, and ~~strikethrough with **bold text**~~.
 
+Inserted text uses Pandoc's and CriticMarkup's spelling: ++this was added++, and it nests like the others — ++inserted with **bold**++.
+
+A lone `+` or a pair with a space between them is ordinary text: 1 + 1, and a++ b ++c stays as written.
+
 ## Heading Level 2
 
 ### Heading Level 3
@@ -166,6 +170,55 @@ A local-image reference is also included for syntax testing:
 ```markdown
 ![Local diagram](images/sample-diagram.png)
 ```
+
+An image with a title, which most readers show on hover:
+
+![Markpad in light mode](../pics/lightmode.png "Light mode")
+
+A reference-style image, where the destination lives elsewhere in the document:
+
+![Drag and drop][dnd-image]
+
+[dnd-image]: ../pics/drag-and-drop.png "Dropping a file onto the editor"
+
+## Wikilinks
+
+Obsidian's spelling, rewritten before rendering:
+
+- A heading in another document: [[markdown-syntax#3. Lists]]
+- With an alias: [[markdown-syntax#3. Lists|see the lists chapter]]
+- A heading in this document: [[#6. Tables]]
+- An embed of a local image: `![[lightmode.png]]`
+
+A wikilink with no heading is deliberately left as literal text, because `[[Notes]]` is also how citation numbering and reference links are written: [[Notes]].
+
+## Block Ids
+
+A paragraph can carry an id and be linked to from anywhere. ^stress-block
+
+That paragraph ends with `^stress-block`, and [[#^stress-block]] points at it.
+
+## Video and Audio
+
+An image reference whose file is a video or a sound becomes a player. The files below do not exist in this repository — the point is that the *syntax* resolves to a player element rather than to a broken image:
+
+![A screen recording](media/demo.mp4)
+
+![An interview](media/episode.mp3)
+
+Video extensions: `mp4`, `webm`, `ogg`, `mov`. Audio: `mp3`, `wav`, `aac`, `flac`, `m4a`.
+
+## YouTube
+
+A YouTube link alone in its paragraph becomes a thumbnail:
+
+https://www.youtube.com/watch?v=dQw4w9WgXcQ
+
+The image form does the same:
+
+![Any caption](https://youtu.be/dQw4w9WgXcQ)
+
+A YouTube link in the middle of a sentence — like https://youtu.be/dQw4w9WgXcQ here — stays an ordinary link, because replacing it would break the sentence around it.
 
 # 5. Blockquotes
 
@@ -351,6 +404,125 @@ Nested task list:
   - [ ] Editing
   - [ ] Export
   - [ ] Search
+
+## Task List Shapes
+
+Toggling a checkbox in the preview has to find the line to rewrite in the
+source. Each shape below is a separate case for that lookup, and every one of
+them is expected to toggle — and to toggle **only itself**.
+
+Ordered, with a dot:
+
+1. [ ] First ordered task
+2. [x] Second ordered task
+3. [ ] Third ordered task
+
+Ordered, with a parenthesis:
+
+1) [ ] Parenthesised marker
+2) [x] Also a task
+
+Other bullet characters:
+
+* [ ] Asterisk marker
++ [x] Plus marker
+
+Inside a quote:
+
+> - [ ] A task in a blockquote
+> - [x] A second one
+> - [ ] A third
+
+Deeply nested, mixing markers and depths:
+
+- [ ] Level one
+  - [x] Level two
+    * [ ] Level three with an asterisk
+      1. [ ] Level four, ordered
+    * [x] Back to level three
+  - [ ] Level two again
+
+## Task Lists With No Blank Line Above Them
+
+A list that begins immediately after prose is a different case for anything
+that counts lines, because there is no blank line for a pattern to run past.
+The next line is prose, and the list starts on the line after it with nothing
+between them:
+- [ ] Straight after the paragraph
+- [x] Second in the run
+- [ ] Third in the run
+
+The same again, this time with a blank line above the list, which is how most
+people write one:
+
+- [ ] After a blank line
+- [x] Second in the run
+- [ ] Third in the run
+
+## Adjacent Tasks
+
+Nothing between these, so an off-by-one lands on a real task rather than on
+nothing — which is the difference between a checkbox that looks dead and one
+that silently ticks its neighbour. Toggle any single line and check that the
+other five are untouched:
+
+- [ ] Adjacent one
+- [ ] Adjacent two
+- [ ] Adjacent three
+- [ ] Adjacent four
+- [ ] Adjacent five
+- [ ] Adjacent six
+
+## A Task Carrying Continuation Lines
+
+The shape from the file attached to #148. A task whose text is one line, followed
+by a dozen indented lines that all belong to the same list item — mixed 4- and
+8-space indents, every line an inline code span, and most ending in two trailing
+spaces, which makes each one a hard break rather than a new paragraph. The whole
+run is a single lazy-continuation paragraph inside the item.
+
+Note also that the list starts immediately after the heading, with no blank line
+between them.
+
+### Essential
+- [x] Repo management  
+    `sudo nano /etc/dnf/dnf.conf`  
+        `fastestmirror=True`  
+        `max_parallel_downloads=10`  
+        `defaultyes=True`  
+    `sudo dnf install https://mirrors.example.org/free/release-$(rpm -E %dist).noarch.rpm -y`  
+    `sudo dnf -y update`  
+        `sudo dnf repolist --all | grep -i example`  
+        `sudo dnf config-manager setopt example-free.enabled=1`  
+    `flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo`  
+- [x] Custom refresh rate  
+    `kscreen-doctor output.1.addCustomMode.1920.1080.75000.reduced`
+
+Two things this exercises that nothing else here does: a checkbox whose item is
+many lines tall, so the control and its text can be laid out apart from one
+another; and continuation lines holding `$(…)`, `|` and `%`, which several of
+the preprocessing passes look for.
+
+The one dimension this file cannot carry is line endings — it is LF throughout,
+and the original was CRLF. That half is covered by
+`scripts/taskToggleLineEndings.test.ts`, which drives both endings through the
+real write-back.
+
+## Task-Like Text That Is Not A Task
+
+None of these should become a checkbox:
+
+Some prose containing - [ ] in the middle of a sentence.
+
+    - [ ] An indented code block, not a list
+
+`- [ ] inline code`
+
+```markdown
+- [ ] A fenced code block
+```
+
+- Not a task, just a bullet whose text starts with a bracket \[x\]
 
 # 9. Footnotes
 

--- a/scripts/mathDelimiterCorpus.json
+++ b/scripts/mathDelimiterCorpus.json
@@ -209,7 +209,7 @@
 		{
 			"name": "a formula in a task item",
 			"markdown": "- [ ] compute $x_1$\n",
-			"html": "<ul data-sourcepos=\"1:1-1:26\">\n<li data-sourcepos=\"1:1-1:26\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> compute $x_1$</li>\n</ul>\n",
+			"html": "<ul class=\"contains-task-list\" data-sourcepos=\"1:1-1:26\">\n<li data-sourcepos=\"1:1-1:26\"><input type=\"checkbox\" data-task-checkbox=\"\" class=\"task-list-item-checkbox\" disabled=\"\" /> compute $x_1$</li>\n</ul>\n",
 			"math": [
 				{
 					"kind": "inline",

--- a/scripts/renderProtocol.test.ts
+++ b/scripts/renderProtocol.test.ts
@@ -172,6 +172,15 @@ test('task checkboxes are made clickable and checked ones mark their item', () =
 				checkbox.checked,
 				`${name}: task-done disagrees with the checkbox state`,
 			);
+			// Fifteen rules in styles.css name this class — the bullet
+			// suppression and the grid that puts the checkbox beside its text.
+			// comrak writes it only on the branch where it opens the `<li>`
+			// itself, which a plain task item does not take, so without this
+			// the list loses its bullet and keeps the checkbox on its own line.
+			assert.ok(
+				li.classList.contains('task-list-item'),
+				`${name}: the item class the stylesheet needs is missing`,
+			);
 		}
 	}
 });

--- a/scripts/taskToggleLineEndings.test.ts
+++ b/scripts/taskToggleLineEndings.test.ts
@@ -93,9 +93,23 @@ async function toggledContent(doc: string, sourceLine: number, nowChecked: boole
 	return write ? (write.args.content as string) : null;
 }
 
-/** The same document in both line endings, so a case can be run over each. */
+/**
+ * The same document in both line endings, so a case can be run over each.
+ *
+ * The blank line before the list is not decoration — it is the condition that
+ * makes this reachable on LF. `\s*` is greedy and `/m` `^` matches at the
+ * start of the blank line, so the match ate the blank line's terminator and
+ * `offset` landed one line early. Every list written the ordinary way, with a
+ * blank line above it, hit this on every platform; CRLF widened it from the
+ * first task of each block to all of them.
+ */
 function document(eol: string) {
-	return ['intro', '- [ ] one', '- [ ] two', '- [ ] three'].join(eol) + eol;
+	return ['intro', '', '- [ ] one', '- [ ] two', '- [ ] three'].join(eol) + eol;
+}
+
+/** A list that starts immediately after prose — the shape that always worked. */
+function documentWithoutBlankLine(eol: string) {
+	return ['intro', '- [ ] one', '- [ ] two'].join(eol) + eol;
 }
 
 for (const [name, eol] of [
@@ -105,31 +119,31 @@ for (const [name, eol] of [
 	test(`${name}: the task the reader clicked is the task that changes`, async () => {
 		// Line 3 is `- [ ] two`. Under the old pattern this resolved to line 2
 		// and rewrote `one` instead — a silent, invisible wrong write.
-		const written = await toggledContent(document(eol), 3, true);
+		const written = await toggledContent(document(eol), 4, true);
 		assert.ok(written, 'the toggle wrote');
-		assert.equal(written, ['intro', '- [ ] one', '- [x] two', '- [ ] three'].join(eol) + eol);
+		assert.equal(written, ['intro', '', '- [ ] one', '- [x] two', '- [ ] three'].join(eol) + eol);
 	});
 
 	test(`${name}: the last task toggles at all`, async () => {
 		// Line 4 is the last task. Under the old pattern nothing matched line 4,
 		// so the write was skipped entirely and the control snapped back. This
 		// is the symptom #148 reports.
-		const written = await toggledContent(document(eol), 4, true);
+		const written = await toggledContent(document(eol), 5, true);
 		assert.ok(written, 'the toggle wrote instead of silently refusing');
-		assert.equal(written, ['intro', '- [ ] one', '- [ ] two', '- [x] three'].join(eol) + eol);
+		assert.equal(written, ['intro', '', '- [ ] one', '- [ ] two', '- [x] three'].join(eol) + eol);
 	});
 
 	test(`${name}: unticking is the same arithmetic`, async () => {
-		const doc = ['intro', '- [x] one', '- [x] two'].join(eol) + eol;
-		const written = await toggledContent(doc, 3, false);
-		assert.equal(written, ['intro', '- [x] one', '- [ ] two'].join(eol) + eol);
+		const doc = ['intro', '', '- [x] one', '- [x] two'].join(eol) + eol;
+		const written = await toggledContent(doc, 4, false);
+		assert.equal(written, ['intro', '', '- [x] one', '- [ ] two'].join(eol) + eol);
 	});
 
 	test(`${name}: only one line changes`, async () => {
 		// The failure mode this guards is a match that spans the previous line's
 		// terminator: the replacement then rewrites two lines at once.
 		const before = document(eol);
-		const written = await toggledContent(before, 3, true);
+		const written = await toggledContent(before, 4, true);
 		assert.ok(written);
 		const changed = written!
 			.split(eol)
@@ -140,13 +154,13 @@ for (const [name, eol] of [
 	test(`${name}: the shapes the write-back claims to support`, async () => {
 		// Ordered, parenthesised, quoted, nested and `*`/`+` bullets all go
 		// through the same pattern; the CRLF bug hit every one of them.
-		const doc = ['intro', '1. [ ] ordered', '2) [ ] paren', '> - [ ] quoted', '  * [ ] nested', '+ [ ] plus'].join(eol) + eol;
+		const doc = ['intro', '', '1. [ ] ordered', '2) [ ] paren', '> - [ ] quoted', '  * [ ] nested', '+ [ ] plus'].join(eol) + eol;
 		for (const [line, expected] of [
-			[2, '1. [x] ordered'],
-			[3, '2) [x] paren'],
-			[4, '> - [x] quoted'],
-			[5, '  * [x] nested'],
-			[6, '+ [x] plus'],
+			[3, '1. [x] ordered'],
+			[4, '2) [x] paren'],
+			[5, '> - [x] quoted'],
+			[6, '  * [x] nested'],
+			[7, '+ [x] plus'],
 		] as const) {
 			const written = await toggledContent(doc, line, true);
 			assert.ok(written, `line ${line} wrote`);
@@ -158,7 +172,37 @@ for (const [name, eol] of [
 test('a tab-indented task keeps its indentation', async () => {
 	// `[ \t]*` has to admit a tab, or a tab-indented task stops being found at
 	// all — the failure the narrowing could plausibly have introduced.
-	const doc = ['intro', '\t- [ ] tabbed'].join('\r\n') + '\r\n';
-	const written = await toggledContent(doc, 2, true);
-	assert.equal(written, ['intro', '\t- [x] tabbed'].join('\r\n') + '\r\n');
+	const doc = ['intro', '', '\t- [ ] tabbed'].join('\r\n') + '\r\n';
+	const written = await toggledContent(doc, 3, true);
+	assert.equal(written, ['intro', '', '\t- [x] tabbed'].join('\r\n') + '\r\n');
+});
+
+// The condition, isolated. A list that begins immediately after prose was
+// always correct on LF — which is why the first version of this file, whose
+// fixtures had no blank line, passed on LF and hid half the bug.
+for (const [name, eol] of [
+	['LF', '\n'],
+	['CRLF', '\r\n'],
+] as const) {
+	test(`${name}: a list with no blank line above it`, async () => {
+		const written = await toggledContent(documentWithoutBlankLine(eol), 3, true);
+		assert.equal(written, ['intro', '- [ ] one', '- [x] two'].join(eol) + eol);
+	});
+}
+
+test('LF: the first task after a blank line is the one that regressed', async () => {
+	// On LF only the first task of each block was wrong: `\s*` could eat the
+	// blank line's single `\n`, but not a task line above it. That is why
+	// samples/stress-test.md — 44 tasks, LF — had exactly six wrong, one per
+	// block. CRLF widened it to every task, because `^` also matches between
+	// a `\r` and its `\n`.
+	const doc = ['intro', '', '- [ ] one', '- [ ] two'].join('\n') + '\n';
+	const written = await toggledContent(doc, 3, true);
+	assert.equal(written, ['intro', '', '- [x] one', '- [ ] two'].join('\n') + '\n');
+});
+
+test('LF: two blank lines above the list', async () => {
+	const doc = ['intro', '', '', '- [ ] one'].join('\n') + '\n';
+	const written = await toggledContent(doc, 4, true);
+	assert.equal(written, ['intro', '', '', '- [x] one'].join('\n') + '\n');
 });

--- a/scripts/taskToggleLineEndings.test.ts
+++ b/scripts/taskToggleLineEndings.test.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { readSource, sliceBetween } from './sourceTree.js';
+
 // Toggling a task checkbox in the preview finds the line to rewrite by counting
 // `\n` up to the regex match. Three rounds of fixes for #148 were verified on
 // macOS, i.e. on LF, and all three missed that the count is wrong on CRLF:
@@ -205,4 +207,49 @@ test('LF: two blank lines above the list', async () => {
 	const doc = ['intro', '', '', '- [ ] one'].join('\n') + '\n';
 	const written = await toggledContent(doc, 4, true);
 	assert.equal(written, ['intro', '', '', '- [x] one'].join('\n') + '\n');
+});
+
+// ---------------------------------------------- the toggle does not re-render
+//
+// Ticking a checkbox writes the buffer, and MarkdownViewer's render effect
+// re-renders whenever the buffer stops matching `_lastRenderedRawContent`. It
+// would rebuild the whole article to arrive at the DOM already on screen — the
+// browser has drawn the native checkbox and the caller has added `task-done` —
+// and rebuilding drops the reader's scroll position, which in a long document
+// throws the view somewhere else entirely.
+
+const sessionSource = readSource(new URL('../src/lib/sessions/documentSession.svelte.ts', import.meta.url));
+
+test('a toggle tells the preview it is already up to date', async () => {
+	const doc = ['intro', '', '- [ ] one', '- [ ] two'].join('\n') + '\n';
+	tabManager.closeAll();
+	invokeCalls = [];
+	handleInvoke = (cmd) => {
+		if (cmd === 'open_markdown_preview') return ['<p>preview</p>', doc, false, false];
+		if (cmd === 'read_file_content_checked') return [doc, false];
+		if (cmd === 'save_file_content') return null;
+		return null;
+	};
+	const session = makeSession();
+	await session.loadMarkdown('/docs/tasks.md');
+	const tab = tabManager.activeTab!;
+
+	await session.toggleTaskCheckbox(3, true);
+
+	assert.equal(
+		(tab as unknown as Record<string, unknown>)._lastRenderedRawContent,
+		tab.rawContent,
+		'the render effect has nothing to do',
+	);
+});
+
+test('it is marked before anything can be awaited', () => {
+	// The render effect arms its 16ms timer the moment the buffer changes and
+	// checks the field BEFORE that — so marking after an `await` would be too
+	// late to prevent the render it has already scheduled.
+	const fn = sliceBetween(sessionSource, 'async function toggleTaskCheckbox(', '\n\tasync function ');
+	const marked = fn.indexOf('markPreviewMatchesBuffer');
+	const awaited = fn.indexOf('await saveContent');
+	assert.ok(marked > 0, 'the toggle marks the preview');
+	assert.ok(marked < awaited, 'marked before the first await after the write');
 });

--- a/scripts/taskToggleLineEndings.test.ts
+++ b/scripts/taskToggleLineEndings.test.ts
@@ -1,0 +1,164 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+// Toggling a task checkbox in the preview finds the line to rewrite by counting
+// `\n` up to the regex match. Three rounds of fixes for #148 were verified on
+// macOS, i.e. on LF, and all three missed that the count is wrong on CRLF:
+//
+//   `\s` matches `\r` as well as `\n`, and JavaScript's `/m` `^` also matches
+//   between a `\r` and its `\n`. With `\s*` greedy, every match began one
+//   character early — on the previous line's `\n` — so the slice held one `\n`
+//   too few and every task resolved to line N-1.
+//
+// On the LAST task that is a no-op: nothing matches `sourceLine`, `toggle`
+// returns false, and the caller restores the control. The reporter reads that
+// as "the checkbox does not work". Everywhere else the off-by-one lands on a
+// *real* task line and silently rewrites the wrong one, which is worse and was
+// never reported because nobody could see it happen.
+//
+// These tests drive the real document session over both line endings. The
+// existing behavioural toggle test lives in `truncatedBufferGuard.test.ts` and
+// passes `sourceLine: 1` — the one line number the bug cannot reach, since at
+// offset 0 there is no preceding terminator for `\s*` to eat.
+
+const g = globalThis as any;
+const runeEffect = (fn: () => void) => {
+	void fn;
+};
+runeEffect.root = (fn: () => unknown) => fn();
+g.$state = (value: unknown) => value;
+g.$state.raw = (value: unknown) => value;
+g.$state.snapshot = (value: unknown) => value;
+g.$derived = (value: unknown) => value;
+g.$derived.by = (fn: () => unknown) => fn();
+g.$effect = runeEffect;
+g.window = g.window ?? {};
+
+let invokeCalls: Array<{ cmd: string; args: any }> = [];
+let handleInvoke: (cmd: string, args: any) => unknown = () => {
+	throw new Error('unexpected invoke');
+};
+
+g.window.__TAURI_INTERNALS__ = {
+	invoke: (cmd: string, args: any) => {
+		invokeCalls.push({ cmd, args });
+		return Promise.resolve(handleInvoke(cmd, args)).then((value) => value);
+	},
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
+
+function makeSession() {
+	return createDocumentSession({
+		setShowHome: () => {},
+		currentFile: () => tabManager.activeTab?.path ?? '',
+		resetScrollHistory: () => {},
+		renderMarkdown: async (raw: string) => `<p>${raw.length}</p>`,
+		afterLoad: async () => {},
+		saveRecentFile: () => {},
+		deleteRecentFile: () => {},
+		setLoadingTabs: () => {},
+		measureInitialViewport: () => {},
+		isScrolling: () => false,
+		renderRichContent: () => {},
+		onError: () => {},
+		selfWriteGraceMs: 400,
+		cancelPendingAutoSave: () => {},
+		askClose: async () => 'discard' as const,
+		onCloseSaveNewerEdits: () => {},
+		onCloseAutoSaveFailed: () => {},
+	});
+}
+
+/**
+ * Opens `doc`, toggles the task on `sourceLine`, and returns what was written.
+ *
+ * Returns null when the toggle refused to write, which is the shape the last
+ * task in a CRLF document had before this fix.
+ */
+async function toggledContent(doc: string, sourceLine: number, nowChecked: boolean) {
+	tabManager.closeAll();
+	invokeCalls = [];
+	handleInvoke = (cmd) => {
+		if (cmd === 'open_markdown_preview') return ['<p>preview</p>', doc, false, false];
+		if (cmd === 'read_file_content_checked') return [doc, false];
+		if (cmd === 'save_file_content') return null;
+		return null;
+	};
+	const session = makeSession();
+	await session.loadMarkdown('/docs/tasks.md');
+	await session.toggleTaskCheckbox(sourceLine, nowChecked);
+	const write = invokeCalls.find((call) => call.cmd === 'save_file_content');
+	return write ? (write.args.content as string) : null;
+}
+
+/** The same document in both line endings, so a case can be run over each. */
+function document(eol: string) {
+	return ['intro', '- [ ] one', '- [ ] two', '- [ ] three'].join(eol) + eol;
+}
+
+for (const [name, eol] of [
+	['LF', '\n'],
+	['CRLF', '\r\n'],
+] as const) {
+	test(`${name}: the task the reader clicked is the task that changes`, async () => {
+		// Line 3 is `- [ ] two`. Under the old pattern this resolved to line 2
+		// and rewrote `one` instead — a silent, invisible wrong write.
+		const written = await toggledContent(document(eol), 3, true);
+		assert.ok(written, 'the toggle wrote');
+		assert.equal(written, ['intro', '- [ ] one', '- [x] two', '- [ ] three'].join(eol) + eol);
+	});
+
+	test(`${name}: the last task toggles at all`, async () => {
+		// Line 4 is the last task. Under the old pattern nothing matched line 4,
+		// so the write was skipped entirely and the control snapped back. This
+		// is the symptom #148 reports.
+		const written = await toggledContent(document(eol), 4, true);
+		assert.ok(written, 'the toggle wrote instead of silently refusing');
+		assert.equal(written, ['intro', '- [ ] one', '- [ ] two', '- [x] three'].join(eol) + eol);
+	});
+
+	test(`${name}: unticking is the same arithmetic`, async () => {
+		const doc = ['intro', '- [x] one', '- [x] two'].join(eol) + eol;
+		const written = await toggledContent(doc, 3, false);
+		assert.equal(written, ['intro', '- [x] one', '- [ ] two'].join(eol) + eol);
+	});
+
+	test(`${name}: only one line changes`, async () => {
+		// The failure mode this guards is a match that spans the previous line's
+		// terminator: the replacement then rewrites two lines at once.
+		const before = document(eol);
+		const written = await toggledContent(before, 3, true);
+		assert.ok(written);
+		const changed = written!
+			.split(eol)
+			.filter((line, index) => line !== before.split(eol)[index]);
+		assert.deepEqual(changed, ['- [x] two'], 'exactly one line differs');
+	});
+
+	test(`${name}: the shapes the write-back claims to support`, async () => {
+		// Ordered, parenthesised, quoted, nested and `*`/`+` bullets all go
+		// through the same pattern; the CRLF bug hit every one of them.
+		const doc = ['intro', '1. [ ] ordered', '2) [ ] paren', '> - [ ] quoted', '  * [ ] nested', '+ [ ] plus'].join(eol) + eol;
+		for (const [line, expected] of [
+			[2, '1. [x] ordered'],
+			[3, '2) [x] paren'],
+			[4, '> - [x] quoted'],
+			[5, '  * [x] nested'],
+			[6, '+ [x] plus'],
+		] as const) {
+			const written = await toggledContent(doc, line, true);
+			assert.ok(written, `line ${line} wrote`);
+			assert.equal(written!.split(eol)[line - 1], expected);
+		}
+	});
+}
+
+test('a tab-indented task keeps its indentation', async () => {
+	// `[ \t]*` has to admit a tab, or a tab-indented task stops being found at
+	// all — the failure the narrowing could plausibly have introduced.
+	const doc = ['intro', '\t- [ ] tabbed'].join('\r\n') + '\r\n';
+	const written = await toggledContent(doc, 2, true);
+	assert.equal(written, ['intro', '\t- [x] tabbed'].join('\r\n') + '\r\n');
+});

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -49,7 +49,13 @@ static BLOCK_ID_RE: LazyLock<Regex> =
 /// so the pattern no longer depends on it either.
 static TASK_ITEM_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
-        r#"<li data-sourcepos="(?<sourcepos>(?<line>\d+):\d+-\d+:\d+)">(?<input><input type="checkbox"(?: (?:checked|disabled)="")* />)"#,
+        // The two `class` groups are optional so this holds whether or not
+        // `tasklist_classes` is on. It is on (see `markdown_options`), which
+        // is what makes the CSS work — but writing the classes in as required
+        // would mean flipping that option back would silently stop annotating
+        // the checkboxes rather than fail a test, and an unannotated checkbox
+        // is one the preview cannot toggle at all.
+        r#"<li(?: class="task-list-item")? data-sourcepos="(?<sourcepos>(?<line>\d+):\d+-\d+:\d+)">(?<input><input type="checkbox"(?: class="task-list-item-checkbox")?(?: (?:checked|disabled)="")* />)"#,
     )
     .expect("valid regex literal")
 });
@@ -381,6 +387,19 @@ fn markdown_options<'a>() -> Options<'a> {
     options.extension.table = true;
     options.extension.autolink = true;
     options.extension.tasklist = true;
+    // Fifteen rules in styles.css hang off `li.task-list-item` and
+    // `ul.contains-task-list` — the bullet suppression and the grid that puts
+    // the checkbox beside its text — and comrak emits neither class unless
+    // this is on. It defaulted to off, so all fifteen were dead: task lists
+    // rendered with the list bullet still showing AND the checkbox on its own
+    // line above the text. The classes are GitHub's, which is where those
+    // selectors came from.
+    //
+    // They went missing in the 0.18 → 0.54 upgrade (#426) together with the
+    // `disabled` change #320/#345 fixed, and unlike that one nobody reported
+    // it as its own defect — it arrived looking like part of the same
+    // breakage. #148 is where it finally surfaced, in a reader's screenshot.
+    options.render.tasklist_classes = true;
     // `++ins++` — Pandoc's and CriticMarkup's spelling for inserted text, and
     // plain characters here until now. It is the only one of its group worth
     // taking, and the rule that decided the others is worth stating, because
@@ -3482,18 +3501,28 @@ mod tests {
     fn task_list_checkbox_is_emitted_at_the_start_of_its_list_item() {
         // The attribute order here is comrak's, captured, not a requirement:
         // 0.18 wrote `disabled="" checked=""` and 0.54 writes them the other
-        // way round. What this pins is that `data-task-checkbox` is present on
+        // way round, and `tasklist_classes` adds a `class` between the tag and
+        // them. What this pins is that `data-task-checkbox` is present on
         // *both* items and that the marker sits at the start of the `<li>`.
-        // `TASK_ITEM_RE` deliberately no longer depends on the order, so a
-        // future reordering fails here — loudly — instead of quietly
-        // un-marking one of the two.
+        // `TASK_ITEM_RE` deliberately depends on neither the order nor the
+        // presence of the class, so a future reordering fails here — loudly —
+        // instead of quietly un-marking one of the two.
+        //
+        // Note the `<ul>` carries `contains-task-list` while these `<li>`s do
+        // not carry `task-list-item`: comrak only writes the item class on the
+        // branch that opens the `<li>` itself. styles.css asks for either, so
+        // the bullet suppression still lands.
         let html = convert_markdown("- [ ] open task\n- [x] completed task\n");
         assert!(
-            html.contains("<li data-sourcepos=\"1:1-1:15\"><input type=\"checkbox\" data-task-checkbox=\"\" disabled=\"\" /> open task</li>"),
+            html.contains("<ul class=\"contains-task-list\""),
+            "the list class the stylesheet needs is missing: {html}",
+        );
+        assert!(
+            html.contains("<li data-sourcepos=\"1:1-1:15\"><input type=\"checkbox\" data-task-checkbox=\"\" class=\"task-list-item-checkbox\" disabled=\"\" /> open task</li>"),
             "unexpected task-list HTML: {html}",
         );
         assert!(
-            html.contains("<li data-sourcepos=\"2:1-2:20\"><input type=\"checkbox\" data-task-checkbox=\"\" checked=\"\" disabled=\"\" /> completed task</li>"),
+            html.contains("<li data-sourcepos=\"2:1-2:20\"><input type=\"checkbox\" data-task-checkbox=\"\" class=\"task-list-item-checkbox\" checked=\"\" disabled=\"\" /> completed task</li>"),
             "unexpected task-list HTML: {html}",
         );
     }

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -603,7 +603,16 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		if (!(await ensureFullContent(tab.id))) return false;
 		const raw = tab.rawContent;
 		const body = getMarkdownBodyWithoutFrontMatter(raw);
-		const updatedBody = body.replace(/^(\s*(?:>\s*)*(?:[-+*]|\d+[.)])\s+)\[( |x|X)\]/gm, (match, prefix, _state, offset) => {
+		// Horizontal whitespace only, and it has to stay that way. `\s` matches
+		// `\r` as well as `\n`, and JavaScript's `/m` `^` also matches at the
+		// position *between* a `\r` and its `\n`. With `\s*` greedy, every match
+		// in a CRLF buffer began one character early — on the previous line's
+		// `\n` — so `body.slice(0, offset)` held one `\n` too few and every task
+		// resolved to line N-1. On the last task that is a no-op the user reads
+		// as "the checkbox does not work" (#148); anywhere else the off-by-one
+		// lands on a *real* task line and silently toggles the wrong one. Every
+		// CRLF document was affected, which is to say every Windows author.
+		const updatedBody = body.replace(/^([ \t]*(?:>[ \t]*)*(?:[-+*]|\d+[.)])[ \t]+)\[( |x|X)\]/gm, (match, prefix, _state, offset) => {
 			const line = body.slice(0, offset).split('\n').length;
 			if (line === sourceLine) return `${prefix}[${nowChecked ? 'x' : ' '}]`;
 			return match;

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -58,6 +58,22 @@ type DocumentSessionOptions = {
 };
 
 /**
+ * Record that the rendered preview already matches `rawContent`.
+ *
+ * `_lastRenderedRawContent` is MarkdownViewer's bookkeeping: its render effect
+ * compares the field against the buffer and re-renders when they differ. A
+ * caller that has updated the preview DOM by hand has to say so, or the effect
+ * rebuilds the article to reach the state already on screen — and takes the
+ * reader's scroll position with it.
+ *
+ * Declared here rather than inlined so the cast lives in one place and the
+ * reason is written once.
+ */
+function markPreviewMatchesBuffer(tab: Tab, rawContent: string) {
+	(tab as unknown as Record<string, unknown>)._lastRenderedRawContent = rawContent;
+}
+
+/**
  * Which heading sections the tab being loaded has folded, read at render time
  * rather than captured up front. A large file is rendered twice — the 50KB
  * preview, then the whole document once the background read lands — and the
@@ -620,6 +636,21 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		const updated = `${raw.slice(0, raw.length - body.length)}${updatedBody}`;
 		if (updated === raw) return false;
 		tabManager.updateTabRawContent(tab.id, updated);
+		// The preview is already showing this content: the browser has drawn
+		// the native checkbox, and the caller adds `task-done` to the item. A
+		// re-render would rebuild the whole article to arrive at the DOM that
+		// is on screen, and rebuilding it drops the reader's scroll position —
+		// ticking something in a long document threw the view somewhere else
+		// entirely, which is worse than the missing render would be.
+		//
+		// In the same synchronous block as the write, deliberately. The render
+		// effect reads `_lastRenderedRawContent` and, if it does not match,
+		// arms a 16ms timer BEFORE anything can be awaited — so marking this
+		// after an `await` would be too late to stop the render it schedules.
+		// The field is MarkdownViewer's, and this is the one place outside it
+		// that may claim the preview is current, because this is the one place
+		// that knows the DOM was updated by hand.
+		markPreviewMatchesBuffer(tab, updated);
 		await saveContent(tab.id);
 		return true;
 	}

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -382,6 +382,20 @@ function processTaskItems(root: Element) {
 		input.removeAttribute("disabled");
 		(input as HTMLInputElement).style.cursor = "pointer";
 
+		// comrak writes `task-list-item` only on the branch where it opens the
+		// `<li>` itself, which a plain task item does not take — so the `<ul>`
+		// gets `contains-task-list` and the items get nothing. That asymmetry
+		// showed as half a fix: the bullet disappeared, because that rule can
+		// match the list, while the grid that puts the checkbox beside its text
+		// stayed dead, because every one of those rules names the item.
+		//
+		// Added here rather than by widening fifteen selectors to
+		// `ul.contains-task-list > li`: this loop already owns which items are
+		// really tasks — `data-task-checkbox` is the renderer's own verdict,
+		// checked above — so the class lands on exactly that set and nothing
+		// else, including in documents where a `<ul>` holds both kinds.
+		li.classList.add("task-list-item");
+
 		const inputParagraph = input.parentElement;
 		if (inputParagraph?.tagName === "P" && inputParagraph.parentElement === li) {
 			li.insertBefore(input, inputParagraph);


### PR DESCRIPTION
Fixes #148.

@arcadepro was right to reopen it, right that 2.6.7 was the last version that worked, and right again when he said the newer fixes only changed the colour. Four separate defects were sitting on this one gesture. Three of them arrived together in the comrak 0.18 → 0.54 upgrade (#426, shipped as 2.6.8), and only one of the three was ever fixed.

| | what broke | fixed by |
|---|---|---|
| checkbox rendered `disabled` | comrak changed the task HTML | #320 / #345 |
| **the toggle wrote to the wrong line** | #345 replaced an EOL-independent write-back with line arithmetic | **here** |
| **task lists lost their styling** | comrak stopped emitting the classes 15 CSS rules depend on | **here** |
| **ticking re-rendered the document** | the buffer write is enough to trigger the render effect | **here** |

## 1. The toggle wrote to the wrong line

```diff
-  let count = 0;
-  raw.replace(/^(\s*[-*+] )\[( |x|X)\]/gm, (match, prefix) => {
-      if (count++ === index) …            // ordinal: EOL-independent
+  body.replace(/…/gm, (match, prefix, _state, offset) => {
+      const line = body.slice(0, offset).split('\n').length;   // line arithmetic
```

`\s` matches `\r` as well as `\n`, and JavaScript's `/m` `^` also matches at the position *between* a `\r` and its `\n`. With `\s*` greedy, a match can begin one character early — on the previous line's terminator — so the slice holds one `\n` too few and the task resolves to line N-1.

**This is not only a CRLF bug**, which is what the first version of this PR claimed. A blank line above the list is the other half of the condition, and that is how most people write a list. Measured against `samples/stress-test.md` before and after:

```
LF, list directly after prose      correct
LF, blank line above the list      the first task of each block is wrong
CRLF                               every task is wrong
```

The old document had 44 tasks and got 6 wrong. Every one of the six was the first task after a blank line.

**On the last task of a list** nothing matches `sourceLine`, the write is skipped, and the control snaps back — indistinguishable from a dead checkbox, which is what #148 reports. **Everywhere else** the off-by-one lands on a *real* task and silently rewrites the neighbour. Nobody filed that, because nobody can see it happen.

Fix: horizontal whitespace only, so a match can never begin before the line start. The Rust `TASK_SOURCE_RE` needs no change — it runs over `markdown.lines()`, already split.

## 2. Task lists lost their styling

`styles.css` has fifteen rules on `li.task-list-item` and `ul.contains-task-list` — the bullet suppression and the grid that puts the checkbox beside its text. comrak emits neither class unless `render.tasklist_classes` is set, and it defaults to off. All fifteen were dead: task lists rendered with the bullet still showing **and** the checkbox alone on a line above its text. This is what the reporter's screenshot shows.

Turning the option on moved the HTML under `TASK_ITEM_RE`, which anchored on `<li data-sourcepos=` immediately followed by `<input type="checkbox"`. comrak now writes a class into both, so the pattern stopped matching and `data-task-checkbox` stopped being injected — the attribute the preview uses to find a checkbox at all. Six tests caught it. Both class groups are now optional, so flipping the option back fails a test rather than silently un-marking every checkbox.

That fixed half of it. comrak writes `task-list-item` only on the branch where it opens the `<li>` itself, which a plain task item does not take — so the `<ul>` got its class and the items got nothing, the bullet disappeared, and every rule that positions the checkbox stayed dead. `processTaskItems` now adds it, which is where the app already decides which items are really tasks.

## 3. Ticking re-rendered the whole document

`toggleTaskCheckbox` is careful not to re-render — it toggles `task-done` on the item and leaves the DOM alone. But writing the buffer is enough on its own: MarkdownViewer's render effect fires whenever `rawContent` stops matching `_lastRenderedRawContent`, so in split view every tick rebuilt the article to arrive at the DOM that was already on screen, and took the reader's scroll position with it. In a long document the view landed somewhere else entirely.

The write now records that the preview already matches — in the same synchronous block, because the effect checks that field and arms a 16ms timer before anything is awaited.

## 4. The stress document could not have caught any of this

`samples/stress-test.md` had two task shapes: a flat `-` list and one nested level. It now carries ordered `1.`, parenthesised `1)`, `*`, `+`, tasks in a blockquote, four levels of mixed nesting, adjacent runs, and a list with no blank line above it beside one with a blank line.

It also carries the shape from the reporter's own attachment: a task whose item is a dozen indented lines, every line an inline code span, most ending in two trailing spaces so each is a hard break. That is the shape where a checkbox and its text can be laid out apart from one another.

```
old document, old pattern:  44 tasks,  6 wrong
new document, old pattern:  76 tasks, 14 wrong
new document, new pattern:  76 tasks,  0 wrong
```

Diffed against `markdown-syntax.md` while in there, the document was also missing **every** wikilink, block id, video/audio embed, YouTube embed and `++inserted++` — so three features could have been broken with the stress test passing end to end. Added.

## Why it survived two releases

All three previous fixes were verified on macOS, where the CRLF half cannot occur. And the suite could not see the rest: the only behavioural call of `toggleTaskCheckbox` lives in `truncatedBufferGuard.test.ts` and passes `sourceLine: 1` — the one line number the bug cannot reach, because at offset 0 there is no preceding terminator for `\s*` to eat.

`scripts/taskToggleLineEndings.test.ts` drives the real document session over **both** line endings, with and without a blank line above the list, across every marker shape. Reverting the pattern fails six cases and leaves the LF-without-blank-line ones passing — so the fixtures reproduce the bug rather than merely asserting the fix.

## Validation

- `npm test` 863 · `npm run check` 0 errors · `cargo test` 141 · `npm audit` 0 vulnerabilities
- Verified by reverting each fix in turn and watching the matching tests go red
- Tested by hand on macOS: every shape in the new document toggles, toggles only itself, and the view no longer jumps

**Not verified**: no run on Windows or Linux, and the rendering fixes are confirmed by screenshot on macOS only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)