### PR TITLE
chore(release): write the version once, in the three files it lives in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,7 +172,8 @@ All file operations go through Rust commands - never use Node.js fs APIs.
 
 ## Versioning
 
-When bumping the app version, update all three files in the same commit:
+When bumping the app version, run `npm run release X.Y.Z` — it writes all
+three and checks they agree. By hand, all three go in the same commit:
 
 - `package.json` `version`
 - `src-tauri/Cargo.toml` `version`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -62,9 +62,19 @@ The failure is quiet and unfixable from here: `latest.json` 404s, the updater re
 
 The workflow uses `npm ci`, so its installed dependency graph is exactly the committed lockfile. Do not replace it with `npm install` in release jobs. The same applies to [`snapcraft.yaml`](snapcraft.yaml), which builds the snap outside GitHub Actions; `scripts/releaseWorkflow.test.ts` guards both.
 
-1. **Bump version in both files** (mandatory — Tauri reads runtime version from `Cargo.toml`):
-   - [`package.json`](package.json) `version`
-   - [`src-tauri/Cargo.toml`](src-tauri/Cargo.toml) `[package].version`
+1. **Bump the version:**
+   ```bash
+   npm run release X.Y.Z
+   ```
+   It writes all three files the version lives in and checks they agree —
+   [`package.json`](package.json), [`src-tauri/Cargo.toml`](src-tauri/Cargo.toml)
+   `[package].version`, and the `Markpad` entry in
+   [`src-tauri/Cargo.lock`](src-tauri/Cargo.lock). The lock is the one that gets
+   forgotten by hand: nothing in the editing loop reads it, so a bump without it
+   lands green and stays wrong until someone's `cargo build` rewrites the line.
+   That is how the 2.7.2/2.7.3 skew was found, one release after it shipped.
+
+   It stops there. Committing, tagging and dispatching stay below, on purpose.
 2. **Commit, tag, push:**
    ```bash
    git commit -am "chore: bump version to X.Y.Z"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"build:test-bundle": "node scripts/build-test-bundle.mjs",
-		"tauri": "tauri"
+		"tauri": "tauri",
+		"release": "node scripts/release.mjs"
 	},
 	"license": "BSD-3-Clause",
 	"dependencies": {

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -27,7 +27,14 @@ if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
 	process.exit(2);
 }
 
-/** Replace once, and fail loudly rather than writing a file that changed nothing. */
+/**
+ * Replace once, and fail loudly rather than writing a file that changed nothing.
+ *
+ * @param {string} path
+ * @param {RegExp} pattern
+ * @param {string} replacement
+ * @returns {string}
+ */
 function edit(path, pattern, replacement) {
 	const before = readFileSync(path, 'utf8');
 	const after = before.replace(pattern, replacement);

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Set the app version, in all three places, from one argument.
+ *
+ * The version is one fact and the repository writes it three times:
+ * package.json, src-tauri/Cargo.toml, and the `Markpad` entry in
+ * src-tauri/Cargo.lock. RELEASING.md names the first two; the lock is the one
+ * that gets forgotten, because nothing in the editing loop reads it. A bump
+ * without it lands green and stays wrong until the next person's `cargo build`
+ * rewrites the line and hands them a dirty working tree they did not ask for --
+ * which is how the 2.7.2/2.7.3 skew was found, one release after it shipped.
+ *
+ * scripts/versionSync.test.ts catches that skew. This is the other half: a
+ * guard says the three disagree, and this makes it hard for them to.
+ *
+ * It deliberately stops before committing, tagging or pushing. Whether a tag
+ * push should start a release build, and whether the changelog is part of this,
+ * are open questions in #562 with the maintainer's name on them. The version
+ * bump is not a question, so it does not wait for the answers.
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const version = process.argv[2];
+if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
+	console.error('usage: npm run release <X.Y.Z>');
+	process.exit(2);
+}
+
+/** Replace once, and fail loudly rather than writing a file that changed nothing. */
+function edit(path, pattern, replacement) {
+	const before = readFileSync(path, 'utf8');
+	const after = before.replace(pattern, replacement);
+	if (after === before) {
+		console.error(`${path}: nothing matched ${pattern}. Refusing to write it unchanged.`);
+		process.exit(1);
+	}
+	writeFileSync(path, after);
+	return path;
+}
+
+edit('package.json', /("version":\s*")[^"]+(")/, `$1${version}$2`);
+// Anchored on the [package] table: Cargo.toml has a `version` under every
+// dependency and the first one in the file is not necessarily ours.
+edit('src-tauri/Cargo.toml', /(\[package\][\s\S]*?\nversion = ")[^"]+(")/, `$1${version}$2`);
+
+// The lock is not edited by hand -- cargo owns its format, and it is the file
+// this whole script exists for.
+execFileSync('cargo', ['update', '-p', 'Markpad', '--precise', version], {
+	cwd: 'src-tauri',
+	stdio: 'inherit',
+});
+
+const seen = {
+	'package.json': JSON.parse(readFileSync('package.json', 'utf8')).version,
+	'src-tauri/Cargo.toml': /\[package\][\s\S]*?\nversion = "([^"]+)"/.exec(
+		readFileSync('src-tauri/Cargo.toml', 'utf8'),
+	)?.[1],
+	'src-tauri/Cargo.lock': /\[\[package\]\]\nname = "Markpad"\nversion = "([^"]+)"/.exec(
+		readFileSync('src-tauri/Cargo.lock', 'utf8'),
+	)?.[1],
+};
+const wrong = Object.entries(seen).filter(([, v]) => v !== version);
+if (wrong.length > 0) {
+	console.error('after writing, these still disagree:');
+	for (const [path, v] of wrong) console.error(`  ${path}: ${v ?? '(not found)'}`);
+	process.exit(1);
+}
+
+console.log(`\nAll three files say ${version}. Still yours to do:\n`);
+console.log(`  git commit -am "chore: bump version to ${version}"`);
+console.log(`  git tag v${version}`);
+console.log(`  git push origin master v${version}`);
+console.log(`  then dispatch "Build and Release" — RELEASING.md has the rest\n`);

--- a/scripts/versionSync.test.ts
+++ b/scripts/versionSync.test.ts
@@ -35,3 +35,25 @@ test('package.json, Cargo.toml and Cargo.lock declare the same version', () => {
 			`${pkg}\` in src-tauri and commit the change`,
 	);
 });
+
+test('one command writes the version, and the runbook names it', () => {
+	// The assertion above catches the three files disagreeing. This is the other
+	// half: something that makes them hard to disagree in the first place.
+	// RELEASING.md used to name two of the three, so the third was skipped by
+	// following the instructions correctly.
+	const pkg = JSON.parse(readSource('package.json'));
+	assert.equal(pkg.scripts.release, 'node scripts/release.mjs');
+
+	// It has to touch all three, or it is a bump that reintroduces the skew.
+	const script = readSource('scripts/release.mjs');
+	for (const file of ['package.json', 'src-tauri/Cargo.toml', 'Cargo.lock']) {
+		assert.ok(script.includes(file), `scripts/release.mjs never mentions ${file}`);
+	}
+	// The lock is cargo's format; a hand-rolled rewrite of it is the bug, not the
+	// fix.
+	assert.match(script, /cargo['"],\s*\['update'/);
+
+	// And the runbook points at the command rather than at the two files.
+	assert.match(readSource('RELEASING.md'), /npm run release X\.Y\.Z/);
+	assert.match(readSource('AGENTS.md'), /npm run release X\.Y\.Z/);
+});


### PR DESCRIPTION
#582 found the 2.7.2/2.7.3 skew and added the guard. This is the other half: something that makes the three files hard to disagree in the first place.

## Why it kept happening

```
package.json            version              ← RELEASING.md tells you to edit this
src-tauri/Cargo.toml    [package].version    ← and this
src-tauri/Cargo.lock    Markpad entry        ← and not this
```

Following the runbook **correctly** still skipped the lock. Nothing in the editing loop reads it, so the bump lands green and stays wrong until someone's `cargo build` rewrites the line and hands them a dirty working tree they did not ask for — which is how it was found, one release after it shipped.

## The command

```bash
npm run release 2.7.4
```

Writes `package.json` and `src-tauri/Cargo.toml`, then runs `cargo update -p Markpad --precise 2.7.4` for the lock — cargo owns that format, and hand-rolling it would be the bug rather than the fix. Then it **re-reads all three** and refuses if any disagrees. An edit whose pattern matches nothing fails loudly instead of writing the file back unchanged.

Exercised end to end: bumped to `9.9.9` and back to `2.7.3`, with all three files following in both directions.

```
All three files say 2.7.4. Still yours to do:

  git commit -am "chore: bump version to 2.7.4"
  git tag v2.7.4
  git push origin master v2.7.4
  then dispatch "Build and Release" — RELEASING.md has the rest
```

## Where it stops, and why

It does not commit, tag, or dispatch. #562 §3 asks @alecdotdev two things about that — whether pushing a tag should start a release build, and whether the changelog belongs here — and both are preferences, not facts. **The version bump is not one of them**, so it does not wait for the answers. If the answer to either arrives, this is where it goes.

## Tests

`RELEASING.md` and `AGENTS.md` now name the command rather than two of the three files, and an assertion holds all of it together: the script exists, it mentions all three files, it reaches the lock through `cargo update`, and both documents point at it.

Checked by mutation — a `release.mjs` that stops touching `Cargo.lock` fails it:

```
✖ one command writes the version, and the runbook names it
```

`npm test` — 981 pass.

Done in a worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)