### PR TITLE
ci: install the six Linux packages a pull request proved the build needs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,29 +197,26 @@ jobs:
 
       - name: Install Linux dependencies
         if: matrix.os == 'linux'
-        # One list, one apt call. This was two `apt-get install` invocations
-        # naming 21 packages between them, five of them in both --
-        # libappindicator3-dev, librsvg2-dev, patchelf, rpm and
-        # libwebkit2gtk-4.1-dev. Same 16 packages, said once.
+        # The same list test_build.yml installs, which is what makes it a
+        # check: a pull request now compiles and bundles against exactly the
+        # packages a release does. An assertion holds the two together.
+        #
+        # It was sixteen. Six of those apt installs anyway --
+        # libwebkit2gtk-4.1-dev depends on libwebkit2gtk-4.1-0,
+        # libjavascriptcoregtk-4.1-dev, gir1.2-webkit2-4.1 and libgtk-3-dev,
+        # and those pull the remaining two -- and four libxcb *-dev packages
+        # and xdg-utils appear in no Tauri v2 prerequisite list. Run
+        # 31487547674 built the .deb, the .rpm and the AppImage on
+        # ubuntu-24.04 with the six below and nothing else.
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            gir1.2-javascriptcoregtk-4.1 \
-            gir1.2-webkit2-4.1 \
-            libappindicator3-dev \
             libgtk-3-dev \
-            libjavascriptcoregtk-4.1-0 \
-            libjavascriptcoregtk-4.1-dev \
-            librsvg2-dev \
-            libwebkit2gtk-4.1-0 \
             libwebkit2gtk-4.1-dev \
-            libxcb1-dev \
-            libxcb-render0-dev \
-            libxcb-shape0-dev \
-            libxcb-xfixes0-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
             patchelf \
-            rpm \
-            xdg-utils
+            rpm
 
       - name: Install Frontend Dependencies
         run: npm ci

--- a/scripts/releaseWorkflow.test.ts
+++ b/scripts/releaseWorkflow.test.ts
@@ -133,6 +133,46 @@ test('a step asks which matrix entry it is, not which runner it landed on', () =
 	}
 });
 
+/** The packages an `apt-get install -y` line asks for, sorted. */
+function aptPackages(source: string): string[] {
+	const line = /apt-get install -y((?:[^\n]*\\\n)*[^\n]*)/.exec(source)?.[1] ?? '';
+	return line
+		.split(/[\s\\]+/)
+		.filter(Boolean)
+		.sort();
+}
+
+test('a release installs the dependencies a pull request proved it can build with', () => {
+	// build.yml only runs on workflow_dispatch, so its apt list is the one part
+	// of the Linux build no pull request exercises -- it asked for sixteen
+	// packages against test_build.yml's six, and nothing said which was right.
+	// Six of the ten extras apt installs anyway as dependencies of
+	// libwebkit2gtk-4.1-dev; the four libxcb *-dev packages and xdg-utils are in
+	// no Tauri v2 prerequisite list. Run 31487547674 built the .deb, the .rpm and
+	// the AppImage on ubuntu-24.04 with six.
+	//
+	// One list rather than a shorter one is the point. Both workflows compile and
+	// bundle, so a difference between them is a release depending on something
+	// nothing tested — which is what this was.
+	assert.deepEqual(
+		aptPackages(sliceFrom(workflow, 'Install Linux dependencies')),
+		aptPackages(sliceFrom(testBuildWorkflow, 'install dependencies (ubuntu only)')),
+		'the release build and the pull request build install different Linux packages',
+	);
+
+	// test.yml compiles but never bundles, so it needs everything above except
+	// the bundlers. Asserted as a subset rather than as its own list, so adding a
+	// dependency in one place cannot leave it behind.
+	const bundlers = new Set(['rpm']);
+	assert.deepEqual(
+		aptPackages(sliceFrom(testWorkflow, 'install dependencies (ubuntu only)')),
+		aptPackages(sliceFrom(testBuildWorkflow, 'install dependencies (ubuntu only)')).filter(
+			(p) => !bundlers.has(p),
+		),
+		'test.yml has drifted from the list the builds use',
+	);
+});
+
 test('a cargo cache cannot outlive the runner image that filled it', () => {
 	// rust-cache's key ends `-Linux-x64`: `runner.os`, not the image. Measured on
 	// two runs of the same job, one per Ubuntu, the key was identical --


### PR DESCRIPTION
> **Stacked on #580.** Base is `ci/one-linux-runner`; merge #580 first and this retargets to `master`. The diff shown is against #580.

`build.yml` asked apt for **sixteen** packages. `test_build.yml` asks for **six**, compiles the same tree and bundles the same three formats. Nothing said which was right — `build.yml` only runs on `workflow_dispatch`, so its apt list is the one part of the Linux build no pull request has ever exercised.

## The ten

**Six apt installs anyway.** `libwebkit2gtk-4.1-dev` depends on `libwebkit2gtk-4.1-0`, `libjavascriptcoregtk-4.1-dev`, `gir1.2-webkit2-4.1` and `libgtk-3-dev`; those pull `libjavascriptcoregtk-4.1-0` and `gir1.2-javascriptcoregtk-4.1` behind them. Naming them changes nothing.

**Four `libxcb *-dev` packages and `xdg-utils`** appear in no [Tauri v2 Debian/Ubuntu prerequisite list](https://v2.tauri.app/start/prerequisites/):

```
sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file \
  libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
```

## The evidence is not that reasoning

[Run 31487547674](https://github.com/sftwrdotdev/Markpad/actions/runs/31487547674), on **`ubuntu-24.04` — the release's own runner**, after #580 moves `test_build.yml` there:

```
install dependencies (ubuntu only) :: success     ← the six
run cargo test                     :: success
Build app                          :: success
Upload artifacts                   :: success

app-bundle-linux   101 MB          ← bundle/deb/*.deb + bundle/rpm/*.rpm
                                     + bundle/appimage/*.AppImage
```

The three Linux formats a release ships were built with these six and nothing else, on the same Ubuntu, by a pull request.

## One list, not a shorter one

That is the part worth keeping. Both workflows compile *and* bundle, so any difference between their lists is a release depending on something nothing tested — which is exactly what this was. The assertion holds them equal, and holds `test.yml` to the same list minus the bundlers, since it compiles but never bundles.

Checked by mutation in both directions:

```
add xdg-utils to build.yml     → ✖ a release installs the dependencies a pull request proved it can build with
remove librsvg2-dev from test.yml → ✖ (same assertion, the test.yml half)
```

Each fails alone. `npm test` — 977 pass.

## The risk, stated

`build.yml` cannot be run outside a release, so this list is exercised for the first time when a release is cut. What makes that acceptable rather than reckless:

- the six are **the list a pull request just built all three bundles with**, on the release's runner, not a list reasoned down from sixteen;
- a wrong answer fails at `apt-get` or at `cargo`, before any asset is uploaded, on a release that is still a draft nobody can install;
- after #580 the two workflows share a runner, so from here on every pull request exercises the release's dependency list on the release's Ubuntu.

Reverting is this commit alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)