### PR TITLE
docs: name the two kinds of test in scripts/, and ask which one a PR added

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,6 +26,16 @@ and chose not to fix here belongs in this section too.
 What you added or changed. For a fix: revert the fix, keep the test, and say
 whether it goes red. A test that passes either way isn't testing the fix.
 
+If the test matches source text rather than running the code, say what the
+anchor is. Pinning a contract the compiler can't check — a Tauri command name,
+an i18n key, a second copy of a fixed behaviour — is what those are for.
+Pinning an internal call site pins today's spelling instead, so it goes red on
+a rename that broke nothing and stays green on a change that broke something.
+
+Not every fix needs one. A defect that announces itself — a crash, a type
+error, something the next person to open the app would see — is already caught
+by `npm run check`, `cargo test` and a single manual run.
+
 ## Verification
 
 The commands you ran and what they said — the ones CI runs are:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,12 @@ All file operations go through Rust commands - never use Node.js fs APIs.
 ## Testing
 
 - **Rust**: `cargo test` in `src-tauri/` directory
-- **Frontend**: `npm test` runs the behavior tests in `scripts/*.test.ts` (`node --test --import tsx`)
+- **Frontend**: `npm test` runs `scripts/*.test.ts` (`node --test --import tsx`). Two kinds
+  live there: behavior tests, which import and run the real modules, and source-shape
+  assertions, which match the source text for a contract the compiler cannot check — a Tauri
+  command name, an i18n key, a second copy of a fixed behavior. A green run is not a claim
+  that every behavior is covered; a source-shape assertion passes as long as the line it
+  matches is still spelled that way.
 - **CI**: Runs `npm audit`, `npm run check`, `npm test` and `cargo test` on PRs
 
 ## Notes


### PR DESCRIPTION
## What this is

Two documentation edits, no code and no test files touched.

- `AGENTS.md` stops calling `scripts/*.test.ts` "the behavior tests" and names what is actually in there.
- The pull request template's **Tests** section asks which kind you added, and says out loud that not every fix needs one.

## Mechanism

The description in `AGENTS.md` dates from when the suite was small enough for it to be true. Counting the tree today: 109 test files, and 31 of them import nothing from `src/` — they match the source text with a regex or an AST walk. Another 53 do both.

Both kinds are worth having, but they fail in opposite directions:

|  | behaviour correct | behaviour broken |
|---|---|---|
| **spelling unchanged** | green ✓ | green ✗ — the line is still there, the behaviour is not |
| **spelling changed** | red ✗ — a rename that broke nothing | red ✓ |

A source-shape assertion checks whether a line is still spelled a certain way. That is exactly right when the spelling *is* the contract and the compiler cannot see it — `invoke('read_file_content')` has to match a Rust function name, `t('common.save')` has to match a dictionary key, `mermaid.render(` must not acquire a third call site (`singleImplementationConvention.test.ts` exists for that). It is wrong when the anchor is an internal call, where a rename is free and pinning it makes ordinary refactoring fail the suite for no behavioural reason.

Calling the whole suite "behavior tests" hides that distinction, and the cost lands on the next reader — human or agent — who reads a green run as coverage it isn't.

## Scope

Deliberately left alone:

- **No test files are added, changed or deleted.** Whether any existing assertion should go is a separate question, one file at a time, and deleting tests is its own risk. This PR only makes the two kinds visible so that question can be asked.
- **No rule, no lint, no CI gate.** The template opens with "Nothing below is required" and this section keeps that voice — it asks a question, it does not reject a PR.
- `AGENTS.md` gets no methodology, only the corrected description. What counts as worth testing is a judgement that belongs in review, not in a file that mostly states facts about the build.

## Tests

None, and none are possible: nothing in `scripts/` reads `AGENTS.md` or the pull request template (`grep -rln 'AGENTS.md\|PULL_REQUEST_TEMPLATE' scripts/` is empty). By the criterion this PR adds, a docs change with no silent failure mode does not get one.

## Verification

Documentation only — no source file changes, so `npm run check` and `cargo test` have nothing new to see and CI runs them anyway. Both edited files were re-read in full after editing.

Not verified: how the template renders in GitHub's PR compose box. The added text is plain paragraphs inside an existing `##` section, so it follows whatever the four sections above it already do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)