### PR TITLE
fix(load): stop an overtaken load from stranding a document on its slice (#547)

### DIFF
--- a/scripts/largeFileLoadRevision.test.ts
+++ b/scripts/largeFileLoadRevision.test.ts
@@ -16,3 +16,157 @@ test('large-file completion requires the current clean load revision and unchang
 		/loadRevisionByTab\.get\(activeId\) === fullLoadRevision[\s\S]*!targetTab\.isDirty[\s\S]*targetTab\.isEditing === initialIsEditing[\s\S]*targetTab\.isSplit === initialIsSplit/,
 	);
 });
+
+// #547. The revision above guarded the SECOND stage only. The first stage wrote
+// the buffer, the encoding and the truncation flag unconditionally, across two
+// awaits — so when two loads overlapped on one tab and the older one's preview
+// read landed last, it overwrote the winner's complete buffer with its 50KB
+// slice and re-raised `isTruncated`. Its own second stage was then correctly
+// rejected by the revision it had just lost. Nothing retried, nothing recorded
+// it, and from then on every save was refused.
+//
+// Two loads overlap because the startup path is delivered on two channels that
+// nothing dedupes: `RunEvent::Opened` stashes it for `send_markdown_path` AND
+// emits `file-path`, and argv is read by both.
+//
+// These drive the real TabManager and the real document session, so they lock
+// the outcome rather than the shape of the guard.
+
+const g = globalThis as any;
+const runeEffect = (fn: () => void) => {
+	void fn;
+};
+runeEffect.root = (fn: () => unknown) => fn();
+g.$state = (value: unknown) => value;
+g.$state.raw = (value: unknown) => value;
+g.$state.snapshot = (value: unknown) => value;
+g.$derived = (value: unknown) => value;
+g.$derived.by = (fn: () => unknown) => fn();
+g.$effect = runeEffect;
+g.window = g.window ?? {};
+
+const PREVIEW_BYTES = 50000;
+const FULL = `# big\n\n${'x'.repeat(PREVIEW_BYTES)}\n\ntail that must never be lost\n`;
+const PARTIAL = FULL.slice(0, PREVIEW_BYTES);
+
+/** Per-call delays, so the two concurrent loads can be ordered deliberately. */
+let previewDelays: number[] = [];
+let previewCall = 0;
+let savedContent: string | null = null;
+
+let handleInvoke: (cmd: string, args: any) => unknown = () => {
+	throw new Error('unexpected invoke');
+};
+
+g.window.__TAURI_INTERNALS__ = {
+	invoke: (cmd: string, args: any) => Promise.resolve(handleInvoke(cmd, args)),
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
+const { settings } = await import('../src/lib/stores/settings.svelte.js');
+
+const errors: string[] = [];
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function makeSession() {
+	return createDocumentSession({
+		setShowHome: () => {},
+		currentFile: () => tabManager.activeTab?.path ?? '',
+		resetScrollHistory: () => {},
+		renderMarkdown: async (raw: string) => `<p>${raw.length}</p>`,
+		afterLoad: async () => {},
+		saveRecentFile: () => {},
+		deleteRecentFile: () => {},
+		setLoadingTabs: () => {},
+		measureInitialViewport: () => {},
+		isScrolling: () => false,
+		renderRichContent: () => {},
+		onError: (message) => errors.push(message),
+		selfWriteGraceMs: 400,
+		cancelPendingAutoSave: () => {},
+		askClose: async () => 'discard' as const,
+		onCloseSaveNewerEdits: () => {},
+		onCloseAutoSaveFailed: () => {},
+	});
+}
+
+function reset() {
+	tabManager.closeAll();
+	errors.length = 0;
+	previewCall = 0;
+	savedContent = null;
+	settings.openFileMode = 'preview';
+	handleInvoke = (cmd, args) => {
+		if (cmd === 'canonicalize_path') return '/docs/big.md';
+		if (cmd === 'open_markdown_preview') {
+			const delay = previewDelays[previewCall++] ?? 0;
+			return wait(delay).then(() => ['<p>preview</p>', PARTIAL, false, false, 'UTF-8']);
+		}
+		if (cmd === 'read_file_content_checked') return [FULL, false, 'UTF-8'];
+		if (cmd === 'save_file_content') {
+			savedContent = args.content;
+			return null;
+		}
+		throw new Error(`unexpected invoke: ${cmd}`);
+	};
+}
+
+/** Both startup channels deliver the same path; only the timing differs. */
+async function loadTwice() {
+	const session = makeSession();
+	// The `file-path` listener does not await its load; `send_markdown_path` does.
+	const first = session.loadMarkdown('/docs/big.md');
+	const second = session.loadMarkdown('/docs/big.md');
+	await Promise.all([first, second]);
+	await wait(500);
+	return { session, tab: tabManager.activeTab! };
+}
+
+test('an overtaken load cannot leave the tab holding its 50KB slice', async () => {
+	reset();
+	// The first load's preview read is slow, so it lands after the second load
+	// has already completed the tab. This is the ordering that stranded it.
+	previewDelays = [120, 10];
+	const { tab } = await loadTwice();
+
+	assert.equal(tab.rawContent, FULL, 'the complete file must survive the stale preview');
+	assert.notEqual(tab.isTruncated, true);
+});
+
+test('a tab left by overlapping loads can still be saved, in full', async () => {
+	reset();
+	previewDelays = [120, 10];
+	const { session, tab } = await loadTwice();
+
+	assert.equal(await session.saveContent(tab.id), true, `save was refused: ${errors.join('; ')}`);
+	// The refusal is the only thing between this state and a truncated write,
+	// so a save that succeeds must be a save of the whole document.
+	assert.equal(savedContent, FULL);
+});
+
+test('overlapping loads settle on the whole file whichever preview read wins', async () => {
+	for (const delays of [
+		[10, 120], // the first load lands first — the ordering that always worked
+		[0, 0], // both resolve on the same tick
+		[120, 10], // the first load lands last
+	]) {
+		reset();
+		previewDelays = delays;
+		const { tab } = await loadTwice();
+		assert.equal(tab.rawContent, FULL, `stranded a slice with delays ${delays.join(',')}`);
+		assert.notEqual(tab.isTruncated, true, `left truncated with delays ${delays.join(',')}`);
+	}
+});
+
+test('a single load of a large file is unaffected', async () => {
+	reset();
+	previewDelays = [0];
+	const session = makeSession();
+	await session.loadMarkdown('/docs/big.md');
+	await wait(400);
+
+	const tab = tabManager.activeTab!;
+	assert.equal(tab.rawContent, FULL);
+	assert.notEqual(tab.isTruncated, true);
+});

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -429,6 +429,17 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 
 			const fullLoadRevision = (loadRevisionByTab.get(activeId) ?? 0) + 1;
 			loadRevisionByTab.set(activeId, fullLoadRevision);
+			// #547: every read below is an await, and this load may be overtaken
+			// while one is in flight — the startup path is delivered on two
+			// channels that nothing dedupes (`RunEvent::Opened` both stashes the
+			// path for `send_markdown_path` and emits `file-path`; argv is read by
+			// both as well), so two loads can run on one tab. The full-load stage
+			// already refuses to apply a stale result; the first stage did not, and
+			// an older preview landing last overwrote the winner's complete buffer
+			// with its 50KB slice, re-raising `isTruncated` — after which every save
+			// is refused and nothing retries. Same revision test, applied to every
+			// write a load makes.
+			const isCurrentLoad = () => loadRevisionByTab.get(activeId) === fullLoadRevision;
 			const isMarkdown = hasMarkdownLinkExtension(filePath);
 			const tab = tabManager.tabs.find((item) => item.id === activeId);
 
@@ -470,6 +481,10 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 				} else {
 					[, content, isFull, lossy, encoding] = (await invoke('open_markdown_preview', { path: filePath, maxBytes: 50000 })) as [string, string, boolean, boolean, string];
 				}
+				// Ahead of the encoding verdict, not just the buffer: a prefix's
+				// detected encoding can differ from the whole file's, and
+				// `tab.encoding` is what the save writes with.
+				if (!isCurrentLoad()) return;
 				// Decided on every load, before the buffer can reach a writer.
 				// Both branches report both, so this also CLEARS the flag on a
 				// file the user has since converted to UTF-8 — and repoints the
@@ -479,6 +494,7 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 				lossySaveWarnedTabs.delete(activeId);
 				if (pendingNavigateTabId) tabManager.navigate(pendingNavigateTabId, filePath, pathKey);
 				const processed = await options.renderMarkdown(content, filePath, foldsForTab(activeId));
+				if (!isCurrentLoad()) return;
 				tabManager.updateTabContent(activeId, processed);
 				// `isFull === false` means this is only the leading slice of a
 				// large file. Marking the tab keeps anything downstream from
@@ -532,6 +548,10 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 				}
 			} else {
 				const [content, lossy, encoding] = (await invoke('read_file_content_checked', { path: filePath })) as [string, boolean, string];
+				// Same race, same guard: this branch reads the whole file, so it
+				// cannot strand a slice, but a stale one still overwrites the
+				// winner's buffer and encoding and flips the tab into the editor.
+				if (!isCurrentLoad()) return;
 				tabManager.setTabDecodedLossy(activeId, lossy);
 				tabManager.setTabEncoding(activeId, encoding);
 				lossySaveWarnedTabs.delete(activeId);


### PR DESCRIPTION
## What this is

One guard, applied to every write a load makes instead of only to the last one.
`Closes #547`, reported by @PathGao.

A document over 50KB is read twice: `open_markdown_preview` returns the first
50KB so something renders at once, and a background full read replaces it. #247
gave every load a revision and made the second stage refuse to apply a stale
result. The first stage was left unguarded, across two awaits.

## Mechanism

The startup path delivers one filename on two channels that nothing dedupes:

| | where | what it does |
|---|---|---|
| push | `lib.rs:3063` | `setup()` emits `file-path` with `argv[1]` |
| pull | `window_runtime.rs:575` | `send_markdown_path` re-reads `std::env::args()` |
| both | `lib.rs:3155-3160` | `RunEvent::Opened` pushes onto `startup_files` **and** emits `file-path` |

The frontend listens for the event (`MarkdownViewer.svelte:3087`, not awaited) and
separately drains the stash (`:3366`). So two loads run on one tab, and which
preview read returns first is a coin flip:

```
t=0    load A  rev=1  -> open_markdown_preview (slow)
t=0+   load B  rev=2  -> open_markdown_preview (fast)
t=110  B stage 2 lands -> whole file, isTruncated false   <- correct state
t=120  A stage 1 lands -> 50KB slice, isTruncated true    <- overwrites it
t=220  A stage 2       -> rev 2 != 1, correctly refused
```

A destroys the good state and then declines to repair the damage it caused.
Nothing retries. The tab keeps `isTruncated`, and every save from then on is
refused — surfaced through the auto-save timer, so a load failure is announced as
a save failure.

Which of `canApplyFullLoad`'s five conditions fails is only ever the revision:
path, `isDirty`, `isEditing` and `isSplit` are all unchanged at bail time.

**Not dev-only, and not a command line quirk.** None of the three channels is
gated on `cfg(dev)` — `RunEvent::Opened` is gated on `target_os = "macos"` only,
and it is the Finder path: double-click, Open With, drag onto the icon.
`tauri.conf.json` registers `fileAssociations`, so double-clicking a `.md` file is
this path. A dev build makes the race *more observable* — slower renders, a debug
Rust build, Vite serving thousands of modules all widen the window — not more
real.

The guard has to sit ahead of `setTabDecodedLossy`/`setTabEncoding` and not merely
ahead of the buffer. #544 made the encoding verdict part of the same write, a 50KB
byte cut can split a multi-byte character (`utf8_truncation_boundary` in
`lib.rs:476` is UTF-8 only, and `samples/encoding-gbk-large.md` is 103,723 bytes
of GBK), and `tab.encoding` is what the save writes with. A stale prefix's verdict
is the wrong one.

The non-markdown branch takes the same guard. It reads the whole file so it cannot
strand a slice, but a stale one still overwrites the winner's buffer and encoding
and flips the tab into the editor.

## Scope

**The blank pane is not fixed here.** A tab can also carry `isTruncated` with an
empty buffer, from `markTabContentUnavailable()` when session restore defers or
fails a read (`windowSession.svelte.ts:255`, `:283`). That is the other half of
the report, it is a different cause that happens to share one flag, and a guard on
this race does not touch it. Worth its own issue.

**The refusal message is left as it is.** It is an untranslated English string
where `toast.partialDocument` already exists, translated, and is what all five
editing entry points show for this flag. Swapping it was tried and dropped: that
sentence says "cannot edit yet", and by the time a save is refused the reader is
already editing — so it is accurate for the entry points and wrong here. Doing it
properly means a new key in 26 languages, in the shape of `lossySaveBlocked`
(what happened, why the write is refused, the way out), for a state this change is
meant to make unreachable. Separately: `saveContentAs` refuses too, so unsaved
edits in this state have no exit at all, where the lossy refusal deliberately
leaves Save As open as one. Both belong with the blank-pane issue.

**Noticed and not fixed: the 50KB threshold has no recorded measurement.** It
arrives in `31adc64` with a one-line message and no numbers. On this machine,
reading `samples/stress-test.md` whole is 0.032ms against 0.022ms for its first
50KB — and the two-stage path then reads it whole anyway *and* renders twice. The
mechanism earns its keep on multi-MB documents, roughly two orders of magnitude
above where it currently engages; the render cost is the part still unmeasured, and
it has to be measured in the app. Mainstream editors do not hand out a partial
writable buffer at all: VS Code declines to display a file past its limit and
offers a Configure Limit button, and Emacs prompts at `large-file-warning-threshold`
and offers `find-file-literally`, which turns features off rather than showing less
of the document. Both degrade *capability*, never *fidelity*. Markpad's preview
slice degrades fidelity, which is safe only under the invariant that a partial
buffer is never writable — the invariant this race broke. Its own issue.

## Tests

`scripts/largeFileLoadRevision.test.ts` was 18 lines of source regex, which is why
nothing caught this: it passes with the bug present, and it still does. It now also
drives the real TabManager and the real document session through every ordering.

Revert the three guards and three of the four new tests go red — the stranded
slice, the refused save, and the ordering sweep. The regex test stays green, which
is the point of adding behavioural ones next to it.

## Verification

```
npm audit       0 vulnerabilities
npm run check   674 files, 0 errors, 0 warnings
npm test        940 pass, 0 fail
cargo test      145 passed, 0 failed   (no Rust file changes on this branch)
```

**Not verified: reproduced in a packaged build.** The race needs the first load's
preview read to land more than ~100ms after the second load's full read has been
applied through its idle callback, and both reads are of the same file issued
milliseconds apart — once it is in the page cache they are both fast and the gap
closes. Repeated launches by hand did not produce it. The evidence that the state
is reachable and that the guard closes it is the test harness, which reproduces the
exact end state (`isTruncated`, 50,000-byte buffer, `saveContent` false) and the
exact interleaving deterministically.

No file was ever corrupted by this: the refusal held every time. What broke was the
tab becoming permanently unsaveable while looking normal, and saying so as if the
save were the problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
