### PR TITLE
chore(ci): install the Linux build dependencies once

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,20 +197,29 @@ jobs:
 
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-24.04'
+        # One list, one apt call. This was two `apt-get install` invocations
+        # naming 21 packages between them, five of them in both --
+        # libappindicator3-dev, librsvg2-dev, patchelf, rpm and
+        # libwebkit2gtk-4.1-dev. Same 16 packages, said once.
         run: |
           sudo apt-get update
-          sudo apt-get install -y libappindicator3-dev \
-          librsvg2-dev \
-          patchelf \
-          rpm \
-          libwebkit2gtk-4.1-0 \
-          libwebkit2gtk-4.1-dev \
-          libjavascriptcoregtk-4.1-0 \
-          libjavascriptcoregtk-4.1-dev \
-          gir1.2-javascriptcoregtk-4.1 \
-          gir1.2-webkit2-4.1
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf rpm xdg-utils \
-          libxcb1-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
+          sudo apt-get install -y \
+            gir1.2-javascriptcoregtk-4.1 \
+            gir1.2-webkit2-4.1 \
+            libappindicator3-dev \
+            libgtk-3-dev \
+            libjavascriptcoregtk-4.1-0 \
+            libjavascriptcoregtk-4.1-dev \
+            librsvg2-dev \
+            libwebkit2gtk-4.1-0 \
+            libwebkit2gtk-4.1-dev \
+            libxcb1-dev \
+            libxcb-render0-dev \
+            libxcb-shape0-dev \
+            libxcb-xfixes0-dev \
+            patchelf \
+            rpm \
+            xdg-utils
 
       - name: Install Frontend Dependencies
         run: npm ci


### PR DESCRIPTION
`Install Linux dependencies` ran two `apt-get install` invocations naming 21 packages between them. Five were in both lists:

```
libappindicator3-dev   librsvg2-dev   patchelf   rpm   libwebkit2gtk-4.1-dev
```

One call, one list, the same 16 packages. Verified by extracting the package set from both revisions of the step: 16 before, 16 after, nothing added, nothing dropped.

No behaviour change — apt installing a package it has already installed is a no-op, so this was never a bug, only two lists to keep in step with each other.

`npm test` — 973 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)