### PR TITLE
fix(snap): stop using the rust plugin, and build snapcraft.yaml on pull requests

### DIFF
--- a/.github/workflows/test_snap.yml
+++ b/.github/workflows/test_snap.yml
@@ -1,0 +1,57 @@
+name: Test Snap Build (No Publish)
+
+# snapcraft.yaml is the only build in this repository that no pull request has
+# ever run. It is built from publish-packages.yml, which checks out a release
+# tag -- so a change to snapcraft.yaml is first executed after it has been
+# merged, tagged and published, and the release it breaks is the one users are
+# already being pointed at. That is exactly how #566's rust-deps fix reached
+# v2.7.3 as a failed publish.
+#
+# This packs the snap and stops. Nothing is uploaded to the release and nothing
+# is pushed to the Snap Store; that stays in publish-packages.yml behind a
+# release a human published. A green run here means `snapcraft pack` produced a
+# .snap, which is the half that has been failing.
+#
+# Path-filtered because it costs ~20 minutes and recompiles the whole app
+# inside LXD. `.github/workflows/test_snap.yml` is in the list so a change to
+# this file tests itself.
+
+on:
+  pull_request:
+    paths:
+      - snapcraft.yaml
+      - .github/workflows/test_snap.yml
+  workflow_dispatch:
+
+concurrency:
+  group: test-snap-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pack:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Snapcraft
+        run: |
+          set -euo pipefail
+          sudo snap install lxd
+          sudo lxd waitready
+          sudo lxd init --auto
+          sudo usermod -aG lxd "$USER"
+          sudo iptables -F FORWARD
+          sudo iptables -P FORWARD ACCEPT
+          sudo snap install snapcraft --classic
+          # The workflow installs whatever the store is serving today, and the
+          # 8.x -> 9.x bump between v2.6.11 and v2.6.12 is what broke the snap
+          # in the first place. Print it, so a future failure of that shape is
+          # one line away rather than a bisect.
+          snap list snapcraft
+
+      - name: Pack
+        run: |
+          set -euo pipefail
+          sg lxd -c 'snapcraft pack'
+          ls -la ./*.snap

--- a/scripts/releaseWorkflow.test.ts
+++ b/scripts/releaseWorkflow.test.ts
@@ -160,13 +160,20 @@ test('a publishing step cannot report success while failing', () => {
 });
 
 test('the snap build can find rustup', () => {
-	// snapcraft's rust plugin looks for rustup in exactly one place other than
-	// PATH: a part named `rust-deps` that the rust part depends on. Naming the
-	// rustup snap in the rust part's own `build-snaps` does not satisfy it, and
-	// had not since v2.6.11. The name is load-bearing and comes from snapcraft,
-	// so it is asserted literally.
-	assert.match(snapcraft, /^\s*rust-deps:$/m);
-	assert.match(snapcraft, /^\s*after: \[rust-deps\]$/m);
+	// Rust has to be installed by a phase that runs before any part is pulled,
+	// because the alternative -- a part that installs it -- is too late for the
+	// part that pulls alongside it. `after:` orders build and stage, not pull.
+	// build-packages is that phase, and apt is also the only carrier tried that
+	// is an ordinary ELF: the rustup snap is linked against its own runtime and
+	// picked the gnome SDK's libc.so.6 off LD_LIBRARY_PATH.
+	assert.match(snapcraft, /^\s*build-packages:\n(?:\s*-\s.*\n)*\s*-\s*rustup$/m);
+	// And nothing may ask snapcraft's rust plugin to validate the environment.
+	// It reported `'rustup' not found` twice with rustup present and runnable,
+	// once from the snap and once from apt. snapcraft.yaml has the run IDs.
+	assert.doesNotMatch(snapcraft, /^\s*plugin: rust$/m);
+	// apt's cargo and rustc are shims that refuse to run until a toolchain is
+	// chosen, and with no rust plugin there is no pull script choosing one.
+	assert.match(snapcraft, /^\s*rustup default stable$/m);
 });
 
 test('the AppImage strip is a script, and its excludelist has one home', () => {

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -63,8 +63,24 @@ parts:
     plugin: nil
     build-snaps:
       - rustup/latest/stable
+    # `extensions: [gnome]` puts the gnome SDK's libraries on LD_LIBRARY_PATH
+    # for every part's build, and the rustup snap's own binary then resolves
+    # libc.so.6 out of the SDK instead of out of the one it was linked
+    # against:
+    #
+    #   /snap/rustup/1504/bin/rustup: symbol lookup error:
+    #   /snap/gnome-46-2404-sdk/current/usr/lib/x86_64-linux-gnu/libc.so.6:
+    #   undefined symbol: __nptl_change_stack_perm, version GLIBC_PRIVATE
+    #
+    # This is the same shape as #463 and #499 on the AppImage side -- a
+    # packaging layer putting its own copy of a library ahead of the one that
+    # had to be used -- moved from the user's machine to the builder.
+    #
+    # Cleared for this one call rather than for the part or the build: the
+    # `node/20/stable` snap below runs under the same LD_LIBRARY_PATH and has
+    # always been fine, and the markpad part links against the SDK on purpose.
     override-build: |
-      rustup default stable
+      env -u LD_LIBRARY_PATH rustup default stable
 
   markpad:
     after: [rust-deps]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -59,28 +59,38 @@ parts:
   # every release still told people to install it. The publishing step no longer
   # swallows anything (.github/workflows/publish-packages.yml); this is the
   # failure it was hiding.
+  #
+  # rustup comes from rustup.rs rather than from the `rustup` snap, which is
+  # what v2.7.3 tried. `extensions: [gnome]` puts the gnome SDK's libraries on
+  # LD_LIBRARY_PATH for every part's build, and a classic snap's binary is
+  # linked against its own runtime, so the snap's rustup resolved libc.so.6 out
+  # of the SDK and died on a symbol that is only ever resolved between a
+  # matched libc.so.6 and ld.so:
+  #
+  #   /snap/rustup/1504/bin/rustup: symbol lookup error:
+  #   /snap/gnome-46-2404-sdk/current/usr/lib/x86_64-linux-gnu/libc.so.6:
+  #   undefined symbol: __nptl_change_stack_perm, version GLIBC_PRIVATE
+  #
+  # This is the same shape as #463 and #499 on the AppImage side -- a packaging
+  # layer putting its own copy of a library ahead of the one that had to be
+  # used -- moved from the user's machine to the builder.
+  #
+  # Prefixing the call with `env -u LD_LIBRARY_PATH` does fix that one line and
+  # is not enough, because snapcraft runs rustup itself when it validates the
+  # rust plugin's environment. That attempt is run 31479631082: `rust-deps`
+  # built, and `markpad` then failed with the short form of the message above,
+  # `'rustup' not found` with no rust-deps clause -- the part is found, the
+  # binary will not run. The installer's rustup is an ordinary ELF against the
+  # instance's glibc, which is the same 2.39 the Ubuntu 24.04-based SDK ships,
+  # so it does not care which of the two is ahead on the path.
   rust-deps:
     plugin: nil
-    build-snaps:
-      - rustup/latest/stable
-    # `extensions: [gnome]` puts the gnome SDK's libraries on LD_LIBRARY_PATH
-    # for every part's build, and the rustup snap's own binary then resolves
-    # libc.so.6 out of the SDK instead of out of the one it was linked
-    # against:
-    #
-    #   /snap/rustup/1504/bin/rustup: symbol lookup error:
-    #   /snap/gnome-46-2404-sdk/current/usr/lib/x86_64-linux-gnu/libc.so.6:
-    #   undefined symbol: __nptl_change_stack_perm, version GLIBC_PRIVATE
-    #
-    # This is the same shape as #463 and #499 on the AppImage side -- a
-    # packaging layer putting its own copy of a library ahead of the one that
-    # had to be used -- moved from the user's machine to the builder.
-    #
-    # Cleared for this one call rather than for the part or the build: the
-    # `node/20/stable` snap below runs under the same LD_LIBRARY_PATH and has
-    # always been fine, and the markpad part links against the SDK on purpose.
+    build-packages:
+      - curl
     override-build: |
-      env -u LD_LIBRARY_PATH rustup default stable
+      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --profile minimal --default-toolchain stable --no-modify-path
+      "$HOME/.cargo/bin/rustup" --version
 
   markpad:
     after: [rust-deps]
@@ -104,6 +114,9 @@ parts:
       - node/20/stable
     override-build: |
       set -e
+      # This replaces the rust plugin's own build step, so the cargo the plugin
+      # would have put on PATH is not there -- name where rust-deps installed it.
+      export PATH="$HOME/.cargo/bin:$PATH"
       craftctl set version="$(node -p "require('./package.json').version")"
       npm ci
       export CARGO_BUILD_JOBS=2

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -45,58 +45,54 @@ apps:
       - home
 
 parts:
-  # snapcraft's rust plugin refuses to build unless it can see rustup, and it
-  # looks for it in exactly one place other than PATH: a part named `rust-deps`
-  # that the rust part depends on. Naming the snap in `build-snaps` below is not
-  # enough, and had not been since v2.6.11 --
+  # `rustup` is an ordinary apt package here, and that is load-bearing twice
+  # over. Two release-blocking failures and two runs of test_snap.yml went into
+  # narrowing it down to the one carrier that satisfies both constraints; both
+  # of the other two are documented here so nobody re-tries them.
   #
-  #   Environment validation failed for part 'markpad': 'rustup' not found and
-  #   part 'markpad' does not depend on a part named 'rust-deps' that would
-  #   satisfy the dependency.
+  #   `build-snaps: [rustup/latest/stable]`, which is what v2.7.3 shipped:
+  #   right place in the lifecycle, wrong kind of binary. `extensions: [gnome]`
+  #   puts the gnome SDK's libraries on LD_LIBRARY_PATH for every part, and a
+  #   classic snap's binary is linked against its own runtime, so it resolved
+  #   libc.so.6 out of the SDK and died on a symbol only ever resolved between
+  #   a matched libc.so.6 and ld.so --
   #
-  # -- which the release workflow swallowed under `continue-on-error`, so the
-  # Snap Store went on serving 2.6.11 for three months and six versions while
-  # every release still told people to install it. The publishing step no longer
-  # swallows anything (.github/workflows/publish-packages.yml); this is the
-  # failure it was hiding.
+  #     /snap/rustup/1504/bin/rustup: symbol lookup error:
+  #     /snap/gnome-46-2404-sdk/current/usr/lib/x86_64-linux-gnu/libc.so.6:
+  #     undefined symbol: __nptl_change_stack_perm, version GLIBC_PRIVATE
   #
-  # rustup comes from rustup.rs rather than from the `rustup` snap, which is
-  # what v2.7.3 tried. `extensions: [gnome]` puts the gnome SDK's libraries on
-  # LD_LIBRARY_PATH for every part's build, and a classic snap's binary is
-  # linked against its own runtime, so the snap's rustup resolved libc.so.6 out
-  # of the SDK and died on a symbol that is only ever resolved between a
-  # matched libc.so.6 and ld.so:
+  #   -- the same shape as #463 and #499 on the AppImage side, a packaging
+  #   layer putting its own copy of a library ahead of the one that had to be
+  #   used, moved from the user's machine to the builder. `env -u
+  #   LD_LIBRARY_PATH` fixes the one call this file makes and not the ones
+  #   snapcraft makes (run 31479631082).
   #
-  #   /snap/rustup/1504/bin/rustup: symbol lookup error:
-  #   /snap/gnome-46-2404-sdk/current/usr/lib/x86_64-linux-gnu/libc.so.6:
-  #   undefined symbol: __nptl_change_stack_perm, version GLIBC_PRIVATE
+  #   The rustup.rs installer in a `rust-deps` part's override-build: right
+  #   kind of binary, wrong place in the lifecycle. `after:` orders build and
+  #   stage, not pull, so both parts pull in the same second and the rust
+  #   plugin's own pull script runs `rustup update stable` before any
+  #   override-build has executed (run 31480354438) --
   #
-  # This is the same shape as #463 and #499 on the AppImage side -- a packaging
-  # layer putting its own copy of a library ahead of the one that had to be
-  # used -- moved from the user's machine to the builder.
+  #     Pulling rust-deps / Pulling markpad     both 10:06:42
+  #     /root/parts/markpad/run/pull.sh: line 4: rustup: command not found
   #
-  # Prefixing the call with `env -u LD_LIBRARY_PATH` does fix that one line and
-  # is not enough, because snapcraft runs rustup itself when it validates the
-  # rust plugin's environment. That attempt is run 31479631082: `rust-deps`
-  # built, and `markpad` then failed with the short form of the message above,
-  # `'rustup' not found` with no rust-deps clause -- the part is found, the
-  # binary will not run. The installer's rustup is an ordinary ELF against the
-  # instance's glibc, which is the same 2.39 the Ubuntu 24.04-based SDK ships,
-  # so it does not care which of the two is ahead on the path.
-  rust-deps:
-    plugin: nil
-    build-packages:
-      - curl
-    override-build: |
-      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-        | sh -s -- -y --profile minimal --default-toolchain stable --no-modify-path
-      "$HOME/.cargo/bin/rustup" --version
-
+  # build-packages are installed before anything is pulled, which is the only
+  # phase early enough, and an apt binary links against the instance's glibc --
+  # the same 2.39 the Ubuntu 24.04-based SDK ships, so it does not care which
+  # of the two is ahead on the library path. It also needs no `rust-deps` part
+  # at all: that part existed to satisfy the rust plugin when rustup was not on
+  # PATH, and now it is.
+  #
+  # None of this was reachable before this file was built on a pull request.
+  # v2.6.11 was the last version to reach the Snap Store; the release workflow
+  # swallowed every failure since under `continue-on-error` and reported green
+  # for three months and six versions while the store told those users they
+  # were current.
   markpad:
-    after: [rust-deps]
     plugin: rust
     source: .
     build-packages:
+      - rustup
       - libwebkit2gtk-4.1-dev
       - build-essential
       - curl
@@ -115,7 +111,8 @@ parts:
     override-build: |
       set -e
       # This replaces the rust plugin's own build step, so the cargo the plugin
-      # would have put on PATH is not there -- name where rust-deps installed it.
+      # would have put on PATH is not there. rustup's pull script installed the
+      # toolchain under the default CARGO_HOME; name it rather than assume it.
       export PATH="$HOME/.cargo/bin:$PATH"
       craftctl set version="$(node -p "require('./package.json').version")"
       npm ci

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -45,17 +45,15 @@ apps:
       - home
 
 parts:
-  # `rustup` is an ordinary apt package here, and that is load-bearing twice
-  # over. Two release-blocking failures and two runs of test_snap.yml went into
-  # narrowing it down to the one carrier that satisfies both constraints; both
-  # of the other two are documented here so nobody re-tries them.
+  # `plugin: nil` with rust from apt, after three runs of test_snap.yml spent
+  # trying to satisfy `plugin: rust` instead. All three are recorded here
+  # because each one looks like the obvious thing to try next.
   #
-  #   `build-snaps: [rustup/latest/stable]`, which is what v2.7.3 shipped:
-  #   right place in the lifecycle, wrong kind of binary. `extensions: [gnome]`
-  #   puts the gnome SDK's libraries on LD_LIBRARY_PATH for every part, and a
-  #   classic snap's binary is linked against its own runtime, so it resolved
-  #   libc.so.6 out of the SDK and died on a symbol only ever resolved between
-  #   a matched libc.so.6 and ld.so --
+  #   `build-snaps: [rustup/latest/stable]`, which is what v2.7.3 shipped.
+  #   `extensions: [gnome]` puts the gnome SDK's libraries on LD_LIBRARY_PATH
+  #   for every part, and a classic snap's binary is linked against its own
+  #   runtime, so it resolved libc.so.6 out of the SDK and died on a symbol
+  #   only ever resolved between a matched libc.so.6 and ld.so --
   #
   #     /snap/rustup/1504/bin/rustup: symbol lookup error:
   #     /snap/gnome-46-2404-sdk/current/usr/lib/x86_64-linux-gnu/libc.so.6:
@@ -63,25 +61,31 @@ parts:
   #
   #   -- the same shape as #463 and #499 on the AppImage side, a packaging
   #   layer putting its own copy of a library ahead of the one that had to be
-  #   used, moved from the user's machine to the builder. `env -u
-  #   LD_LIBRARY_PATH` fixes the one call this file makes and not the ones
-  #   snapcraft makes (run 31479631082).
+  #   used, moved from the user's machine to the builder. Prefixing the call
+  #   with `env -u LD_LIBRARY_PATH` fixes the one this file makes and not the
+  #   ones snapcraft makes (run 31479631082).
   #
-  #   The rustup.rs installer in a `rust-deps` part's override-build: right
-  #   kind of binary, wrong place in the lifecycle. `after:` orders build and
-  #   stage, not pull, so both parts pull in the same second and the rust
-  #   plugin's own pull script runs `rustup update stable` before any
-  #   override-build has executed (run 31480354438) --
+  #   The rustup.rs installer in a `rust-deps` part. `after:` orders build and
+  #   stage, not pull: both parts pull in the same second, so the rust plugin's
+  #   pull script runs `rustup update stable` before any override-build has
+  #   executed (run 31480354438) --
   #
   #     Pulling rust-deps / Pulling markpad     both 10:06:42
   #     /root/parts/markpad/run/pull.sh: line 4: rustup: command not found
   #
-  # build-packages are installed before anything is pulled, which is the only
-  # phase early enough, and an apt binary links against the instance's glibc --
-  # the same 2.39 the Ubuntu 24.04-based SDK ships, so it does not care which
-  # of the two is ahead on the library path. It also needs no `rust-deps` part
-  # at all: that part existed to satisfy the rust plugin when rustup was not on
-  # PATH, and now it is.
+  #   apt's rustup, which does install /usr/bin/rustup, /usr/bin/cargo and
+  #   /usr/bin/rustc. The plugin reported `'rustup' not found` anyway
+  #   (run 31481081985), as it had in run 31479631082 with the snap's rustup
+  #   on PATH and demonstrably runnable.
+  #
+  # Twice the binary was there and the plugin said it was not, so the plugin's
+  # environment validation is the thing to stop asking to pass. Nothing here
+  # uses the plugin: override-build below runs npm and tauri and installs the
+  # binary itself, and has since the snap was first added. `plugin: rust`
+  # contributed a build step this file overrides, a pull script that runs
+  # rustup, and the validation. `plugin: nil` keeps `source:` and drops all
+  # three; rust comes from build-packages, which are installed before any part
+  # is pulled.
   #
   # None of this was reachable before this file was built on a pull request.
   # v2.6.11 was the last version to reach the Snap Store; the release workflow
@@ -89,7 +93,7 @@ parts:
   # for three months and six versions while the store told those users they
   # were current.
   markpad:
-    plugin: rust
+    plugin: nil
     source: .
     build-packages:
       - rustup
@@ -110,10 +114,10 @@ parts:
       - node/20/stable
     override-build: |
       set -e
-      # This replaces the rust plugin's own build step, so the cargo the plugin
-      # would have put on PATH is not there. rustup's pull script installed the
-      # toolchain under the default CARGO_HOME; name it rather than assume it.
-      export PATH="$HOME/.cargo/bin:$PATH"
+      # apt's /usr/bin/cargo and /usr/bin/rustc are rustup shims and refuse to
+      # run until a toolchain is chosen. Nothing else does this now: with
+      # `plugin: nil` there is no pull script to run it first.
+      rustup default stable
       craftctl set version="$(node -p "require('./package.json').version")"
       npm ci
       export CARGO_BUILD_JOBS=2


### PR DESCRIPTION
Fixes the v2.7.3 snap publish failure, and the reason it could only be found in a release.

## What failed

`publish-packages.yml` run [31464054514](https://github.com/sftwrdotdev/Markpad/actions/runs/31464054514) — `chocolatey` green, `snap` red, in the `rust-deps` part #566 added:

```
+ rustup default stable
/snap/rustup/1504/bin/rustup: symbol lookup error:
  /snap/gnome-46-2404-sdk/current/usr/lib/x86_64-linux-gnu/libc.so.6:
  undefined symbol: __nptl_change_stack_perm, version GLIBC_PRIVATE
```

`extensions: [gnome]` puts the gnome SDK's libraries on `LD_LIBRARY_PATH` for every part's build. A classic snap's binary is linked against its own runtime, so the rustup snap resolved `libc.so.6` out of the SDK, and a `GLIBC_PRIVATE` symbol that is only ever resolved between a matched `libc.so.6` and `ld.so` was not there.

## The shape, because it is the third time

| | what a packaging layer inserted | what it shadowed | symptom |
|---|---|---|---|
| #463 | pinned WebKitGTK 2.44.0 in the AppImage | the host's 2.52 | `EGL_BAD_PARAMETER`, blank window |
| #498 / #499 | the runner's `libwayland-client.so.0` | the host's newer one | host `libEGL` fails, blank window |
| this | the gnome SDK on `LD_LIBRARY_PATH` | rustup's own `libc.so.6` | `snapcraft pack` dies before compiling |

The first two happened on users' machines and had to be reported by users. This one happens on the builder, which is the better place for it — once anything actually runs the builder.

## Getting there took three wrong answers, and they are all in the file

Each looked like the obvious next step, so `snapcraft.yaml` now records them rather than leaving them to be re-tried:

1. **`env -u LD_LIBRARY_PATH rustup default stable`** ([31479631082](https://github.com/sftwrdotdev/Markpad/actions/runs/31479631082)). Fixes the call this file makes, not the ones snapcraft makes. `rust-deps` built; `markpad` then failed validation.
2. **The rustup.rs installer in `rust-deps`** ([31480354438](https://github.com/sftwrdotdev/Markpad/actions/runs/31480354438)). Right kind of binary, wrong phase — `after:` orders build and stage, not pull. Both parts pulled in the same second and the rust plugin's pull script ran `rustup update stable` before any `override-build` existed: `pull.sh: line 4: rustup: command not found`.
3. **apt's rustup** ([31481081985](https://github.com/sftwrdotdev/Markpad/actions/runs/31481081985)). noble's package installs `/usr/bin/rustup`, `/usr/bin/cargo` and `/usr/bin/rustc`. `Environment validation failed for part 'markpad': 'rustup' not found` anyway.

Twice the binary was present — in (1) the plugin's own pull script had just run it successfully — and twice the validation said it was not. So the validation is the thing to stop trying to satisfy.

## The change

**`plugin: rust` → `plugin: nil`.** Nothing in this part uses the plugin, and nothing has since the snap was added: `override-build` runs `npm ci`, runs `npx tauri build --no-bundle`, and installs the binary, the icons and the `.desktop` file itself. What `plugin: rust` contributed was a build step this file overrides, a pull script that runs rustup, and the validation above. `plugin: nil` keeps `source:` and drops all three.

Rust comes from `build-packages: [rustup]` — installed before any part is pulled, and an ordinary ELF against the instance's glibc, the same 2.39 the Ubuntu 24.04-based SDK ships, so it does not care which copy is ahead on the library path. `rustup default stable` moves into `override-build`, because the pull script that used to run it is gone and apt's `cargo` and `rustc` are shims that refuse to run without a toolchain.

The `rust-deps` part goes with it. Net result is a shorter file than v2.7.3's, and shorter than v2.6.11's.

## Why a second workflow

`publish-packages.yml` checks out a release tag:

```yaml
- uses: actions/checkout@v7
  with:
    ref: ${{ github.event.release.tag_name || inputs.tag }}
```

That is right for publishing — what reaches the store should be what the release page serves — but it means `snapcraft.yaml` is first executed after a change to it has been merged, tagged and published. No pull request has ever run this file. It is how #566 was written, reviewed, merged, and only then found to be broken, against the release users are currently pointed at. Three of the four attempts above would have been release attempts.

`test_snap.yml` runs `snapcraft pack` on any pull request touching `snapcraft.yaml`, and stops there. No release upload, no `snapcraft push`. The store push stays where it is, behind a release a human published. Path-filtered, because it costs ~20 minutes and recompiles the app inside LXD.

It also prints `snap list snapcraft`. The 8.14.5 → 9.0.1 bump between v2.6.11 and v2.6.12 is what killed the snap in the first place — the workflow installs whatever the store serves that day — so the next failure of that shape should be one line away rather than a bisect.

## Verification

[Run 31481634640](https://github.com/sftwrdotdev/Markpad/actions/runs/31481634640) — the `pack` job on this branch, on snapcraft 9.0.1, the version that has been failing:

```
Installing build-packages   10:21:24
Pulling markpad             10:22:56
Building markpad            10:24:19
Priming markpad             10:32:51
Packed markpad_2.7.3_amd64.snap
-rw-r--r-- 1 runner lxd 84492288 Aug 11 10:33 ./markpad_2.7.3_amd64.snap
```

80.6 MB, 14m55s. **The first `markpad_*.snap` to exist since v2.6.11 was packed on 2026-06-03.** Nothing was pushed to the Snap Store; that stays behind a published release.

The three failed attempts above are the same job on earlier commits of this branch, which is the point of adding it — each of them would otherwise have been a release.

`npm test` — 973 pass. `scripts/releaseWorkflow.test.ts` needed updating: #566 added a test alongside its fix that asserted the fix's shape (a part named `rust-deps`, and `after: [rust-deps]`), so it was holding the file to a spelling that does not build. It now asserts the two constraints the runs established — rust from a phase earlier than any pull, and no rust plugin validation to satisfy.

## Not in this pull request

- Whether the snap should exist at all. #562 asks @alecdotdev for the snapcraft dashboard number, and that decides keep-or-retire. This is worth doing either way: retiring also needs one working build, to upload the version whose description points people at the `.deb` or the AppImage.
- #162 is closed, but the Snap Store still serves 2.6.11 / revision 15, so nobody has ever confirmed it on a build containing the fix. It stays unconfirmable until a publish succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
