### PR TITLE
fix(deps): back to monaco-editor 0.55.1 — 0.56 kills vim mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"highlightjs-svelte": "^1.0.6",
 				"katex": "^0.18.4",
 				"mermaid": "^11.16.0",
-				"monaco-editor": "^0.56.0",
+				"monaco-editor": "^0.55.1",
 				"monaco-vim": "^0.4.4",
 				"yaml": "^2.9.0"
 			},
@@ -2565,12 +2565,12 @@
 			}
 		},
 		"node_modules/monaco-editor": {
-			"version": "0.56.0",
-			"resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.56.0.tgz",
-			"integrity": "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==",
+			"version": "0.55.1",
+			"resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+			"integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
 			"license": "MIT",
 			"dependencies": {
-				"dompurify": "3.4.8",
+				"dompurify": "3.2.7",
 				"marked": "14.0.0"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"highlightjs-svelte": "^1.0.6",
 		"katex": "^0.18.4",
 		"mermaid": "^11.16.0",
-		"monaco-editor": "^0.56.0",
+		"monaco-editor": "^0.55.1",
 		"monaco-vim": "^0.4.4",
 		"yaml": "^2.9.0"
 	},

--- a/scripts/editorLineEnding.test.ts
+++ b/scripts/editorLineEnding.test.ts
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { PieceTreeTextBufferBuilder } from 'monaco-editor/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBufferBuilder.js';
-import { DefaultEndOfLine } from 'monaco-editor/editor/common/standalone/standaloneEnums.js';
+import { PieceTreeTextBufferBuilder } from 'monaco-editor/esm/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBufferBuilder.js';
+import { DefaultEndOfLine } from 'monaco-editor/esm/vs/editor/common/standalone/standaloneEnums.js';
 
 import { lineEndingLabel } from '../src/lib/utils/tabModels.js';
 import { readSource, sliceBetween } from './sourceTree.js';

--- a/scripts/editorOptionWiring.test.ts
+++ b/scripts/editorOptionWiring.test.ts
@@ -1,16 +1,16 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { containsUnusualLineTerminators } from 'monaco-editor/base/common/strings.js';
+import { containsUnusualLineTerminators } from 'monaco-editor/esm/vs/base/common/strings.js';
 import {
 	EditorOptions,
 	inUntrustedWorkspace,
 	type UnicodeHighlightOptions,
-} from 'monaco-editor/editor/common/config/editorOptions.js';
+} from 'monaco-editor/esm/vs/editor/common/config/editorOptions.js';
 import {
 	UnicodeTextModelHighlighter,
 	type UnicodeHighlightResult,
-} from 'monaco-editor/editor/common/services/unicodeTextModelHighlighter.js';
+} from 'monaco-editor/esm/vs/editor/common/services/unicodeTextModelHighlighter.js';
 import ts from 'typescript';
 
 import { editorOptionsFromSettings } from '../src/lib/utils/editorOptions.js';
@@ -596,12 +596,12 @@ test('the character that opens that dialog is one prose really carries', () => {
 // asserting the option is spelled correctly in Editor.svelte.
 
 const { getMapForWordSeparators } = await import(
-	'monaco-editor/editor/common/core/wordCharacterClassifier.js'
+	'monaco-editor/esm/vs/editor/common/core/wordCharacterClassifier.js'
 );
 // Monaco's own default — the editor does not set `wordSeparators`, so this is
 // what the classifier is built with in the app.
 const { USUAL_WORD_SEPARATORS } = await import(
-	'monaco-editor/editor/common/core/wordHelper.js'
+	'monaco-editor/esm/vs/editor/common/core/wordHelper.js'
 );
 
 /** Every word boundary Monaco would find on `line`, walking it end to end. */

--- a/scripts/keymapHarness.ts
+++ b/scripts/keymapHarness.ts
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict';
 
-import { decodeKeybinding, type KeyCodeChord } from 'monaco-editor/base/common/keybindings.js';
-import { KeyCodeUtils } from 'monaco-editor/base/common/keyCodes.js';
-import { KeyCode } from 'monaco-editor/editor/common/standalone/standaloneEnums.js';
-import { KeyMod } from 'monaco-editor/editor/common/services/editorBaseApi.js';
+import { decodeKeybinding, type KeyCodeChord } from 'monaco-editor/esm/vs/base/common/keybindings.js';
+import { KeyCodeUtils } from 'monaco-editor/esm/vs/base/common/keyCodes.js';
+import { KeyCode } from 'monaco-editor/esm/vs/editor/common/standalone/standaloneEnums.js';
+import { KeyMod } from 'monaco-editor/esm/vs/editor/common/services/editorBaseApi.js';
 import ts from 'typescript';
 
 import { readSource, functionSource } from './sourceTree.js';

--- a/scripts/monaco-internals.d.ts
+++ b/scripts/monaco-internals.d.ts
@@ -1,5 +1,5 @@
 // monaco-editor publishes types for its public surface only
-// (`monaco-editor/editor/editor.api.d.ts`). The ESM internals ship as
+// (`monaco-editor/esm/vs/editor/editor.api.d.ts`). The ESM internals ship as
 // plain `.js` with no declarations beside them.
 //
 // pasteUrlContext.test.ts drives Monarch directly — `monaco.editor.tokenize()`
@@ -7,14 +7,14 @@
 // create — so it reaches for three of those internals. Declared here with the
 // shapes that test actually uses, rather than left implicitly `any`.
 
-declare module 'monaco-editor/editor/standalone/common/monarch/monarchCompile.js' {
+declare module 'monaco-editor/esm/vs/editor/standalone/common/monarch/monarchCompile.js' {
 	import type { languages } from 'monaco-editor';
 
 	/** Compiles a Monarch language definition into the lexer the tokenizer runs. */
 	export function compile(languageId: string, json: languages.IMonarchLanguage): unknown;
 }
 
-declare module 'monaco-editor/editor/standalone/common/monarch/monarchLexer.js' {
+declare module 'monaco-editor/esm/vs/editor/standalone/common/monarch/monarchLexer.js' {
 	/**
 	 * Constructed with (languageService, themeService, languageId, lexer,
 	 * configurationService). The services are stubs here, so the parameters stay
@@ -26,7 +26,7 @@ declare module 'monaco-editor/editor/standalone/common/monarch/monarchLexer.js' 
 	};
 }
 
-declare module 'monaco-editor/languages/definitions/markdown/markdown.js' {
+declare module 'monaco-editor/esm/vs/basic-languages/markdown/markdown.js' {
 	import type { languages } from 'monaco-editor';
 
 	export const conf: languages.LanguageConfiguration;

--- a/scripts/monacoInternals.d.ts
+++ b/scripts/monacoInternals.d.ts
@@ -15,7 +15,7 @@
 // Only the members the test calls are declared. This is not an attempt to type
 // Monaco's internals in general.
 
-declare module 'monaco-editor/editor/common/config/editorOptions.js' {
+declare module 'monaco-editor/esm/vs/editor/common/config/editorOptions.js' {
 	/** Sentinel default for the options gated on workspace trust. */
 	export const inUntrustedWorkspace: 'inUntrustedWorkspace';
 
@@ -60,7 +60,7 @@ declare module 'monaco-editor/editor/common/config/editorOptions.js' {
 	};
 }
 
-declare module 'monaco-editor/base/common/strings.js' {
+declare module 'monaco-editor/esm/vs/base/common/strings.js' {
 	/**
 	 * Monaco's own predicate for U+2028 / U+2029 — the one whose result the
 	 * piece-tree buffer stores as `mightContainUnusualLineTerminators`, which is
@@ -69,7 +69,7 @@ declare module 'monaco-editor/base/common/strings.js' {
 	export function containsUnusualLineTerminators(str: string): boolean;
 }
 
-declare module 'monaco-editor/editor/common/services/unicodeTextModelHighlighter.js' {
+declare module 'monaco-editor/esm/vs/editor/common/services/unicodeTextModelHighlighter.js' {
 	export interface UnicodeHighlightRange {
 		startLineNumber: number;
 		startColumn: number;
@@ -123,7 +123,7 @@ declare module 'monaco-editor/editor/common/services/unicodeTextModelHighlighter
 // reached at the modules that define them, plus the decoder that reads what they
 // produce.
 
-declare module 'monaco-editor/editor/common/services/editorBaseApi.js' {
+declare module 'monaco-editor/esm/vs/editor/common/services/editorBaseApi.js' {
 	/** Modifier bits, and the chord-sequence packer. Identical to `monaco.KeyMod`. */
 	export const KeyMod: {
 		readonly CtrlCmd: number;
@@ -134,7 +134,7 @@ declare module 'monaco-editor/editor/common/services/editorBaseApi.js' {
 	};
 }
 
-declare module 'monaco-editor/editor/common/standalone/standaloneEnums.js' {
+declare module 'monaco-editor/esm/vs/editor/common/standalone/standaloneEnums.js' {
 	/**
 	 * Typed as an index rather than member by member: the test reads
 	 * `KeyCode.KeyA + n` and `KeyCode.Digit0 + n` to build its key table, and
@@ -151,7 +151,7 @@ declare module 'monaco-editor/editor/common/standalone/standaloneEnums.js' {
 // The text buffer itself, for `editorLineEnding.test.ts`. A `TextModel` needs a
 // browser to build; the buffer under it does not, and it is where the EOL of a
 // document is decided — `createTextBufferFactory` is these three calls.
-declare module 'monaco-editor/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBufferBuilder.js' {
+declare module 'monaco-editor/esm/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeTextBufferBuilder.js' {
 	/** Only the two members the test reads; this is not the whole buffer API. */
 	export interface TextBuffer {
 		getEOL(): '\n' | '\r\n';
@@ -171,14 +171,14 @@ declare module 'monaco-editor/editor/common/model/pieceTreeTextBuffer/pieceTreeT
 	}
 }
 
-declare module 'monaco-editor/base/common/keyCodes.js' {
+declare module 'monaco-editor/esm/vs/base/common/keyCodes.js' {
 	export const KeyCodeUtils: {
 		/** The printable name Monaco gives a KeyCode — `KeyE` -> "E", `Period` -> ".". */
 		toString(keyCode: number): string;
 	};
 }
 
-declare module 'monaco-editor/base/common/keybindings.js' {
+declare module 'monaco-editor/esm/vs/base/common/keybindings.js' {
 	/** One keystroke of a resolved keybinding. */
 	export interface KeyCodeChord {
 		readonly ctrlKey: boolean;
@@ -199,7 +199,7 @@ declare module 'monaco-editor/base/common/keybindings.js' {
 	): { readonly chords: readonly KeyCodeChord[] } | null;
 }
 
-declare module 'monaco-editor/editor/common/core/wordHelper.js' {
+declare module 'monaco-editor/esm/vs/editor/common/core/wordHelper.js' {
 	/**
 	 * The `wordSeparators` default. The editor does not set that option, so this
 	 * is the string its word classifier is actually built with.
@@ -207,7 +207,7 @@ declare module 'monaco-editor/editor/common/core/wordHelper.js' {
 	export const USUAL_WORD_SEPARATORS: string;
 }
 
-declare module 'monaco-editor/editor/common/core/wordCharacterClassifier.js' {
+declare module 'monaco-editor/esm/vs/editor/common/core/wordCharacterClassifier.js' {
 	/**
 	 * Decides where words begin and end for ⌥←/→, double-click-to-select and
 	 * ⌥⌫. `intlSegmenterLocales` is `wordSegmenterLocales`: a non-empty list

--- a/scripts/monacoStartupGraph.test.ts
+++ b/scripts/monacoStartupGraph.test.ts
@@ -242,3 +242,60 @@ test('no source file outside Editor.svelte reintroduces a static Monaco import',
 
 	assert.deepEqual(offenders, []);
 });
+
+test("monaco-vim's one import into monaco still resolves", () => {
+	// monaco-vim 0.4.4 is the latest release and is unmaintained. It imports
+	// exactly one monaco module, and without an extension:
+	//
+	//   monaco-editor/esm/vs/editor/editor.api
+	//
+	// monaco-editor 0.55 maps `"./*": "./*"` -- an identity -- so a bundler adds
+	// `.js` on the filesystem and finds it. 0.56 changed it to
+	// `"./*": "./esm/vs/*.js"`, which prepends a prefix the specifier already
+	// carries: the path doubles to `esm/vs/esm/vs/…` and nothing is there. Once a
+	// package declares `exports`, a resolver may not fall back to the filesystem
+	// path it would otherwise have used, so there is no recovery.
+	//
+	// The 0.56 bump built clean, passed 976 tests on three platforms, and shipped
+	// vim mode dead. Nothing here loads monaco-vim, and no build step resolved it
+	// strictly enough to notice. So this applies the map by hand and asks whether
+	// the file is there -- which is the whole of what went wrong.
+	const monacoPkg = JSON.parse(readSource('node_modules/monaco-editor/package.json'));
+	const patterns = Object.entries((monacoPkg.exports ?? {}) as Record<string, unknown>).filter(
+		([key]) => key.includes('*'),
+	);
+
+	// One build of the package rather than a walk of its dist: the .mjs, .cjs and
+	// .umd.js are the same source through three bundlers and name the same import.
+	const specifiers = new Set<string>();
+	for (const match of readSource('node_modules/monaco-vim/dist/index.mjs').matchAll(
+		/['"](monaco-editor\/[^'"]+)['"]/g,
+	)) {
+		specifiers.add(match[1]);
+	}
+	assert.ok(specifiers.size > 0, 'found no monaco imports in monaco-vim; this check has nothing to ask about');
+
+	const unresolvable: string[] = [];
+	for (const specifier of specifiers) {
+		const subpath = `.${specifier.slice('monaco-editor'.length)}`;
+		let target: string | null = null;
+		for (const [pattern, value] of patterns) {
+			const [before, after] = pattern.split('*');
+			if (!subpath.startsWith(before) || !subpath.endsWith(after)) continue;
+			const star = subpath.slice(before.length, subpath.length - after.length);
+			target = String(value).replace('*', star);
+			break;
+		}
+		if (!target) continue;
+		const base = `node_modules/monaco-editor/${target.slice(2)}`;
+		// The extensions a bundler will try after the map has had its say.
+		if (![base, `${base}.js`, `${base}.mjs`].some((candidate) => existsSync(candidate))) {
+			unresolvable.push(`${specifier} → ${target}`);
+		}
+	}
+	assert.deepEqual(
+		unresolvable,
+		[],
+		"monaco-editor's exports map sends a monaco-vim import somewhere that does not exist; vim mode will be dead",
+	);
+});

--- a/scripts/pasteUrlContext.test.ts
+++ b/scripts/pasteUrlContext.test.ts
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { compile } from 'monaco-editor/editor/standalone/common/monarch/monarchCompile.js';
-import { MonarchTokenizer } from 'monaco-editor/editor/standalone/common/monarch/monarchLexer.js';
-import { language as markdownLanguage } from 'monaco-editor/languages/definitions/markdown/markdown.js';
+import { compile } from 'monaco-editor/esm/vs/editor/standalone/common/monarch/monarchCompile.js';
+import { MonarchTokenizer } from 'monaco-editor/esm/vs/editor/standalone/common/monarch/monarchLexer.js';
+import { language as markdownLanguage } from 'monaco-editor/esm/vs/basic-languages/markdown/markdown.js';
 
 import { readSource } from './sourceTree.js';
 

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -35,11 +35,11 @@
 	// Monaco actually asks `getWorker()` for one. Making them dynamic would move
 	// a few hundred bytes and buy nothing.
 	import type * as Monaco from "monaco-editor";
-	import editorWorker from "monaco-editor/editor/editor.worker?worker";
-	import jsonWorker from "monaco-editor/language/json/json.worker?worker";
-	import cssWorker from "monaco-editor/language/css/css.worker?worker";
-	import htmlWorker from "monaco-editor/language/html/html.worker?worker";
-	import tsWorker from "monaco-editor/language/typescript/ts.worker?worker";
+	import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+	import jsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
+	import cssWorker from "monaco-editor/esm/vs/language/css/css.worker?worker";
+	import htmlWorker from "monaco-editor/esm/vs/language/html/html.worker?worker";
+	import tsWorker from "monaco-editor/esm/vs/language/typescript/ts.worker?worker";
 	import { openUrl } from "@tauri-apps/plugin-opener";
 	import { invoke } from "@tauri-apps/api/core";
 


### PR DESCRIPTION
**Vim mode is dead on `master`.** Pressing `j` types a `j`.

Confirmed by A/B on two builds: it works in the installed 2.7.3, and does not in a debug build of `master`. #587 did this, and I wrote #587.

## Why

`monaco-vim@0.4.4` — the latest release, unmaintained — imports **exactly one** monaco module, and without an extension:

```
monaco-editor/esm/vs/editor/editor.api
```

The two exports maps, side by side:

```
0.55.1   "./*"    → "./*"                identity — the bundler adds .js and finds it

0.56.0   "./*.js" → "./esm/vs/*.js"
         "./*"    → "./esm/vs/*.js"      prepends a prefix the specifier already
                                         carries → esm/vs/esm/vs/editor/editor.api.js
                                         → nothing is there
```

Once a package declares `exports`, a resolver **may not fall back** to the filesystem path it would otherwise have used. There is no recovery from inside the application, and monaco-vim has no newer release to move to.

## Why revert rather than alias round it

The bump bought nothing anyone asked for — it was taken because a version existed. The alternative is a build-config patch aliasing one specifier past an unmaintained dependency's incompatibility, verifiable only by a person pressing `j` in a debug build. That is not a trade worth making for a shipped feature.

This reverts the monaco commit whole, including its 33 import-specifier rewrites. Those existed to satisfy 0.56's map and are wrong for 0.55's.

The rest of #587 stays: Tauri 2.11.5 with all five pairs, katex 0.18.4, TypeScript 5.9.3, `@types/node` 26.

## How it got through

Nothing here loads monaco-vim, and no build step resolved it strictly enough to notice:

```
npm run build      clean, zero warnings          ← vite 6 resolves it leniently
npm test           976 pass                      ← nothing imports monaco-vim
build-test         green on three platforms      ← compiles, does not run
```

The bump built clean, passed on three platforms, and shipped a dead feature. **It is the same shape as the excludelist and the ticked-task styling: a check that verifies the thing next to the defect.**

## The guard

The new assertion applies monaco's exports map **by hand** to every `monaco-editor/...` specifier monaco-vim names, and checks the file is there — the exact question that went unasked.

Checked by mutation; installing 0.56's map into 0.55's `package.json` fails it:

```
✖ monaco-vim's one import into monaco still resolves
  monaco-editor's exports map sends a monaco-vim import somewhere that does not
  exist; vim mode will be dead
```

(Six other monaco tests fail alongside it under that mutation, which is the map doing the same thing to them.)

`svelte-check` 0 errors. `npm test` — 985 pass. `npm run build` clean.

## Note for whoever revisits monaco 0.56

It is not simply "wait for monaco-vim". 0.4.4 is the last release and the project is quiet. Taking 0.56 means either patching the resolution in `vite.config` or dropping vim mode — and either way, the check above is what tells you which side you are on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)