### PR TITLE
test(youtube): assert the rendered anchor, and teach the shim href/src

### DIFF
--- a/scripts/renderProtocolDom.ts
+++ b/scripts/renderProtocolDom.ts
@@ -347,6 +347,27 @@ export class ShimElement extends ShimNode {
 		this.setAttribute('id', value);
 	}
 
+	// A browser reflects these into the attribute, so `link.href = url` is
+	// visible to `getAttribute('href')` and survives serialization. Without
+	// them the assignment lands on a plain JS property, the attribute is never
+	// written, and a test can see that an anchor was created but not where it
+	// points — which is the whole content of a link.
+	get href(): string {
+		return this.getAttribute('href') || '';
+	}
+
+	set href(value: string) {
+		this.setAttribute('href', value);
+	}
+
+	get src(): string {
+		return this.getAttribute('src') || '';
+	}
+
+	set src(value: string) {
+		this.setAttribute('src', value);
+	}
+
 	get className(): string {
 		return this.getAttribute('class') || '';
 	}

--- a/scripts/youtubeExternalFallback.test.ts
+++ b/scripts/youtubeExternalFallback.test.ts
@@ -1,30 +1,115 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { installShimDom, parseHtml, type ShimElement } from './renderProtocolDom.ts';
 import { offsetOf, readSource, sliceBetween } from './sourceTree.js';
 
-const markdown = readSource('src/lib/utils/markdown.ts');
+installShimDom();
+
+const { processMarkdownHtml } = await import('../src/lib/utils/markdown.ts');
+
 const markdownViewer = readSource('src/lib/MarkdownViewer.svelte');
 const tauriConfig = readSource('src-tauri/tauri.conf.json');
 
-test('YouTube links render as browser-opening thumbnail anchors', () => {
-	assert.match(markdown, /function replaceWithYoutubeLink\(element: Element, videoId: string, href: string\)/);
-	assert.match(markdown, /link\.className = ['"]youtube-link['"]/);
-	assert.match(markdown, /link\.href = href/);
-	assert.match(markdown, /https:\/\/i\.ytimg\.com\/vi\/\$\{videoId\}\/hqdefault\.jpg/);
-	assert.match(markdown, /replaceWithYoutubeLink\(a, videoId, href\)/);
-	assert.doesNotMatch(markdown, /createElement\(["']iframe["']\)/);
+// A YouTube link used to become an <iframe>, which meant the app had to allow
+// framing youtube.com and the video played inside Markpad. It is now a
+// thumbnail wrapped in an ordinary anchor, opened in the user's browser. The
+// two halves have to stay in step: rendering an iframe again with the CSP
+// closed produces a blank rectangle, and reopening the CSP for a renderer that
+// no longer frames anything just widens the attack surface for nothing.
+//
+// This was asserted by matching markdown.ts for the shape of
+// `replaceWithYoutubeLink` — its signature, each assignment inside it, and
+// `doesNotMatch(/createElement\(["']iframe["']\)/)`. All of that describes how
+// the function is written. `processMarkdownHtml` is exported and the suite has
+// a DOM shim, so what it produces can be looked at instead.
+
+const VIDEO = 'dQw4w9WgXcQ'; // 11 chars, which is what getYoutubeId requires
+
+function render(html: string) {
+	return parseHtml(processMarkdownHtml(html, '/doc.md', new Set()));
+}
+
+test('a YouTube link on its own becomes a thumbnail anchor, not a frame', () => {
+	const root = render(`<p><a href="https://www.youtube.com/watch?v=${VIDEO}">watch this</a></p>`);
+
+	const link = root.querySelector('a.youtube-link') as unknown as ShimElement | null;
+	assert.ok(link, 'the anchor is rewritten rather than left alone');
+	assert.equal(link.getAttribute('href'), `https://www.youtube.com/watch?v=${VIDEO}`, 'it still points at YouTube');
+	assert.ok(link.getAttribute('aria-label'), 'and it says where it goes, since the text is now an image');
+
+	const thumbnail = link.querySelector('img') as unknown as ShimElement | null;
+	assert.ok(thumbnail, 'the visible content is the poster frame');
+	assert.equal(thumbnail.getAttribute('src'), `https://i.ytimg.com/vi/${VIDEO}/hqdefault.jpg`);
+
+	assert.equal(root.querySelectorAll('iframe').length, 0, 'nothing is framed');
 });
 
-test('YouTube detection includes recognized embed URLs', () => {
-	assert.match(markdown, /url\.includes\(["']youtube\.com\/embed\/["']\)/);
+test('every recognised YouTube spelling gets the same treatment', () => {
+	// `youtube.com/embed/` in particular: it is the URL people paste FROM an
+	// embed snippet, and the one most likely to be handled by the old frame
+	// path if the detection list ever splits in two.
+	for (const href of [
+		`https://www.youtube.com/watch?v=${VIDEO}`,
+		`https://www.youtube.com/embed/${VIDEO}`,
+		`https://www.youtube.com/v/${VIDEO}`,
+		`https://youtu.be/${VIDEO}`,
+	]) {
+		const root = render(`<p><a href="${href}">link</a></p>`);
+		const link = root.querySelector('a.youtube-link') as unknown as ShimElement | null;
+		assert.ok(link, `${href} is recognised`);
+		assert.equal(
+			(link.querySelector('img') as unknown as ShimElement).getAttribute('src'),
+			`https://i.ytimg.com/vi/${VIDEO}/hqdefault.jpg`,
+		);
+	}
 });
+
+test('a YouTube image embed becomes the same anchor', () => {
+	// `![](https://youtu.be/…)` renders as an <img> whose src is a video page.
+	// Left alone it is a broken image.
+	const root = render(`<p><img src="https://youtu.be/${VIDEO}" alt="video"></p>`);
+
+	const link = root.querySelector('a.youtube-link') as unknown as ShimElement | null;
+	assert.ok(link, 'the image is replaced by the anchor');
+	assert.equal(link.getAttribute('href'), `https://youtu.be/${VIDEO}`);
+});
+
+test('a YouTube link with words around it is left as a link', () => {
+	// Only a paragraph that is nothing but the link becomes a poster. Swapping
+	// a link inside a sentence for a 480px thumbnail would rewrite the prose.
+	const root = render(`<p>see <a href="https://youtu.be/${VIDEO}">this</a> for context</p>`);
+
+	assert.equal(root.querySelectorAll('a.youtube-link').length, 0);
+	const link = root.querySelector('a') as unknown as ShimElement | null;
+	assert.ok(link);
+	assert.equal(link.textContent, 'this', 'the link keeps its own text');
+});
+
+test('a URL that only looks like YouTube is not rewritten', () => {
+	// getYoutubeId requires an 11-character id; anything else stays a link
+	// rather than becoming an anchor around a thumbnail that 404s.
+	const root = render('<p><a href="https://youtu.be/short">link</a></p>');
+
+	assert.equal(root.querySelectorAll('a.youtube-link').length, 0);
+	assert.equal(root.querySelectorAll('img').length, 0);
+});
+
+// --- the halves that are not this module's output ---
 
 test('the app no longer permits YouTube frames', () => {
+	// A contract with the packaged app rather than with a function: the CSP
+	// lives in tauri.conf.json, nothing type-checks it, and a `frame-src` that
+	// outlived the iframe is permission granted for no feature.
 	assert.doesNotMatch(tauriConfig, /frame-src/);
 });
 
 test('linked YouTube thumbnails are not intercepted by image zoom', () => {
+	// Source-shape on purpose: the handler is in a Svelte component this
+	// runner cannot import. The claim is an ordering between two branches —
+	// the anchor must claim the click first, or clicking the poster opens the
+	// zoom overlay instead of the browser — so it is asserted as an ordering
+	// rather than by matching the body's shape.
 	const linkHandler = sliceBetween(
 		markdownViewer,
 		'async function handleLinkClick(e: MouseEvent)',
@@ -34,8 +119,5 @@ test('linked YouTube thumbnails are not intercepted by image zoom', () => {
 	const imageZoom = offsetOf(linkHandler, "const img = target.closest('img');");
 
 	assert.ok(anchorGuard < imageZoom, 'the anchor branch claims the click before image zoom sees it');
-	assert.match(
-		linkHandler,
-		/if \(a\) \{[\s\S]*?if \(relativeMarkdownTarget\) \{[\s\S]*?return;[\s\S]*?\}\n\s*return;\n\s*\}\n\n\s*\/\/ media zoom handling/,
-	);
+	assert.match(linkHandler, /if \(a\) \{[\s\S]*?\n\t\t\treturn;\n\t\t\}/, 'and the anchor branch returns rather than falling through');
 });


### PR DESCRIPTION
## What this is

Third slice of the source-shape → behaviour conversion (after #564, #565). Test files only.

- `youtubeExternalFallback.test.ts` — rewritten to render documents and look at the output.
- `renderProtocolDom.ts` — the shim now reflects `href` and `src` into attributes, as a browser does.

## Mechanism

The old file made six assertions about how `replaceWithYoutubeLink` is written: its exact signature, `link.className = 'youtube-link'`, `link.href = href`, the thumbnail URL template, the call site, and `doesNotMatch(/createElement\(["']iframe["']\)/)`. None of them rendered a document.

What that missed is not subtle. Two decisions make this feature bearable and neither was covered:

- Only a paragraph that is **nothing but** the link becomes a poster. A link in the middle of a sentence stays a link — otherwise prose gets rewritten into a 480px thumbnail.
- An id that is not 11 characters is left alone, rather than becoming an anchor wrapped around a thumbnail URL that 404s.

Both are now tested, along with all four recognised URL spellings. `youtube.com/embed/` earns its own case: it is the URL people paste out of an embed snippet, so it is the one most likely to be missed if the detection list is ever split.

### The shim change

`replaceWithYoutubeLink` sets `link.href = href` and `thumbnail.src = …` as properties. A browser reflects those into attributes; `renderProtocolDom` had accessors for `id` and `className` and nothing else, so the assignment landed on a plain JS property, never reached `getAttribute`, and never reached the serialized HTML:

```
<p><a class="youtube-link" aria-label="Open YouTube video in browser"><img></a></p>
```

An anchor with no href and an image with no src. Every existing shim-based test was blind to where a link points, which is the entire content of a link. Four accessors alongside the existing pair fixes it. The full suite — including the six other files that install the shim — passes with the change: 952 tests, 0 failures.

## Scope

- The CSP assertion is unchanged and stays source-shape. `frame-src` in `tauri.conf.json` is a contract with the packaged app, nothing type-checks it, and a `frame-src` that outlived the iframe is permission granted for a feature that no longer exists.
- The click-ordering assertion stays too, because `handleLinkClick` lives in a Svelte component this runner cannot import — but it is now the ordering it actually claims (`closest('a')` resolved before `closest('img')`) rather than a 60-character regex over the branch bodies that any reformatting would break.
- No source file changes.

## Tests

Restoring the pre-fix renderer — `createElement("iframe")` in place of the anchor — turns 3 of the 7 red. Ran it, then reverted.

The two new negative cases were written against the current behaviour and checked by hand against `getYoutubeId`'s 11-character rule and the `parent.childNodes.length === 1` guard, not derived from the code by inspection alone.

## Verification

```
npm run check   # 674 files, 0 errors
npm test        # 952 pass, 0 fail
```

Not verified: the shim is not a browser. `href`/`src` reflection now matches what a browser does for these two attributes specifically; the rest of the reflection surface (`value`, `checked`, `htmlFor`, …) is still absent, and this PR does not add it speculatively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)