### PR TITLE
fix(clipboard): copy plain text from the preview too (#549)

### DIFF
--- a/scripts/previewCopyPlainText.test.ts
+++ b/scripts/previewCopyPlainText.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { functionSource, readSource, sliceBetween } from './sourceTree.js';
+
+// #549. Two copy entry points read a DOM selection rather than the editor's, so
+// #548's one-implementation-per-operation rule never reached them: ⌘C in the
+// preview, and Edit ▸ Copy in the menu bar, which is a `PredefinedMenuItem::copy`
+// and asks the webview to perform its own copy.
+//
+// Both landed on plain text anyway, but by accident. WebKit's copy writes a
+// WebArchive beside the text, and the only reason a shipped build has none is
+// that `LegacyWebArchive` skips its subresource sweep for origins outside the
+// http family — and `tauri://localhost` is outside it. Measured, same selection,
+// same binary:
+//
+//   tauri build --debug (tauri://localhost)   utf8 70
+//   tauri dev           (http://localhost)    weba 19,081,919 + RTF + HTML
+//
+// Cancelling the copy event is checked first (`Editor::copy` → `tryDHTMLCopy`),
+// before any of that is built, and it is checked whatever the origin. So these
+// assertions hold two things: that the plain-text result is ours rather than the
+// scheme's, and that nobody turns this into a rich copy — which would put
+// flavours into shipped builds that have never been there.
+
+const viewer = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
+const handler = functionSource(viewer, 'handleCopyPlainText');
+
+test('the document-level copy handler is attached', () => {
+	// Document level rather than the preview's `<article>`: `styles.css` puts
+	// `user-select: none` on the app root, so the only selectable surfaces are
+	// the preview and the update dialog's release notes (#532) — and both take
+	// the same native path.
+	const svelteDocument = sliceBetween(viewer, '<svelte:document', '/>');
+	assert.match(svelteDocument, /oncopy=\{handleCopyPlainText\}/);
+});
+
+test('the copy handler writes plain text and cancels the native copy', () => {
+	assert.match(handler, /setData\(\s*'text\/plain'/);
+	// Without this the native copy still runs and still builds the archive.
+	assert.match(handler, /preventDefault\(\)/);
+});
+
+test('the copy handler writes no rich flavour', () => {
+	// The whole point is that every route puts the same plain text on the
+	// clipboard. A `text/html` here would add formatting to shipped builds that
+	// they have never produced, and would be a product decision rather than this
+	// fix — see #549 for why "plain or rich" is a separate question.
+	assert.doesNotMatch(handler, /text\/html/);
+	assert.doesNotMatch(handler, /text\/rtf/i);
+});
+
+test('a selection inside a form control is left to the platform', () => {
+	// Mirrors WebKit's own carve-out in `Editor::performCutOrCopy`: such a
+	// selection already gets plain text and no archive, and `getSelection()`
+	// cannot read it — cancelling here would copy an empty string. Monaco takes
+	// input through a hidden textarea and is covered by the same test, which is
+	// what keeps the editor on its own Rust path (#548).
+	assert.match(handler, /document\.activeElement/);
+	assert.match(handler, /HTMLInputElement/);
+	assert.match(handler, /HTMLTextAreaElement/);
+	const carveOut = handler.indexOf('HTMLTextAreaElement');
+	const write = handler.indexOf('setData');
+	assert.ok(carveOut !== -1 && write !== -1 && carveOut < write, 'the carve-out must return before the write');
+});
+
+test('a collapsed selection is not copied', () => {
+	// Edit ▸ Copy is enabled with nothing selected; writing '' would clear the
+	// clipboard instead of leaving it alone.
+	assert.match(handler, /isCollapsed/);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -2371,6 +2371,40 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		};
 	}
 
+	/**
+	 * Every copy in this app puts plain text on the clipboard, and #548 gave the
+	 * editor one implementation for all six of its entry points. Two entry points
+	 * were left outside it, both reading a DOM selection rather than the editor's:
+	 * ⌘C in the preview, and Edit ▸ Copy in the menu bar (a
+	 * `PredefinedMenuItem::copy`, which asks the WEBVIEW to copy). Those two ended
+	 * up plain text as well, but by accident rather than by decision — WebKit's
+	 * own copy writes a WebArchive beside the text, and the only reason ours has
+	 * none is that `LegacyWebArchive` skips its subresource sweep when the page's
+	 * origin is not in the http family, which `tauri://localhost` is not. Under
+	 * `tauri dev` the same selection carries 19MB (#549): the sweep embeds every
+	 * cached script for the origin, so ten words of prose arrive with the whole
+	 * unbundled module graph attached.
+	 *
+	 * Cancelling the copy event is what WebKit checks first (`Editor::copy` →
+	 * `tryDHTMLCopy`), before it builds any of that, and it is checked whatever
+	 * the origin — so this makes the plain-text result ours on both, instead of
+	 * a property of the scheme that an upstream change could take back.
+	 *
+	 * The carve-out mirrors WebKit's own (`Editor::performCutOrCopy`): a selection
+	 * inside an input or textarea already gets plain text and no archive, and
+	 * `window.getSelection()` cannot read it, so cancelling there would copy an
+	 * empty string. Monaco takes input through a hidden textarea and is covered by
+	 * the same test — as it should be, since the editor has its own path.
+	 */
+	function handleCopyPlainText(e: ClipboardEvent) {
+		const active = document.activeElement;
+		if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) return;
+		const selection = window.getSelection();
+		if (!selection || selection.isCollapsed || !e.clipboardData) return;
+		e.clipboardData.setData('text/plain', selection.toString());
+		e.preventDefault();
+	}
+
 	function handleContextMenu(e: MouseEvent) {
 		if (modalState.show) return;
 		if (mode !== 'app') return;
@@ -3387,6 +3421,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 
 <svelte:document
 	onclick={handleDocumentClick}
+	oncopy={handleCopyPlainText}
 	oncontextmenu={handleContextMenu}
 	onmouseover={handleMouseOver}
 	onmouseout={handleMouseOut}


### PR DESCRIPTION
## What this is

A `copy` listener that writes plain text and cancels the webview's own copy.
`Closes #549`, reported by @PathGao.

#548 gave cut, copy and paste one implementation each and six entry points. Two
entry points stayed outside it, because both read a DOM selection rather than the
editor's: **⌘C in the preview**, where Monaco's keybindings are gated on
`editorTextFocus` and never fire, and **Edit ▸ Copy in the menu bar**, which is a
`PredefinedMenuItem::copy` and asks the webview to perform its own copy.

Both already put plain text on the clipboard in a shipped build. They did so by
accident, and that is the part worth fixing.

## Mechanism

WKWebView's copy writes a WebArchive beside the text. A WebArchive is Safari's
save-the-whole-page format — main resource plus subresource bytes — and for a copy
the main resource is only the selection's markup. Then
`LegacyWebArchive::createFromSelection` does this (`LegacyWebArchive.cpp:752`):

```cpp
if (options.shouldSaveScriptsFromMemoryCache == Yes && responseURL.protocolIsInHTTPFamily()) {
    RegistrableDomain domain { responseURL };
    MemoryCache::singleton().forEachSessionResource(sessionID, [&](auto& resource) {
        if (domain.matches(resource.url()) && resource.hasClients()
            && (resource.type() == Script || resource.type() == JSON))
            subresourceURLs.add(resource.url());
    });
}
```

Every cached script for the origin, regardless of what was selected. Not the
stylesheets or fonts #549 guessed at — `addSubresourcesForCSSStyleSheetsIfNecessary`
returns early unless `options.mainResourceFileName` is set, which it is not for a
copy.

`protocolIsInHTTPFamily()` is the whole story:

| build | origin | http family | sweep |
|---|---|---|---|
| `npm run tauri dev` | `http://localhost:1420` | yes | runs |
| `tauri build` | `tauri://localhost` | no | skipped |

`get_app_url` falls through to `tauri_protocol_url` when `frontendDist` is a path
(`tauri-2.10.2/src/manager/mod.rs:331`). Under dev, Vite serves the module graph
unbundled and unminified — `node_modules/.vite/deps` is 54MB, monaco's ESM tree is
1,227 modules — so the sweep collects nearly all of it.

Same file, same gesture, both builds on this machine:

```
tauri build --debug   utf8 70                                        (no weba)
tauri dev             weba 19,081,919   RTF 616   HTML 603   utf8 79
```

**So the 19MB never reached a shipped build.** What did reach it is a plain-text
clipboard nobody chose: plain only because the scheme closes that gate, with no
code or test saying so.

It also does not scale with the document, which #549 listed as unestablished. Two
selections in the same 805-byte file:

```
utf8 79  ->  weba 19,081,919
utf8 73  ->  weba 19,081,913
```

The archive shrank by exactly the six bytes the text did. Everything else in it is
constant, so `samples/stress-test.md` at 121,794 bytes gives the same number.

The fix is the branch WebKit takes first. `Editor::copy` calls `tryDHTMLCopy()`
before `performCutOrCopy`, so a cancelled copy event means the archive is never
built, and WebKit commits what the handler set as real `public.utf8-plain-text`
(`PlatformPasteboardMac.mm:339`). That check does not look at the origin:

```
tauri dev, after this change   utf8 64   ut16 46                     (no weba)
```

— the flavour shape a shipped build already had. Measurements in dev now represent
the shipped app, which removes the class of false alarm this issue was.

## Scope

**Plain text, not `text/html`.** Every route in this app already puts plain text on
the clipboard. Adding a rich flavour would give shipped builds formatting they have
never produced. Whether the preview *should* paste with formatting is the product
question #549 raises, and it stays open — that is a change in behaviour, not a fix.

**Document level rather than the preview's `<article>`.** `styles.css:16` puts
`user-select: none` on the app root and only two places turn it back on: the
preview, and the update dialog's release notes (#532). One listener covers both.

**The carve-out mirrors WebKit's own.** `Editor::performCutOrCopy`
(`Editor.cpp:1619`) sends a selection inside a form control to `writePlainText` and
never builds an archive, and `window.getSelection()` cannot read such a selection —
cancelling there would copy an empty string. Monaco takes input through a hidden
textarea and is covered by the same test, which is what keeps the editor on its own
Rust path. Verified rather than assumed: Edit ▸ Copy with the caret in the editor
gives `utf8 51` and no `weba`.

**No platform gate.** Plain text is what all three platforms already produce, so
there is nothing to preserve for WebView2 or WebKitGTK — neither writes a
page-snapshot flavour at all (`Pasteboard.h:88` keeps `dataInWebArchiveFormat`
under `PLATFORM(COCOA)`).

## Tests

`scripts/previewCopyPlainText.test.ts`, five assertions. Revert the handler and the
file goes red: `functionSource` cannot find it.

The assertion worth keeping is `doesNotMatch(handler, /text\/html/)` — it fails if
someone turns this into a rich copy, which would be the product decision above
arriving as a refactor.

## Verification

```
npm audit       0 vulnerabilities
npm run check   674 files, 0 errors, 0 warnings
npm test        940 pass, 0 fail
cargo test      145 passed, 0 failed
```

Clipboard readings taken with `osascript -e 'clipboard info'` against both builds,
with a sentinel written to the pasteboard between readings so a copy that did not
fire could not be mistaken for one that did. Plain-text fidelity checked by hand:
the text `selection.toString()` produces is the same ordinary plain text WebKit's
serialiser gave.

**Not verified.** Windows and Linux — reasoned about from WebCore's platform guards,
not run. The update dialog's release notes are covered by the same listener but were
not measured. Preview Edit ▸ Copy was measured in dev but only inferred in a shipped
build, from sharing `Editor::copy` with ⌘C, which *was* measured there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
