### PR TITLE
fix: offer .txt in the Open dialog (#535)

### DIFF
--- a/scripts/fileAssociations.test.ts
+++ b/scripts/fileAssociations.test.ts
@@ -12,3 +12,19 @@ test('installer advertises only Markdown file associations', () => {
 	assert.deepEqual(extensions, ['md', 'markdown']);
 	assert.equal(extensions.includes('txt'), false);
 });
+
+// The other half of the same policy, kept in this file so neither side moves
+// without the reader seeing both. Claiming `.txt` in the installer takes the
+// Text Document association away from Notepad (#179), which is why the test
+// above exists — but Markpad does open, render and save `.txt` like any other
+// note, so the Open dialog has to offer them. Before #535 it listed four
+// extensions by hand and `.txt` was reachable only via "All Files".
+test('the Open dialog offers every extension Markpad treats as a document', () => {
+	const viewer = readSource('src/lib/MarkdownViewer.svelte');
+	const sanitize = readSource('src/lib/utils/sanitize.ts');
+
+	assert.match(sanitize, /MARKDOWN_LINK_EXTENSIONS = \[[^\]]*'txt'/);
+	assert.match(viewer, /\{ name: 'Markdown', extensions: MARKDOWN_LINK_EXTENSIONS \}/);
+	// A literal list is how the two drifted apart in the first place.
+	assert.doesNotMatch(viewer, /extensions: \['md/);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -24,7 +24,7 @@
 	import { hasRealFilePath } from './utils/tabFileActions.js';
 	import ZoomOverlay from './components/ZoomOverlay.svelte';
 import { processMarkdownHtml } from './utils/markdown';
-import { sanitizeMarkdownHtml } from './utils/sanitize.js';
+import { MARKDOWN_LINK_EXTENSIONS, sanitizeMarkdownHtml } from './utils/sanitize.js';
 import {
 	renderDiagramsForPrint,
 	resolveMermaidTheme,
@@ -1976,7 +1976,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		const selected = await open({
 			multiple: true,
 			filters: [
-				{ name: 'Markdown', extensions: ['md', 'markdown', 'mdown', 'mkd'] },
+				// The one list every other part of the app already treats as a
+				// Markpad document — including `.txt`, which loads, renders and
+				// saves like any other note (#535). Hardcoding a shorter list here
+				// only hid those files behind "All Files".
+				{ name: 'Markdown', extensions: MARKDOWN_LINK_EXTENSIONS },
 				{ name: 'All Files', extensions: ['*'] },
 			],
 		});


### PR DESCRIPTION
Fixes #535.

Markpad already treats `.txt` as one of its own documents everywhere that matters — `hasMarkdownLinkExtension` accepts it, so a `.txt` opens, renders, follows wikilinks, reloads on external change and saves back under its own extension; the drop handler routes it to open; the Rust side lists it in `MARKDOWN_LINK_EXTENSIONS` too.

The Open dialog was the one place that spelled the set out by hand, and it spelled four of the five. The files opened fine but were invisible in the picker unless the user switched the filter to "All Files", which reads as "Markpad cannot open .txt".

Fixed at the list rather than at the symptom: the filter now takes the exported `MARKDOWN_LINK_EXTENSIONS`, so the sixth place that needs this set cannot be the next one to miss an entry.

The installer still does not claim `.txt` (#179 / #302) — that association belongs to the system text editor, and taking it is a different act from being able to open the file. Both halves of that policy now sit in `scripts/fileAssociations.test.ts` so neither side moves without the reader seeing the other.

Validation:
- `npm run check` — 0 errors
- `npm test` — 866 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)