### PR TITLE
ci: cache cargo output and stop redundant runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,6 +177,24 @@ jobs:
         with:
           targets: ${{ matrix.rust_target }}
 
+      # Release builds compile the same dependency graph the test workflows
+      # do, from scratch, on four runners. The measurement that motivated
+      # caching is in test.yml: 7m57s of a 12m14s job was the release compile
+      # alone.
+      #
+      # `workspaces` names the cargo workspace root; without it the action
+      # looks for Cargo.lock at the repository root and caches nothing.
+      #
+      # `key` is not optional here. The automatic key covers the job id, the
+      # rustc release/host and a hash of the Cargo files -- and the two
+      # windows-latest entries share all three, differing only in `arch`. The
+      # ARM64 job would otherwise restore the x64 job's target directory.
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          key: ${{ matrix.os }}-${{ matrix.arch }}
+
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-24.04'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,24 @@ on:
     branches:
       - master
 
+# A pull request branch gets pushed to repeatedly, and every push queued
+# another full run of this suite while the previous revision was still being
+# tested. Only the newest revision of a branch is worth testing -- the same
+# reasoning test_build.yml already applies to its platform matrix.
+#
+# `github.ref` is `refs/pull/<n>/merge` under the pull_request trigger and
+# `refs/heads/master` under the push trigger, so the two triggers land in
+# different groups and neither can cancel the other.
+#
+# Cancellation is restricted to pull requests. The push trigger exists because
+# a commit can reach master without ever having been a pull request (see the
+# comment above it); cancelling a master run because a second commit landed
+# would leave the first one untested, which is the exact hole that trigger was
+# added to close.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-22.04
@@ -26,6 +44,25 @@ jobs:
 
       - name: install rust stable
         uses: dtolnay/rust-toolchain@stable
+
+      # Nothing in this repository cached cargo output, so every job compiled
+      # the whole dependency graph from scratch. Measured on the Linux
+      # `build-test` job of run 31382758646: `cargo test` took 2m31s and the
+      # release `Build app` 7m57s out of 12m14s -- 86% of the job was Rust
+      # compilation, none of it reused.
+      #
+      # `src-tauri` is the cargo workspace root. Without naming it the action
+      # looks for Cargo.lock at the repository root, finds none and caches
+      # nothing.
+      #
+      # This job is also what makes the cache reach anything: a pull request
+      # can only restore caches written on its own branch or on the base
+      # branch, and of the three workflows only this one runs on push to
+      # master. Its master runs are what seed a freshly opened branch.
+      - name: cache rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
 
       - name: install dependencies (ubuntu only)
         run: |

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -3,7 +3,30 @@ name: Test Build (No Release)
 on:
   # Keep release packaging changes from reaching a draft release without a
   # platform build check.
+  #
+  # Documentation cannot change what these three platforms compile. No
+  # Markdown file is bundled as a resource -- `tauri.conf.json` has no
+  # `resources` key -- and the frontend suites that do read `samples/*.md` as
+  # fixtures still run on every pull request through test.yml, which carries
+  # no path filter. A documentation-only pull request was therefore spending
+  # three full platform builds, 12m14s on Linux alone, to prove nothing.
+  #
+  # This is only safe while `build-test` is not a required status check: a job
+  # that never starts stays pending forever against a required check, and the
+  # pull request can then never be merged. Checked when this was written --
+  # master's protection reports no required contexts, and `gh pr checks
+  # --required` reports none on the open pull requests. Whoever makes it
+  # required has to delete this filter in the same change.
+  #
+  # `samples/**` is deliberately absent. It holds only `.md` files today, so
+  # `**.md` already covers it, and `npm test` reads `samples/stress-test.md`
+  # as a fixture; naming the directory would drop a future non-Markdown
+  # fixture out of the matrix without anyone noticing.
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'pics/**'
+      - '.github/ISSUE_TEMPLATE/**'
   workflow_dispatch:
 
 # Every push to a pull request queued another full matrix while the previous
@@ -51,6 +74,31 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      # This is the job the 12m14s measurement in test.yml came from: 2m31s of
+      # it was the debug compile behind `cargo test` and 7m57s the release
+      # compile behind `Build app`, all of it from scratch on every run.
+      #
+      # `workspaces` names the cargo workspace root; the action finds no
+      # Cargo.lock without it.
+      #
+      # The automatic key covers the job id, the rustc release/host and a hash
+      # of the Cargo files. All three entries share the job id `build-test`,
+      # which leaves the rustc host as the only thing telling them apart, and
+      # the target list this matrix varies does not appear in the key at all.
+      # `key` makes the cache say which matrix entry wrote it rather than
+      # leaning on that coincidence.
+      #
+      # Note what this cannot do on its own: this workflow has no push
+      # trigger, so its caches are only ever written on pull request branches
+      # and a branch can only restore its own or the base branch's. The first
+      # run of a new pull request will still be a cold compile; later pushes
+      # to the same branch are the ones that hit.
+      - name: cache rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          key: ${{ matrix.os-name }}
 
       - name: install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-22.04'


### PR DESCRIPTION
## What the measurement said

The Linux `build-test` job of run [31382758646](https://github.com/sftwrdotdev/Markpad/actions/runs/31382758646) took **12m14s**:

| step | time |
|---|---|
| `run cargo test` (debug compile) | 2m31s |
| `Build app` (release compile) | 7m57s |
| everything else | 1m46s |

86% of the job is Rust compilation. No workflow in this repository cached any cargo output, so every run recompiled the whole dependency graph from scratch, on every runner.

## What this changes

**1. `Swatinem/rust-cache@v2` in all three workflows**, after the toolchain install, pointed at `workspaces: src-tauri` — that is the cargo workspace root, and without naming it the action looks for `Cargo.lock` at the repository root and caches nothing.

The action's automatic key covers the job id, the rustc release/host and a hash of the Cargo files. That is not enough for either matrix, so both get an explicit `key`:

- **test_build.yml** — all three entries share the job id `build-test`, leaving the rustc host as the only discriminator, and the target list the matrix varies never enters the key. Keyed on `matrix.os-name`.
- **build.yml** — the two `windows-latest` entries share the job id *and* the rustc host, differing only in `arch`. Without a key the ARM64 job would restore the x64 job's target directory. Keyed on `matrix.os`-`matrix.arch`.

**2. `concurrency` with `cancel-in-progress` in test.yml**, the shape test_build.yml already has. Grouped on `github.ref`, which is `refs/pull/<n>/merge` under the pull_request trigger and `refs/heads/master` under the push trigger, so the two can never cancel each other.

One deliberate deviation from a plain `cancel-in-progress: true`: it is `${{ github.event_name == 'pull_request' }}`. The push trigger exists precisely so that a commit reaching master without ever having been a pull request is still tested — the comment above it says so. Cancelling one master run because a second commit landed would leave the first commit untested, putting that hole straight back. Pull request branches, which are where the redundant runs actually pile up, cancel as normal.

**3. `paths-ignore` on test_build.yml's pull_request trigger** — `**.md`, `pics/**`, `.github/ISSUE_TEMPLATE/**`.

I did make this change, because I could confirm it is safe. Two independent checks, both at time of writing:

- `repos/sftwrdotdev/Markpad/branches/master` reports `protected: true` with `required_status_checks.contexts: []` and `checks: []`.
- `gh pr checks --required` reports "no required checks" on both open pull requests (#560, #566).

So `build-test` is not a required status check, and a pull request whose paths are all ignored is not left waiting on a job that never starts. **If `build-test` is ever made required, this filter has to go in the same change** — the reasoning is written into the workflow so that cannot happen quietly.

Why it is safe on the merits: no Markdown file is bundled as a resource (`tauri.conf.json` has no `resources` key), so documentation cannot change what the three platforms compile. The frontend suites that read `samples/*.md` as fixtures still run on every pull request through **test.yml**, which has no path filter — that job also has to keep running because `releaseWorkflow.test.ts` asserts on `README.md`, `RELEASING.md` and the workflow files themselves, so a docs-only pull request can genuinely break it.

`samples/**` is deliberately **not** in the list, though it was on the table. It holds only `.md` files today, so `**.md` already covers it; naming the directory would additionally drop a future non-Markdown fixture out of the matrix without anyone noticing.

## What I cannot promise

- **The speedup depends on the cache hit rate**, which cannot be known before the caches exist. Treat the numbers above as what is being *attacked*, not as what will be saved. The next pull request is what measures it.
- **test_build.yml's cache is the weaker one.** A branch can only restore caches written on itself or on the base branch, and this workflow has no push trigger — its caches are only ever written on pull request branches. So the *first* run of a new pull request is still a cold compile; later pushes to the same branch are the ones that hit. Only test.yml runs on push to master, which is what seeds a fresh branch at all. Giving test_build.yml a master trigger, or a `shared-key` with test.yml, would change that — both have costs and are a call for you, not for this pull request.
- **The per-repository cache limit is 10 GB, and this may strain it.** Three platforms × two profiles (debug for `cargo test`, release for `Build app`) in test_build.yml, plus four more entries in build.yml. Eviction is least-recently-used, so the rarely-run release caches from build.yml could plausibly push out the pull-request caches that actually matter. If that shows up, dropping rust-cache from build.yml is the first thing to try — it is a `workflow_dispatch`-only workflow and does nothing for pull request latency.

## Not done

`build.yml` still has no `cache: npm` on its `setup-node` steps, unlike the two test workflows. Left alone: it is release-only, so it does not affect pull request time, and it is outside what was measured.

## Testing

- `npm test` — 960 pass, 0 fail. (`releaseWorkflow.test.ts` reads all three of these files as text; nothing it asserts on was touched.)
- `npm run check` — 674 files, 0 errors, 0 warnings.
- All three workflows re-parsed as YAML to confirm `paths-ignore` and `concurrency` sit where intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
