### PR TITLE
fix(i18n): require the language, so a call site cannot forget it

### DIFF
--- a/scripts/fileDropRouting.test.ts
+++ b/scripts/fileDropRouting.test.ts
@@ -94,6 +94,6 @@ test('the viewer routes both panes through it, and acts on all three answers', (
 	// to say.
 	assert.match(
 		viewerSource,
-		/function reportUnsupportedDrop\(path: string\)[\s\S]{0,300}?t\('toast\.unsupportedFile'\)/,
+		/function reportUnsupportedDrop\(path: string\)[\s\S]{0,300}?t\('toast\.unsupportedFile', uiLanguage\)/,
 	);
 });

--- a/scripts/i18nCoverage.test.ts
+++ b/scripts/i18nCoverage.test.ts
@@ -247,6 +247,21 @@ test('the scanner actually found the call sites', () => {
 	assert.equal(languages.length, 26);
 });
 
+test('t() requires a language, so a call site cannot forget one', () => {
+	// `lang: LanguageCode = 'en'` made the language optional at ~322 call sites,
+	// and 9 of them omitted it — including the window-control aria-labels a
+	// screen reader reads out, which said "Close" in all 26 languages. tsc is
+	// the real guard now; this asserts the source form so nobody types the
+	// default back in and re-opens the hole.
+	const signature = /export function t\((.*?)\): string/.exec(readSource('src/lib/utils/i18n.ts'));
+	assert.ok(signature, 'the exported t() signature moved; this test can no longer see it');
+	assert.equal(
+		signature[1],
+		'key: string, lang: LanguageCode',
+		't() must take the language as a required parameter, with no default',
+	);
+});
+
 test('every key the source asks for exists in English', () => {
 	// TitleBar called t('common.save'); en.common has close/minimize/maximize/
 	// loadingFullDocument and no save, so the button rendered "common.save".

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -214,7 +214,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 
 	function reportUnsupportedDrop(path: string) {
 		const filename = path.split(/[/\\]/).pop() || 'File';
-		addToast(t('toast.unsupportedFile').replace('{{filename}}', filename), 'error');
+		addToast(t('toast.unsupportedFile', uiLanguage).replace('{{filename}}', filename), 'error');
 	}
 	let editorPaneEl = $state<HTMLElement>();
 	let viewerPaneEl = $state<HTMLElement>();
@@ -3939,14 +3939,14 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 				{#if isSplit || isEditing}
 					<div class="drag-zone editor-zone" class:active={dragTarget === 'editor'}>
 								<div class="drag-message">
-									<span>{t('dragAndDrop.embed')}</span>
+									<span>{t('dragAndDrop.embed', uiLanguage)}</span>
 								</div>
 							</div>
 				{/if}
 				{#if isSplit || !isEditing}
 					<div class="drag-zone viewer-zone" class:active={dragTarget === 'preview'}>
 								<div class="drag-message">
-									<span>{t('dragAndDrop.open')}</span>
+									<span>{t('dragAndDrop.open', uiLanguage)}</span>
 								</div>
 							</div>
 				{/if}

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -428,14 +428,14 @@
 	<div class="window-controls-left" data-tauri-drag-region>
 		{#if isMac && !useNativeMacChrome}
 			<div class="macos-traffic-lights" class:visible={isMac}>
-				<button class="mac-btn mac-close" onclick={() => appWindow.close()} aria-label={t('common.close')}>
+				<button class="mac-btn mac-close" onclick={() => appWindow.close()} aria-label={t('common.close', currentLanguage)}>
 						<svg width="6" height="6" viewBox="0 0 6 6" class="mac-icon"
 								><path d="M0.5 0.5L5.5 5.5M5.5 0.5L0.5 5.5" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" /></svg>
 					</button>
-					<button class="mac-btn mac-minimize" onclick={() => appWindow.minimize()} aria-label={t('common.minimize')}>
+					<button class="mac-btn mac-minimize" onclick={() => appWindow.minimize()} aria-label={t('common.minimize', currentLanguage)}>
 						<svg width="6" height="6" viewBox="0 0 6 6" class="mac-icon"><path d="M0.5 3H5.5" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" /></svg>
 					</button>
-					<button class="mac-btn mac-maximize" onclick={() => appWindow.toggleMaximize()} aria-label={t('common.maximize')}>
+					<button class="mac-btn mac-maximize" onclick={() => appWindow.toggleMaximize()} aria-label={t('common.maximize', currentLanguage)}>
 						<svg width="6" height="6" viewBox="0 0 6 6" class="mac-icon"><path d="M0.5 3H5.5M3 0.5V5.5" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" /></svg>
 					</button>
 			</div>
@@ -1091,16 +1091,16 @@
 
 	<div class="window-controls-right" data-tauri-drag-region>
 		{#if !isMac}
-			<button class="control-btn" onclick={() => appWindow.minimize()} aria-label={t('common.minimize')}>
+			<button class="control-btn" onclick={() => appWindow.minimize()} aria-label={t('common.minimize', currentLanguage)}>
 				<svg width="12" height="12" viewBox="0 0 12 12"><rect fill="currentColor" width="10" height="1" x="1" y="6" /></svg>
 			</button>
-			<button class="control-btn" onclick={() => appWindow.toggleMaximize()} aria-label={t('common.maximize')}>
+			<button class="control-btn" onclick={() => appWindow.toggleMaximize()} aria-label={t('common.maximize', currentLanguage)}>
 				<svg width="12" height="12" viewBox="0 0 12 12"><rect fill="none" stroke="currentColor" stroke-width="1" width="9" height="9" x="1.5" y="1.5" /></svg>
 			</button>
 			<button
 				class="control-btn close-btn"
 				onclick={() => appWindow.close()}
-				aria-label={t('common.close')}>
+				aria-label={t('common.close', currentLanguage)}>
 				<svg width="12" height="12" viewBox="0 0 12 12"><path fill="currentColor" d="M11 1.7L10.3 1 6 5.3 1.7 1 1 1.7 5.3 6 1 10.3 1.7 11 6 6.7 10.3 11 11 10.3 6.7 6z" /></svg>
 			</button>
 		{/if}

--- a/src/lib/utils/i18n.ts
+++ b/src/lib/utils/i18n.ts
@@ -6804,7 +6804,11 @@ for (const [language, sections] of Object.entries(interactiveLabelTranslations) 
     }
 }
 
-export function t(key: string, lang: LanguageCode = 'en'): string {
+// `lang` is deliberately required. When it defaulted to 'en', a call site that
+// forgot to pass the language compiled, ran, and showed English in all 26
+// languages — silently, including on aria-labels a screen reader reads out.
+// The default is the bug; the compiler is the check. Do not restore it.
+export function t(key: string, lang: LanguageCode): string {
     const keys = key.split('.');
     
     const getValue = (dict: any) => {


### PR DESCRIPTION
**Stack 1/5.** Base: `master`.

`t(key, lang = 'en')` made the language optional, so all ~322 call sites had to remember to thread `settings.language` through. Nine did not, and were permanently English in all 26 locales.

Six of the nine are the macOS and Windows window-control `aria-label`s — close, minimise, maximise — which screen readers announce.

| File | Key |
|---|---|
| `MarkdownViewer.svelte:217` | `toast.unsupportedFile` |
| `MarkdownViewer.svelte:3942, 3949` | `dragAndDrop.embed`, `dragAndDrop.open` |
| `TitleBar.svelte:431, 435, 438` | `common.close/minimize/maximize` (macOS) |
| `TitleBar.svelte:1094, 1097, 1103` | `common.minimize/maximize/close` (Windows) |

Dropping the default turns each of them into a compile error. Each site now reads the language mirror its own file already maintains — no new mechanism.

**The list of nine is compiler-verified, not grepped.** `tsconfig.json` covers `src/**` and `scripts/**`, so `svelte-check` returning 0 errors after the default was removed is proof there is no tenth call site in the checked surface.

`i18nCoverage.test.ts` catches a missing *key*; it could never catch a missing *language argument*. A new test pins the signature so the default cannot be restored.

### Verification
- `npm test` 981 pass / 0 fail (980 baseline + 1 new)
- `npm run check` 706 files / 0 errors / 0 warnings

### Deliberately not in this PR
`i18n.ts:6796-6805` merges a second dictionary into the exported `translations` as a module-load side effect, so the value after import differs from the literal. Out of scope here; filed for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
