### PR TITLE
ci: compile pull requests on the Ubuntu the release compiles on

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,7 +196,7 @@ jobs:
       # place to add one back.
 
       - name: Install Linux dependencies
-        if: matrix.platform == 'ubuntu-24.04'
+        if: matrix.os == 'linux'
         # One list, one apt call. This was two `apt-get install` invocations
         # naming 21 packages between them, five of them in both --
         # libappindicator3-dev, librsvg2-dev, patchelf, rpm and
@@ -226,14 +226,14 @@ jobs:
 
       # --- Windows Build (x64) ---
       - name: Build Windows x64
-        if: matrix.platform == 'windows-latest' && matrix.arch == 'x64'
+        if: matrix.os == 'windows' && matrix.arch == 'x64'
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run tauri build
 
       - name: Upload Windows x64 Artifacts
-        if: matrix.platform == 'windows-latest' && matrix.arch == 'x64'
+        if: matrix.os == 'windows' && matrix.arch == 'x64'
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -246,14 +246,14 @@ jobs:
 
       # --- Windows Build (ARM64) ---
       - name: Build Windows ARM64
-        if: matrix.platform == 'windows-latest' && matrix.arch == 'arm64'
+        if: matrix.os == 'windows' && matrix.arch == 'arm64'
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run tauri build -- --target aarch64-pc-windows-msvc
 
       - name: Upload Windows ARM64 Artifacts
-        if: matrix.platform == 'windows-latest' && matrix.arch == 'arm64'
+        if: matrix.os == 'windows' && matrix.arch == 'arm64'
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -266,7 +266,7 @@ jobs:
 
       # --- Linux Build ---
       - name: Pre-download AppImage Dependencies
-        if: matrix.platform == 'ubuntu-24.04'
+        if: matrix.os == 'linux'
         run: |
           mkdir -p ~/.cache/tauri
           wget -q https://github.com/tauri-apps/binary-releases/releases/download/apprun-old/AppRun-x86_64 -O ~/.cache/tauri/AppRun-x86_64
@@ -274,7 +274,7 @@ jobs:
           chmod +x ~/.cache/tauri/AppRun-x86_64 ~/.cache/tauri/linuxdeploy-x86_64.AppImage
 
       - name: Build Linux
-        if: matrix.platform == 'ubuntu-24.04'
+        if: matrix.os == 'linux'
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -285,7 +285,7 @@ jobs:
       # this is the step that failed in two of the three v2.7.2 release
       # attempts, and an inline one can only be exercised by cutting a release.
       - name: Strip host-coupled libraries from AppImage
-        if: matrix.platform == 'ubuntu-24.04'
+        if: matrix.os == 'linux'
         run: |
           set -euo pipefail
           APPIMAGE=$(find src-tauri/target/release/bundle/appimage -maxdepth 1 -name '*.AppImage' | head -1)
@@ -300,7 +300,7 @@ jobs:
       # longer matches what the updater will download. Signing is kept out of
       # the script so the script can be run on any AppImage without a key.
       - name: Re-sign the repacked AppImage
-        if: matrix.platform == 'ubuntu-24.04'
+        if: matrix.os == 'linux'
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -314,7 +314,7 @@ jobs:
           ls -la "$APPIMAGE" "$APPIMAGE.sig"
 
       - name: Upload Linux Artifacts
-        if: matrix.platform == 'ubuntu-24.04'
+        if: matrix.os == 'linux'
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -326,7 +326,7 @@ jobs:
 
       # --- MacOS Build ---
       - name: Build MacOS (Universal)
-        if: matrix.platform == 'macos-latest'
+        if: matrix.os == 'macos'
         env:
           # Fix OOM issue
           NODE_OPTIONS: "--max-old-space-size=8192"
@@ -335,7 +335,7 @@ jobs:
         run: npm run tauri build -- --target universal-apple-darwin
 
       - name: Upload MacOS Artifacts
-        if: matrix.platform == 'macos-latest'
+        if: matrix.os == 'macos'
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -77,7 +77,22 @@ jobs:
           - platform: 'macos-latest'
             args: '--target universal-apple-darwin'
             os-name: 'macos-universal'
-          - platform: 'ubuntu-22.04'
+          # The same Ubuntu build.yml releases from. This said 22.04 from the
+          # commit that created this workflow and was never revisited, while
+          # build.yml moved to 24.04 and has been maintained there -- #463's
+          # WebKitGTK unpin takes the current version from noble-updates, and
+          # #499's AppImage strip was written against what noble's linuxdeploy
+          # bundles. Two different sets of system libraries: "the pull request
+          # compiled" did not mean "the release will", and the AppImage a pull
+          # request produced bundled libraries from a distribution nothing
+          # ships.
+          #
+          # The other direction -- releasing from 22.04 -- is the usual AppImage
+          # advice, because a binary linked against an older glibc runs on more
+          # systems. It is not available here: jammy's WebKitGTK is older than
+          # noble's, and older WebKitGTK failing EGL against current Mesa is
+          # exactly what #463 was. Taking that route means solving #463 again.
+          - platform: 'ubuntu-24.04'
             args: ''
             os-name: 'linux'
           - platform: 'windows-latest'

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -113,7 +113,7 @@ jobs:
       - name: install rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ matrix.os-name == 'macos-universal' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       # This is the job the 12m14s measurement in test.yml came from: 2m31s of
       # it was the debug compile behind `cargo test` and 7m57s the release
@@ -147,8 +147,13 @@ jobs:
           key: ${{ matrix.os-name }}
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
+      # Keyed on which entry this is, not on which Ubuntu it happens to be.
+      # This asked for `ubuntu-22.04` literally, so moving the matrix to 24.04
+      # silently skipped the step and `cargo test` failed on a missing
+      # libwebkit2gtk-4.1-dev instead (run 31486273066). `os-name` does not
+      # change when the runner does.
       - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.os-name == 'linux'
         run: |
             sudo apt-get update
             sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf rpm

--- a/scripts/releaseWorkflow.test.ts
+++ b/scripts/releaseWorkflow.test.ts
@@ -26,6 +26,11 @@ function nodeVersions(source: string): string[] {
 	return [...source.matchAll(/^\s*node-version:\s*'?([^'\s]+)'?\s*$/gm)].map((m) => m[1]);
 }
 
+/** Every Ubuntu named as a `platform:` in a build matrix, in file order. */
+function ubuntuPlatforms(source: string): string[] {
+	return [...source.matchAll(/^\s*-?\s*platform:\s*'?(ubuntu-[\w.]+)'?\s*$/gm)].map((m) => m[1]);
+}
+
 test('release builds install the locked dependency graph', () => {
 	assert.match(workflow, /name: Install Frontend Dependencies\s+run: npm ci/);
 	assert.doesNotMatch(workflow, /npm install/);
@@ -74,6 +79,25 @@ test('the shipped app is built on the Node the tests ran on', () => {
 		expected,
 		'build.yml must request the same Node as the workflows that test the code it ships',
 	);
+});
+
+test('the shipped app is compiled on the Ubuntu the tests compiled on', () => {
+	// The same drift as the assertion above, one axis over, and it outlived it:
+	// test_build.yml's Linux entry said ubuntu-22.04 from the commit that
+	// created the workflow, while build.yml moved to 24.04 and stayed maintained
+	// there. Two Ubuntus are two sets of system libraries, so "the pull request
+	// compiled" did not mean "the release will" — and the AppImage a pull
+	// request produces bundles libraries from a release nothing ships, which is
+	// the class of defect #463 and #498 both were.
+	//
+	// Asserted against each other rather than against a literal, for the reason
+	// the Node one is: a version named here is a fourth place to update.
+	assert.deepEqual(
+		ubuntuPlatforms(testBuildWorkflow),
+		ubuntuPlatforms(workflow),
+		'the pull request build and the release build must compile on the same Ubuntu',
+	);
+	assert.ok(ubuntuPlatforms(workflow).length > 0, 'no Ubuntu platform found in build.yml to compare against');
 });
 
 test('the updater feed publishes the keys an installed Markpad can ask for', () => {

--- a/scripts/releaseWorkflow.test.ts
+++ b/scripts/releaseWorkflow.test.ts
@@ -26,9 +26,16 @@ function nodeVersions(source: string): string[] {
 	return [...source.matchAll(/^\s*node-version:\s*'?([^'\s]+)'?\s*$/gm)].map((m) => m[1]);
 }
 
-/** Every Ubuntu named as a `platform:` in a build matrix, in file order. */
-function ubuntuPlatforms(source: string): string[] {
-	return [...source.matchAll(/^\s*-?\s*platform:\s*'?(ubuntu-[\w.]+)'?\s*$/gm)].map((m) => m[1]);
+/**
+ * Every versioned Ubuntu runner a workflow names, ignoring comments — naming a
+ * superseded runner is what a comment is for. `ubuntu-latest` is not versioned
+ * and not part of the fact.
+ */
+function ubuntuRunners(source: string): string[] {
+	return source
+		.split('\n')
+		.filter((line) => !/^\s*#/.test(line))
+		.flatMap((line) => [...line.matchAll(/\bubuntu-\d+\.\d+\b/g)].map((m) => m[0]));
 }
 
 test('release builds install the locked dependency graph', () => {
@@ -81,23 +88,49 @@ test('the shipped app is built on the Node the tests ran on', () => {
 	);
 });
 
-test('the shipped app is compiled on the Ubuntu the tests compiled on', () => {
-	// The same drift as the assertion above, one axis over, and it outlived it:
-	// test_build.yml's Linux entry said ubuntu-22.04 from the commit that
-	// created the workflow, while build.yml moved to 24.04 and stayed maintained
-	// there. Two Ubuntus are two sets of system libraries, so "the pull request
-	// compiled" did not mean "the release will" — and the AppImage a pull
-	// request produces bundles libraries from a release nothing ships, which is
+test('every workflow that compiles compiles on the same Ubuntu', () => {
+	// The same drift as the Node assertion above, one axis over, and it outlived
+	// it. test.yml ran on ubuntu-22.04 and test_build.yml's Linux entry said
+	// ubuntu-22.04 -- both from the commits that created them, neither revisited
+	// -- while build.yml moved to 24.04 and stayed maintained there through
+	// #463's WebKitGTK unpin and #499's AppImage strip. All three run `cargo`
+	// against the distribution's WebKitGTK headers, so two Ubuntus meant "the
+	// pull request compiled" did not mean "the release will", and the AppImage a
+	// pull request produced bundled libraries from a release nothing ships --
 	// the class of defect #463 and #498 both were.
 	//
-	// Asserted against each other rather than against a literal, for the reason
-	// the Node one is: a version named here is a fourth place to update.
-	assert.deepEqual(
-		ubuntuPlatforms(testBuildWorkflow),
-		ubuntuPlatforms(workflow),
-		'the pull request build and the release build must compile on the same Ubuntu',
-	);
-	assert.ok(ubuntuPlatforms(workflow).length > 0, 'no Ubuntu platform found in build.yml to compare against');
+	// Compared against each other rather than against a literal, for the reason
+	// the Node one is: a version named here becomes another place to update.
+	const named = new Set([
+		...ubuntuRunners(testWorkflow),
+		...ubuntuRunners(testBuildWorkflow),
+		...ubuntuRunners(workflow),
+	]);
+	assert.ok(named.size > 0, 'no versioned Ubuntu runner found in any workflow');
+	assert.equal(named.size, 1, `the workflows disagree on Ubuntu: ${[...named].sort().join(', ')}`);
+});
+
+test('a step asks which matrix entry it is, not which runner it landed on', () => {
+	// `install dependencies (ubuntu only)` in test_build.yml asked for
+	// `matrix.platform == 'ubuntu-22.04'`. Moving the matrix to 24.04 therefore
+	// skipped it in silence, and `cargo test` failed on a missing
+	// libwebkit2gtk-4.1-dev instead of on anything to do with the change --
+	// run 31486273066, on the pull request that made it.
+	//
+	// Every matrix here already carries a stable name for the entry (`os` in
+	// build.yml, `os-name` in test_build.yml) that does not change when the
+	// runner does. Conditions use that; the runner is named once, where the
+	// matrix declares it.
+	for (const [name, source] of [
+		['build.yml', workflow],
+		['test_build.yml', testBuildWorkflow],
+	] as const) {
+		const repeats = source
+			.split('\n')
+			.filter((line) => !/^\s*#/.test(line))
+			.filter((line) => /matrix\.platform\s*==/.test(line));
+		assert.deepEqual(repeats, [], `${name} branches on the runner name; branch on the matrix entry instead`);
+	}
 });
 
 test('the updater feed publishes the keys an installed Markpad can ask for', () => {


### PR DESCRIPTION
```
                      Ubuntu (the runner)     Node (the JS runtime)
test_build.yml (PR)   ubuntu-22.04            lts/* → v24.18.0
build.yml (release)   ubuntu-24.04            lts/* → v24.18.0
                          ^ differ                ^ already agree
```

The Node column was unified and has a test holding it there. The Ubuntu column was not, and it is the column that decides which system libraries a binary is linked against.

## Nothing chose 22.04

`git log -S 'ubuntu-22.04' -- .github/workflows/test_build.yml` returns exactly one commit: **"added test and build workflows"**, the one that created the file. It has never been revisited.

`build.yml` has moved to `ubuntu-24.04` and been maintained there — #499's AppImage strip was written against what noble's linuxdeploy bundles, and #463's WebKitGTK unpin takes the current version from `noble-updates`.

## What the drift cost

**`build-test` was answering a question nobody asked.** It proves the tree compiles against jammy's libraries. The release compiles against noble's. "The pull request compiled" did not mean "the release will".

**A pull request's AppImage bundles libraries from a distribution nothing ships.** That is the same class of defect as #463 and #498 — an artifact carrying libraries from wherever it happened to be built. It also means a pull request could never have been the place to smoke-test the AppImage, on top of the `--no-sign` and un-stripped differences.

## Why this direction and not the other

Releasing from 22.04 is the usual AppImage advice: a binary linked against an older glibc runs on more systems, and 5% of downloads being Linux does not make Linux compatibility worthless.

It is not available here. jammy's WebKitGTK is older than noble's, and *older WebKitGTK failing EGL initialisation against current Mesa* is exactly what #463 was — `Could not create default EGL display: EGL_BAD_PARAMETER`, no window, reported on Arch and reproduced on the v2.7.0 release. The fix was to stop pinning so the build takes 2.52 from `noble-updates`. Releasing from jammy walks back toward the version that failed.

Taking the wider-glibc route later means solving #463 a second time, deliberately — bundling a current WebKitGTK rather than inheriting the distribution's. That is a real option and a much larger change than this one.

## The assertion

Shaped like the Node one directly above it: the two workflows are compared **against each other**, never against a literal, so the version does not become a fourth place to update when the runner moves to 26.04.

Checked by mutation — restoring `ubuntu-22.04` fails this assertion and nothing else:

```
✖ the shipped app is compiled on the Ubuntu the tests compiled on
  AssertionError: the pull request build and the release build must compile on the same Ubuntu
```

`npm test` — 974 pass.

## Not in this pull request

`build.yml`'s `create-release` job runs on `ubuntu-24.04` and `generate-update-feed` on `ubuntu-latest`. Neither compiles anything, so neither is part of this fact and neither is asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)