### PR TITLE
chore: remove an unused import and a command attribute nothing could reach

### DIFF
--- a/scripts/tauriCommandRegistration.test.ts
+++ b/scripts/tauriCommandRegistration.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readSource, sliceBetween } from './sourceTree.js';
+
+const RUST_SOURCES = [
+	'src-tauri/src/lib.rs',
+	'src-tauri/src/window_runtime.rs',
+	'src-tauri/src/tab_transfer.rs',
+	'src-tauri/src/asset_protocol.rs',
+	'src-tauri/src/error.rs',
+	'src-tauri/src/main.rs',
+];
+
+/** Every `#[tauri::command]` function name in the Rust sources. */
+function declaredCommands(): { name: string; file: string }[] {
+	const out: { name: string; file: string }[] = [];
+	for (const file of RUST_SOURCES) {
+		const text = readSource(file);
+		// The attribute, any further attributes stacked under it, then the fn.
+		for (const m of text.matchAll(
+			/#\[tauri::command\][^\n]*\n(?:\s*#\[[^\]]*\]\s*\n)*\s*(?:pub\s+)?(?:async\s+)?fn\s+(\w+)/g,
+		)) {
+			out.push({ name: m[1], file });
+		}
+	}
+	return out;
+}
+
+/** Every name inside `generate_handler![…]`, module path stripped. */
+function registeredCommands(): Set<string> {
+	// `sliceBetween` keeps its start anchor, so the first comma-separated entry
+	// would otherwise be `generate_handler![\n  clipboard_write_text`.
+	const handler = sliceBetween(readSource('src-tauri/src/lib.rs'), 'generate_handler![', '])').replace(
+		'generate_handler![',
+		'',
+	);
+	return new Set(
+		handler
+			.split(',')
+			.map((entry) => entry.trim().split('::').pop() ?? '')
+			.filter(Boolean),
+	);
+}
+
+test('every #[tauri::command] is reachable from the frontend', () => {
+	// A Tauri command is addressed by a string. Nothing in either type system
+	// connects `invoke('render_markdown')` to the Rust function, and nothing
+	// connects the function to `generate_handler!` either — so an attribute can
+	// sit on a function the app can never call, and the compiler is content.
+	//
+	// `convert_markdown` carried one for as long as it existed. It was never
+	// registered, so no `invoke` could ever have reached it; it is the internal
+	// renderer that `render_markdown` and `build_markdown_preview` call. The
+	// attribute claimed an exposure the app did not have, and the only reason
+	// that was ever discovered was someone reading the two lists side by side.
+	const registered = registeredCommands();
+	const unreachable = declaredCommands().filter(({ name }) => !registered.has(name));
+	assert.deepEqual(
+		unreachable,
+		[],
+		`these functions are marked #[tauri::command] but are not in generate_handler!, so no invoke() can reach them: ${unreachable
+			.map(({ name, file }) => `${name} (${file})`)
+			.join(', ')}`,
+	);
+});
+
+test('generate_handler! names nothing that does not exist', () => {
+	// The other direction fails at compile time rather than silently, so this
+	// is a cheaper assertion than the one above — but it also catches a
+	// registration left behind after its function was renamed, which reads as a
+	// working command right up until the build.
+	const declared = new Set(declaredCommands().map(({ name }) => name));
+	const orphaned = [...registeredCommands()].filter((name) => !declared.has(name));
+	assert.deepEqual(orphaned, [], `registered but not declared as a command: ${orphaned.join(', ')}`);
+});

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tauri::{AppHandle, Emitter, Manager, State};
+use tauri::{AppHandle, Emitter, Manager};
 
 /// `![[target]]` / `![[target|size]]`. Deliberately NOT `(?s)`: `.` must not
 /// match a newline, so the pattern cannot pair a lone `![[` in prose with the
@@ -1756,7 +1756,13 @@ fn escape_html_text(text: &str) -> String {
 /// line N. The contract, the rationale and the tests that enforce it live in
 /// `mod tests` under "The line-number contract of `convert_markdown`" —
 /// a new step here must also be registered in `line_preserving_transforms()`.
-#[tauri::command]
+///
+/// Not a Tauri command, despite having carried `#[tauri::command]` until the
+/// attribute was removed. It was never in `generate_handler!`, so no frontend
+/// could ever invoke it — the registered entry point is `render_markdown`, and
+/// this is what that and `build_markdown_preview` call underneath. A command
+/// name is a string with no compiler behind it, so an attribute that claims an
+/// exposure the app does not have is a claim nothing was ever going to check.
 fn convert_markdown(content: &str) -> String {
     // The buffer this command was called with, captured before anything runs
     // and never rebound. What `annotate_task_checkboxes` is handed at the end


### PR DESCRIPTION
Two dead things, one of which was lying rather than merely unused. Also the first pull request that can read the cargo caches #574 seeded, so the numbers below are worth watching.

## `State`

Unused in `lib.rs` for long enough that a doc comment refers to it in the past tense. It was the only warning `cargo check` produced; the build is now clean.

## `convert_markdown` claimed to be a Tauri command

It carried `#[tauri::command]` while never appearing in `generate_handler!`.

The function is not dead — it is the renderer that `render_markdown` and `build_markdown_preview` call underneath. What was dead was the attribute: **no `invoke` could ever have reached it, and nothing would have said so.** A command name is a string with no compiler behind it in either direction, so an attribute claiming an exposure the app does not have compiles happily and reads as live code forever.

So the attribute goes, and a test holds both directions of the list instead:

```
51 declared #[tauri::command]
50 in generate_handler!
 1 that did not match ← the reason this was found at all
```

It was found by reading the two lists side by side, which is exactly the work a test should be doing rather than a person.

## Swept and deliberately left alone

19 exported types in `src/lib` that no other file imports — `TocSide`, `PdfExportContext`, `HeadingReference` and so on. Every one is used inside its own file, so they are over-exported rather than dead. Removing `export` from a type that is already correct is churn with review cost and no benefit.

No other Rust warnings across `--all-targets`, and no unregistered commands beyond the one above.

## Verification

| | |
|---|---|
| `cargo check --all-targets` | clean, zero warnings |
| `npm test` | 967 pass |
| `npm run check` | 677 files, 0 errors |
| mutation: restore the attribute | first assertion fails, second passes |

## Incidentally: the cache measurement

#574 seeded four cargo caches on master (4.45 GB of a 10 GB budget) with a cold run that took **Linux 12m49s, Windows 16m03s, macOS 17m30s**. This is the first pull request that can restore them.

The comparison to make is against 12m14s — the Linux baseline #572 was written from, and the number that had not moved at all before this. #574 says so explicitly: if it has not moved meaningfully now, the honest response is to revert the caching rather than keep it as decoration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)