### PR TITLE
fix(find): re-focus the preview find bar on a repeated Cmd/Ctrl+F

### DIFF
--- a/scripts/findRefocus.test.ts
+++ b/scripts/findRefocus.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { functionSource, readSource } from './sourceTree.js';
+
+// #559: Cmd/Ctrl+F in the preview only ever set `findOpen = true`. Once the bar
+// was open, clicking into the document moved focus out of the input and the
+// shortcut became inert — the assignment writes the value the state already
+// has, so the `$effect` that focuses on open never re-runs. The fix is an
+// explicit focus call on the component, so the second press behaves like the
+// first in every browser find bar: caret back in the field, previous query
+// selected so typing replaces it.
+
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
+const findBar = readSource('src/lib/components/FindBar.svelte');
+
+test('the preview find shortcut focuses the bar rather than only opening it', () => {
+	const trigger = functionSource(viewer, 'triggerFindAction');
+	assert.match(trigger, /findBar\?\.focusInput\(\)/);
+});
+
+test('focusInput selects the previous query instead of clearing it', () => {
+	const focusInput = functionSource(findBar, 'focusInput');
+	assert.match(focusInput, /inputEl\?\.focus\(\)/);
+	assert.match(focusInput, /inputEl\?\.select\(\)/);
+	// Clearing here would defeat the point: the issue asks for the previous
+	// search to come back lit, not for an empty field.
+	assert.doesNotMatch(focusInput, /query\s*=/);
+});
+
+test('opening the bar and re-focusing it share one implementation', () => {
+	// Two copies would drift; the one that stopped selecting would be the one
+	// nobody re-reads.
+	assert.equal(findBar.match(/inputEl\?\.focus\(\)/g)?.length, 1);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -160,7 +160,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	let liveMode = $state(false);
 
 	let findOpen = $state(false);
-	let findBar = $state<{ reapply: () => void; clearHighlights: () => void } | null>(null);
+	let findBar = $state<{
+		reapply: () => void;
+		clearHighlights: () => void;
+		focusInput: () => void;
+	} | null>(null);
 
 	// Decide where Cmd/Ctrl+F should land based on what's visible and where
 	// focus is. The in-window shortcut remains the canonical route on every
@@ -172,7 +176,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		if (editorHasFocus || !previewVisible) {
 			editorPane?.triggerFind?.();
 		} else if (markdownBody) {
+			// Focus explicitly: once the bar is open, `findOpen = true` changes
+			// nothing, so a repeated shortcut after clicking into the document
+			// used to be swallowed (#559).
 			findOpen = true;
+			findBar?.focusInput();
 		}
 	}
 

--- a/src/lib/components/FindBar.svelte
+++ b/src/lib/components/FindBar.svelte
@@ -288,6 +288,20 @@
 		}, DEBOUNCE_MS);
 	}
 
+	/**
+	 * Put the caret back in the input with the previous query selected.
+	 * Re-opening an already-open bar is a no-op — `open` never changes, so
+	 * the effect below does not re-run — which left Cmd/Ctrl+F doing nothing
+	 * once the user had clicked into the document (#559). Chrome, Firefox and
+	 * VS Code all re-focus and re-select on a repeated find shortcut.
+	 */
+	export function focusInput() {
+		tick().then(() => {
+			inputEl?.focus();
+			inputEl?.select();
+		});
+	}
+
 	export function reapply() {
 		// Public hook for parent: call after the preview HTML is replaced
 		// so existing matches survive across re-renders.
@@ -324,10 +338,7 @@
 			return;
 		}
 		// On open, focus and select the input so typing replaces.
-		tick().then(() => {
-			inputEl?.focus();
-			inputEl?.select();
-		});
+		focusInput();
 	});
 
 	function handleKeydown(e: KeyboardEvent) {


### PR DESCRIPTION
Fixes #559.

## The bug

`Cmd/Ctrl+F` in preview mode ran `findOpen = true` and nothing else. Once the bar was open that assignment writes the value the state already holds, so the `$effect` that focuses the input never re-ran — after clicking into the document, the field could only be reached with the mouse.

## The fix

`FindBar` exports `focusInput()` (focus + `select()`, the code the open-effect already ran), and `triggerFindAction` calls it alongside `findOpen = true`. The open path now delegates to the same function, so there is one implementation rather than two that can drift.

The previous query is not cleared, so it comes back selected and typing replaces it — the behaviour the issue asks for, and what Chrome, Firefox and VS Code do on a repeated find shortcut. `close()` (Escape / ×) still clears, unchanged.

The editor pane is untouched: Monaco's own find widget already re-focuses on a repeated shortcut.

## Verification

- `scripts/findRefocus.test.ts` — the shortcut path calls `focusInput`, `focusInput` selects rather than clears, and the focus code exists once.
- `npm run check` clean, `npm test` 944/944 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)