### PR TITLE
test(tags): round-trip the window tag instead of matching three lines

### DIFF
--- a/scripts/windowTags.test.ts
+++ b/scripts/windowTags.test.ts
@@ -3,16 +3,70 @@ import test from 'node:test';
 
 import { offsetOf, readSource } from './sourceTree.js';
 
-const tabs = readSource('src/lib/stores/tabs.svelte.ts');
+const g = globalThis as any;
+const runeEffect = (fn: () => void) => {
+	void fn;
+};
+runeEffect.root = (fn: () => unknown) => fn();
+g.$state = (value: unknown) => value;
+g.$state.raw = (value: unknown) => value;
+g.$state.snapshot = (value: unknown) => value;
+g.$derived = (value: unknown) => value;
+g.$derived.by = (fn: () => unknown) => fn();
+g.$effect = runeEffect;
+g.window = g.window ?? {};
+g.window.__TAURI_INTERNALS__ = g.window.__TAURI_INTERNALS__ ?? { invoke: () => Promise.resolve(null) };
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 const runtime = readSource('src-tauri/src/window_runtime.rs');
 const viewer = readSource('src/lib/MarkdownViewer.svelte');
 const titleBar = readSource('src/lib/components/TitleBar.svelte');
 const home = readSource('src/lib/components/HomePage.svelte');
 
-test('window tags persist with the v2 window snapshot', () => {
-	assert.match(tabs, /windowTag = \$state/);
-	assert.match(tabs, /windowTag: this\.windowTag/);
-	assert.match(tabs, /data\.windowTag\.pinned === true/);
+function roundTrip(): { name: string; color: string; pinned: boolean } | null {
+	const snapshot = tabManager.serializeState();
+	tabManager.closeAll();
+	tabManager.setWindowTag(null);
+	tabManager.restoreState(snapshot);
+	return tabManager.windowTag;
+}
+
+test('a window tag survives the snapshot round trip', () => {
+	tabManager.closeAll();
+	tabManager.addTab('/notes/a.md', 'x');
+	tabManager.setWindowTag({ name: 'Drafts', color: '#ff8c00', pinned: true });
+
+	assert.deepEqual(roundTrip(), { name: 'Drafts', color: '#ff8c00', pinned: true });
+});
+
+test('pinned defaults to false rather than to whatever was written', () => {
+	// `pinned` decides whether the tag creates a reusable session, so an
+	// older snapshot with no `pinned` field, or one carrying a non-boolean,
+	// must not be read as pinned.
+	tabManager.closeAll();
+	tabManager.addTab('/notes/a.md', 'x');
+	tabManager.setWindowTag({ name: 'Drafts', color: '#ff8c00' });
+	assert.equal(tabManager.windowTag?.pinned, false, 'omitted means not pinned');
+	assert.equal(roundTrip()?.pinned, false, 'and it stays that way through the snapshot');
+
+	tabManager.closeAll();
+	tabManager.restoreState(
+		JSON.stringify({ version: 2, tabs: [], windowTag: { name: 'D', color: '#fff', pinned: 'yes' } }),
+	);
+	assert.equal(tabManager.windowTag?.pinned, false, 'a truthy non-boolean is not a pin');
+});
+
+test('a malformed tag produces no tag at all', () => {
+	// A tag with no name renders as an empty chip the user cannot see or
+	// remove; one with no colour has nothing to paint. Restore runs on a fresh
+	// window, so the starting point here is no tag — the read side only ever
+	// installs one, it does not clear an existing one.
+	for (const windowTag of [{ color: '#fff' }, { name: '', color: '#fff' }, { name: 'D' }, null, 'Drafts']) {
+		tabManager.closeAll();
+		tabManager.setWindowTag(null);
+		tabManager.restoreState(JSON.stringify({ version: 2, tabs: [], windowTag }));
+		assert.equal(tabManager.windowTag, null, `${JSON.stringify(windowTag)} is rejected`);
+	}
 });
 
 test('only explicitly pinned tags create reusable sessions', () => {


### PR DESCRIPTION
## What this is

Fifth slice (after #564, #565, #567, #568). `windowTags.test.ts` only; no source changes.

## Mechanism

The persistence test was three regexes:

```js
assert.match(tabs, /windowTag = \$state/);
assert.match(tabs, /windowTag: this\.windowTag/);
assert.match(tabs, /data\.windowTag\.pinned === true/);
```

The first two say a field is declared and mentioned. The third pins the exact comparison `=== true` — which is the right comparison, but pinning the operator is not the same as checking what it protects, and it goes red the moment anyone writes the same guard another way.

`tabManager` is an exported singleton with `setWindowTag`, `serializeState` and `restoreState`, so a tag can be put in, written out, and read back. Three behaviour tests replace the three matches:

- a pinned tag survives the round trip with name, colour and pin intact
- `pinned` defaults to **false**, both when the field is absent and when the snapshot carries a truthy non-boolean. This is the one with consequences: `pinned` decides whether the tag creates a reusable session, so `"yes"` being read as a pin silently changes window behaviour for anyone with an older or hand-edited snapshot.
- a malformed tag (no name, empty name, no colour, a bare string) produces no tag rather than an empty chip the user can neither see nor remove

The third test is written against what the read side actually does: it installs a tag when the data is good and otherwise leaves things alone. Restore runs on a fresh window, so the starting point is no tag; the test says so rather than asserting a clear-on-invalid that is not there.

## Scope

The other three tests are unchanged and stay source-shape, for the reason each of them already is:

- `pub fn save_pinned_tag` / `remove_pinned_tag` in `window_runtime.rs` — a TS↔Rust name, invisible to both compilers
- the TitleBar chip, the pin control, and the Home-menu ordering — markup in a Svelte component this runner cannot import

## Tests

Relaxing `pinned: data.windowTag.pinned === true` to `!!data.windowTag.pinned` — the defect the old regex was pinning the operator against — turns the second test red and leaves the rest green. Ran it, then reverted.

## Verification

```
npm run check   # 674 files, 0 errors
npm test        # 951 pass, 0 fail
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)