### PR TITLE
ci(release): stop publishing packages from inside the build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,18 +194,6 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf rpm xdg-utils \
           libxcb1-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
 
-      - name: Setup Snapcraft
-        if: matrix.platform == 'ubuntu-24.04'
-        continue-on-error: true
-        run: |
-          sudo snap install lxd
-          sudo lxd waitready
-          sudo lxd init --auto
-          sudo usermod -aG lxd $USER
-          sudo iptables -F FORWARD
-          sudo iptables -P FORWARD ACCEPT
-          sudo snap install snapcraft --classic
-
       - name: Install Frontend Dependencies
         run: npm ci
 
@@ -228,28 +216,6 @@ jobs:
           gh release upload v$VERSION "Markpad_${VERSION}_x64.exe" --clobber
           find src-tauri/target/release/bundle/nsis -name "*-setup.exe" -exec gh release upload v$VERSION {} --clobber \;
           find src-tauri/target/release/bundle/nsis -name "*-setup.exe.sig" -exec gh release upload v$VERSION {} --clobber \;
-
-      - name: Create Chocolatey Package
-        if: matrix.platform == 'windows-latest' && matrix.arch == 'x64'
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          mkdir -p packaging/choco/tools
-          cp src-tauri/target/release/Markpad.exe packaging/choco/tools/Markpad.exe
-          cp LICENSE packaging/choco/tools/LICENSE.txt
-          choco pack packaging/choco/markpad-app.nuspec --version ${{ needs.create-release.outputs.version }} --outdir .
-          gh release upload v${{ needs.create-release.outputs.version }} markpad-app.${{ needs.create-release.outputs.version }}.nupkg --clobber
-
-      - name: Publish to Chocolatey
-        if: matrix.platform == 'windows-latest' && matrix.arch == 'x64'
-        continue-on-error: true
-        shell: pwsh
-        env:
-          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
-        run: |
-          choco apikey --key $env:CHOCO_API_KEY --source https://push.chocolatey.org/
-          choco push markpad-app.${{ needs.create-release.outputs.version }}.nupkg --source https://push.chocolatey.org/
 
       # --- Windows Build (ARM64) ---
       - name: Build Windows ARM64
@@ -287,70 +253,37 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run tauri build
 
-      # tauri/linuxdeploy bundles libwayland-client.so.0 (and other host-graphics
-      # libraries) from the ubuntu-24.04 runner into the AppImage. On a host whose
-      # Mesa is newer than the runner's, that older bundled libwayland-client
-      # shadows the system one and breaks host libEGL: WebKit's WebProcess aborts
-      # with "Could not create default EGL display: EGL_BAD_PARAMETER" and the
-      # window comes up blank. These libraries are on the AppImage excludelist
-      # precisely because they must come from the host. Strip them, repack, and
-      # re-sign so the updater signature still matches. See #498; #463 fixed the
-      # separate WebKitGTK version pin.
+      # Why the AppImage has to be repacked at all, and what is removed, is in
+      # scripts/strip-appimage.sh. It is a script rather than a heredoc because
+      # this is the step that failed in two of the three v2.7.2 release
+      # attempts, and an inline one can only be exercised by cutting a release.
       - name: Strip host-coupled libraries from AppImage
         if: matrix.platform == 'ubuntu-24.04'
-        env:
-          TAURI_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
           set -euo pipefail
-
           APPIMAGE=$(find src-tauri/target/release/bundle/appimage -maxdepth 1 -name '*.AppImage' | head -1)
           if [ -z "$APPIMAGE" ]; then
             echo "::error::No AppImage found to repackage" >&2
             exit 1
           fi
-          APPIMAGE=$(realpath "$APPIMAGE")
-          echo "Repackaging $APPIMAGE"
+          echo "APPIMAGE=$(realpath "$APPIMAGE")" >> "$GITHUB_ENV"
+          bash scripts/strip-appimage.sh "$APPIMAGE"
 
-          # appimagetool + a type2 runtime. --appimage-extract-and-run (below) and
-          # --appimage-extract both unpack without libfuse2, which the runner lacks.
-          tools=$(mktemp -d)
-          wget -q https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage -O "$tools/appimagetool"
-          wget -q https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64 -O "$tools/runtime-x86_64"
-          chmod +x "$tools/appimagetool"
-
-          work=$(mktemp -d)
-          ( cd "$work" && "$APPIMAGE" --appimage-extract >/dev/null )
-          libdir="$work/squashfs-root/usr/lib"
-
-          # Host-coupled graphics libraries (AppImageCommunity/pkg2appimage
-          # excludelist). libwayland-client.so.0 is the one that actually breaks
-          # EGL; the rest belong to the host graphics stack for the same reason.
-          for lib in libwayland-client.so.0 libwayland-cursor.so.0 libwayland-egl.so.1 \
-                     libwayland-server.so.0 libxcb-render.so.0 libxcb-shm.so.0; do
-            rm -fv "$libdir/$lib"
-          done
-          if [ -e "$libdir/libwayland-client.so.0" ]; then
-            echo "::error::libwayland-client.so.0 still bundled after strip" >&2
-            exit 1
-          fi
-
-          # Repack in place so the filename (and updater target) is unchanged.
-          ARCH=x86_64 "$tools/appimagetool" --appimage-extract-and-run \
-            --runtime-file "$tools/runtime-x86_64" \
-            "$work/squashfs-root" "$APPIMAGE"
-
-          # Re-sign: tauri build already produced a .sig for the pre-strip file,
-          # which no longer matches. signer sign reads the key/password from the
-          # env above and writes <APPIMAGE>.sig, which the upload and the
-          # latest.json job below both consume.
+      # tauri build already produced a .sig for the pre-strip file, which no
+      # longer matches what the updater will download. Signing is kept out of
+      # the script so the script can be run on any AppImage without a key.
+      - name: Re-sign the repacked AppImage
+        if: matrix.platform == 'ubuntu-24.04'
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
           npm run tauri signer sign -- "$APPIMAGE"
           if [ ! -f "$APPIMAGE.sig" ]; then
             echo "::error::signer sign did not produce $APPIMAGE.sig" >&2
             exit 1
           fi
-
-          echo "Repacked and re-signed:"
           ls -la "$APPIMAGE" "$APPIMAGE.sig"
 
       - name: Upload Linux Artifacts
@@ -363,30 +296,6 @@ jobs:
           find src-tauri/target/release/bundle/rpm -name "*.rpm" -exec gh release upload v${{ needs.create-release.outputs.version }} {} --clobber \;
           find src-tauri/target/release/bundle/appimage -name "*.AppImage" -exec gh release upload v${{ needs.create-release.outputs.version }} {} --clobber \;
           find src-tauri/target/release/bundle/appimage -name "*.AppImage.sig" -exec gh release upload v${{ needs.create-release.outputs.version }} {} --clobber \;
-
-      - name: Build and Publish Snap Package
-        if: matrix.platform == 'ubuntu-24.04'
-        continue-on-error: true
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
-        run: |
-          # Build snap
-          sg lxd -c 'snapcraft pack'
-          sg lxd -c 'snapcraft pack'
-          
-          # Find and upload the snap
-          SNAP_FILE=$(ls *.snap | head -n 1)
-          if [ -n "$SNAP_FILE" ]; then
-            gh release upload v${{ needs.create-release.outputs.version }} $SNAP_FILE --clobber
-            
-            # Publish to snap store
-            snapcraft push $SNAP_FILE --release stable
-          else
-            echo "Snap file not found!"
-            exit 1
-          fi
 
       # --- MacOS Build ---
       - name: Build MacOS (Universal)

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,136 @@
+name: Publish Packages
+
+# Chocolatey and the Snap Store used to be pushed from inside the platform
+# matrix in build.yml, which put an irreversible side effect before the thing
+# that decides whether a release happens at all.
+#
+# It is not hypothetical. Chocolatey's markpad-app 2.7.2 was published at
+# 15:37 UTC on 2026-08-07 by run 31192564528 -- a run that then failed on Linux
+# and produced no release. The release users actually got came out of a
+# different run three hours later. Nothing can un-push a Chocolatey version.
+#
+# So publishing to package managers hangs off `release: published`, which is a
+# human clicking Publish on a draft whose assets they have checked. Both jobs
+# consume that release rather than rebuilding, so what a package manager serves
+# is what the release page serves.
+#
+# Neither job is allowed to swallow a failure. The two steps these replace both
+# were, and the snap build failed under that for three months and six versions
+# while the job reported success -- the Snap Store still served 2.6.11 while
+# every release told people to install it. A publishing channel that cannot fail
+# loudly is a publishing channel nobody is maintaining.
+
+on:
+  release:
+    types: [published]
+  # Recovery, and a way to exercise this without cutting a release: point it at
+  # a tag that already has a published release.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Published release tag, e.g. v2.7.2'
+        required: true
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-packages-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+env:
+  TAG: ${{ github.event.release.tag_name || inputs.tag }}
+
+jobs:
+  chocolatey:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - name: Take the executable from the release
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+          # The portable x64 executable published on the release page, not a
+          # fresh build. A rebuild from the same commit is not guaranteed to be
+          # the same bytes, and VERIFICATION.txt below promises it is.
+          mkdir -p packaging/choco/tools
+          gh release download "$TAG" \
+            --pattern "Markpad_${VERSION}_x64.exe" \
+            --dir packaging/choco/tools
+          mv "packaging/choco/tools/Markpad_${VERSION}_x64.exe" packaging/choco/tools/Markpad.exe
+          cp LICENSE packaging/choco/tools/LICENSE.txt
+
+      - name: Record what the package contains
+        shell: bash
+        run: |
+          set -euo pipefail
+          SHA=$(sha256sum packaging/choco/tools/Markpad.exe | cut -d' ' -f1)
+          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/Markpad_${VERSION}_x64.exe"
+          {
+            echo
+            echo "For this package:"
+            echo
+            echo "  Version:  ${VERSION}"
+            echo "  File:     ${URL}"
+            echo "  SHA256:   ${SHA}"
+          } >> packaging/choco/tools/VERIFICATION.txt
+          cat packaging/choco/tools/VERIFICATION.txt
+
+      - name: Pack and publish
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+        run: |
+          set -euo pipefail
+          choco pack packaging/choco/markpad-app.nuspec --version "$VERSION" --outdir .
+          gh release upload "$TAG" "markpad-app.${VERSION}.nupkg" --clobber
+          choco apikey --key "$CHOCO_API_KEY" --source https://push.chocolatey.org/
+          choco push "markpad-app.${VERSION}.nupkg" --source https://push.chocolatey.org/
+
+  snap:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - name: Setup Snapcraft
+        run: |
+          set -euo pipefail
+          sudo snap install lxd
+          sudo lxd waitready
+          sudo lxd init --auto
+          sudo usermod -aG lxd "$USER"
+          sudo iptables -F FORWARD
+          sudo iptables -P FORWARD ACCEPT
+          sudo snap install snapcraft --classic
+
+      # snapcraft.yaml builds the app from source inside LXD, so this job needs
+      # the checkout above and nothing from the release.
+      - name: Build and publish the snap
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        run: |
+          set -euo pipefail
+          sg lxd -c 'snapcraft pack'
+
+          shopt -s nullglob
+          snaps=( *.snap )
+          if [ ${#snaps[@]} -eq 0 ]; then
+            echo "::error::snapcraft pack reported success but produced no .snap" >&2
+            exit 1
+          fi
+          SNAP_FILE="${snaps[0]}"
+
+          gh release upload "$TAG" "$SNAP_FILE" --clobber
+          snapcraft push "$SNAP_FILE" --release stable

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -81,7 +81,18 @@ The workflow uses `npm ci`, so its installed dependency graph is exactly the com
    - **Windows ARM64**: `Markpad_<version>_arm64.exe` (portable), `*_arm64-setup.exe` (NSIS installer), `*_arm64-setup.exe.sig`
    - **Linux**: `*.deb`, `*.rpm`, `*.AppImage`, `*.AppImage.sig`
    - **Update feed**: `latest.json` (one entry per successfully built platform)
-6. **Click "Publish release"** — this is the gate that activates auto-update for all clients pointing at `releases/latest/download/latest.json`.
+6. **Click "Publish release"** — this is the gate. It activates auto-update for all clients pointing at `releases/latest/download/latest.json`, **and** it starts [`publish-packages.yml`](.github/workflows/publish-packages.yml), which pushes to Chocolatey and the Snap Store.
+7. **Watch `Publish Packages` finish.** Two independent jobs; either can fail without affecting the release that already went out. Re-run the failed job after fixing, or run the workflow by hand with the tag as input.
+
+### Why package managers publish after the release, not during the build
+
+Chocolatey and the Snap Store used to be pushed from inside `build.yml`'s platform matrix, so an irreversible external side effect happened *before* anything decided whether a release existed.
+
+That is not hypothetical. Chocolatey's `markpad-app` 2.7.2 was published at 15:37 UTC on 2026-08-07 by run `31192564528` — a run that then failed on Linux and produced no release. The release users actually got came out of a different run three hours later. A Chocolatey version cannot be un-pushed.
+
+Both steps also carried `continue-on-error: true`, which turned a dead channel into a green check: the snap build failed from v2.6.11 onward and the Snap Store went on serving 2.6.11 for three months and six versions, while every release told people to `sudo snap install markpad`. Neither job swallows a failure now. `scripts/releaseWorkflow.test.ts` holds both properties.
+
+`publish-packages.yml` also takes `workflow_dispatch` with a tag, so it can be exercised against an already-published release without cutting a new one — worth doing after any change to `snapcraft.yaml` or the Chocolatey packaging, since neither is reachable from a pull request.
 
 ## First auto-update-capable release
 
@@ -96,7 +107,7 @@ Mention this clearly in the release notes for the first auto-update-capable vers
 - **macOS** uses one universal binary (`darwin-aarch64` + `darwin-x86_64` share the same `.app.tar.gz` and signature).
 - **Windows** uses NSIS — the auto-updater downloads `*-setup.exe` (verified by `*-setup.exe.sig`) and runs it in `passive` install mode. The existing raw portable `.exe` distribution path is preserved alongside, so users who download the portable `.exe` directly continue to work; only the auto-updater path uses the NSIS installer.
 - **Linux**: only `AppImage` users get auto-updates — `tauri-plugin-updater` doesn't support `.deb` or `.rpm`. `apt`/`rpm` users keep getting updates via their distro package manager (or by downloading a fresh package).
-- **Snap / Chocolatey**: independent distribution channels. Their update mechanisms are unaffected.
+- **Snap / Chocolatey**: independent distribution channels, published by `publish-packages.yml` after the release is published. Their update mechanisms are unaffected. The Chocolatey package wraps the release's own `Markpad_<version>_x64.exe` rather than a second build, which is what `packaging/choco/tools/VERIFICATION.txt` promises.
 
 ## Troubleshooting
 
@@ -107,6 +118,9 @@ Mention this clearly in the release notes for the first auto-update-capable vers
 | `latest.json` missing entirely | The `generate-update-feed` job didn't run — usually because no `*.sig` files were uploaded. Check the `Upload * Artifacts` steps. |
 | Users don't see the update | (1) Did you click *Publish release*? Drafts aren't visible to clients. (2) Is the user on a version older than the first auto-update-capable release? They need a one-time manual reinstall. |
 | Update download succeeds but install fails with signature error | Pubkey mismatch — the Secrets and `tauri.conf.json` `pubkey` belong to different keypairs. |
+| `Strip host-coupled libraries from AppImage` fails | Run [`scripts/strip-appimage.sh`](scripts/strip-appimage.sh) locally against the AppImage from the draft release — it needs no signing key. It failed in two of the three v2.7.2 attempts, once because `signer sign` had a stray flag and once because it was reading the deprecated `TAURI_PRIVATE_KEY` names on a CLI too old to accept the current ones. |
+| `Publish Packages` / snap job fails | Read the snapcraft error rather than re-running: `Environment validation failed for part 'markpad'` means the `rust-deps` part in `snapcraft.yaml` is gone or renamed. Fix, then re-run the workflow with the tag as `workflow_dispatch` input. |
+| `Publish Packages` / chocolatey job fails on push | A version can only be pushed to Chocolatey once. If it is already there, nothing needs doing; if it is not, check `CHOCO_API_KEY`. |
 
 ## Out of scope (not handled by this workflow)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"@sveltejs/adapter-static": "^3.0.10",
 				"@sveltejs/kit": "^2.70.2",
 				"@sveltejs/vite-plugin-svelte": "^5.1.1",
-				"@tauri-apps/cli": "^2",
+				"@tauri-apps/cli": "^2.11.4",
 				"@types/node": "^24.13.3",
 				"svelte": "^5.56.8",
 				"svelte-check": "^4.7.4",
@@ -1065,9 +1065,9 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.9.6.tgz",
-			"integrity": "sha512-3xDdXL5omQ3sPfBfdC8fCtDKcnyV7OqyzQgfyT5P3+zY6lcPqIYKQBvUasNvppi21RSdfhy44ttvJmftb0PCDw==",
+			"version": "2.11.4",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.4.tgz",
+			"integrity": "sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==",
 			"dev": true,
 			"license": "Apache-2.0 OR MIT",
 			"bin": {
@@ -1081,23 +1081,23 @@
 				"url": "https://opencollective.com/tauri"
 			},
 			"optionalDependencies": {
-				"@tauri-apps/cli-darwin-arm64": "2.9.6",
-				"@tauri-apps/cli-darwin-x64": "2.9.6",
-				"@tauri-apps/cli-linux-arm-gnueabihf": "2.9.6",
-				"@tauri-apps/cli-linux-arm64-gnu": "2.9.6",
-				"@tauri-apps/cli-linux-arm64-musl": "2.9.6",
-				"@tauri-apps/cli-linux-riscv64-gnu": "2.9.6",
-				"@tauri-apps/cli-linux-x64-gnu": "2.9.6",
-				"@tauri-apps/cli-linux-x64-musl": "2.9.6",
-				"@tauri-apps/cli-win32-arm64-msvc": "2.9.6",
-				"@tauri-apps/cli-win32-ia32-msvc": "2.9.6",
-				"@tauri-apps/cli-win32-x64-msvc": "2.9.6"
+				"@tauri-apps/cli-darwin-arm64": "2.11.4",
+				"@tauri-apps/cli-darwin-x64": "2.11.4",
+				"@tauri-apps/cli-linux-arm-gnueabihf": "2.11.4",
+				"@tauri-apps/cli-linux-arm64-gnu": "2.11.4",
+				"@tauri-apps/cli-linux-arm64-musl": "2.11.4",
+				"@tauri-apps/cli-linux-riscv64-gnu": "2.11.4",
+				"@tauri-apps/cli-linux-x64-gnu": "2.11.4",
+				"@tauri-apps/cli-linux-x64-musl": "2.11.4",
+				"@tauri-apps/cli-win32-arm64-msvc": "2.11.4",
+				"@tauri-apps/cli-win32-ia32-msvc": "2.11.4",
+				"@tauri-apps/cli-win32-x64-msvc": "2.11.4"
 			}
 		},
 		"node_modules/@tauri-apps/cli-darwin-arm64": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.9.6.tgz",
-			"integrity": "sha512-gf5no6N9FCk1qMrti4lfwP77JHP5haASZgVbBgpZG7BUepB3fhiLCXGUK8LvuOjP36HivXewjg72LTnPDScnQQ==",
+			"version": "2.11.4",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.4.tgz",
+			"integrity": "sha512-1ryOF3ZhpZ/nemHV5zVwBQBz9jDGKmKPvWPADOhc83ig0P4bMc2iER4NbC6r9sjeIZ6RVQ4g3RZIYvezhcl4TQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1112,9 +1112,9 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli-darwin-x64": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.9.6.tgz",
-			"integrity": "sha512-oWh74WmqbERwwrwcueJyY6HYhgCksUc6NT7WKeXyrlY/FPmNgdyQAgcLuTSkhRFuQ6zh4Np1HZpOqCTpeZBDcw==",
+			"version": "2.11.4",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.4.tgz",
+			"integrity": "sha512-uFsGQAAfuyz1k/yGLmkWfkBlgKAqZfxqlHmLWx81QU27RJWfmbNHCIq8T8w1e+VClleIuZUjpHWfoE4E3DLo3A==",
 			"cpu": [
 				"x64"
 			],
@@ -1129,9 +1129,9 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.9.6.tgz",
-			"integrity": "sha512-/zde3bFroFsNXOHN204DC2qUxAcAanUjVXXSdEGmhwMUZeAQalNj5cz2Qli2elsRjKN/hVbZOJj0gQ5zaYUjSg==",
+			"version": "2.11.4",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.4.tgz",
+			"integrity": "sha512-IaHZn5CdBL21oUmjiVOS1ctw6Ip1O0pjp70FwOWmYz1myWe0SY96ZIj2FYf7pT0m8bI2h/hrs5ZbEXXh44/MkQ==",
 			"cpu": [
 				"arm"
 			],
@@ -1146,13 +1146,16 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli-linux-arm64-gnu": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.9.6.tgz",
-			"integrity": "sha512-pvbljdhp9VOo4RnID5ywSxgBs7qiylTPlK56cTk7InR3kYSTJKYMqv/4Q/4rGo/mG8cVppesKIeBMH42fw6wjg==",
+			"version": "2.11.4",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.4.tgz",
+			"integrity": "sha512-N41/ukTRVe6XSuUTESuFdGeOW2i7k62tK+6gHK5Kd5/q5RPvvi19GaWAVPPb9u95HSGmTChSolBfzynUsssFaA==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0 OR MIT",
 			"optional": true,
 			"os": [
@@ -1163,13 +1166,16 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli-linux-arm64-musl": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.9.6.tgz",
-			"integrity": "sha512-02TKUndpodXBCR0oP//6dZWGYcc22Upf2eP27NvC6z0DIqvkBBFziQUcvi2n6SrwTRL0yGgQjkm9K5NIn8s6jw==",
+			"version": "2.11.4",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.4.tgz",
+			"integrity": "sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0 OR MIT",
 			"optional": true,
 			"os": [
@@ -1180,13 +1186,16 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.9.6.tgz",
-			"integrity": "sha512-fmp1hnulbqzl1GkXl4aTX9fV+ubHw2LqlLH1PE3BxZ11EQk+l/TmiEongjnxF0ie4kV8DQfDNJ1KGiIdWe1GvQ==",
+			"version": "2.11.4",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.4.tgz",
+			"integrity": "sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==",
 			"cpu": [
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0 OR MIT",
 			"optional": true,
 			"os": [
@@ -1197,13 +1206,16 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli-linux-x64-gnu": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.9.6.tgz",
-			"integrity": "sha512-vY0le8ad2KaV1PJr+jCd8fUF9VOjwwQP/uBuTJvhvKTloEwxYA/kAjKK9OpIslGA9m/zcnSo74czI6bBrm2sYA==",
+			"version": "2.11.4",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.4.tgz",
+			"integrity": "sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0 OR MIT",
 			"optional": true,
 			"os": [
@@ -1214,13 +1226,16 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli-linux-x64-musl": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.9.6.tgz",
-			"integrity": "sha512-TOEuB8YCFZTWVDzsO2yW0+zGcoMiPPwcUgdnW1ODnmgfwccpnihDRoks+ABT1e3fHb1ol8QQWsHSCovb3o2ENQ==",
+			"version": "2.11.4",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.4.tgz",
+			"integrity": "sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0 OR MIT",
 			"optional": true,
 			"os": [
@@ -1231,9 +1246,9 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli-win32-arm64-msvc": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.9.6.tgz",
-			"integrity": "sha512-ujmDGMRc4qRLAnj8nNG26Rlz9klJ0I0jmZs2BPpmNNf0gM/rcVHhqbEkAaHPTBVIrtUdf7bGvQAD2pyIiUrBHQ==",
+			"version": "2.11.4",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.4.tgz",
+			"integrity": "sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1248,9 +1263,9 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli-win32-ia32-msvc": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.9.6.tgz",
-			"integrity": "sha512-S4pT0yAJgFX8QRCyKA1iKjZ9Q/oPjCZf66A/VlG5Yw54Nnr88J1uBpmenINbXxzyhduWrIXBaUbEY1K80ZbpMg==",
+			"version": "2.11.4",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.4.tgz",
+			"integrity": "sha512-12Hxi0XX/H5VFxO/bGgHkFWhml9VMgEOu9CidjeCeTNQ1l6fpUlbiGgSP7CLI3PFtW9/FfbeHieZ+kyWK5H7CA==",
 			"cpu": [
 				"ia32"
 			],
@@ -1265,9 +1280,9 @@
 			}
 		},
 		"node_modules/@tauri-apps/cli-win32-x64-msvc": {
-			"version": "2.9.6",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.9.6.tgz",
-			"integrity": "sha512-ldWuWSSkWbKOPjQMJoYVj9wLHcOniv7diyI5UAJ4XsBdtaFB0pKHQsqw/ItUma0VXGC7vB4E9fZjivmxur60aw==",
+			"version": "2.11.4",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.4.tgz",
+			"integrity": "sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw==",
 			"cpu": [
 				"x64"
 			],

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"@sveltejs/adapter-static": "^3.0.10",
 		"@sveltejs/kit": "^2.70.2",
 		"@sveltejs/vite-plugin-svelte": "^5.1.1",
-		"@tauri-apps/cli": "^2",
+		"@tauri-apps/cli": "^2.11.4",
 		"@types/node": "^24.13.3",
 		"svelte": "^5.56.8",
 		"svelte-check": "^4.7.4",

--- a/packaging/choco/tools/VERIFICATION.txt
+++ b/packaging/choco/tools/VERIFICATION.txt
@@ -1,10 +1,20 @@
 VERIFICATION
 
-The Markpad executable in this Chocolatey package was built automatically from
-source code using GitHub Actions.
+Markpad is open source and this package is built by its own GitHub Actions
+workflow (.github/workflows/publish-packages.yml).
 
-Source Repository: https://github.com/sftwrdotdev/markpad
+Source Repository: https://github.com/sftwrdotdev/Markpad
 
-The build process produces `Markpad.exe` via `npm run tauri build`, which is
-then copied directly into the `tools` folder of this package. The process is fully
-automated. No pre-compiled binaries from external sources are included.
+The `Markpad.exe` in this package is not a separate build. It is the portable
+x64 executable published on the corresponding GitHub release --
+`Markpad_<version>_x64.exe` -- downloaded from that release and renamed. The
+release asset is produced by `npm run tauri build` in
+.github/workflows/build.yml.
+
+To verify, download that file from the release page and compare it against the
+copy in this package:
+
+  checksum -t sha256 -f Markpad.exe
+
+The expected value and the exact URL it came from are appended below when the
+package is built.

--- a/scripts/releaseWorkflow.test.ts
+++ b/scripts/releaseWorkflow.test.ts
@@ -1,16 +1,19 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { readSource, sliceBetween } from './sourceTree.js';
+import { readSource, sliceBetween, sliceFrom } from './sourceTree.js';
 
 const workflow = readSource('.github/workflows/build.yml');
+const publishWorkflow = readSource('.github/workflows/publish-packages.yml');
 const testWorkflow = readSource('.github/workflows/test.yml');
 const testBuildWorkflow = readSource('.github/workflows/test_build.yml');
 const releasing = readSource('RELEASING.md');
 const snapcraft = readSource('snapcraft.yaml');
+const stripAppImage = readSource('scripts/strip-appimage.sh');
 const cargoToml = readSource('src-tauri/Cargo.toml');
 const packageJson = JSON.parse(readSource('package.json')) as {
 	scripts: Record<string, string>;
+	devDependencies: Record<string, string>;
 	version: string;
 };
 const tauriConf = JSON.parse(readSource('src-tauri/tauri.conf.json')) as {
@@ -116,4 +119,94 @@ test('the updater endpoint names the repository RELEASING.md documents', () => {
 		documented[1],
 		`tauri.conf.json points the updater at ${repo} while RELEASING.md documents ${documented[1]}`,
 	);
+});
+
+test('a package manager is not published from inside the platform matrix', () => {
+	// `choco push` and `snapcraft push` used to run in the Windows and Linux
+	// build jobs, which put an irreversible side effect before the thing that
+	// decides whether a release happens at all. Chocolatey's markpad-app 2.7.2
+	// was published by run 31192564528, which then failed on Linux and produced
+	// no release; the release users got came out of a different run three hours
+	// later. Nothing can un-push a Chocolatey version.
+	//
+	// Matched on the push commands rather than on step names, because the
+	// property is "the build matrix has no irreversible external effect", and a
+	// renamed step would still have one.
+	assert.doesNotMatch(workflow, /choco push/);
+	assert.doesNotMatch(workflow, /snapcraft (pack|push)/);
+	assert.match(publishWorkflow, /choco push/);
+	assert.match(publishWorkflow, /snapcraft push/);
+});
+
+test('package managers are published from a release a human published', () => {
+	// `release: published` fires when a maintainer clicks Publish on the draft,
+	// which RELEASING.md step 6 describes as the gate after checking the assets.
+	// Anything earlier — `created`, a tag push, the end of the build — publishes
+	// on a release nobody has looked at.
+	const on = sliceBetween(publishWorkflow, '\non:', '\npermissions:');
+	assert.match(on, /release:\s*\n\s*types:\s*\[published\]/);
+	assert.doesNotMatch(on, /\bpush:/);
+});
+
+test('a publishing step cannot report success while failing', () => {
+	// The steps this workflow replaces both carried `continue-on-error: true`.
+	// The snap build failed under it from v2.6.11 onward — `'rustup' not found`,
+	// see snapcraft.yaml — for three months and six versions, while the job
+	// reported success and every release still told people to
+	// `sudo snap install markpad`. The Snap Store served 2.6.11 throughout.
+	assert.doesNotMatch(publishWorkflow, /continue-on-error/);
+	assert.doesNotMatch(workflow, /continue-on-error/);
+});
+
+test('the snap build can find rustup', () => {
+	// snapcraft's rust plugin looks for rustup in exactly one place other than
+	// PATH: a part named `rust-deps` that the rust part depends on. Naming the
+	// rustup snap in the rust part's own `build-snaps` does not satisfy it, and
+	// had not since v2.6.11. The name is load-bearing and comes from snapcraft,
+	// so it is asserted literally.
+	assert.match(snapcraft, /^\s*rust-deps:$/m);
+	assert.match(snapcraft, /^\s*after: \[rust-deps\]$/m);
+});
+
+test('the AppImage strip is a script, and its excludelist has one home', () => {
+	// This step failed in two of the three v2.7.2 release attempts. As a heredoc
+	// inside build.yml it could only be exercised by cutting a release; as a
+	// script it can be run against any downloaded AppImage.
+	assert.match(workflow, /bash scripts\/strip-appimage\.sh/);
+	assert.match(stripAppImage, /libwayland-client\.so\.0/);
+	// The libraries are named in the script or nowhere. A second copy in the
+	// workflow is a second copy to keep current.
+	assert.doesNotMatch(workflow, /libwayland/);
+});
+
+test('the strip proves itself against the artifact that ships', () => {
+	// A CI smoke test cannot catch this defect: the runner's Mesa is the one the
+	// libraries were copied from, so nothing mismatches there and the AppImage
+	// starts fine. #498 was found by a user on Arch. That leaves "these
+	// libraries are absent" as the only property checkable before release, and
+	// it has to be checked on the repacked file rather than on the AppDir —
+	// appimagetool packing the wrong directory would pass the weaker check.
+	const verification = sliceFrom(stripAppImage, '--runtime-file');
+	assert.match(verification, /--appimage-extract/);
+	assert.match(verification, /is still bundled after the strip/);
+});
+
+test('signing uses the environment variables the pinned CLI reads', () => {
+	// `tauri signer sign` did not read the TAURI_SIGNING_* names until CLI
+	// 2.10.0, so the strip step had to spell the same secret the deprecated way
+	// (TAURI_PRIVATE_KEY) while `tauri build` used the current one. Those names
+	// are documented as going away, and `signer sign` without a key does not
+	// fail loudly — only the `.sig` existence check turns it into an error.
+	// 2.11.4 also fixes the AppImage bundler writing absolute symlinks for
+	// `.desktop` and `.DirIcon`, in the same artifact this workflow repacks.
+	// See #497.
+	const floor = packageJson.devDependencies['@tauri-apps/cli'];
+	const [, major, minor, patch] = /^\^(\d+)\.(\d+)\.(\d+)$/.exec(floor) ?? [];
+	assert.ok(major, `@tauri-apps/cli must floor at an exact version, found ${floor}`);
+	assert.ok(
+		Number(major) > 2 || (Number(major) === 2 && (Number(minor) > 11 || (Number(minor) === 11 && Number(patch) >= 4))),
+		`@tauri-apps/cli must be floored at ^2.11.4 or later, found ${floor}`,
+	);
+	assert.doesNotMatch(workflow, /TAURI_PRIVATE_KEY/);
+	assert.match(workflow, /TAURI_SIGNING_PRIVATE_KEY_PASSWORD/);
 });

--- a/scripts/strip-appimage.sh
+++ b/scripts/strip-appimage.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# Remove host-coupled graphics libraries from a built AppImage, repack it in
+# place, and prove they are gone.
+#
+# tauri-bundler runs linuxdeploy, which copies libwayland-client.so.0 and
+# friends out of the build machine into the AppImage. On a host whose Mesa is
+# newer than the builder's, that older bundled copy shadows the host one and
+# host libEGL then fails eglGetPlatformDisplay with EGL_BAD_PARAMETER: WebKit's
+# WebProcess aborts and the window comes up blank while the GTK shell survives.
+# These libraries are on the AppImageCommunity/pkg2appimage excludelist
+# precisely because they must come from the host. See #498, and #499 for the
+# investigation that isolated libwayland-client.so.0 as necessary and
+# sufficient. (#463 fixed a separate WebKitGTK version pin.)
+#
+# This lives in a script rather than inline in build.yml for two reasons. It is
+# the step that failed in two of the three v2.7.2 release attempts, and an
+# inline heredoc can only be exercised by cutting a release. And the excludelist
+# below is the one place that names these libraries, so a test can read it.
+#
+# Signing is deliberately NOT done here. tauri build already signed the
+# pre-strip file and that signature no longer matches, so the caller must
+# re-sign — but keeping the key out of this script is what lets anyone run it on
+# a downloaded AppImage without one.
+#
+# Usage: scripts/strip-appimage.sh <path-to.AppImage>
+
+set -euo pipefail
+
+APPIMAGE="${1:-}"
+if [ -z "$APPIMAGE" ] || [ ! -f "$APPIMAGE" ]; then
+	echo "usage: $0 <path-to.AppImage>" >&2
+	exit 2
+fi
+APPIMAGE=$(realpath "$APPIMAGE")
+
+# Host-coupled graphics libraries. libwayland-client.so.0 is the one that
+# actually breaks EGL; the rest belong to the host graphics stack for the same
+# reason and are on the same excludelist.
+EXCLUDED=(
+	libwayland-client.so.0
+	libwayland-cursor.so.0
+	libwayland-egl.so.1
+	libwayland-server.so.0
+	libxcb-render.so.0
+	libxcb-shm.so.0
+)
+
+APPIMAGETOOL_URL=${APPIMAGETOOL_URL:-https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage}
+RUNTIME_URL=${RUNTIME_URL:-https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64}
+
+tools=$(mktemp -d)
+work=$(mktemp -d)
+check=$(mktemp -d)
+trap 'rm -rf "$tools" "$work" "$check"' EXIT
+
+echo "Repackaging $APPIMAGE"
+
+# --appimage-extract and appimagetool's --appimage-extract-and-run both unpack
+# without libfuse2, which the GitHub runner does not have.
+wget -q "$APPIMAGETOOL_URL" -O "$tools/appimagetool"
+wget -q "$RUNTIME_URL" -O "$tools/runtime-x86_64"
+chmod +x "$tools/appimagetool"
+
+( cd "$work" && "$APPIMAGE" --appimage-extract >/dev/null )
+libdir="$work/squashfs-root/usr/lib"
+
+for lib in "${EXCLUDED[@]}"; do
+	rm -fv "$libdir/$lib"
+done
+
+# Repack in place so the file name — which is also the updater target named in
+# latest.json — is unchanged.
+ARCH=x86_64 "$tools/appimagetool" --appimage-extract-and-run \
+	--runtime-file "$tools/runtime-x86_64" \
+	"$work/squashfs-root" "$APPIMAGE"
+
+# Assert the property on the artifact that ships, not on the AppDir it was
+# built from. A CI smoke test cannot catch this defect at all — the runner's
+# Mesa is the one the libraries came from, so nothing mismatches there — which
+# leaves "these libraries are absent" as the only thing that can actually be
+# checked before a user on a newer distro finds out.
+( cd "$check" && "$APPIMAGE" --appimage-extract >/dev/null )
+failed=0
+for lib in "${EXCLUDED[@]}"; do
+	if [ -e "$check/squashfs-root/usr/lib/$lib" ]; then
+		echo "::error::$lib is still bundled after the strip" >&2
+		failed=1
+	fi
+done
+[ "$failed" -eq 0 ] || exit 1
+
+echo "Repacked without ${#EXCLUDED[@]} host-coupled libraries:"
+ls -la "$APPIMAGE"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -26,8 +26,8 @@ description: |
 license: BSD-3-Clause
 website: https://markpad.sftwr.dev
 donation: https://github.com/sponsors/alecdotdev
-source-code: https://github.com/alecdotdev/Markpad
-issues: https://github.com/alecdotdev/Markpad/issues
+source-code: https://github.com/sftwrdotdev/Markpad
+issues: https://github.com/sftwrdotdev/Markpad/issues
 
 confinement: strict
 base: core24
@@ -45,7 +45,29 @@ apps:
       - home
 
 parts:
+  # snapcraft's rust plugin refuses to build unless it can see rustup, and it
+  # looks for it in exactly one place other than PATH: a part named `rust-deps`
+  # that the rust part depends on. Naming the snap in `build-snaps` below is not
+  # enough, and had not been since v2.6.11 --
+  #
+  #   Environment validation failed for part 'markpad': 'rustup' not found and
+  #   part 'markpad' does not depend on a part named 'rust-deps' that would
+  #   satisfy the dependency.
+  #
+  # -- which the release workflow swallowed under `continue-on-error`, so the
+  # Snap Store went on serving 2.6.11 for three months and six versions while
+  # every release still told people to install it. The publishing step no longer
+  # swallows anything (.github/workflows/publish-packages.yml); this is the
+  # failure it was hiding.
+  rust-deps:
+    plugin: nil
+    build-snaps:
+      - rustup/latest/stable
+    override-build: |
+      rustup default stable
+
   markpad:
+    after: [rust-deps]
     plugin: rust
     source: .
     build-packages:
@@ -64,7 +86,6 @@ parts:
       - libjavascriptcoregtk-4.1-0
     build-snaps:
       - node/20/stable
-      - rustup/latest/stable
     override-build: |
       set -e
       craftctl set version="$(node -p "require('./package.json').version")"


### PR DESCRIPTION
## Problem

Four things went wrong around the v2.7.2 release. They are not four bugs — they share two causes.

**An irreversible side effect placed before the decision it depends on.** `choco push` and `snapcraft push` ran inside `build.yml`'s platform matrix. Chocolatey's `markpad-app` 2.7.2 was published at 15:37 UTC on 2026-08-07 by run [`31192564528`](https://github.com/sftwrdotdev/Markpad/actions/runs/31192564528) — a run that then failed on Linux and produced no release. The release users actually got came out of a different run three hours later. A Chocolatey version cannot be un-pushed.

**A failure configured not to be one.** Both pushes carried `continue-on-error: true`. The snap build has failed since v2.6.11:

```
Environment validation failed for part 'markpad': 'rustup' not found and part
'markpad' does not depend on a part named 'rust-deps' that would satisfy the
dependency.
```

That line is from the **successful** 2.7.2 run. The job reported success for three months and six versions while the Snap Store went on serving **2.6.11** (`api.snapcraft.io`, rev 15, 2026-06-03) and every release told people to `sudo snap install markpad`. Nobody reported it, because from the outside it looks like there is nothing to report — snapd checks for updates daily and tells those users they are current.

And the AppImage strip step failed in **two of the three** v2.7.2 release attempts (runs `31192564528`, `31204367106`), once on a stray `-k` and once on signing env vars, in a heredoc that can only be exercised by cutting a release.

## Changes

**Package managers publish after the release, not during the build** — new [`publish-packages.yml`](.github/workflows/publish-packages.yml), triggered by `release: published`, which is a human clicking Publish on a draft whose assets they have checked (RELEASING.md step 6). Two independent jobs, neither swallowing a failure. Also takes `workflow_dispatch` with a tag, so the snap and Chocolatey halves can be exercised against an existing release without cutting a new one — neither is reachable from a pull request otherwise.

**The Chocolatey package now wraps the release's own `Markpad_<version>_x64.exe`** instead of a second build. `VERIFICATION.txt` promised "copied directly" from a build; a rebuild from the same commit is not guaranteed to be the same bytes. It now describes what actually happens and carries the SHA256 and the exact URL, which is what a Chocolatey moderator can check.

**The snap can find rustup** — a `rust-deps` part, which is the one place other than PATH that snapcraft's rust plugin looks. The name comes from snapcraft, so it is asserted literally in the tests.

**The AppImage strip is [`scripts/strip-appimage.sh`](scripts/strip-appimage.sh)** — runnable against any downloaded AppImage, no signing key needed (signing stays in the workflow, which is what keeps the script runnable). It now verifies the **repacked artifact** rather than the AppDir: appimagetool packing the wrong directory would pass the weaker check. The excludelist has one home instead of two.

Worth being explicit about why the check is shaped that way: **a CI smoke test cannot catch this defect.** The runner's Mesa is the one the libraries were copied from, so nothing mismatches there and the AppImage starts fine — #498 had to be found by a user on Arch. "These libraries are absent" is the only property that can be checked before a release.

**`@tauri-apps/cli` floored at `^2.11.4`** — the lockfile resolved `^2` to 2.9.6, which predates the `TAURI_SIGNING_*` names, so the re-sign step had to spell the same secret the deprecated way while `tauri build` used the current one. 2.11.4 also fixes the AppImage bundler writing absolute symlinks for `.desktop` and `.DirIcon` — the same artifact this repacks. Both halves of the case are @PathGao's, in #497.

## Verification

Measured, not assumed:

| | |
|---|---|
| `TAURI_SIGNING_PRIVATE_KEY` + `_PASSWORD` on 2.11.4 | writes the `.sig` |
| the same names on 2.9.6 | `Unable to find the private key` (#497) |
| `npm test` | 948 pass |
| `npm run check` | 674 files, 0 errors |
| `bash -n scripts/strip-appimage.sh`, YAML parse of all three changed files | clean |

Seven assertions added to `scripts/releaseWorkflow.test.ts`, each holding a property rather than a step name — the build matrix has no `choco push` / `snapcraft push`; publishing triggers only on `release: published`; no `continue-on-error` in either file; `rust-deps` exists and is depended on; the strip is a script and the excludelist is not duplicated; the verification runs after the repack; the CLI floor is high enough for the env vars the workflow uses.

**What cannot be verified from a pull request, and how to close it:** snapcraft needs LXD and store credentials, and the strip needs a Linux runner with the signing secret. After merging, run `Publish Packages` by hand against `v2.7.2` — that exercises the snap fix end to end (including the store push) without cutting a release. If it goes green, the next release is the first one in six where the snap is real.

## Not in this PR

Whether Markpad should keep the snap at all, plus code signing on macOS and Windows and the Linux distribution surface — #562.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
