### PR TITLE
fix(updater): let the release notes be selected and copied (#532)

### DIFF
--- a/scripts/updateDialogNotes.test.ts
+++ b/scripts/updateDialogNotes.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readSource } from './sourceTree.js';
+
+const dialog = readSource('src/lib/components/UpdateDialog.svelte');
+const globalStyles = readSource('src/styles.css');
+
+test('release notes can be selected even though the app disables selection', () => {
+	// The app root sets `user-select: none` on purpose. Anything that holds text
+	// a user has to copy out has to say so for itself — nothing else in this
+	// component does, so a rule that quietly went missing here would look like
+	// no rule at all, which is what #532 reported.
+	assert.match(globalStyles, /user-select: none/);
+
+	const notesRule = /\.notes pre \{[^}]*\}/.exec(dialog)?.[0];
+	assert.ok(notesRule, 'the release-notes block must still have its own style rule');
+	assert.match(notesRule, /user-select: text/);
+	assert.match(notesRule, /-webkit-user-select: text/);
+});

--- a/src/lib/components/UpdateDialog.svelte
+++ b/src/lib/components/UpdateDialog.svelte
@@ -343,6 +343,13 @@
 		word-break: break-word;
 		font-family: var(--win-font);
 		font-size: 13px;
+		/* styles.css puts `user-select: none` on the app root so the chrome does
+		   not behave like a web page, and only `.markdown-body` opts back in.
+		   That reaches this box too, which is not chrome: it is release text,
+		   and the release link inside it is the one thing here a user has to be
+		   able to take somewhere else (#532). */
+		user-select: text;
+		-webkit-user-select: text;
 		color: var(--color-fg-muted);
 	}
 


### PR DESCRIPTION
Part of #532 — the copy-and-paste half, on its own.

`styles.css` sets `user-select: none` on the app root so the chrome does not behave like a web page, and only `.markdown-body` opts back in. The update dialog's release-notes box inherited that, which is wrong for what it holds: the notes are text, and the release link inside them is the one thing in the dialog a user has to be able to take somewhere else. #532 reported it as "not even clickable or copy and pastable" — this fixes the second half.

Two declarations on `.notes pre`, plus a test that pins them: the rule is invisible in the component (nothing else in it opts back in), so one that quietly went missing would look like no rule at all.

Deliberately **not** in this PR:

- rendering the URL as something clickable;
- putting the actual release text into `latest.json` — today it holds a placeholder link, because the feed is generated while the release is still a draft and the notes are written by hand afterwards.

### Validation

- `npm run check` — 0 errors
- `npm test` — passing, including the new assertion
- Measured in a browser against this exact rule: the app root computes `user-select: none` while the notes box computes `text`, the whole box selects, and the URL survives the copy intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)