### PR TITLE
fix(preview): a ticked task dims its content once, not once per nesting level

### DIFF
--- a/samples/katex-stress.md
+++ b/samples/katex-stress.md
@@ -1,0 +1,240 @@
+# KaTeX stress
+
+A manual fixture for the one part of maths rendering no automated test reaches.
+The suite checks that the export machinery *finds* KaTeX's fonts; nothing in it
+renders a formula, so nothing in it can tell you a formula came out wrong.
+
+Open this after a KaTeX upgrade, or after touching preview styling or PDF
+export. Three things to look at, in order of how likely they are to be wrong:
+
+1. **Fonts.** Variables italic serif, operators upright, `\mathbb` and
+   `\mathcal` visibly unlike plain letters. A family that failed to load falls
+   back to Times or the UI font, which is obvious once you are looking for it.
+2. **Spacing and stacking.** Fractions, roots, matrices, big operators with
+   limits above and below. A styling rule that stopped applying shows up as
+   collapsed or overlapping layout rather than as an error.
+3. **Export to PDF.** `src/lib/utils/exportFonts.ts` reads `katex.min.css` and
+   subsets the KaTeX faces into the exported file. **Export this document and
+   read the maths in the PDF**, not only on screen — the two can disagree.
+
+KaTeX 0.18.0 renamed its internal CSS classes, which is the shape of upgrade
+this exists for: everything still parses, and the result can still be wrong.
+
+---
+
+## 1 Inline, in running text
+
+The mass–energy relation $E = mc^2$ sits inline, as does a fraction
+$\tfrac{1}{2}$, a root $\sqrt{2}$, a subscript $x_i$, a superscript $x^2$, and
+a combined $x_i^{2}$. Greek runs inline too: $\alpha\beta\gamma\delta\epsilon$,
+$\Gamma\Delta\Theta\Lambda\Xi\Pi\Sigma\Phi\Psi\Omega$.
+
+Inline next to **bold text $a+b$ inside bold**, and *italic with $c+d$ inside*.
+A `code span` then $e+f$ then more text. Punctuation right after maths: $g$,
+$h$. and $i$; and $j$?
+
+Two dollars that are not maths: costs \$5 and \$10. A single `$` alone.
+
+## 2 Display, one per block
+
+$$
+E = mc^2
+$$
+
+$$
+\int_{-\infty}^{\infty} e^{-x^2}\,dx = \sqrt{\pi}
+$$
+
+$$
+\sum_{n=1}^{\infty} \frac{1}{n^2} = \frac{\pi^2}{6}
+$$
+
+$$
+\lim_{x \to 0} \frac{\sin x}{x} = 1
+\qquad
+\prod_{i=1}^{n} i = n!
+$$
+
+## 3 Fonts — the check that matters most
+
+$$
+\mathrm{upright} \quad \mathit{italic} \quad \mathbf{bold} \quad
+\mathsf{sans} \quad \mathtt{mono} \quad \mathcal{ABCDEFG} \quad
+\mathbb{ABCDEFGHIJKLMNOPQRSTUVWXYZ} \quad \mathfrak{ABCDEFG}
+$$
+
+$$
+\text{Roman text inside maths, with a variable } x \text{ between words.}
+$$
+
+Each of those eight should look **visibly different from the others**. If two
+collapse to the same face, a font family did not make it.
+
+## 4 Structure — stacking, spacing, delimiters
+
+$$
+\frac{\displaystyle\frac{a}{b}}{\displaystyle\frac{c}{d}}
+\qquad
+\sqrt{\sqrt{\sqrt{x}}}
+\qquad
+x^{y^{z^{w}}}
+$$
+
+$$
+\left( \frac{1}{2} \right)
+\left[ \frac{1}{2} \right]
+\left\{ \frac{1}{2} \right\}
+\left| \frac{1}{2} \right|
+\left\| \frac{1}{2} \right\|
+\left\langle \frac{1}{2} \right\rangle
+\left\lceil \frac{1}{2} \right\rceil
+\left\lfloor \frac{1}{2} \right\rfloor
+$$
+
+Delimiters must grow with their contents. If they stay small next to a tall
+fraction, the sizing rules did not apply.
+
+## 5 Matrices and arrays
+
+$$
+\begin{pmatrix} a & b \\ c & d \end{pmatrix}
+\begin{bmatrix} a & b \\ c & d \end{bmatrix}
+\begin{vmatrix} a & b \\ c & d \end{vmatrix}
+\begin{Bmatrix} a & b \\ c & d \end{Bmatrix}
+$$
+
+$$
+A = \begin{pmatrix}
+a_{11} & a_{12} & \cdots & a_{1n} \\
+a_{21} & a_{22} & \cdots & a_{2n} \\
+\vdots & \vdots & \ddots & \vdots \\
+a_{m1} & a_{m2} & \cdots & a_{mn}
+\end{pmatrix}
+$$
+
+## 6 Aligned environments
+
+$$
+\begin{aligned}
+\nabla \cdot \mathbf{E} &= \frac{\rho}{\varepsilon_0} \\
+\nabla \cdot \mathbf{B} &= 0 \\
+\nabla \times \mathbf{E} &= -\frac{\partial \mathbf{B}}{\partial t} \\
+\nabla \times \mathbf{B} &= \mu_0\mathbf{J} + \mu_0\varepsilon_0\frac{\partial \mathbf{E}}{\partial t}
+\end{aligned}
+$$
+
+$$
+\begin{cases}
+x + y = 1 & \text{if } x > 0 \\
+x - y = 2 & \text{otherwise}
+\end{cases}
+$$
+
+The `&` columns must line up. This is the shape #197 was about — multi-line
+aligned vector calculus — so it is worth a second look.
+
+## 7 Accents, arrows, operators
+
+$$
+\hat{a} \; \bar{b} \; \vec{c} \; \dot{d} \; \ddot{e} \; \tilde{f} \; \check{g}
+\; \breve{h} \; \acute{i} \; \grave{j} \; \mathring{k} \; \widehat{lmn} \;
+\overline{opq} \; \underline{rst} \; \overrightarrow{uvw}
+$$
+
+$$
+\to \gets \leftrightarrow \Rightarrow \Leftarrow \Leftrightarrow \mapsto
+\longmapsto \rightharpoonup \rightleftharpoons \nearrow \searrow \swarrow \nwarrow
+$$
+
+$$
+\leq \geq \neq \approx \equiv \sim \simeq \cong \propto \parallel \perp
+\subset \subseteq \supset \supseteq \in \notin \cup \cap \setminus
+\forall \exists \nexists \emptyset \infty \partial \nabla \pm \mp \times \div
+$$
+
+## 8 Over- and under-set limits
+
+$$
+\overbrace{a + b + c}^{\text{three terms}}
+\qquad
+\underbrace{x + y + z}_{\text{also three}}
+$$
+
+$$
+\lim_{n \to \infty} \quad \max_{x \in S} \quad \operatorname*{argmin}_{\theta} \quad
+\bigcup_{i=1}^{n} \quad \bigcap_{i=1}^{n} \quad \bigoplus_{i} \quad \iint_D \quad \oint_C
+$$
+
+## 9 Long line — does it scroll or overflow?
+
+$$
+f(x) = a_0 + a_1x + a_2x^2 + a_3x^3 + a_4x^4 + a_5x^5 + a_6x^6 + a_7x^7 + a_8x^8 + a_9x^9 + a_{10}x^{10} + a_{11}x^{11} + a_{12}x^{12} + a_{13}x^{13} + a_{14}x^{14}
+$$
+
+A display wider than the pane should scroll inside its own box rather than push
+the page sideways. Check this in the exported PDF too — that is where an
+overflow becomes a clipped formula instead of a scrollbar.
+
+## 10 Maths inside other things
+
+> A blockquote with display maths inside it:
+>
+> $$
+> \oint_{\partial \Sigma} \mathbf{B} \cdot d\boldsymbol{\ell} = \mu_0 I
+> $$
+
+1. A list item with inline $\alpha$ and a display below it:
+
+   $$
+   \frac{\partial u}{\partial t} = \alpha \frac{\partial^2 u}{\partial x^2}
+   $$
+
+2. Another item, $\beta$, to check the list keeps its numbering.
+
+| formula | meaning |
+|---|---|
+| $e^{i\pi} + 1 = 0$ | Euler's identity |
+| $\sum_{k=0}^{n} \binom{n}{k} = 2^n$ | binomial sum |
+| $\det(A - \lambda I) = 0$ | characteristic equation |
+
+- [ ] A task item with maths: $\nabla^2 \phi = 0$
+- [x] A ticked one: $\hbar = \frac{h}{2\pi}$
+
+The two task items are a pair on purpose: a ticked item is struck through, and
+the strikethrough must not swallow or squash the formula beside it. Compare the
+two lines against each other rather than judging the second one alone.
+
+## 11 CJK next to maths
+
+中文里的行内公式 $a^2 + b^2 = c^2$ 紧挨着汉字，前后都不加空格。
+
+日本語の $\int_0^1 x\,dx = \frac12$ も同様に。
+
+한국어 문장 안의 $\lim_{n\to\infty} a_n = L$ 도 확인.
+
+Full-width punctuation right after maths: $x$。$y$，$z$、
+
+## 12 Things that should NOT render as maths
+
+Not maths: `$100 + $200`. In a code fence:
+
+```
+$$
+this must stay literal
+$$
+```
+
+Escaped: \$x^2\$ should print dollars and a caret, not a superscript.
+
+## 13 Deliberately broken — should show an error, not vanish
+
+$$
+\frac{1}{
+$$
+
+$$
+\undefinedmacro{x}
+$$
+
+Both should render KaTeX's error state — red, in place — rather than
+disappearing silently or taking the rest of the document with them.

--- a/scripts/exportedThemeFidelity.test.ts
+++ b/scripts/exportedThemeFidelity.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 
 import { buildExportDocument, exportThemeAttribute } from '../src/lib/utils/export.js';
 import { DEFAULT_PREVIEW_MAX_WIDTH } from '../src/lib/utils/previewWidth.js';
-import { readSource } from './sourceTree.js';
+import { readSource, sliceBetween } from './sourceTree.js';
 
 const styles = readSource('src/styles.css');
 const exportSource = readSource('src/lib/utils/export.ts');
@@ -112,4 +112,26 @@ test('the copied stylesheet and the article still land in the document', () => {
 	assert.match(doc, /<style>[\s\S]*\.sentinel \{ color: red; \}/);
 	assert.match(doc, /<article class="markdown-body">\n<p id="sentinel">hello<\/p>/);
 	assert.match(doc, /^<!DOCTYPE html>\n/);
+});
+
+test('a ticked task dims its content once, not once per nesting level', () => {
+	// `opacity` composites rather than inherits, so a rule matching every
+	// descendant multiplies itself down the tree. This rule ended in
+	// `:checked *`, which words survive at one or two levels deep and KaTeX does
+	// not: it nests twelve spans, so a formula in a ticked item rendered at
+	// 0.65^12 = 0.006 and disappeared while the text beside it merely faded.
+	// samples/katex-stress.md holds a ticked and an unticked task item next to
+	// each other so the difference is visible rather than arguable.
+	//
+	// Asserted as "no universal descendant selector carries opacity here", not
+	// as a literal selector list, because the defect is the shape and not the
+	// spelling.
+	const styles = readSource('src/styles.css');
+	const block = sliceBetween(styles, 'input[data-task-checkbox]:checked) .task-text', '/* restore');
+	assert.doesNotMatch(
+		block,
+		/:checked\)\s*\*[\s,]/,
+		'a ticked task item applies opacity to every descendant; deep markup compounds it away',
+	);
+	assert.match(block, /opacity:\s*0?\.\d+/, 'the ticked-item rule stopped dimming anything at all');
 });

--- a/scripts/exportedThemeFidelity.test.ts
+++ b/scripts/exportedThemeFidelity.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 
 import { buildExportDocument, exportThemeAttribute } from '../src/lib/utils/export.js';
 import { DEFAULT_PREVIEW_MAX_WIDTH } from '../src/lib/utils/previewWidth.js';
-import { readSource, sliceBetween } from './sourceTree.js';
+import { readSource, sliceFrom } from './sourceTree.js';
 
 const styles = readSource('src/styles.css');
 const exportSource = readSource('src/lib/utils/export.ts');
@@ -116,22 +116,35 @@ test('the copied stylesheet and the article still land in the document', () => {
 
 test('a ticked task dims its content once, not once per nesting level', () => {
 	// `opacity` composites rather than inherits, so a rule matching every
-	// descendant multiplies itself down the tree. This rule ended in
-	// `:checked *`, which words survive at one or two levels deep and KaTeX does
-	// not: it nests twelve spans, so a formula in a ticked item rendered at
-	// 0.65^12 = 0.006 and disappeared while the text beside it merely faded.
-	// samples/katex-stress.md holds a ticked and an unticked task item next to
-	// each other so the difference is visible rather than arguable.
+	// descendant multiplies itself down the tree. Words survive that at one or two
+	// levels deep and KaTeX does not: it nests twelve spans, so a formula in a
+	// ticked item rendered at 0.65^12 = 0.006 and disappeared while the text beside
+	// it merely faded. samples/katex-stress.md keeps a ticked and an unticked task
+	// item next to each other so the difference is visible rather than arguable.
 	//
-	// Asserted as "no universal descendant selector carries opacity here", not
-	// as a literal selector list, because the defect is the shape and not the
-	// spelling.
+	// Scanned across the whole stylesheet rather than inside one rule, because the
+	// first attempt at this fixed `:has(:checked)` -- labelled in the file as the
+	// fallback for reload and initial state -- and left `.task-done`, which is the
+	// class the app actually sets. Both carried it. An assertion scoped to the
+	// block being edited passed, and nothing a user sees had changed.
 	const styles = readSource('src/styles.css');
-	const block = sliceBetween(styles, 'input[data-task-checkbox]:checked) .task-text', '/* restore');
-	assert.doesNotMatch(
-		block,
-		/:checked\)\s*\*[\s,]/,
-		'a ticked task item applies opacity to every descendant; deep markup compounds it away',
+	const universal = styles
+		.split('\n')
+		.filter((line) => /(task-done|data-task-checkbox\]:checked\))\s*\*\s*[,{]/.test(line));
+	assert.deepEqual(
+		universal,
+		[],
+		'a completed task applies opacity to every descendant; deep markup compounds it away',
 	);
-	assert.match(block, /opacity:\s*0?\.\d+/, 'the ticked-item rule stopped dimming anything at all');
+
+	// And both paths still dim something -- deleting the rules would pass the
+	// assertion above for the wrong reason.
+	for (const marker of ['li.task-done .task-text', ':checked) .task-text']) {
+		const block = sliceFrom(styles, marker);
+		assert.match(
+			block.slice(0, 300),
+			/opacity:\s*0?\.\d+/,
+			`the rule at "${marker}" stopped dimming anything at all`,
+		);
+	}
 });

--- a/src/styles.css
+++ b/src/styles.css
@@ -1892,10 +1892,23 @@ body {
 	text-decoration-color: var(--color-fg-muted);
 }
 
+/*
+ * `opacity` does not inherit -- it composites, once per element that declares
+ * it. The selector list here ended in `... :checked *`, every descendant, so a
+ * ticked item multiplied 0.65 by itself all the way down its own markup. Plain
+ * words survived that at one or two levels deep. KaTeX nests twelve spans, so a
+ * formula landed at 0.65^12 = 0.006 and vanished, while the words beside it only
+ * faded -- see the two task items in samples/katex-stress.md, which exist as a
+ * pair for exactly this reason.
+ *
+ * Applied to the wrapper the content sits in, so it happens once. Not moved up
+ * onto the `li`: opacity on an ancestor cannot be undone by a descendant, and
+ * the rules below deliberately restore the checkbox and any nested list to full
+ * opacity. `text-decoration` needs no such help -- it propagates to descendant
+ * text on its own, which is why the `li` rule above already carries it.
+ */
 .markdown-body li.task-list-item:has(input[data-task-checkbox]:checked) .task-text,
-.markdown-body li.task-list-item:has(input[data-task-checkbox]:checked) p,
-.markdown-body li.task-list-item:has(input[data-task-checkbox]:checked) > *:not(input):not(ul):not(ol),
-.markdown-body li.task-list-item:has(input[data-task-checkbox]:checked) * {
+.markdown-body li.task-list-item:has(input[data-task-checkbox]:checked) > *:not(input):not(.task-text):not(ul):not(ol) {
 	text-decoration: line-through;
 	opacity: 0.65;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1870,10 +1870,13 @@ body {
 	text-decoration-color: var(--color-fg-muted);
 }
 
+/* The live path -- `task-done` is the class the app sets. The `:has` block
+ * further down is the fallback for reload and initial state, and both carried
+ * the same defect; fixing one and not the other changes nothing a user sees.
+ * See the note on the `:has` rule for why opacity may not be applied per
+ * descendant, and why it may not move up onto the `li` either. */
 .markdown-body li.task-done .task-text,
-.markdown-body li.task-done p,
-.markdown-body li.task-done > *:not(input):not(ul):not(ol),
-.markdown-body li.task-done * {
+.markdown-body li.task-done > *:not(input):not(.task-text):not(ul):not(ol) {
 	text-decoration: line-through;
 	opacity: 0.65;
 }


### PR DESCRIPTION
A formula inside a ticked task item was invisible.

```
☐ A task item with maths: ∇²φ = 0          ← fine
☑ A̶ ̶t̶i̶c̶k̶e̶d̶ ̶o̶n̶e̶:̶  ℏ =                       ← faint, and the fraction simply gone
```

Found by opening `samples/katex-stress.md` on a debug build. Nothing in the suite renders maths, so nothing in the suite could have said so.

## Why

```css
li.task-done * { opacity: 0.65 }
```

`opacity` **does not inherit — it composites**, once per element that declares it. The selector matched *every descendant*, so a completed item multiplied 0.65 by itself all the way down its own markup.

Measured on this document's own content — KaTeX nests **twelve** spans:

```
0.65^1  = 0.65     "A ticked one:" — one or two levels deep, survives
0.65^5  = 0.116
0.65^12 = 0.0057   the fraction, at the bottom of KaTeX's tree
```

Which is why it read as *truncation*. `ℏ` and `=` are shallow and kept a faint outline; `\frac{h}{2\pi}` is deep and did not. Nothing was cut off — it was rendered at half a percent.

## Both paths, which is the part I got wrong first

`src/styles.css` carries two parallel rule sets for a completed task:

```
li.task-done                                            ← the class the app sets
li.task-list-item:has(input[data-task-checkbox]:checked) ← "fallback for reload / initial state"
```

Both ended in a universal descendant selector with `opacity`. The first commit here fixed only the `:has` fallback, and **nothing a user sees changed** — verified, not assumed: the debug build carried the edit (bundled stylesheet has the new selectors and none of the old, timestamped nine seconds before the binary) and the formula was still invisible.

The assertion passed for the same reason the change did nothing: it sliced the block being edited and asked whether *that block* was right, instead of asking whether the property held. Scoping an assertion to the code being written is how it ends up agreeing with it.

## The shape the fix has to keep

Applied to the wrapper the content sits in, so it happens once.

**Deliberately not moved up onto the `li`.** Opacity on an ancestor cannot be undone by a descendant, and the rules immediately below exist to restore the checkbox and any nested list to full opacity:

```css
/* restore opacity/decoration for certain safe elements like ul/ol/checkboxes/links */
… input[data-task-checkbox] { opacity: 1 !important }
… ul, … ol                  { opacity: 1 }
```

Moving it up would silently break both. `text-decoration` needs no equivalent — it propagates to descendant text on its own, which is why the `li` rules already carry it and always have.

## Not a KaTeX 0.18 regression

0.16 composites identically. Nobody had put a formula in a ticked task item before.

`samples/katex-stress.md` comes with this pull request rather than with #587. It was written for #587 and pushed to that branch five minutes after it merged, so it never reached `master` — checked rather than assumed: `master` has the monaco, katex, TypeScript and Tauri bumps and the version-coupled KaTeX test, and not this file. It belongs here anyway. The fixture is what found this bug, and it keeps a ticked and an unticked task item **next to each other** precisely so the comparison is available rather than having to be thought of.

## Verification

Confirmed by eye on a debug build with both paths fixed — the fraction renders complete and legible, one shade lighter than the unticked item above it. That is the only thing that can confirm it.

The assertion now scans the **whole stylesheet** for either spelling rather than one block. Both mutations fail it on their own:

```
restore the universal selector under task-done  → ✖ a ticked task dims its content once…
restore it under :checked                       → ✖ (same)
```

It also checks both blocks still dim *something*, so deleting the rules cannot pass it for the wrong reason.

`svelte-check` 0 errors. `npm test` — 981 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
