### PR TITLE
refactor(editor): one source for the options both Monaco call sites apply

### DIFF
--- a/scripts/editorOptionWiring.test.ts
+++ b/scripts/editorOptionWiring.test.ts
@@ -13,6 +13,7 @@ import {
 } from 'monaco-editor/esm/vs/editor/common/services/unicodeTextModelHighlighter.js';
 import ts from 'typescript';
 
+import { editorOptionsFromSettings } from '../src/lib/utils/editorOptions.js';
 import { functionSource, readSource, sliceBetween } from './sourceTree.js';
 
 // Editor.svelte translates the settings store into Monaco options and
@@ -28,6 +29,19 @@ function count(source: string, pattern: RegExp): number {
 	return source.match(pattern)?.length ?? 0;
 }
 
+/** A settled settings store, so each test names only the field it is about. */
+const SETTINGS = {
+	minimap: false,
+	wordWrap: 'on',
+	editorMaxWidth: 80,
+	lineNumbers: 'on',
+	renderLineHighlight: 'line',
+	occurrencesHighlight: false,
+	editorFontSize: 14,
+	editorFont: 'Menlo',
+	showWhitespace: false,
+};
+
 test('renderLineHighlight is a Monaco string enum, not a boolean flag', () => {
 	// The store holds 'line' / 'none'. Any non-empty string is truthy, so a
 	// ternary on it can only ever produce "line" and silently defeats both the
@@ -36,43 +50,51 @@ test('renderLineHighlight is a Monaco string enum, not a boolean flag', () => {
 	assert.match(settingsStore, /this\.renderLineHighlight = this\.renderLineHighlight === 'line' \? 'none' : 'line'/);
 	assert.match(settingsStore, /this\.renderLineHighlight = 'none'/, 'zen mode sets the string to none');
 
-	assert.doesNotMatch(
-		editor,
-		/renderLineHighlight:\s*settings\.renderLineHighlight\s*\?/,
-		'renderLineHighlight must never be branched on as a boolean',
-	);
-	assert.doesNotMatch(
-		editor,
-		/renderLineHighlight:\s*settings\.renderLineHighlight\s*(?:===|!==)/,
-		'renderLineHighlight must not be re-derived from a comparison either',
-	);
-	assert.equal(
-		count(editor, /renderLineHighlight: settings\.renderLineHighlight as "line" \| "none"/g),
-		2,
-		'creation and updateOptions both forward the stored string unchanged',
-	);
+	// Both stored values have to survive the trip. A ternary passes for 'line'
+	// and fails for 'none', which is why one evaluation cannot judge this.
+	for (const stored of ['line', 'none'] as const) {
+		assert.equal(
+			editorOptionsFromSettings({ ...SETTINGS, renderLineHighlight: stored }, 100).renderLineHighlight,
+			stored,
+			`the stored string ${stored} is forwarded unchanged`,
+		);
+		assert.equal(
+			(createdEditorOptions({ renderLineHighlight: stored }) as { renderLineHighlight?: string })
+				.renderLineHighlight,
+			stored,
+			`and reaches the created editor as ${stored}`,
+		);
+	}
 });
 
 test('editor options are applied by a single updateOptions effect', () => {
 	// Two competing effects (one nested in onMount, one top level) wrote the
 	// same Monaco options with different values — notably fontSize with and
 	// without the zoom factor — so the winner depended on effect ordering.
-	assert.equal(count(editor, /editor\.updateOptions\(\{/g), 1, 'exactly one updateOptions call site');
+	assert.equal(count(editor, /editor\.updateOptions\(/g), 1, 'exactly one updateOptions call site');
 
-	const block = sliceBetween(editor, 'editor.updateOptions({', '});');
-	assert.match(block, /wordWrapColumn: settings\.editorMaxWidth/, 'wordWrapColumn survived the merge');
-	assert.match(block, /fontSize: settings\.editorFontSize \* \(zoomLevel \/ 100\)/, 'zoom-aware font size is the surviving one');
-	for (const option of [
-		'minimap',
-		'wordWrap:',
-		'lineNumbers',
-		'renderLineHighlight',
-		'occurrencesHighlight',
-		'fontFamily',
-		'renderWhitespace',
-	]) {
-		assert.ok(block.includes(option), `merged effect still applies ${option}`);
-	}
+	// What that one call applies, evaluated rather than read: every option the
+	// two effects used to fight over, and the zoom-aware font size that was the
+	// value they disagreed on.
+	const applied = editorOptionsFromSettings({ ...SETTINGS, editorFontSize: 20, editorMaxWidth: 90 }, 150);
+	assert.equal(applied.fontSize, 30, 'the surviving font size carries the zoom factor');
+	assert.equal(applied.wordWrapColumn, 90, 'wordWrapColumn survived the merge');
+	assert.deepEqual(
+		Object.keys(applied).sort(),
+		[
+			'fontFamily',
+			'fontSize',
+			'lineNumbers',
+			'minimap',
+			'occurrencesHighlight',
+			'renderLineHighlight',
+			'renderWhitespace',
+			'selectionHighlight',
+			'wordWrap',
+			'wordWrapColumn',
+		],
+		'and the set is exactly the options both call sites share',
+	);
 });
 
 test('tab cycling avoids Cmd+Tab, which macOS never delivers to the app', () => {
@@ -181,10 +203,13 @@ test('Show Whitespace renders every whitespace run, not just trailing', () => {
 	// "显示空白"), so "trailing" left interior spaces unmarked.
 	assert.doesNotMatch(editor, /renderWhitespace: settings\.showWhitespace \? "trailing"/);
 	assert.doesNotMatch(editor, /"trailing"/, 'no trailing-only whitespace rendering remains');
+	assert.equal(editorOptionsFromSettings({ ...SETTINGS, showWhitespace: true }, 100).renderWhitespace, 'all');
+	assert.equal(editorOptionsFromSettings({ ...SETTINGS, showWhitespace: false }, 100).renderWhitespace, 'none');
+	// Both call sites read the same function now, so agreeing is structural
+	// rather than something a count has to police.
 	assert.equal(
-		count(editor, /renderWhitespace: settings\.showWhitespace \? "all" : "none"/g),
-		2,
-		'creation and updateOptions agree on "all"',
+		(createdEditorOptions({ showWhitespace: true }) as { renderWhitespace?: string }).renderWhitespace,
+		'all',
 	);
 });
 
@@ -242,7 +267,10 @@ function optionsPassedTo(callee: string, settings: Record<string, unknown> = {})
 		compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ESNext },
 	}).outputText;
 
-	// The literals close over six locals, stubbed rather than reconstructed.
+	// The literals close over six locals and one import, stubbed rather than
+	// reconstructed — except the import, which is the real function: the
+	// settings-derived options live there now, and stubbing them would leave
+	// the evaluated object missing exactly what these tests read.
 	// `documentOptions` is the spread that hands the editor the active tab's
 	// model (or `value`/`language` when there is no tab); an empty object is the
 	// right stub because nothing it can contain is an option this file asserts
@@ -254,13 +282,17 @@ function optionsPassedTo(callee: string, settings: Record<string, unknown> = {})
 		'getTheme',
 		'documentOptions',
 		'zoomLevel',
+		'editorOptionsFromSettings',
 		`return ${js};`,
-	)(settings, '', 'markdown', () => 'app-theme-dark', {}, 100) as Record<string, unknown>;
+	)(settings, '', 'markdown', () => 'app-theme-dark', {}, 100, editorOptionsFromSettings) as Record<
+		string,
+		unknown
+	>;
 }
 
 /** The options object Editor.svelte hands to `monaco.editor.create`, evaluated. */
-function createdEditorOptions(): Record<string, unknown> {
-	return optionsPassedTo('monaco.editor.create');
+function createdEditorOptions(settings: Record<string, unknown> = {}): Record<string, unknown> {
+	return optionsPassedTo('monaco.editor.create', { ...SETTINGS, ...settings });
 }
 
 /**

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -5,6 +5,7 @@
 	import { t, type LanguageCode } from '../utils/i18n.js';
 	import { MARKDOWN_LANGUAGE_ID, shouldLinkifyPastedUrl } from '../utils/pasteContext.js';
 	import { toggleLineMarker, type LineMarkerToolId } from '../utils/editorToolbar.js';
+	import { editorOptionsFromSettings } from '../utils/editorOptions.js';
 	import { getTabModel, lineEndingLabel, tabModelUri } from '../utils/tabModels.js';
 	import { installVimScrollCommands } from '../utils/vimScrollCommands.js';
 	import {
@@ -337,38 +338,15 @@
 			theme: getTheme(),
 			dragAndDrop: true,
 			automaticLayout: true,
-			minimap: { enabled: settings.minimap },
+			// The settings-derived options, shared with the updateOptions
+			// effect below. Zoom is 100 here and not `zoomLevel`: that is
+			// what this literal has always passed, and the effect re-applies
+			// the real factor on the tick after creation.
+			...editorOptionsFromSettings(settings, 100),
 			scrollBeyondLastLine: true,
 			stickyScroll: { enabled: settings.stickyScroll },
 			smoothScrolling: true,
 			cursorSmoothCaretAnimation: 'on',
-			wordWrap: settings.wordWrap as
-				| "on"
-				| "off"
-				| "wordWrapColumn"
-				| "bounded",
-			wordWrapColumn: settings.editorMaxWidth,
-			lineNumbers: settings.lineNumbers as
-				| "on"
-				| "off"
-				| "relative"
-				| "interval",
-			renderLineHighlight: settings.renderLineHighlight as "line" | "none",
-			occurrencesHighlight: settings.occurrencesHighlight
-				? "singleFile"
-				: "off",
-			// The other half of "Highlight Occurrences". Monaco splits the
-			// feature across two options, and `SelectionHighlighter` gates
-			// itself on `selectionHighlight` — it reads `occurrencesHighlight`
-			// only to choose which decoration style to draw with. Left unset,
-			// `selectionHighlight` defaults to true, so with the setting off —
-			// which is its default — selecting a word still highlighted every
-			// other copy of it, from a switch the app never exposed. Same shape
-			// as the defects #369 fixed: a setting that does not control the
-			// thing its label names.
-			selectionHighlight: settings.occurrencesHighlight,
-			fontSize: settings.editorFontSize,
-			fontFamily: settings.editorFont,
 			wordBasedSuggestions: "off",
 			quickSuggestions: false,
 			// Monaco's Unicode highlighter is built for source code, where a
@@ -474,7 +452,6 @@
 			// for LINE_SEPARATOR and PARAGRAPH_SEPARATOR unconditionally, so
 			// they stay as visible as they ever were. Only the dialog goes.
 			unusualLineTerminators: "off",
-			renderWhitespace: settings.showWhitespace ? "all" : "none",
 			padding: { top: 20 },
 			scrollbar: {
 				vertical: "visible",
@@ -1684,28 +1661,7 @@
 
 	$effect(() => {
 		if (editorReady && editor) {
-			editor.updateOptions({
-				minimap: { enabled: settings.minimap },
-				wordWrap: settings.wordWrap as
-					| "on"
-					| "off"
-					| "wordWrapColumn"
-					| "bounded",
-				wordWrapColumn: settings.editorMaxWidth,
-				lineNumbers: settings.lineNumbers as
-					| "on"
-					| "off"
-					| "relative"
-					| "interval",
-				renderLineHighlight: settings.renderLineHighlight as "line" | "none",
-				occurrencesHighlight: settings.occurrencesHighlight
-					? "singleFile"
-					: "off",
-				selectionHighlight: settings.occurrencesHighlight,
-				fontSize: settings.editorFontSize * (zoomLevel / 100),
-				fontFamily: settings.editorFont,
-				renderWhitespace: settings.showWhitespace ? "all" : "none",
-			});
+			editor.updateOptions(editorOptionsFromSettings(settings, zoomLevel));
 		}
 	});
 

--- a/src/lib/utils/editorOptions.ts
+++ b/src/lib/utils/editorOptions.ts
@@ -1,0 +1,62 @@
+import type { editor as MonacoEditor } from "monaco-editor";
+
+/**
+ * The Monaco options derived from the settings store, in one place.
+ *
+ * These ten were written twice: once in the `monaco.editor.create()` literal
+ * and once in the `updateOptions` effect that re-applies them when a setting
+ * changes. Both copies had to agree, and nothing made them — the divergence
+ * that actually happened was `fontSize`, carrying the zoom factor in one copy
+ * and not the other. `editorOptionWiring.test.ts` had an assertion whose whole
+ * job was to count one expression and require the count to be 2, which is what
+ * policing a duplicate looks like when the duplicate is not removable.
+ *
+ * The rest of the creation literal stays where it is: those options are set
+ * once and never re-applied, so they are not duplicated and moving them here
+ * would only put distance between an option and the paragraph explaining it.
+ *
+ * `zoomPercent` is a parameter rather than another settings field because the
+ * two call sites genuinely pass different things — see the note at the
+ * creation site.
+ */
+export function editorOptionsFromSettings(
+	settings: EditorOptionSettings,
+	zoomPercent: number,
+): MonacoEditor.IEditorOptions {
+	return {
+		minimap: { enabled: settings.minimap },
+		wordWrap: settings.wordWrap as "on" | "off" | "wordWrapColumn" | "bounded",
+		wordWrapColumn: settings.editorMaxWidth,
+		lineNumbers: settings.lineNumbers as "on" | "off" | "relative" | "interval",
+		// A Monaco string enum, not a flag. Any non-empty string is truthy, so
+		// a ternary on it can only ever produce "line" — which defeats both the
+		// line-highlight toggle and Zen mode, whose whole effect is 'none'.
+		renderLineHighlight: settings.renderLineHighlight as "line" | "none",
+		occurrencesHighlight: settings.occurrencesHighlight ? "singleFile" : "off",
+		// The other half of "Highlight Occurrences". Monaco splits the feature
+		// across two options, and `SelectionHighlighter` gates itself on
+		// `selectionHighlight` — it reads `occurrencesHighlight` only to choose
+		// which decoration style to draw with. Left unset, `selectionHighlight`
+		// defaults to true, so with the setting off — its default — selecting a
+		// word still highlighted every other copy of it, from a switch the app
+		// never exposed. Same shape as the defects #369 fixed: a setting that
+		// does not control the thing its label names.
+		selectionHighlight: settings.occurrencesHighlight,
+		fontSize: settings.editorFontSize * (zoomPercent / 100),
+		fontFamily: settings.editorFont,
+		renderWhitespace: settings.showWhitespace ? "all" : "none",
+	};
+}
+
+/** The slice of the settings store the options above are derived from. */
+export type EditorOptionSettings = {
+	minimap: boolean;
+	wordWrap: string;
+	editorMaxWidth: number;
+	lineNumbers: string;
+	renderLineHighlight: string;
+	occurrencesHighlight: boolean;
+	editorFontSize: number;
+	editorFont: string;
+	showWhitespace: boolean;
+};


### PR DESCRIPTION
## What this is

The first C2 slice — the ones that need a source change before the behaviour can be tested. `Editor.svelte` loses 51 lines, gains 7, and a 60-line module appears.

## Mechanism

Ten settings-derived options were written twice: in the `monaco.editor.create` literal, and in the `updateOptions` effect that re-applies them when a setting changes. Nothing made the copies agree. The divergence that actually happened is recorded in this test file's own comment:

> Two competing effects (one nested in onMount, one top level) wrote the same Monaco options with different values — **notably fontSize with and without the zoom factor** — so the winner depended on effect ordering.

That is the shape of defect a duplicated literal produces, and the suite's answer to it was to count occurrences:

```js
assert.equal(count(editor, /renderLineHighlight: settings\.renderLineHighlight as "line" \| "none"/g), 2,
  'creation and updateOptions both forward the stored string unchanged');
assert.equal(count(editor, /renderWhitespace: settings\.showWhitespace \? "all" : "none"/g), 2,
  'creation and updateOptions agree on "all"');
```

Two assertions whose entire job is to require that a duplicate stays character-identical. They work, and they are what policing an un-removable duplicate looks like.

`editorOptionsFromSettings(settings, zoomPercent)` removes the duplicate, so there is nothing left to police. Both assertions are replaced by calls to the function **with each stored value** — `'line'` and `'none'`, `true` and `false`. That is the pair the count could never check: a ternary on `renderLineHighlight` passes for `'line'` and silently defeats Zen mode, and the old assertion would have gone green on it as long as the wrong expression appeared twice.

### The harness got stronger too

`optionsPassedTo` parses `Editor.svelte` with the TypeScript compiler, lifts the options literal out of the real `create` call, evaluates it with stubbed locals, and pushes the result through Monaco's own `applyUpdate` and `UnicodeTextModelHighlighter`. It now gets the real `editorOptionsFromSettings` in scope rather than a stub, so the object it evaluates is the fully merged one. The eighteen Monaco-executed tests below are unchanged and now run against the options the app actually passes.

## Scope

- **Behaviour is unchanged, including one oddity that is preserved rather than fixed:** the creation site passes zoom `100`, not `zoomLevel`. That is what the literal has always passed, and the effect re-applies the real factor on the following tick. It is now visible in one line instead of implicit across two literals. Worth deciding on separately; changing it inside a refactor would hide a behaviour change in a diff labelled "no behaviour change".
- The rest of the creation literal stays in `Editor.svelte`. Those options are set once and never re-applied, so they were never duplicated, and moving them would only put distance between an option and the long comment explaining why it is set that way.
- `Editor.svelte`'s keybinding assertions, the osType check and the Ctrl+S registration are untouched; they are about the component, not the options.

## Tests

Three defects introduced one at a time, each reverted after:

| defect | red |
|---|---|
| `renderLineHighlight: settings.renderLineHighlight ? "line" : "none"` | `renderLineHighlight is a Monaco string enum` |
| `fontSize: settings.editorFontSize` (zoom factor dropped) | `editor options are applied by a single updateOptions effect` |
| `renderWhitespace: … ? "trailing" : "none"` | `Show Whitespace renders every whitespace run` |

One test each, and the right one.

Also worth stating: the extraction itself, before the tests were updated, turned **10 tests red** while changing no behaviour whatsoever. Three were the counts above; seven were the Monaco-executed ones failing because the evaluated literal no longer resolved. That is the false-red cost of source-shape assertions, measured on a real refactor.

## Verification

```
npm run check   # 674 files, 0 errors
npm test        # 950 pass, 0 fail
```

Not verified in a running editor: this is a pure extraction with no reachable behaviour difference, but the app was not launched. `npm test` covers the option values; it does not cover Monaco actually receiving them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)