### PR TITLE
chore(deps): bump nanoid past GHSA-2v37-7h3g-55p8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2577,9 +2577,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.16",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"dev": true,
 			"funding": [
 				{


### PR DESCRIPTION
## Why

`npm audit` is a required check (`.github/workflows/test.yml`, guarded by `scripts/workflowSecurityAudit.test.ts`). A newly published advisory against `nanoid <3.3.17` — [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8), high, custom generators can loop indefinitely when size is zero — turned it red on **every** open pull request, including ones that touch nothing related:

- #533 (a preview fix) — [run 31235165628](https://github.com/sftwrdotdev/Markpad/actions/runs/31235165628)
- #532 (a zh-TW translation string) — [run 31233407451](https://github.com/sftwrdotdev/Markpad/actions/runs/31233407451)

The audit step runs before `npm test` and `npm run check`, so a red `test` job currently says nothing about the branch it is reporting on.

## What

Lockfile only, three lines:

```
nanoid 3.3.16 → 3.3.18
```

nanoid is not a direct dependency — it arrives as `vite → postcss → nanoid`, and postcss's range already admits the fixed release, so `npm audit fix` resolves it without touching `package.json`. Unlike the dompurify pin in #528 there is no `overrides` entry to add: nothing is holding the version back, the lockfile was simply resolved before the fix existed.

3.3.18 rather than the advisory's minimum 3.3.17 because that is the current patch release of the same line.

## Verification

- `npm audit` — found 0 vulnerabilities (was 1 high)
- `npm test` — 843/843 pass
- `npm run check` — 666 files, 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)