### PR TITLE
fix(preview): make split-view scroll sync line-accurate

### DIFF
--- a/scripts/jumpToSelectedFragment.test.ts
+++ b/scripts/jumpToSelectedFragment.test.ts
@@ -337,11 +337,46 @@ test('every renderer line reaching the editor goes through the shift', () => {
 	);
 });
 
+// Scroll sync crosses the same boundary in BOTH directions, and it was the
+// consumer this file forgot: `ScrollSyncPosition.line` is a buffer line,
+// because the editor is the only pane that can produce one, while everything
+// the preview answers with counts from the body. On a document with front
+// matter the panes drifted apart by exactly that many lines — a constant
+// offset, unaffected by how precise the block mapping underneath got.
+
+test('scroll sync converts in both directions', () => {
+	const capture = functionSource(viewerSource, 'getPreviewScrollSyncPosition');
+	assert.match(
+		capture,
+		/line: toBufferLine\(line\)/,
+		'a line read off the preview is shifted before the editor sees it',
+	);
+
+	const apply = functionSource(viewerSource, 'scrollPreviewToSyncPosition');
+	assert.match(
+		apply,
+		/toRendererLine\(position\.line\)/,
+		'a line coming from the editor is shifted back before the preview seeks',
+	);
+});
+
+test('the outline is fed body lines from both panes', () => {
+	// `tocActiveLine` has two writers. The preview's already answers in body
+	// lines (`getPreviewScrollAnchor`); the editor's has to be converted, or the
+	// highlighted heading changes depending on which pane you scrolled.
+	const fromEditor = functionSource(viewerSource, 'handleEditorScrollSync');
+	assert.match(fromEditor, /tocActiveLine = toRendererLine\(position\.line\)/);
+
+	const fromPreview = functionSource(viewerSource, 'getPreviewScrollAnchor');
+	assert.doesNotMatch(fromPreview, /toBufferLine|toRendererLine/, 'already a body line');
+});
+
 test('the shift reads the buffer, not the rendered body', () => {
 	// `frontMatterLineOffset(rawContent)` — measuring the render would answer 0
 	// forever, since the render is what the front matter was stripped out of.
-	const shift = functionSource(viewerSource, 'toBufferRange');
-	assert.match(shift, /frontMatterLineOffset\(rawContent\)/);
+	for (const name of ['toBufferRange', 'toBufferLine', 'toRendererLine']) {
+		assert.match(functionSource(viewerSource, name), /frontMatterLineOffset\(rawContent\)/, name);
+	}
 });
 
 test('the selection is read before anything switches mode', () => {

--- a/scripts/jumpToSelectedFragment.test.ts
+++ b/scripts/jumpToSelectedFragment.test.ts
@@ -379,6 +379,20 @@ test('the shift reads the buffer, not the rendered body', () => {
 	}
 });
 
+// The menu is opened BY right-clicking a selection, and two of its items act
+// on that selection (Copy, Edit). Anything that moves focus off the document
+// stops the selection being painted, so the highlight disappears under the
+// menu that exists to act on it.
+
+test('the context menu does not take focus away from the selection', () => {
+	const menuSource = readSource('src/lib/components/ContextMenu.svelte');
+	assert.doesNotMatch(menuSource, /\.focus\(\)/, 'focusing the menu unpaints the selection');
+
+	// Escape still closes it — from the window, since the menu never has focus.
+	assert.match(menuSource, /window\.addEventListener\('keydown'/);
+	assert.match(menuSource, /e\.key === 'Escape'/);
+});
+
 test('the selection is read before anything switches mode', () => {
 	// `toggleEdit` and `editSourceRange` both flip `isEditing`, and a selection
 	// read after that would answer for the editor rather than for the preview

--- a/scripts/previewAnchorRestore.test.ts
+++ b/scripts/previewAnchorRestore.test.ts
@@ -353,7 +353,26 @@ test('a soft-wrapped paragraph resolves to the paragraph, never to its <br>', ()
 	for (const line of [1, 2, 3]) {
 		const match = findAnchorElement(body, line);
 		assert.ok(match, `line ${line} must resolve`);
-		assert.equal((match.element as ShimElement).tagName, 'P', `line ${line} resolved to a boxless element`);
+
+		const element = match.element as ShimElement;
+		assert.notEqual(element.tagName, 'BR', `line ${line} resolved to a boxless element`);
+
+		// Lines after the first now resolve to the soft-line anchor that
+		// `processSoftLineAnchors` puts beside each break — a narrower answer
+		// than the paragraph, and a better one: it reports the position of that
+		// line rather than the top of the block containing it. The anchor is an
+		// empty inline-block, so unlike the `<br>` it has a box to measure,
+		// which is the property this test exists to protect.
+		if (element.getAttribute('class') === 'source-line-anchor') {
+			assert.deepEqual(
+				{ startLine: match.startLine, endLine: match.endLine },
+				{ startLine: line, endLine: line },
+				`the anchor for line ${line} must name that line`,
+			);
+			continue;
+		}
+
+		assert.equal(element.tagName, 'P', `line ${line} resolved to ${element.tagName}`);
 		assert.deepEqual({ startLine: match.startLine, endLine: match.endLine }, { startLine: 1, endLine: 3 });
 	}
 });

--- a/scripts/scrollSyncBlockMapping.test.ts
+++ b/scripts/scrollSyncBlockMapping.test.ts
@@ -265,6 +265,17 @@ function sourceLineSpan(element: ShimElement): number {
 }
 
 /** Does anything in here carry a source range? Non-participants get no box. */
+function startLineOf(element: ShimElement): number | null {
+	const sourcepos = element.getAttribute('data-sourcepos');
+	if (!sourcepos) return null;
+	const line = parseInt(sourcepos.split('-')[0].split(':')[0], 10);
+	return Number.isNaN(line) ? null : line;
+}
+
+function isLineAnchor(element: ShimElement): boolean {
+	return element.getAttribute('class') === 'source-line-anchor';
+}
+
 function isAnnotated(element: ShimElement): boolean {
 	if (element.getAttribute('data-sourcepos')) return true;
 	return elementChildren(element).some(isAnnotated);
@@ -282,7 +293,12 @@ function layOut(root: ShimElement, startTop = 0, gap = BLOCK_GAP): Map<ShimEleme
 	const boxes = new Map<ShimElement, Box>();
 
 	function place(element: ShimElement, top: number): number {
-		const children = elementChildren(element).filter(isAnnotated);
+		// Soft-line anchors sit inline with zero size, so a browser gives them
+		// an `offsetTop` without letting them take any vertical space. They are
+		// positioned by their owning block below, after its own height is
+		// known — laying them out here instead would stack them like blocks and
+		// stretch every wrapped paragraph by one per line.
+		const children = elementChildren(element).filter(isAnnotated).filter((child) => !isLineAnchor(child));
 
 		if (children.length === 0) {
 			const height = leafHeight(element, sourceLineSpan(element));
@@ -317,6 +333,33 @@ function layOut(root: ShimElement, startTop = 0, gap = BLOCK_GAP): Map<ShimEleme
 	for (const child of elementChildren(root)) {
 		if (!isAnnotated(child)) continue;
 		cursor += place(child, cursor) + gap;
+	}
+
+	// Now that every block has a box, give the anchors one. A browser puts each
+	// on the rendered row its source line starts, and in THIS document every
+	// source line of a paragraph is the same height — so that row is exactly
+	// where the block-wide interpolation already points. The anchors therefore
+	// change none of the numbers here, which is the point: this file's premise
+	// is that rendered height is not proportional to SOURCE lines across block
+	// types, not that a paragraph wraps unevenly. `scrollSyncSoftLineAnchors`
+	// covers the case where it does.
+	for (const [block, box] of Array.from(boxes)) {
+		const span = sourceLineSpan(block);
+		if (span < 2) continue;
+		const start = startLineOf(block);
+		if (start === null) continue;
+
+		for (const anchor of block.querySelectorAll('.source-line-anchor')) {
+			if (anchor.parentElement?.closest('[data-sourcepos]') !== block) continue;
+			const line = startLineOf(anchor);
+			if (line === null) continue;
+			// A paragraph here is `26 * sourceLines` tall, so dividing by the
+			// line count puts each anchor exactly on its own rendered row.
+			boxes.set(anchor, {
+				top: box.top + (box.height * (line - start)) / span,
+				height: 0,
+			});
+		}
 	}
 
 	return boxes;
@@ -926,7 +969,10 @@ test('an offset inside a table resolves to the row at it, not to the row after t
 	// last one — the editor sticks at the end of the table until the reader has
 	// scrolled past the whole thing.
 	const raw = getSourceLineAtPreviewOffset(PREVIEW.body, offset, PREVIEW.rawMeasure);
-	assert.equal(raw, LAST_TABLE_RANGE.endLine);
+	assert.ok(
+		raw !== null && raw >= LAST_TABLE_RANGE.endLine,
+		`the raw measure is expected to stick at or past the end of the table, got ${raw}`,
+	);
 });
 
 /* ------------------------------------------------------------------ */
@@ -1063,9 +1109,22 @@ test('an element the app renders around the document does not swallow the offset
 	assert.ok(line !== null, 'an offset over the front-matter panel must still resolve to a block');
 	assert.equal(line, 1);
 
-	// ...and the block under it still answers for itself.
-	assert.equal(getSourceLineAtPreviewOffset(body, 130, measure), 1);
-	assert.equal(getSourceLineAtPreviewOffset(body, 175, measure), 3);
+	// ...and the block under it still answers for itself. Fractionally: the
+	// mapping interpolates between the two samples either side of the offset,
+	// so a position inside the first paragraph reads as "just past line 1"
+	// rather than as a flat 1. That is the half that matches the editor, which
+	// also answers with a fraction — an integer here is what USED to leave the
+	// two panes disagreeing by up to a line.
+	const insideFirst = getSourceLineAtPreviewOffset(body, 130, measure);
+	assert.ok(
+		insideFirst !== null && insideFirst >= 1 && insideFirst < 3,
+		`an offset inside the first paragraph resolved to ${insideFirst}`,
+	);
+	const insideSecond = getSourceLineAtPreviewOffset(body, 175, measure);
+	assert.ok(
+		insideSecond !== null && insideSecond >= 3,
+		`an offset inside the second paragraph resolved to ${insideSecond}`,
+	);
 });
 
 test('a position past the last block resolves to the last block, not to nothing', () => {
@@ -1173,4 +1232,124 @@ test('the binary search costs a logarithm, not a walk', () => {
 
 	getLineAtVerticalOffset(1_234_567, lineCount, topForLine);
 	assert.ok(calls <= 2 * Math.ceil(Math.log2(lineCount)), `binary search made ${calls} measurements`);
+});
+
+/* ------------------------------------------------------------------ */
+/* soft line breaks inside a long paragraph                            */
+/* ------------------------------------------------------------------ */
+//
+// The interpolation across a block assumes every source line in it renders to
+// the same height. Prose breaks that assumption the moment one line wraps and
+// the next does not — and a long paragraph is where the error accumulates,
+// because the block is tall and the mapping has only its two ends to go on.
+//
+// `render.hardbreaks` means every source newline is already a `<br>` carrying
+// the line it ended, so the positions exist in the DOM; they were unreachable
+// only because a `<br>` generates no box. `processSoftLineAnchors` gives each
+// one a zero-sized sibling that does.
+
+/** A comrak-shaped paragraph of `lines` source lines joined by hard breaks. */
+function wrappedParagraph(startLine: number, lines: number): string {
+	const endLine = startLine + lines - 1;
+	const body = Array.from({ length: lines }, (_, index) => {
+		const line = startLine + index;
+		const text = `line ${line} of the paragraph`;
+		return index === lines - 1
+			? text
+			: `${text}<br data-sourcepos="${line}:${text.length}-${line}:${text.length}" />`;
+	}).join('\n');
+	return `<p data-sourcepos="${startLine}:1-${endLine}:24">${body}</p>`;
+}
+
+function renderParagraph(startLine: number, lines: number): ShimElement {
+	return parseHtml(processMarkdownHtml(wrappedParagraph(startLine, lines), FILE_PATH, new Set<string>())).body;
+}
+
+/** Every soft-line anchor in `root`, in document order, with its source line. */
+function anchorsOf(root: ShimElement): { element: ShimElement; line: number }[] {
+	const out: { element: ShimElement; line: number }[] = [];
+	const walk = (node: ShimElement) => {
+		for (const child of node.childNodes) {
+			if (child.nodeType !== NODE_ELEMENT) continue;
+			const element = child as ShimElement;
+			if (element.getAttribute('class') === 'source-line-anchor') {
+				const [start] = (element.getAttribute('data-sourcepos') ?? '').split('-');
+				out.push({ element, line: Number(start?.split(':')[0]) });
+			}
+			walk(element);
+		}
+	};
+	walk(root);
+	return out;
+}
+
+test('a long paragraph gets one anchor per soft line break', () => {
+	// Four source lines, three breaks — and the anchor names the line the break
+	// STARTS, because "where does line N begin on screen" is the question the
+	// mapping asks.
+	const anchors = anchorsOf(renderParagraph(10, 4));
+	assert.deepEqual(
+		anchors.map((a) => a.line),
+		[11, 12, 13],
+	);
+});
+
+test('a short paragraph is left alone', () => {
+	// Two lines cost half a line of interpolation error at worst. Anchoring
+	// them would be DOM nobody can see the benefit of, and most paragraphs in a
+	// document are short.
+	assert.deepEqual(anchorsOf(renderParagraph(10, 2)), []);
+});
+
+test('the <br> itself is untouched', () => {
+	// Replacing it would put the layout, selection and copy behaviour of every
+	// wrapped paragraph at risk to save one node per line.
+	const html = processMarkdownHtml(wrappedParagraph(10, 4), FILE_PATH, new Set<string>());
+	assert.equal((html.match(/<br /g) ?? []).length, 3, 'all three breaks survive');
+});
+
+test('a line inside the paragraph resolves to its own anchor, not to an interpolation', () => {
+	// The case the anchors exist for: line 10 wraps to three rendered lines and
+	// the rest wrap to one, so the block is 6 rendered lines tall while holding
+	// 4 source lines. Interpolating puts line 11 a third of the way down —
+	// 2 rendered lines in — when it really starts 3 in.
+	const root = renderParagraph(10, 4);
+	const paragraph = root.querySelector('p');
+	assert.ok(paragraph);
+	const anchors = anchorsOf(root);
+
+	const ROW = 20;
+	const PARAGRAPH_TOP = 100;
+	// line 10 wraps to 3 rows, then one row each for 11, 12, 13.
+	const rowOfLine = new Map([
+		[11, 3],
+		[12, 4],
+		[13, 5],
+	]);
+
+	const boxes = new Map<unknown, { top: number; height: number }>();
+	boxes.set(paragraph, { top: PARAGRAPH_TOP, height: 6 * ROW });
+	for (const { element, line } of anchors) {
+		boxes.set(element, { top: PARAGRAPH_TOP + (rowOfLine.get(line) ?? 0) * ROW, height: 0 });
+	}
+	const measure = (node: unknown) => boxes.get(node) ?? { top: 0, height: 0 };
+
+	const interpolated = PARAGRAPH_TOP + 6 * ROW * ((11 - 10) / (13 - 10));
+	const actual = getPreviewOffsetForSourceLine(root as AnchorNode, 11, measure as never);
+
+	assert.equal(actual, PARAGRAPH_TOP + 3 * ROW, 'line 11 lands where line 11 is drawn');
+	assert.notEqual(actual, interpolated, 'and not where the block-wide interpolation would put it');
+});
+
+test('an anchor carries no height, and the mapping never asks it for one', () => {
+	// A single-line range makes `getAnchorScrollTop` take ratio 0, so the
+	// height is multiplied away — which is what lets the anchor be invisible.
+	const root = renderParagraph(10, 4);
+	const anchors = anchorsOf(root);
+	assert.ok(anchors.length > 0);
+
+	const measure = (node: unknown) =>
+		node === anchors[0].element ? { top: 250, height: 0 } : { top: 0, height: 999 };
+
+	assert.equal(getPreviewOffsetForSourceLine(root as AnchorNode, 11, measure as never), 250);
 });

--- a/scripts/tocFollowsEditor.test.ts
+++ b/scripts/tocFollowsEditor.test.ts
@@ -20,7 +20,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { readSource, sliceBetween } from './sourceTree.js';
+import { functionSource, readSource, sliceBetween } from './sourceTree.js';
 
 import { activeTocIdForLine, sourceLineOf } from '../src/lib/utils/tocFollow.js';
 
@@ -101,10 +101,17 @@ test('the editor position reaches the outline whether or not scroll sync is on',
 	// The line is recorded before the sync check, not inside it: following the
 	// editor is not the same feature as moving the preview, and #169 asks for it
 	// in editor-only mode, where there is no preview to move.
-	assert.match(
-		viewerSource,
-		/function handleEditorScrollSync\(position: ScrollSyncPosition\) \{\s*\n\s*if \(position\.line !== undefined\) tocActiveLine = position\.line;/,
-	);
+	//
+	// The line is converted on the way in: `position` is in the editor's
+	// numbering and the outline is built from `data-sourcepos`, which counts
+	// from the body. See jumpToSelectedFragment.test.ts for that boundary.
+	const handler = functionSource(viewerSource, 'handleEditorScrollSync');
+	const record = handler.indexOf('tocActiveLine =');
+	const syncCheck = handler.indexOf('isScrollSynced');
+
+	assert.ok(record !== -1 && syncCheck !== -1, 'both statements must still be here');
+	assert.ok(record < syncCheck, 'the outline is fed before the sync check, not inside it');
+	assert.match(handler, /if \(position\.line !== undefined\) tocActiveLine = toRendererLine\(position\.line\);/);
 });
 
 test('the preview feeds the same state, off the line it already measures', () => {

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -3869,6 +3869,25 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		border-radius: 8px;
 	}
 
+	/*
+	 * A measurable position for a soft line break, so split-view scroll sync
+	 * can resolve a line inside a long paragraph instead of interpolating
+	 * across the whole block. See `processSoftLineAnchors`.
+	 *
+	 * `inline-block` is the point — it is what gives the element a CSS box, and
+	 * therefore an `offsetTop` the anchor lookup can read. Everything else here
+	 * is about taking that box back out of the layout: no width, no height, and
+	 * `vertical-align: top` so a zero-height box cannot sit on the baseline and
+	 * push the line it is on. It holds no text, so selection and copy step over
+	 * it.
+	 */
+	:global(.source-line-anchor) {
+		display: inline-block;
+		width: 0;
+		height: 0;
+		vertical-align: top;
+	}
+
 	:global(.mermaid-diagram) {
 		margin: 1em 0;
 		display: flex;

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -1168,7 +1168,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 
 		const line = getSourceLineAtPreviewOffset(target, target.scrollTop, measurePreviewBox);
 
-		return line === null ? position : { ...position, line };
+		return line === null ? position : { ...position, line: toBufferLine(line) };
 	}
 
 	function scrollPreviewToSyncPosition(position: ScrollSyncPosition) {
@@ -1178,7 +1178,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		let targetScroll: number | null = null;
 
 		if (position.section === 'body' && position.line !== undefined) {
-			const offset = getPreviewOffsetForSourceLine(markdownBody, position.line, measurePreviewBox);
+			const offset = getPreviewOffsetForSourceLine(
+				markdownBody,
+				toRendererLine(position.line),
+				measurePreviewBox,
+			);
 			if (offset !== null) targetScroll = offset;
 		}
 
@@ -1217,7 +1221,8 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	let tocActiveLine = $state<number | null>(null);
 
 	function handleEditorScrollSync(position: ScrollSyncPosition) {
-		if (position.line !== undefined) tocActiveLine = position.line;
+		// The outline is built from `data-sourcepos`, so it counts from the body.
+		if (position.line !== undefined) tocActiveLine = toRendererLine(position.line);
 
 		if (tabManager.activeTab?.isScrollSynced) {
 			scrollPreviewToSyncPosition(position);
@@ -1791,6 +1796,22 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		const offset = frontMatterLineOffset(rawContent);
 		if (!offset) return range;
 		return { startLine: range.startLine + offset, endLine: range.endLine + offset };
+	}
+
+	/**
+	 * The same conversion for a single line, in both directions.
+	 *
+	 * `ScrollSyncPosition.line` is a BUFFER line, because the editor is the only
+	 * pane that can produce one and the buffer is all it knows. Everything on the
+	 * preview side — `data-sourcepos`, the outline built from it — counts from
+	 * the first line of the body. Every crossing between the two has to say so.
+	 */
+	function toBufferLine(line: number): number {
+		return line + frontMatterLineOffset(rawContent);
+	}
+
+	function toRendererLine(line: number): number {
+		return line - frontMatterLineOffset(rawContent);
 	}
 
 	async function saveContent(tabId?: string): Promise<boolean> {

--- a/src/lib/components/ContextMenu.svelte
+++ b/src/lib/components/ContextMenu.svelte
@@ -27,12 +27,26 @@
 		}
 	});
 
+	/**
+	 * Escape closes the menu, and it listens on the window rather than on the
+	 * menu itself.
+	 *
+	 * The menu used to focus itself so its own `keydown` would fire. But this
+	 * menu is opened by right-clicking the preview, and right-clicking a
+	 * selection is how you copy or edit it — moving focus off the document
+	 * stops the selection being painted, so the highlight vanished under the
+	 * menu that was opened to act on it. Nothing else here wanted focus: there
+	 * is no arrow-key navigation, and the overlay handles click-to-dismiss.
+	 */
 	$effect(() => {
-		if (show && menuEl) {
-			setTimeout(() => {
-				menuEl?.focus();
-			}, 10);
-		}
+		if (!show) return;
+
+		const onKeydown = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') onhide();
+		};
+
+		window.addEventListener('keydown', onKeydown);
+		return () => window.removeEventListener('keydown', onKeydown);
 	});
 
 	let adjustedX = $derived(menuEl && x + menuEl.offsetWidth > innerWidth ? innerWidth - menuEl.offsetWidth - 8 : x);
@@ -52,8 +66,7 @@
 			onclick={(e) => e.stopPropagation()}
 			oncontextmenu={(e) => { e.preventDefault(); e.stopPropagation(); }}
 			role="menu"
-			tabindex="-1"
-			onkeydown={(e) => e.key === 'Escape' && onhide()}>
+			tabindex="-1">
 			{#each items as item}
 				{#if item.separator}
 					<div class="menu-separator"></div>

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -1,4 +1,5 @@
 import { convertFileSrc } from "@tauri-apps/api/core";
+import { parseSourceposLineRange } from "./previewAnchor.js";
 import { carrySourcepos } from "./richContent.js";
 
 const alertIcons: Record<string, string> = {
@@ -461,6 +462,77 @@ function processTaskItems(root: Element) {
 	}
 }
 
+/**
+ * How many source lines a block has to span before its soft line breaks are
+ * worth anchoring.
+ *
+ * Two lines cost half a line of interpolation error at worst, which nobody can
+ * see; the anchors are for the long paragraphs where the error accumulates.
+ * Keeping short blocks untouched is most of the DOM saving, because most
+ * paragraphs are short.
+ */
+const LINE_ANCHOR_MIN_SPAN = 3;
+
+/**
+ * Give each soft line break inside a long block a measurable position.
+ *
+ * Split-view scroll sync is asymmetric. The editor answers "which line is at
+ * this pixel" from Monaco's real layout, so it knows the height of every line
+ * including its wraps. The preview answers the reverse by interpolating across
+ * the block that owns the line — which assumes every source line in the block
+ * renders to the same height. Prose breaks that assumption whenever one line
+ * wraps to three and the next to one, and a long paragraph is where the error
+ * shows.
+ *
+ * The information to do better is already in the DOM. `render.hardbreaks` is
+ * on, so every source newline becomes a `<br>`, and comrak stamps each one
+ * with the line it ended. What a `<br>` cannot do is be measured: it generates
+ * no CSS box, which is why `BOXLESS_TAGS` in previewAnchor.ts excludes it —
+ * resolving to one hands the caller `offsetTop = 0` and scrolls to the top of
+ * the document.
+ *
+ * So each break gets a sibling that does generate a box, carrying the line the
+ * break starts rather than the one it ends. Zero-width and zero-height, so it
+ * changes nothing on screen; `previewAnchor` needs only `offsetTop` from it,
+ * because a single-line range never interpolates and never reads the height.
+ *
+ * The `<br>` itself is left alone. Replacing it would put the layout, text
+ * selection and copy behaviour of every wrapped paragraph at risk to save one
+ * node per line.
+ */
+function processSoftLineAnchors(root: Element, doc: Document) {
+	for (const block of Array.from(root.querySelectorAll("[data-sourcepos]"))) {
+		const range = parseSourceposLineRange(block.getAttribute("data-sourcepos"));
+		if (!range || range.endLine - range.startLine + 1 < LINE_ANCHOR_MIN_SPAN) continue;
+
+		for (const br of Array.from(block.querySelectorAll("br[data-sourcepos]"))) {
+			// Only the breaks this block owns. A nested block keeps its own, and
+			// it will be visited in its own turn if it is long enough to qualify.
+			//
+			// From the PARENT: `closest` matches the element it starts on, and
+			// the `<br>` carries a `data-sourcepos` of its own, so starting on
+			// it answers with the `<br>` every time and nothing would qualify.
+			if (br.parentElement?.closest("[data-sourcepos]") !== block) continue;
+
+			const at = parseSourceposLineRange(br.getAttribute("data-sourcepos"));
+			if (!at) continue;
+
+			// The line AFTER the break: the anchor marks where the next source
+			// line starts on screen, which is the question the mapping asks.
+			const line = at.endLine + 1;
+			if (line > range.endLine) continue;
+
+			const anchor = doc.createElement("span");
+			anchor.className = "source-line-anchor";
+			anchor.setAttribute("data-sourcepos", `${line}:1-${line}:1`);
+			anchor.setAttribute("aria-hidden", "true");
+			// `insertBefore` rather than `after`: it is the older API, and the
+			// render-protocol DOM the tests drive implements it.
+			br.parentNode?.insertBefore(anchor, br.nextSibling);
+		}
+	}
+}
+
 export function processMarkdownHtml(
 	html: string,
 	filePath: string,
@@ -674,6 +746,7 @@ export function processMarkdownHtml(
 	processBlockIds(doc.body, doc);
 	processTaskItems(doc.body);
 	processInlineMath(doc.body);
+	processSoftLineAnchors(doc.body, doc);
 
 	const headings = Array.from(doc.querySelectorAll("h1, h2, h3, h4, h5, h6"));
 	// The heading↔wrapper pairing only needs to be unique within this

--- a/src/lib/utils/previewAnchor.ts
+++ b/src/lib/utils/previewAnchor.ts
@@ -452,6 +452,117 @@ export function getAnchorScrollTop(
 	return Math.max(0, elementTop + elementHeight * ratio - offset);
 }
 
+/* ------------------------------------------------------------------ */
+/* the sample table                                                    */
+/* ------------------------------------------------------------------ */
+//
+// Scroll sync maps a pixel to a source line and back. It used to do that by
+// descending to the single narrowest annotated element containing the offset
+// and interpolating across ITS range — which has two problems that only show
+// up together.
+//
+// The first is that it measures every child at every level on the way down, so
+// the cost is linear in the size of the document on an event that fires many
+// times a second. The second is worse: adding more annotated elements makes it
+// LESS accurate, because a finer element is a narrower range, and an element
+// spanning a single line cannot interpolate at all — the answer quantises to
+// whole lines. Any attempt to improve the mapping by giving it more to work
+// with made it step instead of glide.
+//
+// So the model is the one VS Code's Markdown preview uses
+// (`extensions/markdown-language-features/preview-src/scroll-sync.ts`): a flat,
+// ordered table of (element, line) samples, a binary search for the pair the
+// offset falls between, and interpolation BETWEEN the two —
+//
+//     progress = (offset - previous.top) / (next.top - previous.top)
+//     line     = previous.line + progress * (next.line - previous.line)
+//
+// In that shape an extra sample is always an improvement: it splits an
+// interval, and interpolating across a shorter interval is never worse. It
+// also measures O(log n) elements instead of O(n).
+
+type LineSample = { element: AnchorNode; line: number };
+
+/**
+ * Every annotated element in document order, one sample each, deduplicated so
+ * that a line is represented by the innermost element that starts on it.
+ *
+ * A `<ul>` and its first `<li>` start on the same source line, as do a
+ * `<blockquote>` and its first paragraph. Keeping both would put two samples
+ * at one line and give the interval between them zero span. The inner one is
+ * kept because it is the one whose box actually bounds the text.
+ *
+ * Not memoised: this walks the tree without measuring anything, and the
+ * measuring is what costs. Caching it would mean invalidating on every render,
+ * and a stale table would silently map to the wrong lines.
+ */
+function collectLineSamples(root: AnchorNode): LineSample[] {
+	const samples: LineSample[] = [];
+
+	const visit = (node: AnchorNode) => {
+		for (const child of elementChildren(node)) {
+			// A collapsed fold is `height: 0; overflow: hidden`, and its
+			// children keep reporting the offsets they would have if it were
+			// open. Following them in would put samples below the fold at
+			// positions above it — which does not merely misplace those
+			// samples, it breaks the ordering the binary search depends on for
+			// everything after them. The fold answers for its own contents, at
+			// the one place the reader can actually see them.
+			//
+			// This is the same guard VS Code applies with `isVisible`, done by
+			// class so that building the table still costs no measurement.
+			if (isCollapsedContainer(child)) {
+				const span = ownRange(child) ?? resolveSpan(child);
+				if (span) samples.push({ element: child, line: span.startLine });
+				continue;
+			}
+
+			const own = ownRange(child);
+			if (!own) {
+				visit(child);
+				continue;
+			}
+
+			const before = samples.length;
+			visit(child);
+			// Only if no descendant already claimed this line.
+			if (samples[before]?.line !== own.startLine) {
+				samples.splice(before, 0, { element: child, line: own.startLine });
+			}
+		}
+	};
+
+	visit(root);
+	return samples;
+}
+
+/**
+ * The samples either side of `offset`: the last one at or above it, and the
+ * first one below.
+ *
+ * Binary search over `top`, which is monotonic in document order for the
+ * elements that survive the deduplication above — they are siblings or
+ * ancestors laid out in flow, so a later element never starts higher.
+ */
+function samplesAround(
+	samples: LineSample[],
+	offset: number,
+	measure: MeasureAnchorBox,
+): { previous: LineSample; next?: LineSample } {
+	let low = 0;
+	let high = samples.length - 1;
+
+	while (low < high) {
+		const mid = Math.ceil((low + high) / 2);
+		if (measure(samples[mid].element).top <= offset) low = mid;
+		else high = mid - 1;
+	}
+
+	const previous = samples[low];
+	const next = samples[low + 1];
+	return next ? { previous, next } : { previous };
+}
+
 /**
  * The source line rendered at `offset` in the preview's scroll content —
  * fractional, interpolated across the block that owns the offset.
@@ -469,17 +580,29 @@ export function getSourceLineAtPreviewOffset(
 	offset: number,
 	measure: MeasureAnchorBox,
 ): number | null {
-	const match = findAnchorElementAtOffset(root, offset, measure);
-	if (!match) return null;
+	if (!Number.isFinite(offset)) return null;
 
-	const box = measure(match.element);
-	if (!Number.isFinite(box.top) || !Number.isFinite(box.height)) return null;
+	const samples = collectLineSamples(root);
+	if (samples.length === 0) return null;
 
-	const totalLines = match.endLine - match.startLine;
-	if (totalLines <= 0 || box.height <= 0) return match.startLine;
+	const { previous, next } = samplesAround(samples, offset, measure);
+	const previousTop = measure(previous.element).top;
+	if (!Number.isFinite(previousTop)) return null;
 
-	const ratio = Math.max(0, Math.min(1, (offset - box.top) / box.height));
-	return match.startLine + totalLines * ratio;
+	if (next) {
+		const nextTop = measure(next.element).top;
+		const span = nextTop - previousTop;
+		if (!Number.isFinite(span) || span <= 0) return previous.line;
+
+		const progress = Math.max(0, Math.min(1, (offset - previousTop) / span));
+		return previous.line + progress * (next.line - previous.line);
+	}
+
+	// Past the last sample: its own height is all there is to go on, and a
+	// height of one rendered line is worth one source line.
+	const height = measure(previous.element).height;
+	if (!Number.isFinite(height) || height <= 0) return previous.line;
+	return previous.line + Math.max(0, (offset - previousTop) / height);
 }
 
 /**
@@ -495,11 +618,41 @@ export function getPreviewOffsetForSourceLine(
 	line: number,
 	measure: MeasureAnchorBox,
 ): number | null {
-	const match = findNearestAnchorElement(root, line);
-	if (!match) return null;
+	if (!Number.isFinite(line)) return null;
 
-	const box = measure(match.element);
-	if (!Number.isFinite(box.top) || !Number.isFinite(box.height)) return null;
+	const samples = collectLineSamples(root);
+	if (samples.length === 0) return null;
 
-	return getAnchorScrollTop(box.top, box.height, match, line, 0);
+	// The mirror of `samplesAround`, over lines rather than pixels. Both
+	// directions read the same table, so a round trip through the pair lands
+	// where it started.
+	let low = 0;
+	let high = samples.length - 1;
+	while (low < high) {
+		const mid = Math.ceil((low + high) / 2);
+		if (samples[mid].line <= line) low = mid;
+		else high = mid - 1;
+	}
+
+	const previous = samples[low];
+	const next = samples[low + 1];
+	const previousTop = measure(previous.element).top;
+	if (!Number.isFinite(previousTop)) return null;
+
+	if (next) {
+		const lineSpan = next.line - previous.line;
+		if (lineSpan <= 0) return Math.max(0, previousTop);
+
+		const nextTop = measure(next.element).top;
+		if (!Number.isFinite(nextTop)) return Math.max(0, previousTop);
+
+		const progress = Math.max(0, Math.min(1, (line - previous.line) / lineSpan));
+		return Math.max(0, previousTop + progress * (nextTop - previousTop));
+	}
+
+	// Past the last sample, as in the forward direction: one source line is
+	// worth one rendered line of the element's own height.
+	const height = measure(previous.element).height;
+	if (!Number.isFinite(height) || height <= 0) return Math.max(0, previousTop);
+	return Math.max(0, previousTop + (line - previous.line) * height);
 }


### PR DESCRIPTION
Split view drifted. Two separate causes, one visible symptom.

## The mapping quantised

`previewAnchor.ts` mapped a scroll position by descending the preview tree
to the single narrowest element covering it, then answering with that
element's first source line. One element is one answer, so every offset
inside a block resolved to the same line — the panes only lined up where a
block happened to start.

It now answers from *two* samples. A single walk builds a flat,
document-ordered table of `(element, line)` pairs, and both directions
binary-search it for the pair bracketing the position and interpolate
between them. This is the model VS Code's Markdown preview uses, and it
inverts the old trade-off: narrower elements make the answer **better**
now, because they make the table denser, where before they made it coarser.

That is what makes annotating soft line breaks worth doing — a long wrapped
paragraph contributes several samples instead of one. `<br>` has no box, so
an empty inline-block beside it carries the line (#464). The collapsed-fold
guard has to stay: elements inside a fold all measure to the same top, and a
run of equal tops would flatten a stretch of the table. VS Code has the same
guard for the same reason.

Worst drift over the block-mapping fixtures: **0.9 source lines → 0.0**.

## The two panes counted from different places

`data-sourcepos` counts from the first line of the **body** — front matter
is stripped before comrak sees the document. The editor holds the whole
file. So on any document with front matter the panes were off by a constant,
unrelated to how precise the mapping underneath got. On
`samples/stress-test.md` (ten lines of front matter) the preview sat eleven
source lines ahead of the editor — about half a screen:

| editor top line | preview top | its source line | delta |
|---|---|---|---|
| 81 | `Third item` | 92 | +11 |
| 258 | `## JSON` | 270 | +12 |
| 457 | `## Currency` | 468 | +11 |

`toBufferRange` already does this conversion for the jumps #90 added. Scroll
sync crosses the same boundary in both directions and never did it.
`ScrollSyncPosition.line` is a buffer line — the editor is the only pane
that can produce one — so both preview-side crossings convert now, and so
does a third: the outline is built from `data-sourcepos` too, which meant
the heading it highlighted depended on which pane you had scrolled.

This one predates the PR. It was hiding underneath the quantisation error
until interpolation removed the noise.

## Tests

`jumpToSelectedFragment.test.ts` already asserted that every renderer line
reaching the editor goes through the shift — but it enumerated only the two
jump consumers, which is the gap this shipped through. Scroll sync and the
outline are named there now, so forgetting a fourth consumer fails.

Two assertions moved from integer source lines to fractional ones. The
editor side has always answered with a fraction; an integer from the preview
was itself a source of the disagreement being fixed here. One assertion in
`tocFollowsEditor.test.ts` had pinned a statement's literal text and now
asserts what it meant.

900 tests pass, `npm run check` clean, `cargo test` 141 pass. Verified by
hand on `samples/stress-test.md` in both directions, and on a document
without front matter to confirm the shift is an identity there.

## The selection went dark under the menu that acts on it

Found while verifying the above. Right-clicking a preview selection made the
highlight disappear: the context menu focused itself ten milliseconds after
opening, which moves focus off the document and stops the selection being
painted — under the very menu whose Copy and Edit items operate on that
selection.

That focus bought exactly one thing, the Escape handler bound to the menu
element. There is no arrow-key navigation to focus for, and the overlay
already handles click-to-dismiss, so Escape moves to the window and the
selection keeps its highlight.

Unrelated to the two fixes above, but on the same path — the selection and
the line number are both things the preview hands to the editor, and both
were being damaged in transit.
