### PR TITLE
fix: detect a document's encoding and save it back in the same one (#372)

### DIFF
--- a/scripts/checkedReadMigration.test.ts
+++ b/scripts/checkedReadMigration.test.ts
@@ -174,7 +174,7 @@ test('the unchecked read command is gone, and nothing calls it', () => {
 
 test('entering the editor reads the fidelity and stores it', () => {
 	const toggle = sliceBetween(viewer, 'async function toggleEdit', 'async function saveContent');
-	assert.match(toggle, /\[content, lossy\] = \(await invoke\('read_file_content_checked', \{ path: tab\.path \}\)\)/);
+	assert.match(toggle, /\[content, lossy, encoding\] = \(await invoke\('read_file_content_checked', \{ path: tab\.path \}\)\)/);
 	const read = offsetOf(toggle, 'read_file_content_checked');
 	const flag = offsetOf(toggle, 'setTabDecodedLossy(tab.id, lossy)');
 	const store = offsetOf(toggle, 'setTabRawContent(tab.id, content)');
@@ -183,7 +183,7 @@ test('entering the editor reads the fidelity and stores it', () => {
 
 test('entering split view reads the fidelity and stores it', () => {
 	const enter = sliceBetween(viewer, 'async function toggleSplitView', '} else {');
-	assert.match(enter, /\[content, lossy\] = \(await invoke\('read_file_content_checked', \{ path: tab\.path \}\)\)/);
+	assert.match(enter, /\[content, lossy, encoding\] = \(await invoke\('read_file_content_checked', \{ path: tab\.path \}\)\)/);
 	const flag = offsetOf(enter, 'setTabDecodedLossy(tab.id, lossy)');
 	const store = offsetOf(enter, 'setTabRawContent(tab.id, content)');
 	assert.ok(flag < store, 'flag the tab before the buffer is published');

--- a/scripts/documentEncodingRoundTrip.test.ts
+++ b/scripts/documentEncodingRoundTrip.test.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { functionSource, readSource, sliceBetween } from './sourceTree.js';
+
 /*
  * #372: a document in a legacy encoding (GBK, Big5, Shift-JIS, CP-1252 …) is
  * detected and decoded on open, and a save writes it back as the SAME
@@ -189,4 +191,91 @@ test('a payload without an encoding is rejected rather than defaulted', async ()
 	void encoding;
 
 	assert.equal(validateTransferPayload(JSON.stringify(withoutEncoding)), null);
+});
+
+// ---------------------------------------------------------- the status bar
+//
+// Detection without an indicator is worse than no detection: a GBK document
+// now opens, reads correctly and saves back as GBK, and the slot that is
+// supposed to name the encoding was still rendering the literal `UTF-8` it
+// had rendered since before Markpad could open the file at all. The one place
+// the user could have caught a misdetection was asserting the opposite.
+//
+// This is the same defect #540 fixed one slot to the left, where the line
+// ending was hardcoded `CRLF`.
+
+test('the status bar names the encoding the document was decoded from', () => {
+	const editor = readSource('src/lib/components/Editor.svelte');
+	const statusBar = sliceBetween(editor, '<div class="status-bar">', '</div>\n{/if}');
+
+	assert.match(statusBar, /<div class="status-item">\{encoding\}<\/div>/, 'the slot shows the state');
+	assert.doesNotMatch(editor, /editor\.status\.utf8/, 'the hardcoded UTF-8 string is gone');
+
+	// Off the tab, not off Monaco: the encoding belongs to the file the buffer
+	// was decoded from, and the store is what carries it through a save.
+	assert.match(
+		editor,
+		/let encoding = \$derived\(tabManager\.activeTab\?\.encoding \?\? 'UTF-8'\)/,
+		'and it is read from the tab rather than kept as a synced copy',
+	);
+});
+
+test('no locale still translates a hardcoded UTF-8 label', () => {
+	// A dead key reads like a supported feature to whoever finds it next.
+	assert.doesNotMatch(readSource('src/lib/utils/i18n.ts'), /utf8:/);
+});
+
+// ------------------------------------------- saying why a save was refused
+//
+// Refusing is only half of it. The user pasted an emoji into a GBK document
+// and got "auto-save failed, unsaved changes still in memory" — true, and no
+// help at all: it names neither the character nor the encoding, and the way
+// out (Save As, which writes UTF-8) is not in it.
+//
+// Rust sends a code and this side owns the wording, so the reason a save was
+// refused reaches the user in the language the rest of the app is in. The
+// generic English `Failed to save file: <OS message>` stays for genuine I/O
+// failures, which the user cannot act on beyond reading the OS.
+
+test('the unmappable-character refusal crosses as a code, not as English prose', () => {
+	const rust = readSource('src-tauri/src/lib.rs');
+	assert.match(rust, /const UNMAPPABLE_CODE: &str = "ENCODING_UNMAPPABLE";/);
+	assert.match(rust, /return Err\(UNMAPPABLE_CODE\.to_owned\(\)\)/, 'a marker, carrying nothing');
+
+	// The sentence it replaced must not come back: a translated toast and an
+	// English one saying the same thing is worse than either alone.
+	assert.doesNotMatch(rust, /cannot represent every character it now contains/);
+});
+
+test('every locale can say which encoding refused the save', () => {
+	const i18n = readSource('src/lib/utils/i18n.ts');
+	const locales = i18n.match(/lossySaveBlocked:/g) ?? [];
+	const translated = i18n.match(/encodingUnmappable:/g) ?? [];
+
+	assert.ok(locales.length >= 5, 'precondition: the sibling refusal is translated');
+	assert.equal(translated.length, locales.length, 'both refusals reach the same languages');
+
+	// The encoding is named, not implied — "some characters cannot be saved"
+	// leaves the user with nothing to search for.
+	for (const line of i18n.split('\n').filter((l) => l.includes('encodingUnmappable:'))) {
+		assert.match(line, /\{\{encoding\}\}/, `no encoding placeholder: ${line.trim().slice(0, 60)}`);
+	}
+});
+
+test('the code is turned into the translation, and only that code is', () => {
+	const session = readSource('src/lib/sessions/documentSession.svelte.ts');
+	const describe = functionSource(session, 'describeSaveFailure');
+
+	assert.match(describe, /toast\.encodingUnmappable/);
+	assert.match(describe, /replace\('\{\{encoding\}\}', tab\.encoding\)/,
+		'the encoding comes off the tab, not back out of the error');
+	assert.match(describe, /return \{ message: 'Failed to save file', detail: error \}/,
+		'an I/O failure still reads as one, OS message and all');
+
+	// `onError` renders `${message}: ${detail}`, so returning the raw error as
+	// the detail printed the code the user was never meant to see:
+	//   …请用"另存为"写入一份 UTF-8 副本: ENCODING_UNMAPPABLE:GBK
+	// The translated branch sends the document's path instead, which is what
+	// `toast.lossySaveBlocked` has always done.
+	assert.match(describe, /detail: tab\.path,/, 'the marker never reaches the toast');
 });

--- a/scripts/documentEncodingRoundTrip.test.ts
+++ b/scripts/documentEncodingRoundTrip.test.ts
@@ -1,0 +1,192 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+/*
+ * #372: a document in a legacy encoding (GBK, Big5, Shift-JIS, CP-1252 …) is
+ * detected and decoded on open, and a save writes it back as the SAME
+ * encoding — the behaviour Notepad, VS Code and Typora all have, and the one
+ * an app that calls itself "the Notepad equivalent for Markdown" is measured
+ * against.
+ *
+ * The decoding and encoding themselves are Rust and are tested there
+ * (`saving_an_unedited_legacy_document_reproduces_its_bytes_exactly` is the
+ * one that matters). What has to hold on this side is the wiring, because it
+ * is the wiring that decides which bytes reach the file:
+ *
+ *     read  →  tab.encoding  →  save
+ *
+ * A break anywhere in that chain does not fail loudly. It writes the user's
+ * GBK document back as UTF-8, silently, on an auto-save 1.5s after the first
+ * keystroke — no error, no toast, and every other tool that opens the file
+ * afterwards sees mojibake. So the chain is driven here end to end rather
+ * than read for.
+ */
+
+const g = globalThis as any;
+const runeEffect = (fn: () => void) => {
+	void fn;
+};
+runeEffect.root = (fn: () => unknown) => fn();
+g.$state = (value: unknown) => value;
+g.$state.raw = (value: unknown) => value;
+g.$state.snapshot = (value: unknown) => value;
+g.$derived = (value: unknown) => value;
+g.$derived.by = (fn: () => unknown) => fn();
+g.$effect = runeEffect;
+g.window = g.window ?? {};
+Object.defineProperty(g, 'navigator', { value: { language: 'en-US' }, configurable: true });
+Object.defineProperty(g, 'localStorage', {
+	value: { getItem: () => null, setItem: () => {}, removeItem: () => {}, clear: () => {} },
+	configurable: true,
+});
+
+/** What the backend reports for the next read. Set per test. */
+let fileEncoding = 'UTF-8';
+let fileLossy = false;
+const BODY = '# 中文标题';
+
+/** Every `save_file_content` the session issued, in order. */
+let writes: Array<{ path: string; content: string; encoding: string }> = [];
+
+g.window.__TAURI_INTERNALS__ = {
+	invoke: (command: string, args: Record<string, unknown>) => {
+		const cmd = command.replace(/^plugin:[^|]*\|/, '');
+		if (cmd === 'get_os_type') return Promise.resolve('macos');
+		if (cmd === 'canonicalize_path') return Promise.resolve(args.path);
+		if (cmd === 'open_markdown_preview') {
+			return Promise.resolve(['', BODY, true, fileLossy, fileEncoding]);
+		}
+		if (cmd === 'read_file_content_checked') return Promise.resolve([BODY, fileLossy, fileEncoding]);
+		if (cmd === 'save_file_content') {
+			writes.push(args as unknown as { path: string; content: string; encoding: string });
+			return Promise.resolve(null);
+		}
+		return Promise.resolve(null);
+	},
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
+const { buildTransferredTab, snapshotTab, validateTransferPayload } = await import(
+	'../src/lib/utils/tabTransfer.js'
+);
+
+function makeSession() {
+	return createDocumentSession({
+		setShowHome: () => {},
+		currentFile: () => tabManager.activeTab?.path ?? '',
+		resetScrollHistory: () => {},
+		renderMarkdown: async () => '',
+		afterLoad: async () => {},
+		saveRecentFile: () => {},
+		deleteRecentFile: () => {},
+		setLoadingTabs: () => {},
+		measureInitialViewport: () => {},
+		isScrolling: () => false,
+		renderRichContent: () => {},
+		onError: () => {},
+		selfWriteGraceMs: 400,
+		cancelPendingAutoSave: () => {},
+		askClose: async () => 'discard' as const,
+		onCloseSaveNewerEdits: () => {},
+		onCloseAutoSaveFailed: () => {},
+	});
+}
+
+/** A tab opened from a file the backend reports as `encoding`. */
+async function openedAs(encoding: string, lossy = false) {
+	tabManager.closeAll();
+	writes = [];
+	fileEncoding = encoding;
+	fileLossy = lossy;
+	const session = makeSession();
+	await session.loadMarkdown('/notes/legacy.md');
+	return { session, tab: tabManager.activeTab! };
+}
+
+test('opening a legacy document records the encoding it was read in', async () => {
+	const { tab } = await openedAs('GBK');
+	assert.equal(tab.encoding, 'GBK');
+	assert.equal(tab.hasReplacementChars, false, 'a detected encoding decodes; it does not substitute');
+});
+
+test('saving that document writes it back as itself, not as UTF-8', async () => {
+	// The whole issue in one assertion. Under the old behaviour this write
+	// carried the buffer and nothing else, so the file became UTF-8 — or,
+	// before the buffer was decoded at all, U+FFFD.
+	const { session, tab } = await openedAs('GBK');
+
+	tabManager.updateTabRawContent(tab.id, `${BODY}\n\nedited`);
+	assert.equal(await session.saveContent(tab.id), true);
+
+	assert.deepEqual(writes.map((write) => write.encoding), ['GBK']);
+	assert.equal(writes[0].path, '/notes/legacy.md');
+});
+
+test('a UTF-8 document is still written as UTF-8', async () => {
+	// The fence. Everything above passes for a build that writes some
+	// arbitrary encoding to every file it touches.
+	const { session, tab } = await openedAs('UTF-8');
+
+	tabManager.updateTabRawContent(tab.id, 'edited');
+	assert.equal(await session.saveContent(tab.id), true);
+
+	assert.deepEqual(writes.map((write) => write.encoding), ['UTF-8']);
+});
+
+test('a byte order mark is a property of the file, so it is carried too', async () => {
+	// Windows-authored Markdown, and the case a plain "is it UTF-8?" test
+	// misses: the text decodes perfectly, and dropping the BOM on save still
+	// changes the file for every tool that reads it.
+	const { session, tab } = await openedAs('UTF-8-BOM');
+	assert.equal(tab.encoding, 'UTF-8-BOM');
+
+	tabManager.updateTabRawContent(tab.id, 'edited');
+	assert.equal(await session.saveContent(tab.id), true);
+	assert.deepEqual(writes.map((write) => write.encoding), ['UTF-8-BOM']);
+});
+
+test('a re-read repoints the save at what the file is NOW', async () => {
+	// The user converted the file to UTF-8 in another program. The tab must
+	// stop writing GBK, and it learns that from the read rather than from
+	// remembering how it was first opened.
+	const { session, tab } = await openedAs('GBK');
+
+	fileEncoding = 'UTF-8';
+	await session.loadMarkdown('/notes/legacy.md');
+	assert.equal(tabManager.activeTab!.encoding, 'UTF-8');
+
+	tabManager.updateTabRawContent(tab.id, 'edited');
+	assert.equal(await session.saveContent(tab.id), true);
+	assert.deepEqual(writes.map((write) => write.encoding), ['UTF-8']);
+});
+
+test('an untitled buffer has an encoding before anything has been read', async () => {
+	// Required, not optional, on the Tab — so a buffer that never came from a
+	// file still answers, and answers the only thing it could be.
+	tabManager.closeAll();
+	tabManager.addNewTab();
+	assert.equal(tabManager.activeTab!.encoding, 'UTF-8');
+});
+
+test('a moved tab keeps its encoding across the window boundary', async () => {
+	// The buffer is a decode of a file in this encoding; the destination
+	// window auto-saves it. A payload that dropped the field would rewrite the
+	// user's GBK document as UTF-8 the moment it landed.
+	const { tab } = await openedAs('Shift_JIS');
+
+	const payload = JSON.stringify(snapshotTab(tab));
+	const validated = validateTransferPayload(payload);
+	assert.notEqual(validated, null, 'precondition: the payload validates');
+	assert.equal(buildTransferredTab(validated!, [], 'Untitled').encoding, 'Shift_JIS');
+});
+
+test('a payload without an encoding is rejected rather than defaulted', async () => {
+	// Same rule as `hasReplacementChars`: a missing field must not be read as
+	// "UTF-8, go ahead", because that is a write to the user's file.
+	const { tab } = await openedAs('Big5');
+	const { encoding, ...withoutEncoding } = snapshotTab(tab);
+	void encoding;
+
+	assert.equal(validateTransferPayload(JSON.stringify(withoutEncoding)), null);
+});

--- a/scripts/lossyDecodeSaveGuard.test.ts
+++ b/scripts/lossyDecodeSaveGuard.test.ts
@@ -5,11 +5,17 @@ import type { Tab } from '../src/lib/stores/tabs.svelte.js';
 import { buildTransferredTab, snapshotTab, validateTransferPayload } from '../src/lib/utils/tabTransfer.js';
 import { offsetOf, readSource, sliceBetween } from './sourceTree.js';
 
-// Every read path decodes leniently (#371): a file in a legacy encoding
-// (GBK, Big5, Shift-JIS, EUC-KR, CP1251 ...) opens as U+FFFD mojibake instead
-// of failing. U+FFFD is not reversible — the original bytes are gone from the
-// buffer. Writing that buffer back over the source file (auto-save does it
-// 1.5s after the first keystroke) destroys the document permanently.
+// Every read path decodes leniently (#371): a file it cannot read opens with
+// U+FFFD substituted for the bytes it could not, instead of failing. U+FFFD is
+// not reversible — the original bytes are gone from the buffer. Writing that
+// buffer back over the source file (auto-save does it 1.5s after the first
+// keystroke) destroys the document permanently.
+//
+// Detection (#372) removed the common cause rather than the guard: a legacy
+// encoding (GBK, Big5, Shift-JIS, CP-1252 ...) is now read properly and
+// written back as itself — `documentEncodingRoundTrip.test.ts` drives that.
+// What is left here is the file NO encoding can read, which is still a buffer
+// that must never reach its own file.
 //
 // The guard: Rust reports the fidelity of every decode, the tab carries it —
 // through window restore and cross-window moves — and `documentSession`
@@ -31,17 +37,18 @@ const guard = () => sliceBetween(session, 'function refuseIfLossilyDecoded', 'fu
 
 test('one decoder, and it reports what it destroyed', () => {
 	// The fact is known exactly once — when the bytes are decoded — and was
-	// thrown away. `String::from_utf8` returning `Err` IS the fact, so the
-	// shared decoder from #371 carries it instead of growing a second path.
+	// thrown away. Detection (#372) made the decode able to succeed where it
+	// used to substitute, but not able to always succeed, so the decoder still
+	// carries the verdict rather than growing a second path.
 	assert.match(rust, /struct DecodedText \{[^}]*\bcontent: String,[^}]*\blossy: bool/s);
-	assert.match(rust, /fn decode_utf8_lossy\(bytes: Vec<u8>\) -> DecodedText/);
+	assert.match(rust, /fn decode_text\(bytes: &\[u8\]\) -> DecodedText/);
 	assert.match(rust, /fn read_to_string_lossy\(path: &str\) -> std::io::Result<DecodedText>/);
-	assert.equal(rust.match(/fn decode_utf8/g)?.length, 1, 'exactly one decoder');
+	assert.equal(rust.match(/fn decode_text\(/g)?.length, 1, 'exactly one decoder');
 });
 
 test('both read commands can report fidelity', () => {
-	assert.match(rust, /async fn open_markdown_preview\([^)]*\)\s*-> Result<\(String, String, bool, bool\), String>/s);
-	assert.match(rust, /async fn read_file_content_checked\(path: String\) -> Result<\(String, bool\), String>/);
+	assert.match(rust, /async fn open_markdown_preview\([^)]*\)\s*-> Result<\(String, String, bool, bool, String\), String>/s);
+	assert.match(rust, /async fn read_file_content_checked\(path: String\) -> Result<\(String, bool, String\), String>/);
 	assert.match(rust, /read_file_content_checked,/, 'the command must be registered');
 });
 
@@ -51,7 +58,7 @@ test('a preview cut inside a multi-byte character is not called lossy', () => {
 	// large CJK/emoji document out of saving — a guard worse than the bug.
 	const preview = sliceBetween(rust, 'fn build_markdown_preview', '#[tauri::command]');
 	const trim = offsetOf(preview, 'utf8_truncation_boundary');
-	assert.ok(trim < offsetOf(preview, 'decode_utf8_lossy'), 'the split tail is dropped before fidelity is judged');
+	assert.ok(trim < offsetOf(preview, 'decode_text('), 'the split tail is dropped before fidelity is judged');
 });
 
 test('the tab carries the fidelity of its buffer', () => {
@@ -66,7 +73,7 @@ test('the tab carries the fidelity of its buffer', () => {
 test('every load decides the flag instead of leaving it stale', () => {
 	// A reload of a file the user has since converted to UTF-8 must clear it.
 	const body = loadMarkdown();
-	assert.match(body, /as \[string, string, boolean, boolean\]/);
+	assert.match(body, /as \[string, string, boolean, boolean, string\]/);
 	assert.match(body, /setTabDecodedLossy\(activeId, lossy\)/);
 	// The full load REPLACES the preview's buffer, so it brings its own
 	// verdict: a file can be valid UTF-8 for the first 50KB and not after.
@@ -82,7 +89,7 @@ test('the editable-pane shortcut reports fidelity too', () => {
 	const body = loadMarkdown();
 	assert.match(
 		body,
-		/if \(initialIsEditing \|\| initialIsSplit\) \{\s*\[content, lossy\] = \(await invoke\('read_file_content_checked'/,
+		/if \(initialIsEditing \|\| initialIsSplit\) \{\s*\[content, lossy, encoding\] = \(await invoke\('read_file_content_checked'/,
 	);
 	// `ensureFullContent` was the one place the bare command survived, and only
 	// because it re-read a file whose tab loadMarkdown had already flagged —
@@ -147,9 +154,13 @@ test('saveContent is the choke point auto-save and the close dialogs share', () 
 
 test('Save As to a new file stays open as the escape hatch', () => {
 	const body = saveContentAs();
-	assert.match(body, /invoke\('save_file_content', \{ path: selected, content: snapshot \}\)/);
+	// Explicitly UTF-8, never the tab's own encoding: the copy exists to be
+	// readable when the original could not be read, or could not represent
+	// what the user typed into it.
+	assert.match(body, /invoke\('save_file_content', \{ path: selected, content: snapshot, encoding: 'UTF-8' \}\)/);
 	// Once written, the buffer matches a UTF-8 file of its own.
 	assert.match(body, /setTabDecodedLossy\(tab\.id, false\)/);
+	assert.match(body, /setTabEncoding\(tab\.id, 'UTF-8'\)/);
 });
 
 test('Save As onto the same file is still a destructive overwrite', () => {
@@ -174,7 +185,7 @@ test('the refusal tells the user what to do and is not repeated per keystroke', 
 	assert.match(body, /toast\.lossySaveBlocked/);
 	assert.match(body, /lossySaveWarnedTabs\.has\(tab\.id\)/);
 	const i18n = readSource('src/lib/utils/i18n.ts');
-	assert.match(i18n, /lossySaveBlocked: 'Not saved: this file is not UTF-8/);
+	assert.match(i18n, /lossySaveBlocked: 'Not saved: parts of this file could not be read in any encoding/);
 	assert.match(i18n, /use "Save As" to write a copy/);
 });
 
@@ -203,6 +214,7 @@ function makeTab(overrides: Partial<Tab> = {}): Tab {
 		splitRatio: 0.5,
 		isScrollSynced: false,
 		hasReplacementChars: true,
+		encoding: 'UTF-8',
 		collapsedHeaders: new Set<string>(),
 		...overrides,
 	};

--- a/scripts/renderedHtmlField.test.ts
+++ b/scripts/renderedHtmlField.test.ts
@@ -450,6 +450,7 @@ test('every Tab construction site starts the rendered-HTML field empty', () => {
 		splitRatio: 0.5,
 		isScrollSynced: false,
 		hasReplacementChars: false,
+		encoding: 'UTF-8',
 	});
 
 	assert.equal(tabManager.tabs.length, 5, 'precondition: every construction site produced a tab');

--- a/scripts/tabPathIdentity.test.ts
+++ b/scripts/tabPathIdentity.test.ts
@@ -172,6 +172,7 @@ test('a tab arriving from another window does not duplicate a file open here', (
 		splitRatio: 0.5,
 		isScrollSynced: false,
 		hasReplacementChars: false,
+		encoding: 'UTF-8',
 		history: ['/notes/shared.md'],
 		historyIndex: 0,
 	});

--- a/scripts/tabTransfer.test.ts
+++ b/scripts/tabTransfer.test.ts
@@ -39,6 +39,7 @@ function makeTab(overrides: Partial<Tab> = {}): Tab {
 		splitRatio: 0.3,
 		isScrollSynced: true,
 		hasReplacementChars: false,
+		encoding: 'UTF-8',
 		collapsedHeaders: new Set<string>(),
 		...overrides,
 	};

--- a/scripts/undoHistoryPerTab.test.ts
+++ b/scripts/undoHistoryPerTab.test.ts
@@ -745,6 +745,7 @@ test('a tab moved to another window has its model disposed on the way out', () =
 			scrollPercentage: 0,
 			anchorLine: 0,
 			hasReplacementChars: false,
+			encoding: 'UTF-8',
 			history: ['/docs/a.md'],
 			historyIndex: 0,
 		},

--- a/scripts/windowTagPerWindow.test.ts
+++ b/scripts/windowTagPerWindow.test.ts
@@ -68,6 +68,7 @@ const TRANSFER_PAYLOAD = JSON.stringify({
 	isSplit: false,
 	isScrollSynced: false,
 	hasReplacementChars: false,
+	encoding: 'UTF-8',
 	splitRatio: 0.5,
 	scrollTop: 0,
 	scrollPercentage: 0,
@@ -95,7 +96,7 @@ g.window.__TAURI_INTERNALS__ = {
 			case 'claim_detached_tab':
 				return Promise.resolve(TRANSFER_PAYLOAD);
 			case 'read_file_content_checked':
-				return Promise.resolve(['# a', false]);
+				return Promise.resolve(['# a', false, 'UTF-8']);
 			default:
 				return Promise.resolve(null);
 		}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -8,7 +8,9 @@ version = "2.7.2"
 dependencies = [
  "arboard",
  "base64 0.22.1",
+ "chardetng",
  "comrak",
+ "encoding_rs",
  "font-kit",
  "http",
  "http-range",
@@ -616,6 +618,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chardetng"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13de944a44b5064ee5d3a5ceccc49a41bfec50f2580e66f82e87703acdb88b53"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
 
 [[package]]
 name = "chrono"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,6 +51,8 @@ font-kit = "0.14"
 base64 = "0.22"
 arboard = "3"
 image = { version = "0.25", default-features = false, features = ["png"] }
+chardetng = "1"
+encoding_rs = "0.8"
 
 
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -336,12 +336,29 @@ struct DecodedText {
 ///    a browser must not do (it can smuggle script through an escape
 ///    sequence) and a text editor has no reason not to.
 ///
+/// Known gap: UTF-16 without a BOM. Step 1 misses it and `chardetng` does not
+/// look for it by design, so such a file reaches step 3 and is guessed at as a
+/// single-byte encoding — readable as nonsense, with every other byte a NUL.
+/// It round-trips (the guess is a total mapping, so a save reproduces it), and
+/// no BOM-less UTF-16 has been reported; naming it is cheaper than a detector
+/// that would have to weigh NUL frequency against genuinely binary input.
+///
 /// Before this, every read decoded as UTF-8 and substituted U+FFFD, so a
 /// legacy-encoded (GBK/Big5/Shift-JIS/CP-1252) document opened as mojibake
 /// that could not be saved. The detection is a heuristic and can be wrong;
 /// what protects the file is not the guess but `lossy` plus writing back
-/// through the same encoding, so bytes the guess reproduces exactly are
-/// unchanged and bytes it cannot are never written at all.
+/// through the same encoding, so the document's TEXT survives a save even
+/// when the guess is wrong, and a character the encoding cannot hold is
+/// never written at all.
+///
+/// Text, not bytes. Several legacy encodings spell one character more than
+/// one way — Shift_JIS reaches U+2160 at both 0x8754 (NEC) and 0xFA4A (IBM)
+/// — and a decode followed by an encode normalises to whichever the encoder
+/// prefers. Saving an untouched document written by a tool that chose the
+/// other spelling therefore rewrites those bytes, silently and losslessly.
+/// This is what every editor with one encoder per encoding does, VS Code
+/// included; it is worth knowing before reading `lossy` as a byte-level
+/// guarantee, which it is not.
 fn decode_text(bytes: &[u8]) -> DecodedText {
     let decoded = |encoding: &'static encoding_rs::Encoding, label: &str, body: &[u8]| {
         let (content, had_errors) = encoding.decode_without_bom_handling(body);
@@ -374,6 +391,16 @@ fn decode_text(bytes: &[u8]) -> DecodedText {
     let encoding = detector.guess(None, chardetng::Utf8Detection::Deny);
     decoded(encoding, encoding.name(), bytes)
 }
+
+/// What `encode_text` refuses with when the buffer holds a character the
+/// document's encoding has no representation for — an emoji pasted into a GBK
+/// file, say. Matched by `documentSession.saveContent`, which turns it into a
+/// translated toast.
+///
+/// A marker, carrying nothing. The label was in here at first and it was
+/// redundant: the frontend passed the encoding INTO this call, so it already
+/// knows which one refused.
+const UNMAPPABLE_CODE: &str = "ENCODING_UNMAPPABLE";
 
 /// Turn a buffer back into bytes in `label`'s encoding, or refuse.
 ///
@@ -423,9 +450,13 @@ fn encode_text(content: &str, label: &str) -> Result<Vec<u8>, String> {
                 .ok_or_else(|| format!("Unknown text encoding: {label}"))?;
             let (bytes, _, unmappable) = encoding.encode(content);
             if unmappable {
-                return Err(format!(
-                    "This document is {label}, which cannot represent every character it now contains. Use \"Save As\" to write it as UTF-8."
-                ));
+                // A marker, not a sentence. The frontend has to say this in
+                // the user's own language — its sibling refusal
+                // (`toast.lossySaveBlocked`, for a buffer nothing could
+                // decode) is translated six ways, and the reason a save was
+                // refused is the half of the message that has to be
+                // understood.
+                return Err(UNMAPPABLE_CODE.to_owned());
             }
             Ok(bytes.into_owned())
         }
@@ -3534,7 +3565,13 @@ mod tests {
     /// is the test that fails if anything ever routes a save through UTF-8
     /// again.
     #[test]
-    fn saving_an_unedited_legacy_document_reproduces_its_bytes_exactly() {
+    fn saving_an_unedited_legacy_document_reproduces_its_canonical_bytes() {
+        // CANONICAL, not "the bytes any tool would have written": the samples
+        // below are encoded by `encoding_rs` itself, so this pins the round
+        // trip for the spelling its encoder emits. Where a legacy encoding
+        // offers a second spelling of the same character (Shift_JIS's IBM
+        // extension, for one) a save normalises to this one. See the note on
+        // `decode_text` — the guarantee is over the text, not the bytes.
         for (encoding, text) in LEGACY_SAMPLES {
             let original = legacy_bytes(encoding, text);
             let decoded = decode_text(&original);
@@ -3627,10 +3664,16 @@ mod tests {
         // the character the user typed. Refusing leaves the buffer dirty and
         // sends the reason to a toast, which is how a read-only file behaves.
         let error = encode_text("hello 😀", "GBK").unwrap_err();
-        assert!(error.contains("GBK"), "unhelpful message: {error}");
-        assert!(error.contains("Save As"), "no way out offered: {error}");
+
+        // A code the frontend can match, carrying the label it has to name.
+        // The wording itself lives in `i18n.ts`, translated: the reason a save
+        // was refused is the half of the message that must be understood, and
+        // an English sentence from Rust is the half that would not be.
+        assert_eq!(error, "ENCODING_UNMAPPABLE");
 
         assert!(encode_text("hello 😀", UTF8_LABEL).is_ok());
+        // UTF-16 holds every character too, and takes the other branch.
+        assert!(encode_text("hello 😀", UTF16LE_LABEL).is_ok());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -284,41 +284,156 @@ pub(crate) fn canonical_identity(path: &Path) -> std::io::Result<PathBuf> {
     }
 }
 
-/// Text decoded from a file, together with the fidelity of that decode.
+/// The encoding label of a plain UTF-8 file — the default for a new buffer
+/// and for everything Markpad generates itself (HTML and SVG exports).
+const UTF8_LABEL: &str = "UTF-8";
+/// UTF-8 with a leading byte order mark. Not a WHATWG label, because WHATWG
+/// has no name for it: `encoding_rs` reports both as "UTF-8" and the BOM is
+/// carried out of band. Windows editors write it constantly and a save that
+/// dropped it would change the file for every other tool that reads it.
+const UTF8_BOM_LABEL: &str = "UTF-8-BOM";
+const UTF16LE_LABEL: &str = "UTF-16LE";
+const UTF16BE_LABEL: &str = "UTF-16BE";
+
+/// Text decoded from a file, together with the fidelity of that decode and
+/// the encoding it has to be written back as.
 struct DecodedText {
     content: String,
-    /// `true` when the bytes were not valid UTF-8 and every offending byte was
-    /// replaced with U+FFFD. `content` is then a destructive rendering of the
+    /// `true` when the decoder could not represent some of the bytes and put
+    /// U+FFFD in their place. `content` is then a destructive rendering of the
     /// file: the original bytes cannot be recovered from it, so writing it
     /// back over the source file destroys the document permanently. This is
     /// known exactly once — at the moment of decoding — so it travels to the
     /// frontend with the text it describes, and the frontend refuses that
     /// write (see `documentSession.saveContent`).
+    ///
+    /// Detection made this rare rather than routine: a GBK document used to
+    /// set it on every byte above ASCII, and now sets it only when nothing
+    /// decodes the file cleanly — a truncated multi-byte tail, or bytes that
+    /// are not text at all.
     lossy: bool,
+    /// What `encode_text` needs to turn the buffer back into the bytes it came
+    /// from: a WHATWG label (`GBK`, `Big5`, `Shift_JIS`, `windows-1252`, …) or
+    /// one of the four constants above. Travels to the frontend, is kept on
+    /// the tab, and comes back with the save.
+    ///
+    /// Always `UTF-8` when `lossy`, so the rescue copy a user writes with Save
+    /// As is Unicode rather than a re-encoding of replacement characters.
+    encoding: String,
 }
 
-/// Decode `bytes` as UTF-8, substituting U+FFFD for invalid sequences rather
-/// than rejecting the whole file. `read_to_string` refuses a document on its
-/// first invalid byte, which made a legacy-encoded (GBK/Big5/Shift-JIS) file
-/// openable or not purely by size: the truncated-preview path has always
-/// decoded leniently, so the same file failed at 50 KB and succeeded at
-/// 51 KB. Every read path now uses one decoder — and every read path reports
-/// whether that decoder had to destroy anything.
-fn decode_utf8_lossy(bytes: Vec<u8>) -> DecodedText {
-    match String::from_utf8(bytes) {
-        Ok(content) => DecodedText {
-            content,
+/// Decode a document, detecting its encoding the way a browser does.
+///
+/// Three steps, in the order of how much they can be trusted:
+///
+/// 1. **A byte order mark decides on its own.** UTF-8, UTF-16LE and UTF-16BE
+///    BOMs are unambiguous, and Windows-authored Markdown is full of them.
+/// 2. **Valid UTF-8 is UTF-8.** No heuristic gets a say over the encoding
+///    every modern file is actually in, and this keeps the common path free.
+/// 3. **Otherwise guess**, with `chardetng` — the detector Firefox ships for
+///    exactly this question — and decode with what it says. UTF-8 is denied
+///    because step 2 has already ruled it out; ISO-2022-JP is allowed, which
+///    a browser must not do (it can smuggle script through an escape
+///    sequence) and a text editor has no reason not to.
+///
+/// Before this, every read decoded as UTF-8 and substituted U+FFFD, so a
+/// legacy-encoded (GBK/Big5/Shift-JIS/CP-1252) document opened as mojibake
+/// that could not be saved. The detection is a heuristic and can be wrong;
+/// what protects the file is not the guess but `lossy` plus writing back
+/// through the same encoding, so bytes the guess reproduces exactly are
+/// unchanged and bytes it cannot are never written at all.
+fn decode_text(bytes: &[u8]) -> DecodedText {
+    let decoded = |encoding: &'static encoding_rs::Encoding, label: &str, body: &[u8]| {
+        let (content, had_errors) = encoding.decode_without_bom_handling(body);
+        DecodedText {
+            content: content.into_owned(),
+            lossy: had_errors,
+            encoding: if had_errors { UTF8_LABEL } else { label }.to_owned(),
+        }
+    };
+
+    if let Some((encoding, bom_len)) = encoding_rs::Encoding::for_bom(bytes) {
+        let label = if encoding == encoding_rs::UTF_8 {
+            UTF8_BOM_LABEL
+        } else {
+            encoding.name()
+        };
+        return decoded(encoding, label, &bytes[bom_len..]);
+    }
+
+    if let Ok(content) = std::str::from_utf8(bytes) {
+        return DecodedText {
+            content: content.to_owned(),
             lossy: false,
-        },
-        Err(error) => DecodedText {
-            content: String::from_utf8_lossy(error.as_bytes()).into_owned(),
-            lossy: true,
-        },
+            encoding: UTF8_LABEL.to_owned(),
+        };
+    }
+
+    let mut detector = chardetng::EncodingDetector::new(chardetng::Iso2022JpDetection::Allow);
+    detector.feed(bytes, true);
+    let encoding = detector.guess(None, chardetng::Utf8Detection::Deny);
+    decoded(encoding, encoding.name(), bytes)
+}
+
+/// Turn a buffer back into bytes in `label`'s encoding, or refuse.
+///
+/// The refusals are the point. A legacy encoding covers a fraction of Unicode,
+/// so an emoji pasted into a Shift-JIS document has no representation in it —
+/// and `encoding_rs::Encoding::encode` would quietly write `&#128512;`, a
+/// numeric character reference that is only meaningful in HTML. Reporting the
+/// failure leaves the buffer dirty and puts the reason in a toast, which is
+/// how the read-only case behaves (#373); writing a corrupted approximation is
+/// the same data loss this whole change exists to remove, arriving from the
+/// other direction.
+///
+/// UTF-16 is encoded here rather than by `encoding_rs`, whose UTF-16 encoders
+/// are defined by WHATWG to emit UTF-8 — correct for the web, and a silent
+/// change of the file's encoding for an editor. Every other label is checked
+/// against `output_encoding` for the same substitution.
+fn encode_text(content: &str, label: &str) -> Result<Vec<u8>, String> {
+    let utf16 = |big_endian: bool| {
+        let mut bytes = if big_endian {
+            vec![0xFE, 0xFF]
+        } else {
+            vec![0xFF, 0xFE]
+        };
+        for unit in content.encode_utf16() {
+            let pair = if big_endian {
+                unit.to_be_bytes()
+            } else {
+                unit.to_le_bytes()
+            };
+            bytes.extend_from_slice(&pair);
+        }
+        Ok(bytes)
+    };
+
+    match label {
+        UTF8_LABEL => Ok(content.as_bytes().to_vec()),
+        UTF8_BOM_LABEL => {
+            let mut bytes = vec![0xEF, 0xBB, 0xBF];
+            bytes.extend_from_slice(content.as_bytes());
+            Ok(bytes)
+        }
+        UTF16LE_LABEL => utf16(false),
+        UTF16BE_LABEL => utf16(true),
+        _ => {
+            let encoding = encoding_rs::Encoding::for_label(label.as_bytes())
+                .filter(|encoding| encoding.output_encoding() == *encoding)
+                .ok_or_else(|| format!("Unknown text encoding: {label}"))?;
+            let (bytes, _, unmappable) = encoding.encode(content);
+            if unmappable {
+                return Err(format!(
+                    "This document is {label}, which cannot represent every character it now contains. Use \"Save As\" to write it as UTF-8."
+                ));
+            }
+            Ok(bytes.into_owned())
+        }
     }
 }
 
 fn read_to_string_lossy(path: &str) -> std::io::Result<DecodedText> {
-    Ok(decode_utf8_lossy(fs::read(path)?))
+    Ok(decode_text(&fs::read(path)?))
 }
 
 /// Length of `bytes` with an incomplete trailing UTF-8 sequence removed.
@@ -1698,21 +1813,12 @@ fn annotate_task_checkboxes(html: String, markdown: &str) -> String {
         .into_owned()
 }
 
-#[tauri::command]
-async fn open_markdown(path: String) -> Result<String, String> {
-    tauri::async_runtime::spawn_blocking(move || {
-        let content = fs::read_to_string(path).map_err(|e| e.to_string())?;
-        Ok(convert_markdown(&content))
-    })
-    .await
-    .unwrap_or_else(|e| Err(e.to_string()))
-}
-
 struct MarkdownPreview {
     html: String,
     content: String,
     is_full: bool,
     lossy: bool,
+    encoding: String,
 }
 
 /// The body of `open_markdown_preview`, kept synchronous and path-taking so
@@ -1731,6 +1837,7 @@ fn build_markdown_preview(path: &Path, max_bytes: usize) -> Result<MarkdownPrevi
             content: decoded.content,
             is_full: true,
             lossy: decoded.lossy,
+            encoding: decoded.encoding,
         });
     }
 
@@ -1750,7 +1857,13 @@ fn build_markdown_preview(path: &Path, max_bytes: usize) -> Result<MarkdownPrevi
     // fell inside one of its characters.
     vec_buf.truncate(utf8_truncation_boundary(&vec_buf));
 
-    let preview = decode_utf8_lossy(vec_buf);
+    // Detection runs on the prefix, so it can differ from what the whole file
+    // would say — and a legacy multi-byte character cut in half here is a
+    // `lossy` preview of a document that is perfectly decodable. Neither
+    // matters for the file's safety: a truncated buffer is refused by
+    // `saveContent` outright, and the full read that precedes any edit
+    // (`ensureFullContent`) replaces both answers with the whole file's.
+    let preview = decode_text(&vec_buf);
 
     let html = convert_markdown(&preview.content);
     Ok(MarkdownPreview {
@@ -1758,17 +1871,18 @@ fn build_markdown_preview(path: &Path, max_bytes: usize) -> Result<MarkdownPrevi
         content: preview.content,
         is_full: false,
         lossy: preview.lossy,
+        encoding: preview.encoding,
     })
 }
 
-/// Returns `(html, content, is_full, lossy)`. See `DecodedText::lossy`: the
-/// frontend uses it to refuse writing the buffer back over a file it could
-/// not decode faithfully.
+/// Returns `(html, content, is_full, lossy, encoding)`. See `DecodedText`: the
+/// frontend refuses to write a `lossy` buffer back over its file, and saves a
+/// faithful one as the `encoding` it came in.
 #[tauri::command]
 async fn open_markdown_preview(
     path: String,
     max_bytes: usize,
-) -> Result<(String, String, bool, bool), String> {
+) -> Result<(String, String, bool, bool, String), String> {
     tauri::async_runtime::spawn_blocking(move || {
         let preview = build_markdown_preview(Path::new(&path), max_bytes)?;
         Ok((
@@ -1776,6 +1890,7 @@ async fn open_markdown_preview(
             preview.content,
             preview.is_full,
             preview.lossy,
+            preview.encoding,
         ))
     })
     .await
@@ -1929,10 +2044,11 @@ async fn render_markdown(content: String) -> Result<String, String> {
     .unwrap_or_else(|e| Err(e.to_string()))
 }
 
-/// Reads a file, with the fidelity of the decode: returns `(content, lossy)`.
-/// Since every read path decodes leniently, a caller that puts the text into
-/// an EDITABLE buffer must carry `lossy` onto the tab — otherwise the first
-/// auto-save writes U+FFFD over a file that was merely in another encoding.
+/// Reads a file, with the fidelity of the decode and the encoding it was
+/// decoded from: returns `(content, lossy, encoding)`. A caller that puts the
+/// text into an EDITABLE buffer must carry BOTH onto the tab — `lossy` so the
+/// first auto-save does not write U+FFFD over a file that could not be read,
+/// and `encoding` so it does not write UTF-8 over one that could.
 ///
 /// This is now the only read-to-string command. Its sibling
 /// `read_file_content` returned the text and dropped the verdict; it survived
@@ -1949,10 +2065,10 @@ async fn render_markdown(content: String) -> Result<String, String> {
 /// returns. `spawn_blocking` moves the wait onto the blocking pool, which is
 /// what `tauri::async_runtime` provides it for.
 #[tauri::command]
-async fn read_file_content_checked(path: String) -> Result<(String, bool), String> {
+async fn read_file_content_checked(path: String) -> Result<(String, bool, String), String> {
     tauri::async_runtime::spawn_blocking(move || {
         read_to_string_lossy(&path)
-            .map(|decoded| (decoded.content, decoded.lossy))
+            .map(|decoded| (decoded.content, decoded.lossy, decoded.encoding))
             .map_err(|e| e.to_string())
     })
     .await
@@ -1998,13 +2114,26 @@ async fn read_file_as_data_url(path: String) -> Result<String, String> {
     .unwrap_or_else(|e| Err(e.to_string()))
 }
 
+/// Writes `content` to `path` as `encoding` — the label the file was decoded
+/// from, so a legacy document is saved as the bytes it arrived as instead of
+/// being silently converted to UTF-8 behind the user's back. Callers with text
+/// Markpad generated itself (the HTML and SVG exports) pass `UTF-8`.
+///
+/// The label is not trusted: it makes a round trip through the frontend, and
+/// `encode_text` rejects one it does not recognise rather than falling back to
+/// a default that would write the wrong bytes.
+///
+/// Encoding happens BEFORE `atomic_write`, so a document with a character its
+/// encoding cannot represent fails without the file being touched at all.
+///
 /// Async because `atomic_write` fsyncs twice (the file, then its directory).
 /// On a network or removable volume that is seconds of blocking I/O, and on
 /// the main thread it would stall every window until the save completes.
 #[tauri::command]
-async fn save_file_content(path: String, content: String) -> Result<(), String> {
+async fn save_file_content(path: String, content: String, encoding: String) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
-        atomic_write(Path::new(&path), content.as_bytes()).map_err(|e| e.to_string())
+        let bytes = encode_text(&content, &encoding)?;
+        atomic_write(Path::new(&path), &bytes).map_err(|e| e.to_string())
     })
     .await
     .unwrap_or_else(|e| Err(e.to_string()))
@@ -2911,7 +3040,6 @@ pub fn run() {
             clipboard_write_text,
             clipboard_read_text,
             clipboard_read_image,
-            open_markdown,
             open_markdown_preview,
             render_markdown,
             list_heading_anchors,
@@ -3325,107 +3453,249 @@ mod tests {
         fs::remove_dir_all(dir).unwrap();
     }
 
-    #[test]
-    fn every_read_path_decodes_legacy_encodings_leniently() {
-        // "中文" in GBK. `read_to_string` rejects the whole document on the
-        // first invalid byte, so the same file used to open or fail purely by
-        // size: the truncated-preview branch has always decoded leniently.
-        let gbk = [0xD6u8, 0xD0, 0xCE, 0xC4];
-        assert!(String::from_utf8(gbk.to_vec()).is_err());
-
-        let path = temp_path("gbk.txt");
-        fs::write(&path, gbk).unwrap();
-        assert!(
-            fs::read_to_string(&path).is_err(),
-            "strict decoding is expected to reject these bytes",
-        );
-
-        let decoded = read_to_string_lossy(path.to_str().unwrap())
-            .expect("lenient decoding must open the file instead of failing");
-        assert!(decoded.content.contains('\u{FFFD}'), "got: {:?}", decoded.content);
-
-        fs::remove_file(path).unwrap();
-    }
-
     // --- Decode fidelity ------------------------------------------------
     //
-    // Opening these files leniently is deliberate (above). What must never
-    // follow is writing the result back: U+FFFD is not reversible, so an
-    // auto-save 1.5s after the first keystroke would destroy a document that
-    // was merely in another encoding. Every read path therefore reports
-    // whether its decode was destructive, and the frontend refuses that write
-    // (documentSession.saveContent). These pin the reporting half.
-    const GBK_ZHONGWEN: &[u8] = &[0xD6, 0xD0, 0xCE, 0xC4];
+    // #372: a legacy-encoded document used to be decoded as UTF-8 with U+FFFD
+    // substituted for every byte the decoder disagreed with, and writing that
+    // buffer back destroyed the file — U+FFFD is not reversible. The decoder
+    // now detects the encoding instead, and the save writes the same encoding
+    // back, so the bytes on disk survive a save that changed nothing.
+    //
+    // The load-bearing assertion in most of these is the byte-for-byte round
+    // trip. Whether the detector names the encoding the author had in mind is
+    // a heuristic and can be wrong; what protects the document is that the
+    // bytes it produces are the bytes it was given.
 
-    #[test]
-    fn gbk_bytes_are_reported_as_a_lossy_decode() {
-        let decoded = decode_utf8_lossy(GBK_ZHONGWEN.to_vec());
-        assert!(decoded.lossy, "GBK bytes cannot decode faithfully as UTF-8");
+    /// A Simplified Chinese line long enough for the detector to have
+    /// something to work with — four bytes of CJK could be almost any legacy
+    /// codepage, and a real document never is that short.
+    const CHINESE_SAMPLE: &str = "# 中文标题\n\n这是一个用国标编码保存的文档，里面全是汉字。\n";
+
+    /// One realistic document per legacy encoding Markpad is likely to meet.
+    /// Each is text that encoding can represent and UTF-8 disagrees with.
+    const LEGACY_SAMPLES: [(&'static encoding_rs::Encoding, &str); 4] = [
+        (encoding_rs::GBK, CHINESE_SAMPLE),
+        (
+            encoding_rs::BIG5,
+            "# 中文標題\n\n這是一個用大五碼儲存的文件。\n",
+        ),
+        (
+            encoding_rs::SHIFT_JIS,
+            "# 日本語の見出し\n\nこれはシフトJISで保存された文書です。\n",
+        ),
+        (
+            encoding_rs::WINDOWS_1252,
+            "# Café résumé\n\nNaïve façade — priced at 50\u{A0}£.\n",
+        ),
+    ];
+
+    fn legacy_bytes(encoding: &'static encoding_rs::Encoding, text: &str) -> Vec<u8> {
+        let (bytes, _, unmappable) = encoding.encode(text);
         assert!(
-            decoded.content.contains('\u{FFFD}'),
-            "expected replacement characters, got {:?}",
-            decoded.content,
+            !unmappable,
+            "fixture must be representable in {}",
+            encoding.name()
         );
+        assert!(
+            std::str::from_utf8(&bytes).is_err(),
+            "fixture must not also be valid UTF-8, or it proves nothing",
+        );
+        bytes.into_owned()
+    }
+
+    /// The bug, in one assertion: these bytes must not come back as U+FFFD.
+    #[test]
+    fn a_legacy_encoded_document_decodes_instead_of_becoming_replacement_characters() {
+        for (encoding, text) in LEGACY_SAMPLES {
+            let decoded = decode_text(&legacy_bytes(encoding, text));
+
+            assert!(
+                !decoded.lossy,
+                "{} was reported as undecodable",
+                encoding.name()
+            );
+            assert!(
+                !decoded.content.contains('\u{FFFD}'),
+                "{} decoded to mojibake: {:?}",
+                encoding.name(),
+                decoded.content,
+            );
+            assert_eq!(
+                decoded.content,
+                text,
+                "{} decoded to the wrong text",
+                encoding.name()
+            );
+        }
+    }
+
+    /// The destructive path itself: open a legacy file, save it back
+    /// unchanged, and the file on disk must be the file that was opened. This
+    /// is the test that fails if anything ever routes a save through UTF-8
+    /// again.
+    #[test]
+    fn saving_an_unedited_legacy_document_reproduces_its_bytes_exactly() {
+        for (encoding, text) in LEGACY_SAMPLES {
+            let original = legacy_bytes(encoding, text);
+            let decoded = decode_text(&original);
+            assert!(!decoded.lossy, "{} decode was lossy", encoding.name());
+
+            let written = encode_text(&decoded.content, &decoded.encoding)
+                .unwrap_or_else(|e| panic!("{} could not be written back: {e}", encoding.name()));
+            assert_eq!(
+                written,
+                original,
+                "a save of an unedited {} document changed the file",
+                encoding.name(),
+            );
+        }
+    }
+
+    /// The reported symptom, from the other side: the U+FFFD buffer the old
+    /// decoder produced cannot be turned back into the document. Not a test of
+    /// current behaviour — a statement of why the round trip above has to be
+    /// the mechanism rather than a nicety.
+    #[test]
+    fn a_lossy_decode_cannot_be_reversed() {
+        let original = legacy_bytes(encoding_rs::GBK, CHINESE_SAMPLE);
+        let mojibake = String::from_utf8_lossy(&original).into_owned();
+
+        assert!(mojibake.contains('\u{FFFD}'));
+        assert_ne!(mojibake.into_bytes(), original);
     }
 
     #[test]
-    fn valid_utf8_is_reported_as_faithful() {
-        let decoded = decode_utf8_lossy("中文".as_bytes().to_vec());
+    fn valid_utf8_is_never_handed_to_the_detector() {
+        // Detection is a heuristic; UTF-8 is not. A file that decodes as UTF-8
+        // is UTF-8, whatever a frequency table thinks of it.
+        let decoded = decode_text("中文".as_bytes());
         assert!(!decoded.lossy);
         assert_eq!(decoded.content, "中文");
+        assert_eq!(decoded.encoding, UTF8_LABEL);
     }
 
     #[test]
-    fn read_file_content_checked_reports_a_lossy_file() {
-        // The tripwire that used to assert `read_file_content` REFUSES these
-        // bytes. #371 made every read path lenient, so refusing is no longer
-        // the protection — reporting is. A caller that fills an editable
-        // buffer must use this command and carry the flag onto the tab.
+    fn a_byte_order_mark_survives_the_round_trip() {
+        // Windows-authored Markdown, all three flavours. The BOM is kept out
+        // of the buffer — `\u{FEFF}# Title` is not a heading, so leaving it in
+        // silently un-renders the first line — and put back on the save.
+        for (label, bom) in [
+            (UTF8_BOM_LABEL, vec![0xEF, 0xBB, 0xBF]),
+            (UTF16LE_LABEL, vec![0xFF, 0xFE]),
+            (UTF16BE_LABEL, vec![0xFE, 0xFF]),
+        ] {
+            let text = "# Title\n\nBody.\n";
+            let mut original = bom;
+            match label {
+                UTF16LE_LABEL => original.extend(text.encode_utf16().flat_map(u16::to_le_bytes)),
+                UTF16BE_LABEL => original.extend(text.encode_utf16().flat_map(u16::to_be_bytes)),
+                _ => original.extend_from_slice(text.as_bytes()),
+            }
+
+            let decoded = decode_text(&original);
+            assert!(!decoded.lossy, "{label} decode was lossy");
+            assert_eq!(decoded.encoding, label);
+            assert_eq!(decoded.content, text, "{label} left the BOM in the buffer");
+            assert_eq!(
+                encode_text(&decoded.content, &decoded.encoding).unwrap(),
+                original,
+                "a save dropped or moved the {label} byte order mark",
+            );
+        }
+    }
+
+    #[test]
+    fn bytes_nothing_decodes_are_still_reported_as_lossy() {
+        // The guard that predates detection has to keep working, because
+        // detection does not make every file readable: a UTF-16 document with
+        // a half character at the end has no faithful reading, and the buffer
+        // it produces must not be written back over it. Reported as UTF-8 so
+        // the Save As rescue copy is Unicode rather than a re-encoding of
+        // replacement characters.
+        let truncated = [0xFF, 0xFE, b'A', 0x00, b'B'];
+
+        let decoded = decode_text(&truncated);
+        assert!(decoded.lossy, "got {:?}", decoded.content);
+        assert!(decoded.content.contains('\u{FFFD}'));
+        assert_eq!(decoded.encoding, UTF8_LABEL);
+    }
+
+    #[test]
+    fn a_character_the_encoding_cannot_represent_fails_the_save() {
+        // Typing an emoji into a GBK document. `encoding_rs::encode` would
+        // write `&#128512;` — an HTML escape, in a Markdown file, replacing
+        // the character the user typed. Refusing leaves the buffer dirty and
+        // sends the reason to a toast, which is how a read-only file behaves.
+        let error = encode_text("hello 😀", "GBK").unwrap_err();
+        assert!(error.contains("GBK"), "unhelpful message: {error}");
+        assert!(error.contains("Save As"), "no way out offered: {error}");
+
+        assert!(encode_text("hello 😀", UTF8_LABEL).is_ok());
+    }
+
+    #[test]
+    fn an_unrecognised_encoding_label_is_refused_rather_than_defaulted() {
+        // The label makes a round trip through the frontend, so it is untrusted
+        // input by the time it comes back. Falling back to UTF-8 here would
+        // write the wrong bytes over the file the label came from.
+        assert!(encode_text("text", "definitely-not-an-encoding").is_err());
+        // WHATWG defines the UTF-16 and `replacement` ENCODERS as emitting
+        // UTF-8, which for a browser is a security rule and for an editor is a
+        // silent conversion of the user's file. UTF-16 is handled before this
+        // branch; `replacement` has no business getting past it.
+        assert!(encode_text("text", "iso-2022-kr").is_err());
+    }
+
+    #[test]
+    fn read_file_content_checked_reports_the_encoding_it_used() {
         let path = temp_path("gbk-checked.md");
-        fs::write(&path, GBK_ZHONGWEN).unwrap();
+        let original = legacy_bytes(encoding_rs::GBK, CHINESE_SAMPLE);
+        fs::write(&path, &original).unwrap();
 
         let decoded = read_to_string_lossy(path.to_str().unwrap()).unwrap();
         fs::remove_file(&path).unwrap();
 
-        assert!(
-            decoded.lossy,
-            "read_file_content_checked returned mojibake without reporting it",
+        assert!(!decoded.lossy);
+        assert_eq!(decoded.content, CHINESE_SAMPLE);
+        assert_eq!(
+            encode_text(&decoded.content, &decoded.encoding).unwrap(),
+            original,
         );
-        assert!(decoded.content.contains('\u{FFFD}'));
     }
 
     #[test]
-    fn a_small_non_utf8_file_is_flagged_by_the_preview_too() {
-        // The ≤max_bytes branch. Before #371 it decoded strictly and could
-        // only fail, so it needed no flag; now it opens the same mojibake the
-        // truncated branch always did, and needs the same guard.
-        let path = temp_path("gbk-small.md");
-        let mut bytes = b"# ".to_vec();
-        bytes.extend_from_slice(GBK_ZHONGWEN);
-        fs::write(&path, &bytes).unwrap();
-
-        let preview = build_markdown_preview(&path, 50_000).unwrap();
-        fs::remove_file(&path).unwrap();
-
-        assert!(preview.is_full, "this file fits in the preview budget");
-        assert!(preview.lossy, "the save guard has nothing to go on without this");
-        assert!(preview.content.contains('\u{FFFD}'));
-    }
-
-    #[test]
-    fn an_oversized_non_utf8_preview_is_flagged() {
+    fn the_preview_decodes_a_legacy_file_at_both_sizes() {
+        // The two branches the issue's size table describes. They used to
+        // disagree — strict below the budget, lossy above it — so the same
+        // document opened or failed depending on how long it was. One decoder
+        // now serves both, and neither produces mojibake.
         let path = temp_path("gbk-preview.md");
-        let mut bytes = b"# ".to_vec();
-        bytes.extend_from_slice(GBK_ZHONGWEN);
-        bytes.extend_from_slice(b"\nplus enough text to exceed the preview budget\n");
-        fs::write(&path, &bytes).unwrap();
+        let mut original = legacy_bytes(encoding_rs::GBK, CHINESE_SAMPLE);
+        original.extend_from_slice(&legacy_bytes(encoding_rs::GBK, CHINESE_SAMPLE));
+        fs::write(&path, &original).unwrap();
 
-        let preview = build_markdown_preview(&path, 8).unwrap();
+        let whole = build_markdown_preview(&path, 50_000).unwrap();
+        assert!(whole.is_full);
+        assert!(
+            !whole.lossy,
+            "the small-file branch produced {:?}",
+            whole.content
+        );
+        assert_eq!(whole.encoding, "GBK");
+        assert_eq!(
+            encode_text(&whole.content, &whole.encoding).unwrap(),
+            original,
+        );
+
+        // Cut on a byte boundary the detector still has plenty of text before.
+        let cut = build_markdown_preview(&path, original.len() / 2).unwrap();
         fs::remove_file(&path).unwrap();
-
-        assert!(!preview.is_full);
-        assert!(preview.lossy);
-        assert!(preview.content.contains('\u{FFFD}'));
+        assert!(!cut.is_full);
+        assert!(
+            !cut.content.contains("\u{FFFD}\u{FFFD}"),
+            "the truncated branch fell back to mojibake: {:?}",
+            cut.content,
+        );
     }
 
     #[test]

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -1659,8 +1659,9 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 						// its own verdict instead of relying on the one
 						// `loadMarkdown` left behind — a file can be converted
 						// to UTF-8 (or away from it) between the two reads.
-						const [content, lossy] = (await invoke('read_file_content_checked', { path: tab.path })) as [string, boolean];
+						const [content, lossy, encoding] = (await invoke('read_file_content_checked', { path: tab.path })) as [string, boolean, string];
 						tabManager.setTabDecodedLossy(tab.id, lossy);
+						tabManager.setTabEncoding(tab.id, encoding);
 						// Goes through the store so a tab that held only the
 						// large-file preview slice stops being flagged partial.
 						tabManager.setTabRawContent(tab.id, content);
@@ -2262,7 +2263,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		});
 		if (dest) {
 			try {
-				await invoke('save_file_content', { path: dest, content: svg });
+				await invoke('save_file_content', { path: dest, content: svg, encoding: 'UTF-8' });
 				addToast('Diagram saved as SVG');
 			} catch (e) {
 				addToast(`Failed to save diagram: ${e}`, 'error');
@@ -2532,8 +2533,9 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 					// Checked, like every other read that fills an editable
 					// buffer: split view is an editor, so this tab must carry
 					// the fidelity of its own decode rather than inherit one.
-					const [content, lossy] = (await invoke('read_file_content_checked', { path: tab.path })) as [string, boolean];
+					const [content, lossy, encoding] = (await invoke('read_file_content_checked', { path: tab.path })) as [string, boolean, string];
 					tabManager.setTabDecodedLossy(tab.id, lossy);
+					tabManager.setTabEncoding(tab.id, encoding);
 					tabManager.setTabRawContent(tab.id, content);
 				} catch (e) {
 					console.error('Failed to load raw content for split view', e);

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -96,6 +96,22 @@
 	let wordCount = $state(0);
 	let currentLanguage = $state("markdown");
 	let lineEnding = $state<"LF" | "CRLF">("LF");
+	/**
+	 * The encoding the document was decoded from, and the one a save writes it
+	 * back as (#372).
+	 *
+	 * Derived from the tab rather than synced from the model like `lineEnding`
+	 * is: a line ending is a property of the Monaco buffer, an encoding is a
+	 * property of the file that buffer came from. The store already holds it,
+	 * so a copy kept in sync here could only go stale.
+	 *
+	 * This slot used to be the literal string `UTF-8`, which was true of every
+	 * file Markpad could open. Detection made it a lie for exactly the
+	 * documents the indicator matters most for — a GBK file now opens, reads
+	 * correctly and saves back as GBK, and the status bar was still claiming
+	 * UTF-8.
+	 */
+	let encoding = $derived(tabManager.activeTab?.encoding ?? 'UTF-8');
 	let currentTabId = tabManager.activeTabId;
 
 	// A Monaco action captures its label when it is registered, so actions built
@@ -1887,7 +1903,7 @@
 		     puts it on `Tab.encoding`. Wire this to that field when it lands —
 		     duplicating the detection to make the label true sooner would leave
 		     two answers to one question. -->
-		<div class="status-item">{t('editor.status.utf8')}</div>
+		<div class="status-item">{encoding}</div>
 	</div>
 {/if}
 

--- a/src/lib/components/Tab.svelte
+++ b/src/lib/components/Tab.svelte
@@ -139,6 +139,24 @@
 			],
 		};
 	}
+
+	/**
+	 * The path, plus the encoding when it is not the one everybody assumes.
+	 *
+	 * A save writes the document back as the encoding it was opened in, so a
+	 * GBK or Shift-JIS file stays GBK or Shift-JIS — which is right, and is
+	 * invisible unless something says so. This is the smallest place that can:
+	 * no chrome, no translation (encoding labels are not translated), and it
+	 * says nothing at all for the UTF-8 files that are almost every file.
+	 *
+	 * A status-bar control that lets the reader CHANGE the encoding — reopen
+	 * as, convert to — is the other half and is deliberately not here; see the
+	 * discussion on #372.
+	 */
+	function tabTooltip(tab: Tab): string {
+		const name = hasRealFilePath(tab.path) ? tab.path : tab.title;
+		return tab.encoding === 'UTF-8' ? name : `${name} (${tab.encoding})`;
+	}
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -147,7 +165,7 @@
 	class="tab {isActive ? 'active' : ''}"
 	class:last={isLast}
 	role="group"
-	title={hasRealFilePath(tab.path) ? tab.path : tab.title}
+	title={tabTooltip(tab)}
 	oncontextmenu={handleContextMenu}
 	onmouseenter={startTitleMarquee}
 	onmouseleave={stopTitleMarquee}>

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -260,6 +260,51 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 	 * `targetPath !== tab.path` stays as the cheap first test so the common
 	 * Ctrl+S case never consults anything further.
 	 */
+	/**
+	 * The prefix `encode_text` refuses with when the document's encoding has no
+	 * representation for something the buffer now holds — an emoji pasted into
+	 * a GBK file being the way most people will meet it.
+	 */
+	const UNMAPPABLE_CODE = 'ENCODING_UNMAPPABLE';
+
+	/**
+	 * A save failure, said in a way the user can act on, and what to show
+	 * beside it.
+	 *
+	 * The translation that matters here is not English-to-Chinese. It is
+	 * `ENCODING_UNMAPPABLE` — a fact about the program — turned into "this
+	 * document is GBK, GBK cannot hold that character, write a UTF-8 copy
+	 * instead": a fact about what the user should do next. That the result then
+	 * exists in six languages is the cheap half, and it rides on machinery the
+	 * app already has.
+	 *
+	 * Which is also the rule for what belongs here. A failure the user can act
+	 * on gets a code and a sentence this side writes. A failure they cannot —
+	 * the 91 places that hand back an OS error — keeps the OS's own words,
+	 * because those words are the whole of the information and the only string
+	 * worth searching for. "Permission denied (os error 13)", translated, is a
+	 * sentence nobody can look up.
+	 *
+	 * `onError` renders `${message}: ${detail}`, so `detail` is in front of the
+	 * user too: the document's path for a refusal we explained, the raw error
+	 * for one we did not. Returning the marker here printed it to the user,
+	 * which is the failure this shape exists to prevent.
+	 */
+	function describeSaveFailure(error: unknown, tab: Tab): { message: string; detail: unknown } {
+		if (!String(error).includes(UNMAPPABLE_CODE)) {
+			return { message: 'Failed to save file', detail: error };
+		}
+
+		// `tab.encoding` is what was handed to the command that just refused,
+		// so it is the encoding that could not hold the character. Rust used to
+		// send the label back and this read it off the error; the round trip
+		// was telling us something we had said ourselves a moment earlier.
+		return {
+			message: t('toast.encodingUnmappable', settings.language).replace('{{encoding}}', tab.encoding),
+			detail: tab.path,
+		};
+	}
+
 	function refuseIfLossilyDecoded(tab: Tab, targetPath: string, targetKey?: string): boolean {
 		if (!tab.hasReplacementChars || targetPath === '') return false;
 		if (targetPath !== tab.path && !isSameFilePath({ path: targetPath, pathKey: targetKey }, tab)) return false;
@@ -570,7 +615,8 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 				return true;
 			} catch (error) {
 				clearSelfWrite(targetPath);
-				options.onError('Failed to save file', error);
+				const { message, detail } = describeSaveFailure(error, tab);
+				options.onError(message, detail);
 				return false;
 			}
 		});
@@ -627,7 +673,8 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 				return true;
 			} catch (error) {
 				clearSelfWrite(selected);
-				options.onError('Failed to save file as', error);
+				const { message, detail } = describeSaveFailure(error, tab);
+				options.onError(message === 'Failed to save file' ? 'Failed to save file as' : message, detail);
 				return false;
 			}
 		});

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -217,8 +217,11 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 			// the fidelity again costs nothing and makes the flag a property of
 			// the buffer instead of a memory of how it was obtained; it also
 			// CLEARS the flag for a file converted to UTF-8 since the load.
-			const [full, lossy] = (await invoke('read_file_content_checked', { path: tab.path })) as [string, boolean];
+			const [full, lossy, encoding] = (await invoke('read_file_content_checked', { path: tab.path })) as [string, boolean, string];
 			tabManager.setTabDecodedLossy(tabId, lossy);
+			// The preview's answer came from the first 50KB; this one is the
+			// whole file's, and it is the one every save from here on uses.
+			tabManager.setTabEncoding(tabId, encoding);
 			tabManager.setTabRawContent(tabId, full);
 			return true;
 		} catch (error) {
@@ -233,9 +236,9 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 
 	/**
 	 * Refuse to write a buffer back over the file it was decoded from when
-	 * that decode was lossy: the file is not UTF-8, the bytes it disagreed
-	 * with are already U+FFFD in the buffer, and the original is unrecoverable
-	 * from it. Every writer — Ctrl+S, the auto-save timer in
+	 * that decode was lossy: no encoding could read the file, the bytes
+	 * nothing could read are already U+FFFD in the buffer, and the original is
+	 * unrecoverable from it. Every writer — Ctrl+S, the auto-save timer in
 	 * MarkdownViewer.svelte, the close dialogs in canCloseTab, the task
 	 * checkbox — funnels through saveContent/saveContentAs, so this is the
 	 * one place that has to hold.
@@ -244,9 +247,10 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 	 * genuine UTF-8 file, which is correct and is the user's way out; an
 	 * untitled buffer (path === '') has no source file to destroy.
 	 *
-	 * This is damage control, not encoding support: Markpad cannot read GBK
-	 * or Shift-JIS in the first place (that needs a real decoder), and this
-	 * only stops it from overwriting what it could not read.
+	 * Detection (#372) narrowed this a great deal without replacing it: GBK,
+	 * Big5, Shift-JIS and the rest are now read properly and written back as
+	 * themselves, so the everyday legacy document never reaches here. What is
+	 * left is the file nothing can read, and no decoder makes that go away.
 	 *
 	 * "The same file" is the filesystem's judgement, not the string's: a Save As
 	 * typed as `/notes/Legacy.md` for a tab opened as `/notes/legacy.md` is the
@@ -414,16 +418,19 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 				let content: string;
 				let isFull: boolean;
 				let lossy: boolean;
+				let encoding: string;
 				if (initialIsEditing || initialIsSplit) {
-					[content, lossy] = (await invoke('read_file_content_checked', { path: filePath })) as [string, boolean];
+					[content, lossy, encoding] = (await invoke('read_file_content_checked', { path: filePath })) as [string, boolean, string];
 					isFull = true;
 				} else {
-					[, content, isFull, lossy] = (await invoke('open_markdown_preview', { path: filePath, maxBytes: 50000 })) as [string, string, boolean, boolean];
+					[, content, isFull, lossy, encoding] = (await invoke('open_markdown_preview', { path: filePath, maxBytes: 50000 })) as [string, string, boolean, boolean, string];
 				}
 				// Decided on every load, before the buffer can reach a writer.
-				// Both branches report it, so this also CLEARS the flag on a
-				// file the user has since converted to UTF-8.
+				// Both branches report both, so this also CLEARS the flag on a
+				// file the user has since converted to UTF-8 — and repoints the
+				// save at the encoding it converted to.
 				tabManager.setTabDecodedLossy(activeId, lossy);
+				tabManager.setTabEncoding(activeId, encoding);
 				lossySaveWarnedTabs.delete(activeId);
 				if (pendingNavigateTabId) tabManager.navigate(pendingNavigateTabId, filePath, pathKey);
 				const processed = await options.renderMarkdown(content, filePath, foldsForTab(activeId));
@@ -440,8 +447,8 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 					};
 					updateLoading(activeId, true);
 					options.measureInitialViewport();
-					(invoke('read_file_content_checked', { path: filePath }) as Promise<[string, boolean]>)
-						.then(([fullContent, fullLossy]) => {
+					(invoke('read_file_content_checked', { path: filePath }) as Promise<[string, boolean, string]>)
+						.then(([fullContent, fullLossy, fullEncoding]) => {
 							const applyFull = () => {
 								try {
 									if (options.isScrolling()) return void setTimeout(applyFull, 100);
@@ -453,9 +460,11 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 											tabManager.setTabRawContent(activeId, fullContent);
 											// This buffer REPLACES the preview's, so it
 											// carries its own verdict — the preview only
-											// saw the first 50KB and a file can be valid
-											// UTF-8 up to there and not after.
+											// saw the first 50KB, and both the fidelity
+											// and the detected encoding of a prefix can
+											// differ from the whole file's.
 											tabManager.setTabDecodedLossy(activeId, fullLossy);
+											tabManager.setTabEncoding(activeId, fullEncoding);
 											updateLoading(activeId, false);
 											if (tabManager.activeTabId === activeId) setTimeout(options.renderRichContent, 10);
 										})
@@ -477,8 +486,9 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 						});
 				}
 			} else {
-				const [content, lossy] = (await invoke('read_file_content_checked', { path: filePath })) as [string, boolean];
+				const [content, lossy, encoding] = (await invoke('read_file_content_checked', { path: filePath })) as [string, boolean, string];
 				tabManager.setTabDecodedLossy(activeId, lossy);
+				tabManager.setTabEncoding(activeId, encoding);
 				lossySaveWarnedTabs.delete(activeId);
 				if (pendingNavigateTabId) tabManager.navigate(pendingNavigateTabId, filePath, pathKey);
 				if (tab) tab.isEditing = true;
@@ -544,7 +554,12 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 			const snapshot = tab.rawContent;
 			markSelfWrite(targetPath);
 			try {
-				await invoke('save_file_content', { path: targetPath, content: snapshot });
+				// The tab's own encoding, so a GBK or Shift-JIS document is
+				// written back as the file it was opened from rather than
+				// silently converted to UTF-8 by every auto-save. An untitled
+				// buffer saved through the dialog above still carries the
+				// `UTF-8` it was created with, which is what it should be.
+				await invoke('save_file_content', { path: targetPath, content: snapshot, encoding: tab.encoding });
 				markSelfWrite(targetPath);
 				if (tab.path === '') {
 					tabManager.updateTabPath(tab.id, targetPath, targetKey);
@@ -592,12 +607,19 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 			const snapshot = tab.rawContent;
 			markSelfWrite(selected);
 			try {
-				await invoke('save_file_content', { path: selected, content: snapshot });
+				// Deliberately UTF-8, not `tab.encoding`. Save As is the way out
+				// of both failure modes this file guards: a buffer nothing could
+				// decode, and one holding a character its own encoding cannot
+				// represent. Writing the copy in the encoding that caused the
+				// problem would take the exit away.
+				await invoke('save_file_content', { path: selected, content: snapshot, encoding: 'UTF-8' });
 				markSelfWrite(selected);
 				tabManager.updateTabPath(tab.id, selected, selectedKey);
 				// The buffer now has a UTF-8 file of its own that it matches
-				// exactly, so it is safe to save from here on.
+				// exactly, so it is safe to save from here on — and every save
+				// from here on has to agree about what that file is.
 				tabManager.setTabDecodedLossy(tab.id, false);
+				tabManager.setTabEncoding(tab.id, 'UTF-8');
 				lossySaveWarnedTabs.delete(tab.id);
 				options.saveRecentFile(selected);
 				tab.originalContent = snapshot;

--- a/src/lib/sessions/windowSession.svelte.ts
+++ b/src/lib/sessions/windowSession.svelte.ts
@@ -261,15 +261,17 @@ export function createWindowSession(options: WindowSessionOptions) {
 					// that leaves nothing behind.
 					await writeProgress(progress);
 					try {
-						// `_checked`, because restore fills an editable buffer: reads
-						// decode leniently, so a file in a legacy encoding comes back
-						// as U+FFFD mojibake that must never be written over its
-						// source. Without this, reopening the app laundered the flag
-						// away and the next auto-save destroyed the document.
-						const [raw, lossy] = (await invoke('read_file_content_checked', { path: tab.path })) as [string, boolean];
+						// `_checked`, because restore fills an editable buffer, and
+						// both of its answers belong to the tab: `lossy` so a file
+						// nothing could decode is never written back over, and the
+						// encoding so a legacy one is written back as itself.
+						// Without this, reopening the app laundered them away and
+						// the next auto-save destroyed or converted the document.
+						const [raw, lossy, encoding] = (await invoke('read_file_content_checked', { path: tab.path })) as [string, boolean, string];
 						if (options.isDisposed()) return;
 						await options.applyRestoredContent(tab.id, raw);
 						tabManager.setTabDecodedLossy(tab.id, lossy);
+						tabManager.setTabEncoding(tab.id, encoding);
 						if (options.isDisposed()) return;
 					} catch (error) {
 						if (options.isDisposed()) return;

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -142,16 +142,32 @@ export interface Tab {
 	 */
 	isTruncated?: boolean;
 	/**
-	 * `rawContent` was decoded with U+FFFD substitutions because the file is
-	 * not UTF-8 (GBK, Big5, Shift-JIS ...). The buffer is NOT a copy of the
-	 * file and the original bytes cannot be recovered from it, so writing it
-	 * back over that file destroys the document — documentSession.saveContent
-	 * refuses to. Required, not optional: unlike `isTruncated` above, this one
+	 * `rawContent` was decoded with U+FFFD substitutions because NO encoding
+	 * could read the file: a truncated multi-byte tail, or bytes that are not
+	 * text at all. Not merely "not UTF-8" — a legacy codepage is detected and
+	 * decoded (see `encoding`), which is what #372 was about. The buffer is
+	 * NOT a copy of the file and the original bytes cannot be recovered from
+	 * it, so writing it back over that file destroys the document —
+	 * documentSession.saveContent refuses to. Required, not optional: unlike
+	 * `isTruncated` above, this one
 	 * DOES travel through a transfer payload, and a construction site that
 	 * forgets it would default to "safe to overwrite" — the failure mode here
 	 * is a destroyed document, so the compiler asks every one of them.
 	 */
 	hasReplacementChars: boolean;
+	/**
+	 * The encoding `rawContent` was decoded from, and the one a save writes it
+	 * back as: `UTF-8` (the default, and everything Markpad creates itself),
+	 * `UTF-8-BOM`, `UTF-16LE`, `UTF-16BE`, or a WHATWG label for a legacy
+	 * codepage — `GBK`, `Big5`, `Shift_JIS`, `windows-1252`. Set by whichever
+	 * read filled the buffer; the Rust `decode_text` decides it.
+	 *
+	 * Required for the same reason as `hasReplacementChars`: a construction
+	 * site that forgot it would silently rewrite a legacy document as UTF-8 —
+	 * not the data loss #372 reported, but still a change to the user's file
+	 * that nobody asked for and that other tools would notice.
+	 */
+	encoding: string;
 	/**
 	 * `path` as the FILESYSTEM identifies it: case folded, Unicode normalized
 	 * and symlinks resolved, the way the volume itself does those (see the Rust
@@ -307,7 +323,8 @@ class TabManager {
 					// Not persisted — see serializeState.
 					collapsedHeaders: new Set<string>(),
 					isTruncated: false,
-					hasReplacementChars: false
+					hasReplacementChars: false,
+					encoding: 'UTF-8'
 				});
 			}
 
@@ -443,6 +460,7 @@ class TabManager {
 			collapsedHeaders: new Set<string>(),
 			isTruncated: false,
 			hasReplacementChars: false,
+			encoding: 'UTF-8',
 			pathKey
 		});
 
@@ -476,7 +494,8 @@ class TabManager {
 			isScrollSynced: false,
 			collapsedHeaders: new Set<string>(),
 			isTruncated: false,
-			hasReplacementChars: false
+			hasReplacementChars: false,
+			encoding: 'UTF-8'
 		});
 
 		this.activeTabId = id;
@@ -510,7 +529,8 @@ class TabManager {
 			isScrollSynced: false,
 			collapsedHeaders: new Set<string>(),
 			isTruncated: false,
-			hasReplacementChars: false
+			hasReplacementChars: false,
+			encoding: 'UTF-8'
 		});
 
 		this.activeTabId = id;
@@ -667,6 +687,25 @@ class TabManager {
 		const tab = this.tabs.find((t) => t.id === id);
 		if (tab) {
 			tab.hasReplacementChars = lossy;
+		}
+	}
+
+	/**
+	 * Record which encoding this buffer was decoded from, so the save writes
+	 * the file back as itself. Set by the same reads that set the flag above,
+	 * and for the same reason: it is a property of the buffer in hand, not a
+	 * memory of how the tab was first opened — a file converted to UTF-8 since
+	 * the load must stop being written as GBK.
+	 *
+	 * Separate from `setTabDecodedLossy` rather than an argument to it: they
+	 * answer different questions ("could this be read?" and "what was it read
+	 * as?"), and every caller that has one has the other, so folding them
+	 * together would buy a line and cost the name.
+	 */
+	setTabEncoding(id: string, encoding: string) {
+		const tab = this.tabs.find((t) => t.id === id);
+		if (tab) {
+			tab.encoding = encoding;
 		}
 	}
 

--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -449,7 +449,7 @@ export async function exportAsHtml(ctx: ExportContext): Promise<ExportHtmlResult
 	});
 
 	try {
-		await invoke('save_file_content', { path: selected, content: fullHtml });
+		await invoke('save_file_content', { path: selected, content: fullHtml, encoding: 'UTF-8' });
 		return {
 			path: selected,
 			embeddedImages: article.embeddedImages,

--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -272,6 +272,7 @@ export const translations: Record<LanguageCode, Translation> = {
             openExportedFileFailed: 'Could not open exported file',
             partialDocument: 'Cannot edit yet — this file is not fully loaded',
             lossySaveBlocked: 'Not saved: parts of this file could not be read in any encoding and became "�" when it was opened. Saving would destroy the original — use "Save As" to write a copy',
+            encodingUnmappable: 'Not saved: {{encoding}} cannot represent every character this document now contains (an emoji, most likely). Use "Save As" to write a copy as UTF-8',
             restoreInterrupted: 'Markpad did not finish restoring your session last time',
             restoreInterruptedDeferred: 'Markpad did not finish opening {path} last time, so it was skipped. Open it yourself to try again'
         },
@@ -333,8 +334,7 @@ export const translations: Record<LanguageCode, Translation> = {
                 lineCol: 'Ln {{line}}, Col {{col}}',
                 selected: '{{count}} selected',
                 selections: '{{count}} selections',
-                words: '{{count}} words',
-                utf8: 'UTF-8'
+                words: '{{count}} words'
             }
         },
         tooltip: {
@@ -600,7 +600,8 @@ export const translations: Record<LanguageCode, Translation> = {
 			savedNewerEdits: '已保存 — 因为存在更新的编辑,继续保持编辑模式',
 			openExportedFileFailed: '无法打开导出的文件',
 			partialDocument: '暂时无法编辑 — 文件尚未完整加载',
-			lossySaveBlocked: '未保存：此文件的部分内容无法用任何编码读取，打开时已变成“�”。直接保存会破坏原文件 — 请用“另存为”写入新文件'
+			lossySaveBlocked: '未保存：此文件的部分内容无法用任何编码读取，打开时已变成“�”。直接保存会破坏原文件 — 请用“另存为”写入新文件',
+			encodingUnmappable: '未保存：{{encoding}} 无法表示文档中新增的部分字符（多半是表情符号）。请用“另存为”写入一份 UTF-8 副本'
         },
         externalChange: {
             message: '此文件在你有未保存修改时被外部程序改动。',
@@ -660,8 +661,7 @@ export const translations: Record<LanguageCode, Translation> = {
                 lineCol: '行 {{line}}, 列 {{col}}',
                 selected: '已选择 {{count}}',
                 selections: '{{count}} 个选择',
-                words: '{{count}} 字',
-                utf8: 'UTF-8'
+                words: '{{count}} 字'
             }
         },
         tooltip: {
@@ -884,7 +884,8 @@ export const translations: Record<LanguageCode, Translation> = {
             unsupportedFile: 'サポートされていないファイル形式: {{filename}}',
             autoSaveFailed: '自動保存に失敗しました — 未保存の変更はメモリ内に残っています',
             savedNewerEdits: '保存しました — 新しい編集があるため編集モードを継続します',
-            lossySaveBlocked: '保存しませんでした：このファイルの一部はどの文字コードでも読めず、開いた時点で「�」に置き換わっています。上書き保存すると元のファイルが壊れます —「名前を付けて保存」で新しいファイルに書き出してください'
+            lossySaveBlocked: '保存しませんでした：このファイルの一部はどの文字コードでも読めず、開いた時点で「�」に置き換わっています。上書き保存すると元のファイルが壊れます —「名前を付けて保存」で新しいファイルに書き出してください',
+            encodingUnmappable: '保存しませんでした：{{encoding}} ではこの文書に含まれる一部の文字（多くは絵文字）を表現できません。「名前を付けて保存」で UTF-8 の複製を作成してください'
         },
         modal: {
             confirmExit: '終了を確認',
@@ -908,8 +909,7 @@ export const translations: Record<LanguageCode, Translation> = {
                 lineCol: '行 {{line}}, 列 {{col}}',
                 selected: '{{count}} 選択',
                 selections: '{{count}} つの選択',
-                words: '{{count}} 語',
-                utf8: 'UTF-8'
+                words: '{{count}} 語'
             }
         },
         tooltip: {
@@ -1176,7 +1176,8 @@ export const translations: Record<LanguageCode, Translation> = {
             savedNewerEdits: '已儲存——因有更新的編輯內容，繼續保持編輯模式',
             openExportedFileFailed: '無法開啟匯出的檔案',
             partialDocument: '尚無法編輯 — 此檔案尚未完全讀取',
-            lossySaveBlocked: '未儲存：此檔案的部分內容無法用任何編碼讀取，開啟時已變成「�」。直接儲存會破壞原檔案 — 請用「另存新檔」寫入新檔案'
+            lossySaveBlocked: '未儲存：此檔案的部分內容無法用任何編碼讀取，開啟時已變成「�」。直接儲存會破壞原檔案 — 請用「另存新檔」寫入新檔案',
+            encodingUnmappable: '未儲存：{{encoding}} 無法表示此文件新增的部分字元（多半是表情符號）。請用「另存新檔」寫入一份 UTF-8 複本'
         },
         externalChange: {
             message: '當您有未儲存的變更時，此檔案在磁碟上已被修改。',
@@ -1236,8 +1237,7 @@ export const translations: Record<LanguageCode, Translation> = {
                 lineCol: '第 {{line}} 行，第 {{col}} 欄',
                 selected: '已選取 {{count}} 個字元',
                 selections: '已選取 {{count}} 處',
-                words: '{{count}} 個字詞',
-                utf8: 'UTF-8'
+                words: '{{count}} 個字詞'
             }
         },
         tooltip: {
@@ -1490,7 +1490,8 @@ export const translations: Record<LanguageCode, Translation> = {
             autoSaveFailed: '자동 저장 실패 — 저장되지 않은 변경 사항은 메모리에 남아 있습니다',
             savedNewerEdits: '저장됨 — 새로운 편집이 있어 편집 모드를 유지합니다',
             openExportedFileFailed: '내보낸 파일을 열 수 없습니다',
-            lossySaveBlocked: '저장하지 않음: 이 파일의 일부는 어떤 인코딩으로도 읽을 수 없어 열 때 "�"로 바뀌었습니다. 덮어쓰면 원본이 손상됩니다 — "다른 이름으로 저장"으로 새 파일에 저장하세요'
+            lossySaveBlocked: '저장하지 않음: 이 파일의 일부는 어떤 인코딩으로도 읽을 수 없어 열 때 "�"로 바뀌었습니다. 덮어쓰면 원본이 손상됩니다 — "다른 이름으로 저장"으로 새 파일에 저장하세요',
+            encodingUnmappable: '저장하지 않음: {{encoding}}(으)로는 이 문서에 포함된 일부 문자(대개 이모지)를 표현할 수 없습니다. "다른 이름으로 저장"으로 UTF-8 사본을 만드세요'
         },
         modal: {
             confirmExit: '종료 확인',
@@ -1544,7 +1545,6 @@ export const translations: Record<LanguageCode, Translation> = {
                 selected: '{{count}}개 선택됨',
                 selections: '{{count}}개 선택 영역',
                 words: '{{count}}개 단어',
-                utf8: 'UTF-8',
                 lines: '{{count}}개 줄'
             }
         },
@@ -1768,7 +1768,8 @@ export const translations: Record<LanguageCode, Translation> = {
             unsupportedFile: 'Неподдерживаемый тип файла: {{filename}}',
             autoSaveFailed: 'Автосохранение не удалось — несохранённые правки остались только в памяти',
             savedNewerEdits: 'Сохранено — остаюсь в режиме редактирования, так как есть более новые правки',
-            lossySaveBlocked: 'Не сохранено: часть содержимого файла не читается ни в одной кодировке и при открытии стала «�». Сохранение уничтожит оригинал — используйте «Сохранить как» для записи копии'
+            lossySaveBlocked: 'Не сохранено: часть содержимого файла не читается ни в одной кодировке и при открытии стала «�». Сохранение уничтожит оригинал — используйте «Сохранить как» для записи копии',
+            encodingUnmappable: 'Не сохранено: кодировка {{encoding}} не может представить некоторые символы этого документа (скорее всего, эмодзи). Используйте «Сохранить как», чтобы записать копию в UTF-8'
         },
         modal: {
             confirmExit: 'Подтвердить выход',

--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -271,7 +271,7 @@ export const translations: Record<LanguageCode, Translation> = {
             savedNewerEdits: 'Saved — staying in edit mode because you have newer edits',
             openExportedFileFailed: 'Could not open exported file',
             partialDocument: 'Cannot edit yet — this file is not fully loaded',
-            lossySaveBlocked: 'Not saved: this file is not UTF-8, so parts of it became "�" when it was opened. Saving would destroy the original — use "Save As" to write a copy',
+            lossySaveBlocked: 'Not saved: parts of this file could not be read in any encoding and became "�" when it was opened. Saving would destroy the original — use "Save As" to write a copy',
             restoreInterrupted: 'Markpad did not finish restoring your session last time',
             restoreInterruptedDeferred: 'Markpad did not finish opening {path} last time, so it was skipped. Open it yourself to try again'
         },
@@ -600,7 +600,7 @@ export const translations: Record<LanguageCode, Translation> = {
 			savedNewerEdits: '已保存 — 因为存在更新的编辑,继续保持编辑模式',
 			openExportedFileFailed: '无法打开导出的文件',
 			partialDocument: '暂时无法编辑 — 文件尚未完整加载',
-			lossySaveBlocked: '未保存：此文件不是 UTF-8 编码，打开时部分内容已变成“�”。直接保存会破坏原文件 — 请用“另存为”写入新文件'
+			lossySaveBlocked: '未保存：此文件的部分内容无法用任何编码读取，打开时已变成“�”。直接保存会破坏原文件 — 请用“另存为”写入新文件'
         },
         externalChange: {
             message: '此文件在你有未保存修改时被外部程序改动。',
@@ -884,7 +884,7 @@ export const translations: Record<LanguageCode, Translation> = {
             unsupportedFile: 'サポートされていないファイル形式: {{filename}}',
             autoSaveFailed: '自動保存に失敗しました — 未保存の変更はメモリ内に残っています',
             savedNewerEdits: '保存しました — 新しい編集があるため編集モードを継続します',
-            lossySaveBlocked: '保存しませんでした：このファイルは UTF-8 ではないため、開いた時点で一部が「�」に置き換わっています。上書き保存すると元のファイルが壊れます —「名前を付けて保存」で新しいファイルに書き出してください'
+            lossySaveBlocked: '保存しませんでした：このファイルの一部はどの文字コードでも読めず、開いた時点で「�」に置き換わっています。上書き保存すると元のファイルが壊れます —「名前を付けて保存」で新しいファイルに書き出してください'
         },
         modal: {
             confirmExit: '終了を確認',
@@ -1176,7 +1176,7 @@ export const translations: Record<LanguageCode, Translation> = {
             savedNewerEdits: '已儲存——因有更新的編輯內容，繼續保持編輯模式',
             openExportedFileFailed: '無法開啟匯出的檔案',
             partialDocument: '尚無法編輯 — 此檔案尚未完全讀取',
-            lossySaveBlocked: '未儲存：此檔案不是 UTF-8 編碼，開啟時部分內容已變成「�」。直接儲存會破壞原檔案 — 請用「另存新檔」寫入新檔案'
+            lossySaveBlocked: '未儲存：此檔案的部分內容無法用任何編碼讀取，開啟時已變成「�」。直接儲存會破壞原檔案 — 請用「另存新檔」寫入新檔案'
         },
         externalChange: {
             message: '當您有未儲存的變更時，此檔案在磁碟上已被修改。',
@@ -1490,7 +1490,7 @@ export const translations: Record<LanguageCode, Translation> = {
             autoSaveFailed: '자동 저장 실패 — 저장되지 않은 변경 사항은 메모리에 남아 있습니다',
             savedNewerEdits: '저장됨 — 새로운 편집이 있어 편집 모드를 유지합니다',
             openExportedFileFailed: '내보낸 파일을 열 수 없습니다',
-            lossySaveBlocked: '저장하지 않음: 이 파일은 UTF-8이 아니어서 열 때 일부가 "�"로 바뀌었습니다. 덮어쓰면 원본이 손상됩니다 — "다른 이름으로 저장"으로 새 파일에 저장하세요'
+            lossySaveBlocked: '저장하지 않음: 이 파일의 일부는 어떤 인코딩으로도 읽을 수 없어 열 때 "�"로 바뀌었습니다. 덮어쓰면 원본이 손상됩니다 — "다른 이름으로 저장"으로 새 파일에 저장하세요'
         },
         modal: {
             confirmExit: '종료 확인',
@@ -1768,7 +1768,7 @@ export const translations: Record<LanguageCode, Translation> = {
             unsupportedFile: 'Неподдерживаемый тип файла: {{filename}}',
             autoSaveFailed: 'Автосохранение не удалось — несохранённые правки остались только в памяти',
             savedNewerEdits: 'Сохранено — остаюсь в режиме редактирования, так как есть более новые правки',
-            lossySaveBlocked: 'Не сохранено: файл не в кодировке UTF-8, при открытии часть содержимого стала «�». Сохранение уничтожит оригинал — используйте «Сохранить как» для записи копии'
+            lossySaveBlocked: 'Не сохранено: часть содержимого файла не читается ни в одной кодировке и при открытии стала «�». Сохранение уничтожит оригинал — используйте «Сохранить как» для записи копии'
         },
         modal: {
             confirmExit: 'Подтвердить выход',

--- a/src/lib/utils/tabTransfer.ts
+++ b/src/lib/utils/tabTransfer.ts
@@ -39,6 +39,13 @@ export interface TransferableTab {
 	 * looks safe to save. See `Tab.hasReplacementChars`.
 	 */
 	hasReplacementChars: boolean;
+	/**
+	 * Travels for the same reason and with the same consequence: the buffer is
+	 * a decode of a file in this encoding, and a destination window that
+	 * defaulted to UTF-8 would rewrite the user's GBK document the first time
+	 * it auto-saved after the move.
+	 */
+	encoding: string;
 	splitRatio: number;
 	scrollTop: number;
 	scrollPercentage: number;
@@ -47,7 +54,7 @@ export interface TransferableTab {
 	history: string[];
 }
 
-const STRING_FIELDS = ['path', 'title', 'rawContent', 'originalContent'] as const;
+const STRING_FIELDS = ['path', 'title', 'rawContent', 'originalContent', 'encoding'] as const;
 const BOOLEAN_FIELDS = [
 	'isDirty',
 	'isEditing',
@@ -75,6 +82,7 @@ export function snapshotTab(tab: Tab): TransferableTab {
 		isSplit: tab.isSplit,
 		isScrollSynced: tab.isScrollSynced,
 		hasReplacementChars: tab.hasReplacementChars,
+		encoding: tab.encoding,
 		splitRatio: tab.splitRatio,
 		scrollTop: tab.scrollTop,
 		scrollPercentage: tab.scrollPercentage,
@@ -128,6 +136,7 @@ export function validateTransferPayload(json: string): TransferableTab | null {
 		isSplit: obj.isSplit as boolean,
 		isScrollSynced: obj.isScrollSynced as boolean,
 		hasReplacementChars: obj.hasReplacementChars as boolean,
+		encoding: obj.encoding as string,
 		splitRatio: obj.splitRatio as number,
 		scrollTop: obj.scrollTop as number,
 		scrollPercentage: obj.scrollPercentage as number,
@@ -188,5 +197,6 @@ export function buildTransferredTab(
 		isScrollSynced: snap.isScrollSynced,
 		collapsedHeaders: new Set<string>(),
 		hasReplacementChars: snap.hasReplacementChars,
+		encoding: snap.encoding,
 	};
 }


### PR DESCRIPTION
Closes #372.

A document in a legacy encoding opened full of U+FFFD and, before the interim
guard in #406, saving wrote that back — permanently. The guard stopped the
destruction by refusing the save, which turned the bug from dangerous into
useless: the file could be read and copied out of, never edited.

This reads it properly instead.

## Detecting

Three steps, in the order of how much they can be trusted:

1. **A BOM decides on its own.** UTF-8, UTF-16LE and UTF-16BE are unambiguous,
   and Windows-authored Markdown is full of them.
2. **Valid UTF-8 is UTF-8.** No heuristic gets a say over the encoding every
   modern file is actually in, and the common path stays free.
3. **Otherwise guess**, with `chardetng` — the detector Firefox ships for this
   question. UTF-8 is denied because step 2 ruled it out; ISO-2022-JP is
   allowed, which a browser must not do and an editor has no reason not to.

Worth being explicit about step 2, because it is what makes this narrower than
it looks: VS Code ships `files.autoGuessEncoding` **off by default**, and that
setting guesses at files that are already valid UTF-8. Here the detector only
runs once UTF-8 has failed — the point where the alternative is mojibake.

## Writing it back

`save_file_content` takes the label the file was decoded from, so a GBK
document is written as GBK rather than silently converted by the first
auto-save. UTF-16 is encoded here rather than by `encoding_rs`, whose UTF-16
encoders are defined by WHATWG to emit UTF-8 — correct for the web, a silent
change of the file's encoding for an editor.

Encoding happens **before** `atomic_write`, so a document holding a character
its encoding cannot represent fails without the file being touched. That
refusal matters: `encoding_rs::encode` would otherwise write `&#128512;` — an
HTML numeric reference, into a Markdown file, replacing the character that was
typed. Save As is the way out, and is deliberately always UTF-8.

Verified by hand on real files rather than only in tests — GBK at 26 KB and
98 KB, Shift-JIS at 3 KB:

- all detected correctly, `lossy=false`, byte-identical round trip
- the >50 KB one takes the truncated-preview path and still gets the encoding
- an **auto-save** (the exact path #372 describes as destroying the file)
  wrote back as GBK with 26465 of 26596 bytes untouched — only the edited
  region changed. A silent conversion to UTF-8 would have rewritten every
  Chinese byte in the file.

## Two things review changed (second commit)

**The status bar was still the literal string `UTF-8`.** True of every file
Markpad could open until now; a lie for exactly the documents an encoding
indicator exists for. The one place a reader could have caught a misdetection
was asserting the opposite. Same defect #540 fixed one slot to the left.

**The refusal spoke English.** Pasting an emoji into a GBK file is refused
correctly, but the reader got the generic "auto-save failed" in their own
language and the reason in English, in another corner of the screen. Rust
returns a marker now and the frontend writes the sentence — the same shape
`toast.lossySaveBlocked` has always used. The translation that matters is not
English-to-Chinese; it is a fact about the program turned into a fact about
what to do next. Six languages is the cheap half, on machinery already here.

The line that follows from it is in the comment: a failure the user can act on
gets a code and a sentence we write; the 91 sites that hand back an OS error
keep the OS's own words, which are the whole of the information and the only
string worth searching for.

## Known limits

- **BOM-less UTF-16** is not detected — `chardetng` does not look for it by
  design — and reaches the single-byte guess. It round-trips, so nothing is
  destroyed, but it reads as nonsense. Named in `decode_text`.
- **`lossy` is a guarantee over text, not bytes.** Several legacy encodings
  spell one character more than one way (Shift_JIS reaches U+2160 at both
  0x8754 and 0xFA4A), so a decode/encode pair normalises to whichever the
  encoder prefers, with no flag raised. Every editor with one encoder per
  encoding does this, VS Code included.
- **No encoding picker.** VS Code puts "Reopen with Encoding" and "Save with
  Encoding" behind the status-bar item; this has neither, so a misdetection is
  recovered from only by Save As, and converting to UTF-8 is possible but
  undiscoverable — it is a side effect of Save As rather than an action with a
  name. Left out deliberately: it is a UI surface, and #372 asked for a call on
  that separately. Filed as a follow-up.

## Dependencies

`encoding_rs` 0.8 and `chardetng` 1 — the pair Firefox uses, and the ones #372
named. Both are the maintainer's call, which is why the issue asked rather than
opening a PR.

145 Rust tests, 906 frontend tests, `npm run check` clean.