### PR TITLE
fix(preview): hide the disclosure triangle, which one colon never did

### DIFF
--- a/scripts/exportedThemeFidelity.test.ts
+++ b/scripts/exportedThemeFidelity.test.ts
@@ -148,3 +148,32 @@ test('a ticked task dims its content once, not once per nesting level', () => {
 		);
 	}
 });
+
+test('the marker rules are pseudo-elements, which is what makes them apply', () => {
+	// `summary:marker` sat in the stylesheet as a single colon. `:marker` is not
+	// a pseudo-class, so the rule matched nothing and the disclosure triangle was
+	// never hidden -- silently, for as long as it had been there. esbuild, which
+	// vite 6 minifies with, passes it through; lightningcss, which vite 8 uses,
+	// rejects it by name:
+	//
+	//   'marker' is not recognized as a valid pseudo-class.
+	//   Did you mean '::marker' (pseudo-element) or is this a typo?
+	//
+	// A rule that matches nothing is invisible in every direction: nothing renders
+	// differently, nothing errors, and the CSS reads as if it works.
+	//
+	// Only the pseudo-elements with no legacy spelling. `:before`, `:after`,
+	// `:first-line` and `:first-letter` are CSS2 and every browser still accepts
+	// one colon -- this file inherits several from github-markdown-css and they
+	// work. The ones CSS3 introduced have no such form: written with one colon
+	// they parse as an unknown pseudo-class and the whole rule is discarded.
+	const styles = readSource('src/styles.css');
+	const singleColon = styles
+		.split('\n')
+		.filter((line) => /[^:]:(marker|placeholder|selection|backdrop|file-selector-button)\b/.test(line));
+	assert.deepEqual(
+		singleColon,
+		[],
+		'a CSS3 pseudo-element is written with one colon here, so the rule matches nothing',
+	);
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -707,7 +707,7 @@ body {
 	cursor: pointer;
 }
 
-.markdown-body details summary:marker {
+.markdown-body details summary::marker {
 	display: none;
 }
 


### PR DESCRIPTION
```css
.markdown-body details summary:marker { display: none }
```

`:marker` is not a pseudo-class. **The rule matched nothing**, so the disclosure triangle on a `<details>` block has never been hidden — silently, for as long as the rule has been there.

A rule that matches nothing is invisible in every direction: nothing renders differently from the day before, nothing errors, and the CSS reads as if it works. It is the kind of defect that only surfaces when some other tool has an opinion about it.

## How it surfaced

Installing vite 8 to find out whether it was takeable. Vite 8 minifies with lightningcss, which says so by name where esbuild passes it straight through:

```
[lightningcss minify] 'marker' is not recognized as a valid pseudo-class.
Did you mean '::marker' (pseudo-element) or is this a typo?

4829 |  .markdown-body details summary:marker {
     |                                 ^
```

The vite 8 upgrade is not in this pull request — it needs more than this. This is the finding it handed over on the way.

## The guard, and the distinction it had to learn

Only pseudo-elements **with no legacy spelling**:

```
:before  :after  :first-line  :first-letter    CSS2 — one colon is valid, browsers accept both
::marker ::placeholder ::selection             CSS3 — no single-colon form exists
::backdrop ::file-selector-button              one colon parses as an unknown pseudo-class
                                               and the whole rule is discarded
```

The first version of the assertion flagged six legitimate `:before` rules this file inherits from github-markdown-css. They work, and narrowing the rule is what put the distinction in the comment.

Checked by mutation — putting the single colon back fails it:

```
✖ the marker rules are pseudo-elements, which is what makes them apply
  a CSS3 pseudo-element is written with one colon here, so the rule matches nothing
```

`svelte-check` 0 errors. `npm test` — 985 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)