### PR TITLE
fix(editor): two Monaco defaults that only hurt non-Latin scripts (#393)

### DIFF
--- a/scripts/editorOptionWiring.test.ts
+++ b/scripts/editorOptionWiring.test.ts
@@ -311,16 +311,24 @@ const CJK_PROSE = [
 	'你好，世界。（测试）！？',
 ];
 
-test('the editor turns off ambiguous-character highlighting and nothing else', () => {
+test('the editor narrows the Unicode highlighter without switching it off', () => {
 	// Reports #186 and #94 are both Monaco outlining fullwidth punctuation.
-	// Narrowness is the assertion: `unicodeHighlight: false` or a third
-	// sub-option would also make the boxes go away, and would take the
-	// invisible-character warning with it.
+	// Narrowness is the assertion: `unicodeHighlight: false`, or turning
+	// `invisibleCharacters` off, would also make the boxes go away and would
+	// take the NBSP warning with it. Two overrides are allowed, and only two:
+	// the confusable rule off, and one character exempted from the invisible
+	// rule (#393 — U+3000 is the space bar under a CJK IME).
 	const options = createdEditorOptions();
 	assert.deepEqual(
-		options.unicodeHighlight,
-		{ ambiguousCharacters: false },
-		'exactly one sub-option is overridden',
+		Object.keys(options.unicodeHighlight as object).sort(),
+		['allowedCharacters', 'ambiguousCharacters'],
+		'no third sub-option, and invisibleCharacters is not among them',
+	);
+	assert.equal((options.unicodeHighlight as UnicodeHighlightOptions).ambiguousCharacters, false);
+	assert.deepEqual(
+		(options.unicodeHighlight as { allowedCharacters: Record<string, true> }).allowedCharacters,
+		{ '　': true },
+		'exactly one character is exempted',
 	);
 });
 
@@ -360,6 +368,55 @@ test('the invisible-character warning survives the fix', () => {
 
 	const found = outlined(['a b', 'x​z'], effective);
 	assert.equal(found.invisibleCharacterCount, 2, 'NBSP and zero-width space are still flagged');
+});
+
+// U+3000 IDEOGRAPHIC SPACE is what a CJK IME puts on the page when the author
+// presses the space bar, and it is in Monaco's invisible set — so #462 took the
+// boxes off the punctuation and left them on the space. `allowedLocales` cannot
+// help: `strings.js` getData() flattens every locale bucket into one 465-entry
+// set, so U+3000 is in it unconditionally. Only `allowedCharacters` reaches it.
+//
+// Note the fixtures above are Latin. Measured while fixing #393, a zero-width
+// space inside CJK text is not flagged at all — shouldHighlightNonBasicASCII()
+// suppresses it when the surrounding word holds no basic ASCII. So the hazard
+// this option guards is real, but not everywhere the comment above implies.
+const CJK_IDEOGRAPHIC_SPACE = [
+	'\u4eca\u5929\u3000\u5929\u6c14\u5f88\u597d\u3002',
+	'\u3000\u6bb5\u843d\u9996\u884c\u7f29\u8fdb\u4e24\u683c\u3002',
+	'\u5b89\u88c5\u4f9d\u8d56\u3000\u7136\u540e\u8fd0\u884c\u6d4b\u8bd5\u3002',
+];
+
+test('the space bar under a CJK IME is not outlined', () => {
+	const effective = effectiveUnicodeHighlight(createdEditorOptions().unicodeHighlight);
+	const found = outlined(CJK_IDEOGRAPHIC_SPACE, effective);
+	assert.equal(
+		found.ranges.length,
+		0,
+		`nothing outlined around U+3000, got ${JSON.stringify(
+			found.ranges.map((r) => CJK_IDEOGRAPHIC_SPACE[r.startLineNumber - 1]),
+		)}`,
+	);
+});
+
+test('the U+3000 fixtures still reproduce the bug once the exemption is taken away', () => {
+	// Same guard as the ambiguous-character pair above: without this, the test
+	// before it could pass because a Monaco upgrade dropped U+3000 from the
+	// invisible set, and would then be asserting nothing.
+	const withoutExemption = effectiveUnicodeHighlight({ ambiguousCharacters: false });
+	const found = outlined(CJK_IDEOGRAPHIC_SPACE, withoutExemption);
+	assert.ok(
+		found.invisibleCharacterCount >= 3,
+		`Monaco still boxes U+3000 by default, got ${found.invisibleCharacterCount}`,
+	);
+});
+
+test('exempting U+3000 does not exempt the NBSP that breaks a list', () => {
+	// The narrow exemption has to stay narrow: an NBSP after `-` stops the list
+	// from parsing, and that is why invisibleCharacters is still on.
+	const effective = effectiveUnicodeHighlight(createdEditorOptions().unicodeHighlight);
+	const found = outlined(['-\u00a0item', '\u4eca\u5929\u3000\u5929\u6c14'], effective);
+	assert.equal(found.invisibleCharacterCount, 1, 'the NBSP is flagged, the U+3000 is not');
+	assert.equal(found.ranges[0].startLineNumber, 1, 'and it is the NBSP line');
 });
 
 // ------------------------------------------------- the defaults left in force
@@ -479,4 +536,86 @@ test('the character that opens that dialog is one prose really carries', () => {
 		false,
 		'ordinary line endings are not what this is about',
 	);
+});
+
+
+// ─────────────────────────────────────────── wordSegmenterLocales
+//
+// Word-wise navigation splits on `wordSeparators`, and a language that puts no
+// spaces between its words offers none — so ⌥→ crosses a whole Chinese clause,
+// double-click selects it, ⌥⌫ deletes it. `wordSegmenterLocales` switches on
+// `Intl.Segmenter`, which knows where the words are.
+//
+// Driven through Monaco's own `getMapForWordSeparators`, the function
+// `wordOperations.js` and `cursorWordOperations.js` both call, rather than
+// asserting the option is spelled correctly in Editor.svelte.
+
+const { getMapForWordSeparators } = await import(
+	'monaco-editor/esm/vs/editor/common/core/wordCharacterClassifier.js'
+);
+// Monaco's own default — the editor does not set `wordSeparators`, so this is
+// what the classifier is built with in the app.
+const { USUAL_WORD_SEPARATORS } = await import(
+	'monaco-editor/esm/vs/editor/common/core/wordHelper.js'
+);
+
+/** Every word boundary Monaco would find on `line`, walking it end to end. */
+function wordStarts(line: string, locales: string[]): number[] {
+	const classifier = getMapForWordSeparators(USUAL_WORD_SEPARATORS, locales);
+	const starts: number[] = [];
+	for (let offset = 0; offset < line.length; ) {
+		const found = classifier.findNextIntlWordAtOrAfterOffset(line, offset);
+		if (!found) break;
+		starts.push(found.index);
+		offset = found.index + Math.max(1, found.segment.length);
+	}
+	return starts;
+}
+
+test('a Chinese clause is one word without the segmenter and several with it', () => {
+	// The sentence a reporter would type. No spaces, so `wordSeparators` has
+	// nothing to go on.
+	const line = '这是一个用于测试的段落';
+
+	assert.deepEqual(wordStarts(line, []), [], 'precondition: no segmenter, no boundaries');
+	assert.ok(wordStarts(line, ['zh', 'ja']).length > 1, 'the clause splits into words');
+});
+
+test('the list is a switch, not a whitelist — ICU dispatches by script', () => {
+	// None of these scripts are named in `wordSegmenterLocales`, and all of
+	// them segment. Worth pinning, because the obvious "cleanup" is to trim the
+	// list to match the languages in the comment, and that would change nothing
+	// while making the code claim something false.
+	const unnamed = {
+		thai: 'นี่คือประโยคภาษาไทยสำหรับทดสอบ',
+		khmer: 'នេះគឺជាប្រយោគភាសាខ្មែរ',
+		lao: 'ນີ້ແມ່ນປະໂຫຍກພາສາລາວ',
+	};
+
+	for (const [name, line] of Object.entries(unnamed)) {
+		assert.deepEqual(wordStarts(line, []), [], `precondition: ${name} has no boundaries unsegmented`);
+		assert.ok(wordStarts(line, ['zh', 'ja']).length > 1, `${name} segments without being listed`);
+	}
+
+	// And the two spellings that look like they should differ, do not.
+	const han = '私は日本語の文章を書いています';
+	assert.deepEqual(wordStarts(han, ['zh']), wordStarts(han, ['ja']));
+	assert.deepEqual(wordStarts(han, ['zh']), wordStarts(han, ['zh', 'ja']));
+});
+
+test('space-delimited languages are left exactly as they were', () => {
+	// The reason this can be turned on for everyone rather than keyed off the
+	// UI language: it costs the other half of the world nothing.
+	for (const line of [
+		'The quick brown fox jumps',
+		'이 문장은 한국어 표시를 테스트합니다',
+		'Đây là một câu tiếng Việt',
+		'Это предложение на русском',
+	]) {
+		assert.deepEqual(
+			wordStarts(line, ['zh', 'ja']),
+			[...line.matchAll(/\S+/g)].map((m) => m.index),
+			`segmentation moved a boundary in: ${line}`,
+		);
+	}
 });

--- a/scripts/monacoInternals.d.ts
+++ b/scripts/monacoInternals.d.ts
@@ -198,3 +198,36 @@ declare module 'monaco-editor/esm/vs/base/common/keybindings.js' {
 		os: 1 | 2 | 3,
 	): { readonly chords: readonly KeyCodeChord[] } | null;
 }
+
+declare module 'monaco-editor/esm/vs/editor/common/core/wordHelper.js' {
+	/**
+	 * The `wordSeparators` default. The editor does not set that option, so this
+	 * is the string its word classifier is actually built with.
+	 */
+	export const USUAL_WORD_SEPARATORS: string;
+}
+
+declare module 'monaco-editor/esm/vs/editor/common/core/wordCharacterClassifier.js' {
+	/**
+	 * Decides where words begin and end for ⌥←/→, double-click-to-select and
+	 * ⌥⌫. `intlSegmenterLocales` is `wordSegmenterLocales`: a non-empty list
+	 * builds an `Intl.Segmenter`, which is the only thing that finds word
+	 * boundaries in a script that writes no spaces.
+	 */
+	export interface WordCharacterClassifier {
+		/**
+		 * The next segmenter-found word at or after `offset`, or null once the
+		 * line is exhausted. Always null when no locales were given — there is
+		 * no segmenter to ask.
+		 */
+		findNextIntlWordAtOrAfterOffset(
+			lineContent: string,
+			offset: number,
+		): { index: number; segment: string } | null;
+	}
+
+	export function getMapForWordSeparators(
+		wordSeparators: string,
+		intlSegmenterLocales: readonly string[],
+	): WordCharacterClassifier;
+}

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -381,14 +381,51 @@
 			// not. Latin technical terms inside CJK prose are the normal case,
 			// and `**粗体**，` triggers it with no Latin word at all.
 			//
-			// invisibleCharacters stays at its default: a stray zero-width space
-			// or NBSP is a real hazard in Markdown (an NBSP after `-` stops a
-			// list from parsing) and it never fires on something typed on
-			// purpose. nonBasicASCII needs no setting — it defaults to
+			// invisibleCharacters stays on, but not for the reason first written
+			// here. That comment claimed it "never fires on something typed on
+			// purpose"; measured against this Monaco build, U+3000 IDEOGRAPHIC
+			// SPACE — the space bar under every CJK IME — is in the invisible
+			// set and gets outlined, which is the same complaint as #186/#94 one
+			// option over. The set is the flattened union of every locale bucket
+			// (`strings.js` getData()), 465 code points, so `allowedLocales`
+			// cannot exclude it; only `allowedCharacters` can.
+			//
+			// The rest stays on because the NBSP hazard is real: an NBSP after
+			// `-` stops a list from parsing. Worth recording that the other
+			// stated hazard does NOT hold — a zero-width space inside CJK text
+			// is not flagged at all, because shouldHighlightNonBasicASCII()
+			// suppresses it when the surrounding word has no basic ASCII.
+			//
+			// nonBasicASCII needs no setting — it defaults to
 			// `inUntrustedWorkspace` and standalone Monaco's workspace-trust
 			// service returns true unconditionally, so it is already off; were it
 			// on, every ideograph would be boxed rather than the punctuation.
-			unicodeHighlight: { ambiguousCharacters: false },
+			unicodeHighlight: {
+				ambiguousCharacters: false,
+				allowedCharacters: { "　": true },
+			},
+			// Word-wise navigation — ⌥←/→, double-click-to-select, ⌥⌫ — splits on
+			// `wordSeparators`, and a language that does not put spaces between
+			// its words has none. So a whole Chinese clause counts as one word:
+			// ⌥→ jumps the sentence, double-click selects it, ⌥⌫ deletes it.
+			//
+			// A non-empty list switches on `Intl.Segmenter` (see
+			// `wordCharacterClassifier.js`), which knows where the words are.
+			//
+			// It is closer to a switch than to a whitelist, and the naming hides
+			// that: ICU dispatches its dictionary breaking by SCRIPT, not by this
+			// list. Thai, Khmer, Lao, Burmese and Tibetan get segmented too and
+			// none of them are named here, while `['zh']`, `['ja']` and
+			// `['zh','ja']` all produce identical output — even on Han text,
+			// where the two dictionaries might have been expected to disagree.
+			// Written as the two the app has locales for, rather than a longer
+			// list that would read as a claim about coverage it does not make.
+			//
+			// Nothing is taken from space-delimited languages: Korean,
+			// Vietnamese, Russian and English segment word-for-word identically
+			// to splitting on whitespace. An unsupported tag is dropped by
+			// Monaco's own `validate()`, so this cannot fail closed.
+			wordSegmenterLocales: ['zh', 'ja'],
 			// The same argument one option over. U+2028 (LINE SEPARATOR) and
 			// U+2029 (PARAGRAPH SEPARATOR) break a JavaScript string literal,
 			// which is what Monaco's guard is for; in Markdown they are just


### PR DESCRIPTION
Two items from the audit in #393. Neither is a bug in Markpad — both are Monaco
defaults that are right for code in English and wrong for prose in a script
that behaves differently.

## The space bar under a CJK IME is outlined

#462 turned off `unicodeHighlight.ambiguousCharacters` and closed #186 and #94
with it. The boxes came off the fullwidth punctuation and stayed on U+3000
IDEOGRAPHIC SPACE — which is what the space bar produces under every Chinese
and Japanese IME. Same reporters, same typing, same hover offering an **Adjust
settings** button that leads nowhere in standalone Monaco.

That character is caught by `invisibleCharacters`, a different flag, and
`allowedLocales` cannot narrow it: `strings.js` `getData()` flattens every
locale bucket into one 465-entry set, so U+3000 is in it unconditionally. Only
`allowedCharacters` reaches it.

The flag itself stays on, deliberately — an NBSP after `-` stops a list from
parsing, and nobody types one on purpose. Worth recording that the comment
justifying it was wrong in the other direction: it claimed the highlighter
"never fires on something typed on purpose", and U+3000 is exactly that.

## Word-wise navigation treats a Chinese clause as one word

⌥←/→, double-click-to-select and ⌥⌫ split on `wordSeparators`. A language that
puts no spaces between its words supplies none, so the whole clause is one
word: ⌥→ crosses the sentence, double-click selects it, ⌥⌫ deletes it.

`wordSegmenterLocales` switches on `Intl.Segmenter`, which knows where the
words are. `这是一个用于测试的段落` goes from one word to seven.

**It reads like a whitelist and is closer to a switch.** ICU dispatches its
dictionary breaking by SCRIPT, not by this list:

| script | in the list? | segmented? |
|---|---|---|
| Chinese, Japanese | yes | yes |
| Thai, Khmer, Lao, Burmese, Tibetan | **no** | **yes** |

and `['zh']`, `['ja']` and `['zh','ja']` produce identical output — including on
Han text, where the two dictionaries might have been expected to differ. Pinned
in a test, because the obvious tidy-up is to trim the list to match the comment,
which would change nothing while making the code claim something false.

Space-delimited languages lose nothing. Korean, Vietnamese, Russian and English
segment word-for-word identically to splitting on whitespace — which is why
this can be on for everyone rather than keyed to the UI language. That would be
the wrong key anyway: it is the document's script that decides, not the
language of the menus.

## Tests

Driven through Monaco's own code rather than by asserting the options are
spelled correctly — `UnicodeTextModelHighlighter.computeUnicodeHighlights` for
the first, `getMapForWordSeparators` (the function `wordOperations.js` and
`cursorWordOperations.js` both call) for the second. Each fixture is also
checked to still reproduce the original bug once the fix is removed, so a
passing test cannot mean the fixture stopped exercising anything.

## Verified

By hand on macOS: the IME space is no longer outlined, ⌥←/→ and double-click
move by word in Chinese prose, and English in the same document behaves exactly
as before.

The segmentation results above were measured in Node's ICU. Dictionary breaking
is standard across ICU builds, but it was not exercised inside WKWebView,
WebView2 or WebKitGTK.