### PR TITLE
fix: bring Cargo.lock to 2.7.3 and guard the three version files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,14 +172,22 @@ All file operations go through Rust commands - never use Node.js fs APIs.
 
 ## Versioning
 
-When bumping the app version, update both files in the same commit:
+When bumping the app version, update all three files in the same commit:
 
 - `package.json` `version`
 - `src-tauri/Cargo.toml` `version`
+- `src-tauri/Cargo.lock` — not by hand: run `cargo update -p Markpad --precise
+  <version>` in `src-tauri` (or any `cargo check` there, which rewrites it as a
+  side effect) and commit the one-line diff.
 
 Tauri runtime reads `app.package_info().version` from `Cargo.toml`, while the
 Tauri config and the frontend rely on `package.json`. Keeping them in sync is
 mandatory for `tauri-plugin-updater` to compare versions correctly.
+
+The lock file is the one that gets forgotten, because nothing in the editing
+loop reads it — a bump without it lands green and stays wrong until the next
+person's `cargo build` rewrites the line and leaves them a dirty working tree.
+`scripts/versionSync.test.ts` asserts the three agree.
 
 ## Releasing
 

--- a/scripts/versionSync.test.ts
+++ b/scripts/versionSync.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readSource } from './sourceTree.js';
+
+// `package.json` and `src-tauri/Cargo.toml` are the two files AGENTS.md tells
+// you to bump. `src-tauri/Cargo.lock` is the third, and it is the one that gets
+// forgotten: nothing in the editing loop reads it, so a bump lands green and
+// stays wrong until someone runs `cargo build` — which rewrites the one line to
+// match `Cargo.toml` and hands them a dirty working tree they did not ask for.
+// That is how the 2.7.2/2.7.3 skew was found, one release after it shipped.
+//
+// The fix is `cargo update -p Markpad --precise <version>` (or any `cargo
+// check` in `src-tauri`, which does it as a side effect), then commit the
+// one-line diff.
+
+test('package.json, Cargo.toml and Cargo.lock declare the same version', () => {
+	const pkg = JSON.parse(readSource('package.json')).version;
+
+	const toml = /^version = "([^"]+)"/m.exec(readSource('src-tauri/Cargo.toml'))?.[1];
+	assert.ok(toml, 'no top-level version key in src-tauri/Cargo.toml');
+
+	// Anchored on the package entry, not on the first `version` in the file:
+	// the lock has 661 of them and Markpad's is not the first.
+	const lock = /\[\[package\]\]\nname = "Markpad"\nversion = "([^"]+)"/.exec(
+		readSource('src-tauri/Cargo.lock'),
+	)?.[1];
+	assert.ok(lock, 'no Markpad package entry in src-tauri/Cargo.lock');
+
+	assert.equal(toml, pkg, 'src-tauri/Cargo.toml is out of step with package.json');
+	assert.equal(
+		lock,
+		pkg,
+		'src-tauri/Cargo.lock is out of step with package.json; run `cargo update -p Markpad --precise ' +
+			`${pkg}\` in src-tauri and commit the change`,
+	);
+});

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Markpad"
-version = "2.7.2"
+version = "2.7.3"
 dependencies = [
  "arboard",
  "base64 0.22.1",


### PR DESCRIPTION
`src-tauri/Cargo.lock` recorded `version = "2.7.2"` for the `Markpad` package while `src-tauri/Cargo.toml` and `package.json` both said `2.7.3` — the lock was not regenerated during the last bump. Nothing in the editing loop reads it, so the skew landed green and stayed. It surfaces on the next `cargo build`, which rewrites the line and hands whoever built a dirty working tree they did not ask for.

- `cargo update -p Markpad --precise 2.7.3` — one-line lock change, no dependency movement.
- AGENTS.md's Versioning section named two files that must move together; it now names the third, with the command.
- `scripts/versionSync.test.ts` asserts the three agree, in the style of `ciCacheBudget.test.ts` / `dependabotConfig.test.ts`. Verified it fails on the pre-fix lock with the fix command in the assertion message.

No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)