### PR TITLE
refactor(close): make the unsaved-tab review a function that can be run

### DIFF
--- a/scripts/viewModeWithoutSaving.test.ts
+++ b/scripts/viewModeWithoutSaving.test.ts
@@ -433,7 +433,7 @@ test('closing the window still reviews unsaved tabs', () => {
 	assert.match(exit, /if \(\w+ !== 'discard'\) return;/, "an answer other than 'discard' stops the exit");
 
 	const closeHandler = sliceBetween(viewer, 'appWindow.onCloseRequested', 'onDragDropEvent');
-	assert.match(closeHandler, /await canCloseTab\(dirty\.id\)/);
+	assert.match(closeHandler, /canCloseTab,\n/, 'the walk still runs the per-tab dialog');
 });
 
 test('the view toggles no longer re-read the file to leave an editable pane', () => {

--- a/scripts/windowClosePerTab.test.ts
+++ b/scripts/windowClosePerTab.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
 import test from 'node:test';
 
+import { reviewDirtyTabs, type ReviewTab } from '../src/lib/sessions/closeReview.js';
 import { offsetOf, readSource, sliceBetween, sliceFrom } from './sourceTree.js';
 
 const viewer = readSource('src/lib/MarkdownViewer.svelte');
@@ -18,6 +19,35 @@ function closeHandler(): string {
 	return sliceBetween(viewer, 'appWindow.onCloseRequested', 'onDragDropEvent');
 }
 
+/**
+ * A window of tabs the walk can be run against, with every collaborator
+ * recorded. `answers` is what the dialog returns for each tab it is shown, in
+ * order; anything not listed is a save.
+ */
+function window_(paths: string[], answers: Record<string, boolean> = {}) {
+	const tabs = paths.map((path, i) => ({ id: `t${i}`, path, isDirty: true }));
+	const log: string[] = [];
+	const review = {
+		nextDirtyTab: () => tabs.find((t) => t.isDirty) as ReviewTab | undefined,
+		setActive: (id: string) => void log.push(`active:${id}`),
+		settle: async () => {},
+		canCloseTab: async (id: string) => {
+			log.push(`ask:${id}`);
+			const answer = answers[id] ?? true;
+			// Saving resolves the tab; cancelling leaves it as it was.
+			if (answer) tabs.find((t) => t.id === id)!.isDirty = false;
+			return answer;
+		},
+		closeTab: (id: string) => {
+			log.push(`close:${id}`);
+			const at = tabs.findIndex((t) => t.id === id);
+			if (at !== -1) tabs.splice(at, 1);
+		},
+		shouldCloseAfterResolving: (_tab: ReviewTab) => true,
+	};
+	return { tabs, log, review };
+}
+
 test('the aggregate unsaved-files modal is gone from the close handler', () => {
 	const handler = closeHandler();
 	assert.doesNotMatch(handler, /youHaveUnsavedFiles/);
@@ -29,34 +59,82 @@ test('the aggregate unsaved-files modal is gone from the close handler', () => {
 	assert.doesNotMatch(handler, /\.isDirty\s*=\s*false/);
 });
 
-test('dirty tabs are reviewed one at a time through the existing canCloseTab flow', () => {
-	const handler = closeHandler();
-	// activate the tab under review so the user sees what the dialog is about
-	assert.match(handler, /tabManager\.setActive\(dirty\.id\);/);
-	// the existing localized per-tab dialog decides save / discard / cancel
-	assert.match(handler, /await canCloseTab\(dirty\.id\)/);
-	// a resolved tab actually closes before moving on
-	assert.match(handler, /tabManager\.closeTab\(dirty\.id\);/);
+test('every dirty tab is activated, asked about, and then closed, one at a time', async () => {
+	const { log, review } = window_(['/a.md', '/b.md']);
+
+	assert.equal(await reviewDirtyTabs(review), true, 'the walk completes');
+	assert.deepEqual(log, ['active:t0', 'ask:t0', 'close:t0', 'active:t1', 'ask:t1', 'close:t1']);
 });
 
-test('cancelling the per-tab dialog stops the walk and keeps the window open', () => {
-	const handler = closeHandler();
-	assert.match(handler, /if \(!\(await canCloseTab\(dirty\.id\)\)\) return;/);
+test('the tab is activated before it is asked about', async () => {
+	// The dialog names one document. A reader looking at a different one
+	// cannot tell which file they are being asked to save.
+	const { log, review } = window_(['/a.md']);
+	await reviewDirtyTabs(review);
+
+	assert.ok(log.indexOf('active:t0') < log.indexOf('ask:t0'));
 });
 
-test('the close is prevented synchronously before the per-tab walk', () => {
+test('cancelling stops the walk, and the tabs after it are never touched', async () => {
+	const { tabs, log, review } = window_(['/a.md', '/b.md', '/c.md'], { t1: false });
+
+	assert.equal(await reviewDirtyTabs(review), false, 'the caller is told to keep the window open');
+	assert.deepEqual(log, ['active:t0', 'ask:t0', 'close:t0', 'active:t1', 'ask:t1']);
+	assert.deepEqual(tabs.map((t) => t.path), ['/b.md', '/c.md'], 'the unreviewed tabs are still open');
+});
+
+test('a tab that becomes dirty again during the walk is reviewed again', async () => {
+	// The list is re-consulted every round rather than captured up front: a
+	// save can leave a tab dirty again, and tabs can be opened or closed while
+	// a dialog is up. A stale list walks past unsaved work.
+	const { tabs, review } = window_(['/a.md']);
+	let redirtied = false;
+	const once = review.canCloseTab;
+	review.canCloseTab = async (id: string) => {
+		const answer = await once(id);
+		if (!redirtied) {
+			redirtied = true;
+			tabs.push({ id: 'late', path: '/late.md', isDirty: true });
+		}
+		return answer;
+	};
+	review.shouldCloseAfterResolving = () => false;
+
+	await reviewDirtyTabs(review);
+
+	assert.deepEqual(tabs.filter((t) => t.isDirty), [], 'the tab that appeared mid-walk was reviewed too');
+});
+
+test('a resolved tab is kept open when the window state is about to be snapshotted', async () => {
+	const { tabs, log, review } = window_(['/a.md']);
+	review.shouldCloseAfterResolving = (tab: ReviewTab) => tab.path === '';
+
+	assert.equal(await reviewDirtyTabs(review), true);
+	assert.deepEqual(log, ['active:t0', 'ask:t0'], 'resolved, not closed');
+	assert.equal(tabs.length, 1);
+});
+
+test('the close is prevented synchronously before the walk starts', () => {
 	const handler = closeHandler();
 	const branchStart = offsetOf(handler, 'if (dirtyTabs.length > 0) {');
 	const prevent = offsetOf(handler, 'event.preventDefault()', branchStart);
-	const walk = offsetOf(handler, 'canCloseTab(dirty.id)', branchStart);
+	const walk = offsetOf(handler, 'reviewDirtyTabs({', branchStart);
 	assert.ok(prevent < walk, 'the close is prevented before the walk starts');
 });
 
 test('the window closes only after every dirty tab is resolved', () => {
 	const handler = closeHandler();
-	const walk = offsetOf(handler, 'canCloseTab(dirty.id)');
+	const walk = offsetOf(handler, 'reviewDirtyTabs({');
 	const close = offsetOf(handler, 'appWindow.close()', walk);
 	assert.ok(walk < close, 'the window closes after the walk, not during it');
+});
+
+test('a cancelled walk stops the handler before it persists or closes', () => {
+	const handler = closeHandler();
+	const walk = offsetOf(handler, 'reviewDirtyTabs({');
+	const bail = offsetOf(handler, 'if (!resolved) return;', walk);
+	assert.ok(bail < offsetOf(handler, 'persistWindowState()', walk), 'cancel returns before the snapshot');
+	assert.ok(bail < offsetOf(handler, 'appWindow.close()', walk), 'and before the close is re-triggered');
 });
 
 test('a second close request cannot start a competing walk', () => {
@@ -70,10 +148,11 @@ test('a second close request cannot start a competing walk', () => {
 });
 
 test('the walk proceeds in strict tab-strip order', () => {
+	// Which tab is next is the component's half of the walk: the order comes
+	// from the tab array, and an active-first shortcut made the sequence look
+	// random to the reader. The walking itself is covered above.
 	const handler = closeHandler();
-	// Predictable left-to-right order: always the first dirty tab in the
-	// array; no active-first shortcut that made the sequence look random.
-	assert.match(handler, /const dirty = tabManager\.tabs\.find\(\(t\) => t\.isDirty\);/);
+	assert.match(handler, /nextDirtyTab: \(\) => tabManager\.tabs\.find\(\(t\) => t\.isDirty\)/);
 	assert.doesNotMatch(handler, /active\?\.isDirty/);
 });
 

--- a/scripts/windowStateRestore.test.ts
+++ b/scripts/windowStateRestore.test.ts
@@ -148,7 +148,7 @@ test('the discard choice reverts the tab to its last saved content', () => {
 
 test('the close flow resolves dirty tabs before serializing window state', () => {
 	const handler = closeHandler();
-	const walk = offsetOf(handler, 'canCloseTab(dirty.id)');
+	const walk = offsetOf(handler, 'reviewDirtyTabs({');
 	const persist = offsetOf(handler, 'persistWindowState()');
 	assert.ok(walk < persist, 'dirty tabs must be resolved before the snapshot is written');
 });
@@ -205,13 +205,15 @@ test('exit discards the snapshot only once startup has finished', () => {
 
 test('with restore enabled resolved titled tabs stay open for the snapshot', () => {
 	const handler = closeHandler();
-	// tabs are closed one-by-one only when restore is off (or untitled)
-	assert.match(handler, /restoreStateOnReopen \|\| dirty\.path === ''/);
+	// tabs are closed one-by-one only when restore is off (or untitled).
+	// The walk itself is covered by windowClosePerTab, which runs it; what is
+	// asserted here is the policy the component hands it.
+	assert.match(handler, /!settings\.restoreStateOnReopen \|\| tab\.path === ''/);
 });
 
 test('auto-save fast path silently saves titled tabs before the walk', () => {
 	const handler = closeHandler();
 	const fastPath = offsetOf(handler, 'if (settings.autoSave) {');
-	const walk = offsetOf(handler, 'canCloseTab(dirty.id)');
+	const walk = offsetOf(handler, 'reviewDirtyTabs({');
 	assert.ok(fastPath < walk, 'the silent save runs before the per-tab walk');
 });

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -18,6 +18,7 @@
 	import Toc from './components/Toc.svelte';
 	import Toast from './components/Toast.svelte';
 	import FindBar from './components/FindBar.svelte';
+	import { reviewDirtyTabs } from './sessions/closeReview.js';
 	import { exportAsHtml as _exportHtml, exportAsPdf as _exportPdf } from './utils/export';
 	import { askToOpenExportedFile } from './utils/openExportedFile.js';
 	import { isHomePath } from './utils/homeTab.js';
@@ -3294,21 +3295,21 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 							// let the dialog name each tab. Re-find every round —
 							// a save can leave a tab dirty again (TOCTOU) and
 							// tabs can change while a dialog is up.
-							while (true) {
-								const dirty = tabManager.tabs.find((t) => t.isDirty);
-								if (!dirty) break;
-								tabManager.setActive(dirty.id);
-								await tick();
-								if (!(await canCloseTab(dirty.id))) return;
+							const resolved = await reviewDirtyTabs({
+								nextDirtyTab: () => tabManager.tabs.find((t) => t.isDirty),
+								setActive: (id) => tabManager.setActive(id),
+								settle: tick,
+								canCloseTab,
+								closeTab: (id) => tabManager.closeTab(id),
 								// Resolved tabs (saved, or reverted by Don't Save)
 								// stay open for the window-state snapshot when
 								// restore is enabled; untitled tabs have nothing to
 								// restore, and with restore off the red button
 								// closes tabs one by one.
-								if (!settings.restoreStateOnReopen || dirty.path === '') {
-									tabManager.closeTab(dirty.id);
-								}
-							}
+								shouldCloseAfterResolving: (tab) =>
+									!settings.restoreStateOnReopen || tab.path === '',
+							});
+							if (!resolved) return;
 						} finally {
 							isCloseWalkActive = false;
 						}

--- a/src/lib/sessions/closeReview.ts
+++ b/src/lib/sessions/closeReview.ts
@@ -1,0 +1,50 @@
+/** The fields the review needs from a tab. */
+export type ReviewTab = { id: string; path: string };
+
+export type CloseReview = {
+	/** The leftmost tab still holding unsaved changes, or undefined when none do. */
+	nextDirtyTab: () => ReviewTab | undefined;
+	setActive: (id: string) => void;
+	/** Let the activation paint before a modal covers it — `tick()` in the app. */
+	settle: () => Promise<void>;
+	/** The same per-tab unsaved-changes dialog a single tab close shows. */
+	canCloseTab: (id: string) => Promise<boolean>;
+	closeTab: (id: string) => void;
+	/** Whether a resolved tab is closed, or left open for the restore snapshot. */
+	shouldCloseAfterResolving: (tab: ReviewTab) => boolean;
+};
+
+/**
+ * Walk the dirty tabs one at a time, resolving each through the dialog the
+ * reader already knows (issue #189 — this replaced one aggregate "you have N
+ * unsaved files" modal).
+ *
+ * Returns false if the reader cancelled, which stops the walk and keeps the
+ * window open with the tabs that are left.
+ *
+ * `nextDirtyTab` is re-consulted every round rather than iterated over a list
+ * captured up front. A save can leave a tab dirty again, and tabs can be opened
+ * or closed while a dialog is up; a stale list would either skip a tab holding
+ * unsaved work or try to close one that is already gone.
+ *
+ * Extracted from `MarkdownViewer.svelte` so this can be run rather than
+ * described. What it replaced was `assert.match(handler, /if \(!\(await
+ * canCloseTab\(dirty\.id\)\)\) return;/)` — an assertion that the source
+ * contains a `return`, which is as close to "cancelling stops the walk" as
+ * matching text gets.
+ */
+export async function reviewDirtyTabs(review: CloseReview): Promise<boolean> {
+	while (true) {
+		const dirty = review.nextDirtyTab();
+		if (!dirty) return true;
+
+		// Activate first: the dialog names one tab, and a reader looking at a
+		// different document cannot tell which.
+		review.setActive(dirty.id);
+		await review.settle();
+
+		if (!(await review.canCloseTab(dirty.id))) return false;
+
+		if (review.shouldCloseAfterResolving(dirty)) review.closeTab(dirty.id);
+	}
+}


### PR DESCRIPTION
## What this is

The last C2 slice. `MarkdownViewer.svelte`'s window-close review moves into `sessions/closeReview.ts` so it can be run instead of matched.

## Mechanism

The review is the path that decides whether unsaved work survives a window close: walk the dirty tabs, activate each, show the same per-tab dialog a single tab close shows, stop if the reader cancels. It was a `while (true)` inside `onCloseRequested`, and the strongest thing the suite could say about it was:

```js
assert.match(handler, /if \(!\(await canCloseTab\(dirty\.id\)\)\) return;/);
```

That asserts the source contains a `return`. It is as close to "cancelling stops the walk" as matching text gets, and it says nothing about what happens to the tabs after the one that was cancelled.

`reviewDirtyTabs(review)` takes its collaborators as callbacks — the shape `createDocumentSession` already uses in this repo — and returns `false` when the reader cancels. Six behaviour tests replace three matches, and three of the six cover things no regex could reach:

- **the tab is activated before it is asked about.** The dialog names one document; a reader looking at a different one cannot tell which file they are being asked to save. Swapping those two lines is invisible to a text match and obvious to the test.
- **the tabs after a cancel are never touched.** Asserted as the recorded call log plus the surviving tab list, not as the presence of a `return`.
- **a tab that becomes dirty again mid-walk is reviewed again.** This is why the list is re-consulted every round rather than captured up front: a save can leave a tab dirty again, and tabs can be opened or closed while a dialog is up. A stale list walks straight past unsaved work. Nothing tested it before.

## Scope

The component keeps what is genuinely its own, and each of those still has its source-shape assertion:

- the `isCloseWalkActive` re-entrancy guard (the native red button is not blocked by the in-app overlay)
- the auto-save fast path that runs before the walk
- the restore-vs-close policy, passed in as `shouldCloseAfterResolving`
- `event.preventDefault()` before, `appWindow.close()` after

Behaviour is unchanged; this is a move plus a `return false` where a bare `return` used to leave the handler.

## Tests

| defect | red |
|---|---|
| cancel check dropped (`await canCloseTab(…)` with the result ignored) | `cancelling stops the walk…` |
| activation moved to after the dialog | 4 tests, including `the tab is activated before it is asked about` |

Both reverted after.

## The tax, measured again

Four assertions in three other files (`viewModeWithoutSaving`, `windowStateRestore` ×2, and one more here) anchored on the string `canCloseTab(dirty.id)` and had to be retargeted at `reviewDirtyTabs({`. **Nothing any of them claims changed.** That is the same false-red cost measured in #571, from a different direction: pinning a call site makes every file that mentions it a dependent of that spelling.

## Verification

```
npm run check   # 678 files, 0 errors
npm test        # 973 pass, 0 fail
```

Not verified in a running app: the walk is exercised against recorded callbacks, so what Tauri's `onCloseRequested` does with a prevented event is still taken on trust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)