### PR TITLE
feat(find): open the preview find bar on the selected text

### DIFF
--- a/scripts/findSeed.test.ts
+++ b/scripts/findSeed.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { findSeedFromSelection } from '../src/lib/utils/findSeed.js';
+import { readSource } from './sourceTree.js';
+
+/** A `Selection` as far as `findSeedFromSelection` is concerned. */
+function selecting(text: string, where: 'preview' | 'elsewhere' | 'caret' = 'preview') {
+	const node = where === 'elsewhere' ? 'outside' : 'inside';
+	return { isCollapsed: where === 'caret', anchorNode: node, focusNode: node, toString: () => text } as unknown as Selection;
+}
+
+/** The rendered document. `contains` is the only question the seed asks of it. */
+const preview = { contains: (node: unknown) => node === 'inside' } as unknown as Node;
+
+test('what Cmd/Ctrl+F starts from, given what is selected', () => {
+	const seed = (s: Selection | null, root: Node | null = preview) => findSeedFromSelection(s, root);
+
+	assert.equal(seed(selecting('deterministic')), 'deterministic');
+	// Across `**bold**`, a link or inline code the selection spans several text
+	// nodes; reading only one would leave the feature off in the commonest case.
+	assert.equal(seed(selecting('bold word')), 'bold word');
+	assert.equal(seed(selecting('  spaced  ')), 'spaced', 'a double-click drags the trailing space in');
+
+	// Empty means "leave the box alone" — a repeated Cmd/Ctrl+F re-focuses the
+	// previous query (#559) rather than wiping it.
+	assert.equal(seed(selecting('first\nsecond')), '', 'multi-line: Monaco’s rule in the other pane');
+	assert.equal(seed(selecting('   ')), '', 'whitespace only');
+	assert.equal(seed(selecting('x', 'caret')), '', 'a caret with nothing selected');
+	assert.equal(seed(selecting('x', 'elsewhere')), '', 'selected in a modal or the tab strip');
+	assert.equal(seed(null), '', 'no selection');
+	assert.equal(seed(selecting('x'), null), '', 'no preview on screen');
+});
+
+test('the seed is wired to the find bar', () => {
+	// One line the compiler cannot check: a pure function nothing calls is dead code.
+	assert.match(readSource('src/lib/MarkdownViewer.svelte'), /if \(seed\) findBar\?\.setQuery\(seed\);/);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -74,6 +74,7 @@ import {
 	type MarkdownLinkTarget as RelativeMarkdownTarget,
 } from './utils/markdownLinks.js';
 import { resolveLocalFileLinkPath } from './utils/localFileLinks.js';
+import { findSeedFromSelection } from './utils/findSeed.js';
 import { normalizeAssetPath } from './utils/exportHtml.js';
 import {
 	dropRecentFile,
@@ -165,6 +166,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		reapply: () => void;
 		clearHighlights: () => void;
 		focusInput: () => void;
+		setQuery: (value: string) => void;
 	} | null>(null);
 
 	// Decide where Cmd/Ctrl+F should land based on what's visible and where
@@ -177,6 +179,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		if (editorHasFocus || !previewVisible) {
 			editorPane?.triggerFind?.();
 		} else if (markdownBody) {
+			// Seed BEFORE opening, so the bar that appears already holds the query.
+			// Nothing to seed leaves the previous query alone, which is what a
+			// repeated Cmd/Ctrl+F expects.
+			const seed = findSeedFromSelection(window.getSelection(), markdownBody);
+			if (seed) findBar?.setQuery(seed);
 			// Focus explicitly: once the bar is open, `findOpen = true` changes
 			// nothing, so a repeated shortcut after clicking into the document
 			// used to be swallowed (#559).

--- a/src/lib/components/FindBar.svelte
+++ b/src/lib/components/FindBar.svelte
@@ -302,6 +302,18 @@
 		});
 	}
 
+	/**
+	 * Put a query in the box from outside — what Cmd/Ctrl+F does with the text the
+	 * user had selected in the preview.
+	 *
+	 * Only the assignment: the `query` effect below is what schedules the search,
+	 * so a seed behaves exactly like typing, including the debounce and the guard
+	 * that holds the search back until the bar is open.
+	 */
+	export function setQuery(value: string) {
+		query = value;
+	}
+
 	export function reapply() {
 		// Public hook for parent: call after the preview HTML is replaced
 		// so existing matches survive across re-renders.

--- a/src/lib/utils/findSeed.ts
+++ b/src/lib/utils/findSeed.ts
@@ -1,0 +1,21 @@
+/**
+ * The query the preview's find bar should open with, given what the reader has
+ * selected. Empty means "leave the box alone" — which is what a repeated
+ * Cmd/Ctrl+F with nothing selected expects.
+ *
+ * `selection.toString()` deliberately, rather than the text of one node: a
+ * selection crossing `**bold**`, a link or inline code spans several nodes, and
+ * those are the words a reader is most likely to have highlighted.
+ *
+ * Single-line selections only. That is Monaco's rule — its
+ * `seedSearchStringFromSelection` seeds from a selection while it stays on one
+ * line — so the editor pane already behaves this way, and the app agrees with
+ * itself about one keystroke instead of inventing a second rule. A paragraph in
+ * the search box matches nothing and buries the query the user was about to type.
+ */
+export function findSeedFromSelection(selection: Selection | null, root: Node | null): string {
+	if (!root || !selection || selection.isCollapsed) return '';
+	if (!root.contains(selection.anchorNode) || !root.contains(selection.focusNode)) return '';
+	const text = selection.toString().trim();
+	return text.includes('\n') ? '' : text;
+}


### PR DESCRIPTION
Reworked from #231, which bundled this with a Copy-as-Markdown command. The copy half is not landing (reasoning in that thread); this is the half that closes a real gap. The commit keeps @junglesub as the author.

## What changes

Select a word in the rendered preview, press <kbd>Cmd/Ctrl</kbd>+<kbd>F</kbd>, and the bar opens with that word already in it.

The editor pane has behaved this way for as long as it has used Monaco — `seedSearchStringFromSelection` defaults to seeding — so the two panes disagreed about the same keystroke, and the preview was the one that made you retype the word you were already pointing at.

## Decisions

**The seed is `selection.toString()`**, not the text of one node. A selection crossing `**bold**`, a link or inline code spans several text nodes, and those are the words a reader is most likely to have highlighted. Reading a single node would have left the feature off in the commonest case.

**Single-line selections only** — Monaco's own rule in the other pane, so the app agrees with itself about one keystroke instead of growing a second rule. A paragraph in the search box matches nothing and buries the query the user was about to type.

**Nothing to seed leaves the previous query alone** rather than clearing it: a caret with nothing selected, a selection in a modal or the tab strip, whitespace. A repeated <kbd>Cmd/Ctrl</kbd>+<kbd>F</kbd> still just re-focuses and re-selects the box (#559).

**`setQuery` is the assignment and nothing else.** The existing `query` effect schedules the search, so a seed goes through the same debounce and the same not-yet-open guard as typing. `applyHighlights` and the scroll-restore path are untouched.

Not included: starting from the *selected occurrence* rather than the first match. #231 spent ~110 lines on it — a `pendingActiveRange` / `getRangeMatchIndex` / `getClosestMarkIndex` fallback chain, an `untrack` change to the `sanitizedHtml` effect, and an extra `reapply()` in the render path — inside a tree walk that mutates the nodes it is walking. It can come back on its own merits.

## Testing

`npm test` — 977 pass. `npm run check` — clean.

The decision of whether to seed is the whole feature, so it lives in `src/lib/utils/findSeed.ts` as a pure function the test imports and runs, plus one source-shape line for the wiring (a pure function nothing calls is dead code). Checked by mutation: dropping the single-line rule fails it, and so does dropping the containment guard.

Manually verified on macOS with a debug build: selecting across bold and inline code, selecting in the tab strip, repeated <kbd>Cmd</kbd>+<kbd>F</kbd> with no selection, and split view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)