### PR TITLE
refactor(scroll): give the buffer's lines and the renderer's different types

### DIFF
--- a/scripts/jumpToSelectedFragment.test.ts
+++ b/scripts/jumpToSelectedFragment.test.ts
@@ -322,17 +322,46 @@ test('the real stress document shifts by its front matter', () => {
 // through `toBufferRange`. A test that only pinned the arithmetic would pass
 // with either call site still handing over a raw body line.
 
+const { asBufferLine, asRendererLine, lineCoordinates } = await import('../src/lib/utils/lineCoordinates.js');
+
+test('the shift is what the module applies, in both directions', () => {
+	// The arithmetic itself, called rather than matched. A round trip through
+	// the pair has to be the identity, or a position handed from one pane to the
+	// other and back walks up the document by the height of the front matter
+	// every time it crosses.
+	const raw = ['---', 'title: "T"', 'tags:', '  - a', '---', '', '# Title'].join('\n') + '\n';
+	const coords = lineCoordinates(raw);
+	assert.equal(coords.frontMatterLines, 6);
+
+	assert.equal(coords.toBufferLine(asRendererLine(1)), 7, 'the body starts on buffer line 7');
+	assert.equal(coords.toRendererLine(asBufferLine(7)), 1);
+	for (const line of [1, 2, 40, 137]) {
+		assert.equal(coords.toRendererLine(coords.toBufferLine(asRendererLine(line))), line, `renderer line ${line}`);
+		assert.equal(coords.toBufferLine(coords.toRendererLine(asBufferLine(line + 6))), line + 6, `buffer line ${line + 6}`);
+	}
+
+	// A range shifts by the same amount at both ends, so it still covers the
+	// same text rather than growing or sliding.
+	assert.deepEqual(coords.toBufferRange({ startLine: 3, endLine: 9 }), { startLine: 9, endLine: 15 });
+
+	// And a document without front matter is left exactly where it is, which is
+	// why the shift went unnoticed for as long as it did.
+	const plain = lineCoordinates('# Title\n\nbody\n');
+	assert.equal(plain.frontMatterLines, 0);
+	assert.deepEqual(plain.toBufferRange({ startLine: 3, endLine: 9 }), { startLine: 3, endLine: 9 });
+});
+
 test('every renderer line reaching the editor goes through the shift', () => {
 	// Two consumers hand a `data-sourcepos` number to the editor, and both have
 	// to shift it. `toggleEditView` is not a third: it resolves the range and
 	// passes it to `editSourceRange`, which is where the shift happens.
 	const edit = functionSource(viewerSource, 'editSourceRange');
-	assert.match(edit, /pendingEditReveal = toBufferRange\(range\)/, 'the context menu and ⌘E shift');
+	assert.match(edit, /pendingEditReveal = lineCoords\.toBufferRange\(range\)/, 'the context menu and ⌘E shift');
 
 	// The outline is wired inline in the markup rather than in a function.
 	assert.match(
 		viewerSource,
-		/editorPane\.revealHeader\(\s*sourceLine === null \? null : toBufferRange\(/,
+		/editorPane\.revealHeader\(\s*sourceLine === null \? null : lineCoords\.toBufferLine\(/,
 		'the outline shifts',
 	);
 });
@@ -348,14 +377,14 @@ test('scroll sync converts in both directions', () => {
 	const capture = functionSource(viewerSource, 'getPreviewScrollSyncPosition');
 	assert.match(
 		capture,
-		/line: toBufferLine\(line\)/,
+		/lineCoords\.bufferLineAtPreviewOffset\(/,
 		'a line read off the preview is shifted before the editor sees it',
 	);
 
 	const apply = functionSource(viewerSource, 'scrollPreviewToSyncPosition');
 	assert.match(
 		apply,
-		/toRendererLine\(position\.line\)/,
+		/lineCoords\.previewOffsetForBufferLine\(/,
 		'a line coming from the editor is shifted back before the preview seeks',
 	);
 });
@@ -365,18 +394,19 @@ test('the outline is fed body lines from both panes', () => {
 	// lines (`getPreviewScrollAnchor`); the editor's has to be converted, or the
 	// highlighted heading changes depending on which pane you scrolled.
 	const fromEditor = functionSource(viewerSource, 'handleEditorScrollSync');
-	assert.match(fromEditor, /tocActiveLine = toRendererLine\(position\.line\)/);
+	assert.match(fromEditor, /tocActiveLine = lineCoords\.toRendererLine\(position\.line\)/);
 
 	const fromPreview = functionSource(viewerSource, 'getPreviewScrollAnchor');
 	assert.doesNotMatch(fromPreview, /toBufferLine|toRendererLine/, 'already a body line');
 });
 
 test('the shift reads the buffer, not the rendered body', () => {
-	// `frontMatterLineOffset(rawContent)` — measuring the render would answer 0
+	// `lineCoordinates(rawContent)` — measuring the render would answer 0
 	// forever, since the render is what the front matter was stripped out of.
-	for (const name of ['toBufferRange', 'toBufferLine', 'toRendererLine']) {
-		assert.match(functionSource(viewerSource, name), /frontMatterLineOffset\(rawContent\)/, name);
-	}
+	// One derivation, so there is one answer for the whole document rather than
+	// a per-call-site chance to read the wrong thing.
+	assert.match(viewerSource, /let lineCoords = \$derived\(lineCoordinates\(rawContent\)\)/);
+	assert.equal(viewerSource.match(/lineCoordinates\(/g)?.length, 1);
 });
 
 // The menu is opened BY right-clicking a selection, and two of its items act

--- a/scripts/lineCoordinates.test.ts
+++ b/scripts/lineCoordinates.test.ts
@@ -1,0 +1,167 @@
+/**
+ * The shift between the editor's line numbers and the preview's.
+ *
+ * `renderMarkdownPreview` hands comrak the body with the front matter stripped
+ * off, so every `data-sourcepos` — and the outline, the tab's reading position
+ * and both halves of scroll sync with it — counts from the first line of the
+ * BODY, while the editor holds the whole file. The difference is exactly the
+ * number of buffer lines the front matter occupies, and it is ZERO in a
+ * document that has none.
+ *
+ * That zero is why this file exists. Every fixture in the suite this module was
+ * extracted from was a document without front matter, so both numberings agreed
+ * and a crossing that forgot to convert passed everything. The tests here are
+ * the ones that only say something when the offset is not zero: the round trip
+ * through both directions, the range, and — the half no arithmetic test can
+ * reach — the trip out to a pixel in the preview and back.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+	asBufferLine,
+	asRendererLine,
+	lineCoordinates,
+	type BufferLine,
+} from '../src/lib/utils/lineCoordinates.ts';
+
+/** Six buffer lines of YAML, so the body starts on buffer line 7. */
+const WITH_FRONT_MATTER = ['---', 'title: "T"', 'tags:', '  - a', '---', '', '# Title'].join('\n') + '\n';
+const FRONT_MATTER_LINES = 6;
+
+test('the offset is the number of buffer lines above the body', () => {
+	assert.equal(lineCoordinates(WITH_FRONT_MATTER).frontMatterLines, FRONT_MATTER_LINES);
+	assert.equal(lineCoordinates('# Title\n\nbody\n').frontMatterLines, 0);
+	// `\r\n` contains a `\n`, so the count is the same one.
+	assert.equal(lineCoordinates(['---', 'title: "T"', '---', '', '# Title'].join('\r\n') + '\r\n').frontMatterLines, 4);
+});
+
+test('the two directions are inverses, with front matter in the way', () => {
+	const coords = lineCoordinates(WITH_FRONT_MATTER);
+
+	// The heading is line 1 of the body and line 7 of the buffer.
+	assert.equal(coords.toBufferLine(asRendererLine(1)), 7);
+	assert.equal(coords.toRendererLine(asBufferLine(7)), 1);
+
+	// And the round trip closes from either end. This is the assertion the old
+	// suite could not have failed: with `frontMatterEnd = 0` everywhere, both
+	// conversions were the identity and so was the composition of two wrong
+	// ones.
+	for (const line of [1, 2, 3, 40, 1_000, 13_419]) {
+		assert.equal(coords.toBufferLine(coords.toRendererLine(asBufferLine(line))), line, `buffer line ${line}`);
+		assert.equal(coords.toRendererLine(coords.toBufferLine(asRendererLine(line))), line, `renderer line ${line}`);
+	}
+
+	// A fractional line — scroll sync sends one on every event — shifts the same
+	// way, because the offset is a whole number of lines whatever the fraction.
+	assert.equal(coords.toBufferLine(asRendererLine(12.25)), 18.25);
+	assert.equal(coords.toRendererLine(asBufferLine(18.25)), 12.25);
+});
+
+test('a document without front matter is left exactly where it is', () => {
+	const coords = lineCoordinates('# Title\n\nbody\n');
+	for (const line of [1, 17, 900]) {
+		assert.equal(coords.toBufferLine(asRendererLine(line)), line);
+		assert.equal(coords.toRendererLine(asBufferLine(line)), line);
+	}
+});
+
+test('a range shifts at both ends, so it still covers the same text', () => {
+	const coords = lineCoordinates(WITH_FRONT_MATTER);
+	assert.deepEqual(coords.toBufferRange({ startLine: 1, endLine: 4 }), { startLine: 7, endLine: 10 });
+	// Same width in, same width out: a range that grew or slid would open the
+	// editor on the wrong lines even when its start happened to be right.
+	assert.deepEqual(coords.toBufferRange({ startLine: 9, endLine: 9 }), { startLine: 15, endLine: 15 });
+});
+
+/* ------------------------------------------------------------------ */
+/* out to a pixel and back                                             */
+/* ------------------------------------------------------------------ */
+//
+// The other half of the module: the preview's own line <-> pixel mapping with
+// the shift applied around it, which is what the viewer calls on every scroll
+// event. A fake tree is enough here — `scrollSyncBlockMapping.test.ts` drives
+// the same pair over real `processMarkdownHtml` output — because what is under
+// test is the composition, not the descent.
+
+type FakeBlock = {
+	nodeType: number;
+	tagName: string;
+	childNodes: FakeBlock[];
+	getAttribute(name: string): string | null;
+	top: number;
+	height: number;
+};
+
+function block(line: number, top: number, height: number): FakeBlock {
+	return {
+		nodeType: 1,
+		tagName: 'P',
+		childNodes: [],
+		getAttribute: (name) => (name === 'data-sourcepos' ? `${line}:1-${line}:10` : null),
+		top,
+		height,
+	};
+}
+
+/**
+ * Three rendered blocks, on BODY lines 1, 5 and 9. They start 200px down
+ * because the front matter renders as a panel above them — which is the point:
+ * neither the pixels nor the `data-sourcepos` lines know anything about the six
+ * buffer lines of YAML the editor is holding.
+ */
+const BLOCKS = [block(1, 200, 40), block(5, 300, 40), block(9, 500, 60)];
+const ROOT: FakeBlock = {
+	nodeType: 1,
+	tagName: 'DIV',
+	childNodes: BLOCKS,
+	getAttribute: () => null,
+	top: 0,
+	height: 600,
+};
+
+const measure = (node: unknown) => ({ top: (node as FakeBlock).top, height: (node as FakeBlock).height });
+
+test('a preview offset answers in buffer lines, and takes them back', () => {
+	const coords = lineCoordinates(WITH_FRONT_MATTER);
+
+	// The first block is body line 1, which is buffer line 7.
+	assert.equal(coords.bufferLineAtPreviewOffset(ROOT, 200, measure), 7);
+	assert.equal(coords.previewOffsetForBufferLine(ROOT, asBufferLine(7), measure), 200);
+
+	// Halfway between the first two samples in lines is halfway in pixels.
+	assert.equal(coords.bufferLineAtPreviewOffset(ROOT, 250, measure), 9);
+	assert.equal(coords.previewOffsetForBufferLine(ROOT, asBufferLine(9), measure), 250);
+
+	// Every sample, both ways round.
+	for (const line of [7, 9, 11, 13, 15] as BufferLine[]) {
+		const offset = coords.previewOffsetForBufferLine(ROOT, line, measure);
+		assert.ok(offset !== null, `no offset for buffer line ${line}`);
+		assert.equal(coords.bufferLineAtPreviewOffset(ROOT, offset, measure), line, `buffer line ${line}`);
+	}
+});
+
+test('the same preview, read without the shift, is six lines out', () => {
+	// The control, and the defect this module exists to make unrepresentable: a
+	// caller that treats the preview's own numbering as the editor's is off by
+	// the height of the front matter everywhere, uniformly, however good the
+	// block mapping underneath it is.
+	const plain = lineCoordinates('# Title\n');
+	assert.equal(plain.bufferLineAtPreviewOffset(ROOT, 200, measure), 1);
+	assert.equal(
+		lineCoordinates(WITH_FRONT_MATTER).bufferLineAtPreviewOffset(ROOT, 200, measure)! -
+			plain.bufferLineAtPreviewOffset(ROOT, 200, measure)!,
+		FRONT_MATTER_LINES,
+	);
+});
+
+test('a preview with nothing annotated in it answers nothing, not line zero', () => {
+	// The caller falls back to the proportional mapping on `null`. A `0` would
+	// be a buffer line, and would send the pane to the top of the document.
+	const coords = lineCoordinates(WITH_FRONT_MATTER);
+	const empty: FakeBlock = { nodeType: 1, tagName: 'DIV', childNodes: [], getAttribute: () => null, top: 0, height: 0 };
+
+	assert.equal(coords.bufferLineAtPreviewOffset(empty, 400, measure), null);
+	assert.equal(coords.previewOffsetForBufferLine(empty, asBufferLine(12), measure), null);
+});

--- a/scripts/scrollSyncBlockMapping.test.ts
+++ b/scripts/scrollSyncBlockMapping.test.ts
@@ -60,8 +60,21 @@ const {
 	getVerticalOffsetForLine,
 } = await import('../src/lib/utils/scrollSync.ts');
 
+const { asBufferLine, asRendererLine, lineCoordinates } = await import('../src/lib/utils/lineCoordinates.ts');
+
 type AnchorNode = Parameters<typeof getSourceLineAtPreviewOffset>[0];
 type ScrollSyncPosition = Parameters<typeof getScrollTopForSyncPosition>[0];
+type LineCoordinates = ReturnType<typeof lineCoordinates>;
+
+/**
+ * A line written the way `data-sourcepos` writes it: counted from the first
+ * line of the body. Every literal line number in this file is one, because
+ * every fixture below is built out of that attribute.
+ */
+const bodyLine = asRendererLine;
+
+/** The coordinates of a document with no front matter, where the two numberings coincide. */
+const NO_FRONT_MATTER = lineCoordinates('# A document with no front matter\n');
 
 const FILE_PATH = '/documents/stress.md';
 
@@ -408,10 +421,16 @@ type Preview = {
 	scrollMax: number;
 };
 
-function buildPreview(doc: DocumentBuilder, gap = BLOCK_GAP): Preview {
+/**
+ * `frontMatterHeight` is the front-matter panel: the preview renders one above
+ * the document, it carries no source range, and every rendered block therefore
+ * starts that many pixels further down. Nothing else about the mapping changes,
+ * which is the property the front-matter test below is after.
+ */
+function buildPreview(doc: DocumentBuilder, gap = BLOCK_GAP, frontMatterHeight = 0): Preview {
 	const body = parseHtml(processMarkdownHtml(doc.html(), FILE_PATH, new Set<string>())).body;
 	wrapCodeBlocks(body);
-	const boxes = layOut(body, 0, gap);
+	const boxes = layOut(body, frontMatterHeight, gap);
 
 	let contentHeight = 0;
 	for (const box of boxes.values()) contentHeight = Math.max(contentHeight, box.top + box.height);
@@ -474,8 +493,13 @@ type Editor = {
 	scrollMax: number;
 };
 
-function buildEditor(doc: DocumentBuilder): Editor {
-	const lineCount = doc.lineCount;
+/**
+ * `frontMatterLines` are buffer lines above the body: the editor holds them,
+ * the preview renders them as a panel with no source range of its own, and
+ * every line number the two panes exchange differs by exactly that many.
+ */
+function buildEditor(doc: DocumentBuilder, frontMatterLines = 0): Editor {
+	const lineCount = doc.lineCount + frontMatterLines;
 	return {
 		lineCount,
 		topForLine: (line) => (line - 1) * EDITOR_LINE_HEIGHT,
@@ -488,13 +512,16 @@ function buildEditor(doc: DocumentBuilder): Editor {
 // These four functions are the arithmetic of `getEditorScrollSyncPosition`,
 // `syncScrollToPosition`, `getPreviewScrollSyncPosition` and
 // `scrollPreviewToSyncPosition`, over injected measurements instead of Monaco
-// and the DOM. Everything they call is imported from `src/`.
+// and the DOM. Everything they call is imported from `src/` — including the
+// front-matter shift, which the preview pair used to leave out entirely
+// because it re-implemented the viewer's glue rather than calling it.
 
 function editorPositionAt(editor: Editor, scrollTop: number, frontMatterEnd = 0): ScrollSyncPosition {
 	const position = getScrollSyncPositionFromPixels(scrollTop, editor.scrollMax, frontMatterEnd);
 	if (position.section !== 'body') return position;
 
-	const line = getLineAtVerticalOffset(scrollTop, editor.lineCount, editor.topForLine);
+	// Monaco counts from the first line of the file, so this is a buffer line.
+	const line = asBufferLine(getLineAtVerticalOffset(scrollTop, editor.lineCount, editor.topForLine));
 	return Number.isFinite(line) ? { ...position, line } : position;
 }
 
@@ -523,15 +550,16 @@ function editorScrollTopFor(
 	return { scrollTop, clamped: scrollTop !== target };
 }
 
-function previewPositionAt(preview: Preview, scrollTop: number, frontMatterEnd = 0): ScrollSyncPosition {
+function previewPositionAt(
+	preview: Preview,
+	scrollTop: number,
+	frontMatterEnd = 0,
+	coords: LineCoordinates = NO_FRONT_MATTER,
+): ScrollSyncPosition {
 	const position = getScrollSyncPositionFromPixels(scrollTop, preview.scrollMax, frontMatterEnd);
 	if (position.section !== 'body') return position;
 
-	const line = getSourceLineAtPreviewOffset(
-		preview.body,
-		scrollTop,
-		preview.measure,
-	);
+	const line = coords.bufferLineAtPreviewOffset(preview.body, scrollTop, preview.measure);
 	return line === null ? position : { ...position, line };
 }
 
@@ -539,11 +567,12 @@ function previewScrollTopFor(
 	preview: Preview,
 	position: ScrollSyncPosition,
 	frontMatterEnd = 0,
+	coords: LineCoordinates = NO_FRONT_MATTER,
 ): { scrollTop: number; clamped: boolean } {
 	let target: number | null = null;
 
 	if (position.section === 'body' && position.line !== undefined) {
-		const offset = getPreviewOffsetForSourceLine(preview.body, position.line, preview.measure);
+		const offset = coords.previewOffsetForBufferLine(preview.body, position.line, preview.measure);
 		if (offset !== null) target = offset;
 	}
 
@@ -702,6 +731,112 @@ test('driving the preview lands the editor on the same source line', (t) => {
 		worst <= LINE_SLACK,
 		`the editor drifted ${worst.toFixed(1)} source lines at preview scrollTop ${Math.round(worstAt)}`,
 	);
+});
+
+/* ------------------------------------------------------------------ */
+/* the same document, with front matter above it                       */
+/* ------------------------------------------------------------------ */
+//
+// Everything above this point is a document with no front matter, where the
+// editor's line numbers and `data-sourcepos`'s are the same numbers — so the
+// conversion between them could be left out entirely and every measurement
+// above would still pass. It was left out, in this file: the glue here used to
+// be a copy of the viewer's rather than a call into it, and the copy had no
+// shift in it at all.
+//
+// The same fixture, then, with six buffer lines of YAML above the body and the
+// panel the preview renders for them. Nothing about the block mapping changes;
+// what changes is that a pane which forgets to convert is now six lines out,
+// everywhere, uniformly.
+
+const FRONT_MATTER_LINES = 6;
+const FM_COORDS = lineCoordinates(['---', 'title: "T"', 'tags:', '  - a', '---', '', '# Heading'].join('\n') + '\n');
+/** The rendered front-matter panel: a fixed height, and no source range at all. */
+const FM_PANEL = 180;
+
+const FM_PREVIEW = buildPreview(DOC, BLOCK_GAP, FM_PANEL);
+const FM_EDITOR = buildEditor(DOC, FRONT_MATTER_LINES);
+const FM_EDITOR_END = FRONT_MATTER_LINES * EDITOR_LINE_HEIGHT;
+
+/** Which BODY line each pane is showing, which is the only thing they can be compared on. */
+function fmEditorBodyLineAt(scrollTop: number): number {
+	const line = getLineAtVerticalOffset(scrollTop, FM_EDITOR.lineCount, FM_EDITOR.topForLine);
+	return FM_COORDS.toRendererLine(asBufferLine(line));
+}
+
+function fmPreviewBodyLineAt(scrollTop: number): number {
+	const line = getSourceLineAtPreviewOffset(FM_PREVIEW.body, scrollTop, FM_PREVIEW.measure);
+	assert.ok(line !== null, `the preview must resolve a source line at ${scrollTop}px`);
+	return line;
+}
+
+test('the fixture has front matter in both panes, of different heights', () => {
+	assert.equal(FM_COORDS.frontMatterLines, FRONT_MATTER_LINES);
+	assert.equal(FM_EDITOR.lineCount, DOC.lineCount + FRONT_MATTER_LINES);
+	// The preview's panel and the editor's six lines of text are not the same
+	// number of pixels, which is the reason `scrollSync.ts` splits the range at
+	// the boundary instead of carrying a single ratio.
+	assert.notEqual(FM_PANEL, FM_EDITOR_END);
+	assert.equal(FM_PREVIEW.measure(FM_PREVIEW.body.querySelectorAll('p')[0]).top, FM_PANEL);
+});
+
+test('with front matter the panes still show the same body line', (t) => {
+	let worst = 0;
+	let worstAt = 0;
+	let unconverted = 0;
+
+	for (const scrollTop of sweep(FM_EDITOR.scrollMax, 0, 1, 200)) {
+		if (scrollTop <= FM_EDITOR_END) continue;
+
+		const sent = editorPositionAt(FM_EDITOR, scrollTop, FM_EDITOR_END);
+		assert.equal(sent.section, 'body');
+		assert.ok(sent.line !== undefined, 'the editor resolves a line for every body position');
+
+		const landed = previewScrollTopFor(FM_PREVIEW, sent, FM_PANEL, FM_COORDS);
+		if (landed.clamped) continue;
+
+		const drift = Math.abs(fmPreviewBodyLineAt(landed.scrollTop) - fmEditorBodyLineAt(scrollTop));
+		if (drift > worst) {
+			worst = drift;
+			worstAt = scrollTop;
+		}
+
+		// The control: the same buffer line handed to the preview as if it were
+		// a body line, which is what every consumer here did before the shift
+		// existed and what the copied glue in this file kept doing after it.
+		const naive = previewScrollTopFor(FM_PREVIEW, sent, FM_PANEL, NO_FRONT_MATTER);
+		if (!naive.clamped) {
+			unconverted = Math.max(unconverted, Math.abs(fmPreviewBodyLineAt(naive.scrollTop) - fmEditorBodyLineAt(scrollTop)));
+		}
+	}
+
+	t.diagnostic(`converted: worst drift ${worst.toFixed(1)} body lines; unconverted: ${unconverted.toFixed(1)}`);
+
+	assert.ok(
+		unconverted > FRONT_MATTER_LINES - 1,
+		`the control must be off by about the front matter, got ${unconverted.toFixed(1)} lines`,
+	);
+	assert.ok(
+		worst <= LINE_SLACK,
+		`the preview drifted ${worst.toFixed(1)} body lines from the editor at scrollTop ${Math.round(worstAt)}`,
+	);
+});
+
+test('a position inside the front matter carries no line, and lands in the panel', () => {
+	// Front matter renders as a panel with no source range, so there is nothing
+	// for a line to resolve against and the section ratio is the only thing that
+	// can carry the position. That carve-out is what `scrollSync.ts` is for, and
+	// it has to survive the panes having different-sized front matter.
+	const inside = editorPositionAt(FM_EDITOR, FM_EDITOR_END / 2, FM_EDITOR_END);
+	assert.equal(inside.section, 'frontmatter');
+	assert.equal(inside.line, undefined);
+
+	const landed = previewScrollTopFor(FM_PREVIEW, inside, FM_PANEL, FM_COORDS);
+	assert.equal(landed.scrollTop, FM_PANEL / 2);
+
+	// And the boundary maps onto the boundary exactly, from either side.
+	assert.equal(previewScrollTopFor(FM_PREVIEW, { section: 'frontmatter', ratio: 1 }, FM_PANEL, FM_COORDS).scrollTop, FM_PANEL);
+	assert.equal(previewScrollTopFor(FM_PREVIEW, { section: 'body', ratio: 0 }, FM_PANEL, FM_COORDS).scrollTop, FM_PANEL);
 });
 
 test('the ends of the document are the ends of the mapping', (t) => {
@@ -866,7 +1001,7 @@ test('the pixel two blocks share belongs to the lower one', () => {
 
 	assert.equal(getSourceLineAtPreviewOffset(preview.body, box.top, preview.measure), 3);
 	assert.equal(getSourceLineAtPreviewOffset(preview.body, box.top + box.height, preview.measure), 5);
-	assert.equal(getPreviewOffsetForSourceLine(preview.body, 3, preview.measure), box.top);
+	assert.equal(getPreviewOffsetForSourceLine(preview.body, bodyLine(3), preview.measure), box.top);
 });
 
 test('repeating the echo does not walk the panes down the document', () => {
@@ -937,7 +1072,7 @@ test('a row reports an offset measured from its table, and a code block from its
 });
 
 test('a line inside a table maps into that table, not to the top of the document', () => {
-	const line = LAST_TABLE_RANGE.startLine + 7;
+	const line = bodyLine(LAST_TABLE_RANGE.startLine + 7);
 	const table = PREVIEW.measure(LAST_TABLE);
 
 	const offset = getPreviewOffsetForSourceLine(PREVIEW.body, line, PREVIEW.measure);
@@ -1068,7 +1203,7 @@ test('a preview holding no annotated block falls back to the ratio', () => {
 	const measure = () => ({ top: 0, height: 0 });
 
 	assert.equal(getSourceLineAtPreviewOffset(empty, 400, measure), null);
-	assert.equal(getPreviewOffsetForSourceLine(empty, 12, measure), null);
+	assert.equal(getPreviewOffsetForSourceLine(empty, bodyLine(12), measure), null);
 
 	const emptyPreview: Preview = { body: empty, measure, rawMeasure: measure, contentHeight: 0, scrollMax: 600 };
 	const position = previewPositionAt(emptyPreview, 300);
@@ -1077,7 +1212,7 @@ test('a preview holding no annotated block falls back to the ratio', () => {
 	assert.equal(position.ratio, 0.5);
 
 	// And a line arriving from the editor still moves it, by ratio.
-	assert.equal(previewScrollTopFor(emptyPreview, { section: 'body', ratio: 0.25, line: 400 }).scrollTop, 150);
+	assert.equal(previewScrollTopFor(emptyPreview, { section: 'body', ratio: 0.25, line: asBufferLine(400) }).scrollTop, 150);
 });
 
 test('an element the app renders around the document does not swallow the offset', () => {
@@ -1166,7 +1301,7 @@ test('a collapsed fold answers for its hidden contents', () => {
 
 	// Line 3 is inside the collapsed section; it must map to the wrapper's own
 	// position and not to where its hidden paragraph claims to be.
-	const offset = getPreviewOffsetForSourceLine(body, 3, measure);
+	const offset = getPreviewOffsetForSourceLine(body, bodyLine(3), measure);
 	assert.equal(offset, 38);
 });
 
@@ -1335,7 +1470,7 @@ test('a line inside the paragraph resolves to its own anchor, not to an interpol
 	const measure = (node: unknown) => boxes.get(node) ?? { top: 0, height: 0 };
 
 	const interpolated = PARAGRAPH_TOP + 6 * ROW * ((11 - 10) / (13 - 10));
-	const actual = getPreviewOffsetForSourceLine(root as AnchorNode, 11, measure as never);
+	const actual = getPreviewOffsetForSourceLine(root as AnchorNode, bodyLine(11), measure as never);
 
 	assert.equal(actual, PARAGRAPH_TOP + 3 * ROW, 'line 11 lands where line 11 is drawn');
 	assert.notEqual(actual, interpolated, 'and not where the block-wide interpolation would put it');
@@ -1351,5 +1486,5 @@ test('an anchor carries no height, and the mapping never asks it for one', () =>
 	const measure = (node: unknown) =>
 		node === anchors[0].element ? { top: 250, height: 0 } : { top: 0, height: 999 };
 
-	assert.equal(getPreviewOffsetForSourceLine(root as AnchorNode, 11, measure as never), 250);
+	assert.equal(getPreviewOffsetForSourceLine(root as AnchorNode, bodyLine(11), measure as never), 250);
 });

--- a/scripts/tocFollowsEditor.test.ts
+++ b/scripts/tocFollowsEditor.test.ts
@@ -22,7 +22,16 @@ import test from 'node:test';
 
 import { functionSource, readSource, sliceBetween } from './sourceTree.js';
 
-import { activeTocIdForLine, sourceLineOf } from '../src/lib/utils/tocFollow.js';
+import { activeTocIdForLine, sourceLineOf, type TocLineEntry } from '../src/lib/utils/tocFollow.js';
+import { asBufferLine, asRendererLine, lineCoordinates } from '../src/lib/utils/lineCoordinates.js';
+
+/**
+ * Every line in the outline is a BODY line, because the outline is built out of
+ * `data-sourcepos` and that attribute counts from the first line of the body.
+ * The alias is here so each fixture below says which of the two numberings it
+ * is written in — the distinction this whole file turns on.
+ */
+const bodyLine = asRendererLine;
 
 const tocSource = readSource(new URL('../src/lib/components/Toc.svelte', import.meta.url));
 const viewerSource = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
@@ -30,21 +39,21 @@ const settingsSource = readSource(new URL('../src/lib/stores/settings.svelte.ts'
 const settingsComponentSource = readSource(new URL('../src/lib/components/Settings.svelte', import.meta.url));
 
 /** An outline of a document whose headings are 20 source lines apart. */
-const OUTLINE = [
-	{ id: 'intro', line: 1 },
-	{ id: 'setup', line: 21 },
+const OUTLINE: TocLineEntry[] = [
+	{ id: 'intro', line: bodyLine(1) },
+	{ id: 'setup', line: bodyLine(21) },
 	{ id: 'a-block-anchor', line: null },
-	{ id: 'usage', line: 41 },
-	{ id: 'api', line: 61 },
+	{ id: 'usage', line: bodyLine(41) },
+	{ id: 'api', line: bodyLine(61) },
 ];
 
 test('the active entry is the last heading at or above the editor position', () => {
-	assert.equal(activeTocIdForLine(OUTLINE, 1), 'intro');
-	assert.equal(activeTocIdForLine(OUTLINE, 20), 'intro');
-	assert.equal(activeTocIdForLine(OUTLINE, 21), 'setup');
-	assert.equal(activeTocIdForLine(OUTLINE, 40.7), 'setup');
-	assert.equal(activeTocIdForLine(OUTLINE, 41), 'usage');
-	assert.equal(activeTocIdForLine(OUTLINE, 4000), 'api');
+	assert.equal(activeTocIdForLine(OUTLINE, bodyLine(1)), 'intro');
+	assert.equal(activeTocIdForLine(OUTLINE, bodyLine(20)), 'intro');
+	assert.equal(activeTocIdForLine(OUTLINE, bodyLine(21)), 'setup');
+	assert.equal(activeTocIdForLine(OUTLINE, bodyLine(40.7)), 'setup');
+	assert.equal(activeTocIdForLine(OUTLINE, bodyLine(41)), 'usage');
+	assert.equal(activeTocIdForLine(OUTLINE, bodyLine(4000)), 'api');
 });
 
 test('a position above every heading takes the first entry, as the preview does', () => {
@@ -52,19 +61,19 @@ test('a position above every heading takes the first entry, as the preview does'
 	// loop, so front matter — or anything above the first heading — leaves the
 	// first entry highlighted. Answering `null` here instead would blank the
 	// outline on the way past the top of a document scrolled in the editor.
-	assert.equal(activeTocIdForLine([{ id: 'later', line: 12 }], 3), 'later');
+	assert.equal(activeTocIdForLine([{ id: 'later', line: bodyLine(12) }], bodyLine(3)), 'later');
 });
 
 test('an entry with no source range never becomes active, and never hides one that has', () => {
 	// Block anchors (`^id`) are in the outline and carry no range of their own.
 	// A `null` must not be read as line 0 and swallow every position after it.
-	assert.equal(activeTocIdForLine(OUTLINE, 45), 'usage');
-	assert.equal(activeTocIdForLine([{ id: 'block', line: null }], 900), 'block');
+	assert.equal(activeTocIdForLine(OUTLINE, bodyLine(45)), 'usage');
+	assert.equal(activeTocIdForLine([{ id: 'block', line: null }], bodyLine(900)), 'block');
 });
 
 test('nothing to follow yields nothing, rather than a stale entry', () => {
-	assert.equal(activeTocIdForLine([], 12), null);
-	assert.equal(activeTocIdForLine(OUTLINE, Number.NaN), null);
+	assert.equal(activeTocIdForLine([], bodyLine(12)), null);
+	assert.equal(activeTocIdForLine(OUTLINE, bodyLine(Number.NaN)), null);
 });
 
 test('the start line comes from the sourcepos comrak wrote, or nothing', () => {
@@ -111,7 +120,27 @@ test('the editor position reaches the outline whether or not scroll sync is on',
 
 	assert.ok(record !== -1 && syncCheck !== -1, 'both statements must still be here');
 	assert.ok(record < syncCheck, 'the outline is fed before the sync check, not inside it');
-	assert.match(handler, /if \(position\.line !== undefined\) tocActiveLine = toRendererLine\(position\.line\);/);
+	assert.match(handler, /tocActiveLine = lineCoords\.toRendererLine\(position\.line\)/);
+});
+
+test('the editor position is converted before the outline compares it', () => {
+	// What the assertion above cannot see, and what a regular expression over
+	// the viewer's source never could: whether the conversion is the RIGHT one.
+	// This is the shift itself, over the outline's own rule.
+	const raw = ['---', 'title: "T"', 'tags:', '  - a', '---', '', '# Intro'].join('\n') + '\n';
+	const coords = lineCoordinates(raw);
+	assert.equal(coords.frontMatterLines, 6, 'the fixture must actually have front matter');
+
+	// The reader is on the last line of the intro section: body line 20, which
+	// is buffer line 26 because six lines of YAML sit above it.
+	const position = asBufferLine(20 + coords.frontMatterLines);
+	assert.equal(activeTocIdForLine(OUTLINE, coords.toRendererLine(position)), 'intro');
+
+	// Handed over unconverted it is past the next heading, and the outline
+	// highlights the section the reader has not reached yet. That is the whole
+	// defect, and it is invisible in a document without front matter — which is
+	// every other fixture in this file.
+	assert.equal(activeTocIdForLine(OUTLINE, asRendererLine(position)), 'setup');
 });
 
 test('the preview feeds the same state, off the line it already measures', () => {

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -43,7 +43,6 @@ import {
 	findAnchorElement,
 	findSourceLineRange,
 	getAnchorScrollTop,
-	getPreviewOffsetForSourceLine,
 	getSourceLineAtPreviewOffset,
 	measureAnchorBox,
 	mergeSourceLineRanges,
@@ -54,8 +53,14 @@ import {
 	type OffsetLayoutNode,
 } from './utils/previewAnchor.js';
 import {
+	asRendererLine,
+	lineCoordinates,
+	type BufferLine,
+	type BufferLineRange,
+	type RendererLine,
+} from './utils/lineCoordinates.js';
+import {
 	addFrontMatterListItems,
-	frontMatterLineOffset,
 	getMarkdownBodyWithoutFrontMatter,
 	getFrontMatterListItems,
 	parseFrontMatter,
@@ -150,7 +155,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		runEditorAction: (actionId: string, payload?: any) => void;
 		undo: () => void;
 		redo: () => void;
-		revealHeader: (sourceLine: number | null, text: string) => void;
+		revealHeader: (sourceLine: BufferLine | null, text: string) => void;
 		revealSourceRange: (startLine: number, endLine: number) => void;
 		triggerFind: () => void;
 		// The three the editor's context menu runs, which are the three its
@@ -1224,9 +1229,9 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		// This is the carve-out `scrollSync.ts` exists for, unchanged.
 		if (position.section !== 'body') return position;
 
-		const line = getSourceLineAtPreviewOffset(target, target.scrollTop, measurePreviewBox);
+		const line = lineCoords.bufferLineAtPreviewOffset(target, target.scrollTop, measurePreviewBox);
 
-		return line === null ? position : { ...position, line: toBufferLine(line) };
+		return line === null ? position : { ...position, line };
 	}
 
 	function scrollPreviewToSyncPosition(position: ScrollSyncPosition) {
@@ -1236,9 +1241,9 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		let targetScroll: number | null = null;
 
 		if (position.section === 'body' && position.line !== undefined) {
-			const offset = getPreviewOffsetForSourceLine(
+			const offset = lineCoords.previewOffsetForBufferLine(
 				markdownBody,
-				toRendererLine(position.line),
+				position.line,
 				measurePreviewBox,
 			);
 			if (offset !== null) targetScroll = offset;
@@ -1276,11 +1281,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	 * the entry, so the two panes cannot disagree about which heading is
 	 * current while both are on screen.
 	 */
-	let tocActiveLine = $state<number | null>(null);
+	let tocActiveLine = $state<RendererLine | null>(null);
 
 	function handleEditorScrollSync(position: ScrollSyncPosition) {
 		// The outline is built from `data-sourcepos`, so it counts from the body.
-		if (position.line !== undefined) tocActiveLine = toRendererLine(position.line);
+		if (position.line !== undefined) tocActiveLine = lineCoords.toRendererLine(position.line);
 
 		if (tabManager.activeTab?.isScrollSynced) {
 			scrollPreviewToSyncPosition(position);
@@ -1302,14 +1307,17 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	 * it had no opinion about `<br>`, which carries a source range and no box, so
 	 * an anchor at the top of the document could resolve to one (#464).
 	 */
-	function getPreviewScrollAnchor(target: HTMLElement): number | null {
+	function getPreviewScrollAnchor(target: HTMLElement): RendererLine | null {
 		const line = getSourceLineAtPreviewOffset(
 			target,
 			target.scrollTop + PREVIEW_ANCHOR_OFFSET,
 			measurePreviewBox,
 		);
 
-		return line === null ? null : Math.round(line);
+		// Straight off `data-sourcepos`, so it is already a renderer line: the
+		// two consumers — the tab's saved reading position and the outline —
+		// both count from the first line of the body.
+		return line === null ? null : asRendererLine(Math.round(line));
 	}
 
 	function syncEditorToPreviewScroll(target: HTMLElement) {
@@ -1416,7 +1424,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			if (options.pushHistory !== false) pushScrollHistory();
 			const containerRect = markdownBody.getBoundingClientRect();
 			const elRect = el.getBoundingClientRect();
-			const targetScrollTop = elRect.top - containerRect.top + markdownBody.scrollTop - 60;
+			const targetScrollTop = elRect.top - containerRect.top + markdownBody.scrollTop - PREVIEW_ANCHOR_OFFSET;
 			markdownBody.scrollTo({ top: targetScrollTop, behavior: 'smooth' });
 			return true;
 		}
@@ -1741,7 +1749,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	 * effect below spends it the moment they do, and immediately when the
 	 * editor is already on screen (split view).
 	 */
-	let pendingEditReveal = $state<LineRange | null>(null);
+	let pendingEditReveal = $state<BufferLineRange | null>(null);
 
 	$effect(() => {
 		const range = pendingEditReveal;
@@ -1838,40 +1846,27 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		if (!isEditing) await toggleEdit();
 		// `toggleEdit` swallows a failed read and stays in reading mode. Arming
 		// the jump anyway would fire it at whatever document is edited next.
-		if (range && tabManager.activeTab?.isEditing) pendingEditReveal = toBufferRange(range);
+		if (range && tabManager.activeTab?.isEditing) pendingEditReveal = lineCoords.toBufferRange(range);
 	}
 
 	/**
-	 * A renderer line range moved onto the buffer's numbering.
+	 * This document's two line numberings, and the only thing that converts
+	 * between them.
 	 *
 	 * `data-sourcepos` counts from the first line of the BODY, because that is
 	 * what `renderMarkdownPreview` hands comrak — front matter is stripped
-	 * first. The editor holds the whole file. Without this every jump into a
-	 * document with front matter lands that many lines early, and the outline
-	 * has been doing exactly that: `Toc.svelte` reads the same attribute and
-	 * passes it to `revealHeader` untouched.
-	 */
-	function toBufferRange(range: LineRange): LineRange {
-		const offset = frontMatterLineOffset(rawContent);
-		if (!offset) return range;
-		return { startLine: range.startLine + offset, endLine: range.endLine + offset };
-	}
-
-	/**
-	 * The same conversion for a single line, in both directions.
+	 * first. The editor holds the whole file. The shift between the two used to
+	 * be spelled out by hand at each of the five places they meet, and a place
+	 * that forgot it landed every jump that many lines early — which the outline
+	 * did for as long as it existed. `lineCoordinates.ts` owns the shift now,
+	 * and the two numberings are different TYPES, so a crossing that forgets to
+	 * convert no longer compiles.
 	 *
-	 * `ScrollSyncPosition.line` is a BUFFER line, because the editor is the only
-	 * pane that can produce one and the buffer is all it knows. Everything on the
-	 * preview side — `data-sourcepos`, the outline built from it — counts from
-	 * the first line of the body. Every crossing between the two has to say so.
+	 * Derived from `rawContent`, which is the buffer: measuring the render would
+	 * answer 0 forever, since the render is what the front matter was stripped
+	 * out of.
 	 */
-	function toBufferLine(line: number): number {
-		return line + frontMatterLineOffset(rawContent);
-	}
-
-	function toRendererLine(line: number): number {
-		return line - frontMatterLineOffset(rawContent);
-	}
+	let lineCoords = $derived(lineCoordinates(rawContent));
 
 	async function saveContent(tabId?: string): Promise<boolean> {
 		const saved = await documentSession.saveContent(tabId);
@@ -3815,7 +3810,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 										{collapsedHeaders} 
 										ontoggleFold={toggleFold} 
 										oncopyref={(text: string, slug: string) => copyHeadingReference(text, slug)}
-										onjump={(id: string, text: string, sourceLine: number | null) => {
+										onjump={(id: string, text: string, sourceLine: RendererLine | null) => {
 											// A floating outline that is covering the text has done its
 											// job the moment you pick an entry: it exists to be called
 											// up, used once and dismissed. Pinned it is a permanent
@@ -3829,7 +3824,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 												// short by the front matter's height for as long as both
 												// have existed.
 												editorPane.revealHeader(
-													sourceLine === null ? null : toBufferRange({ startLine: sourceLine, endLine: sourceLine }).startLine,
+													sourceLine === null ? null : lineCoords.toBufferLine(sourceLine),
 													text,
 												);
 											}

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -20,6 +20,7 @@
 		getVerticalOffsetForLine,
 		type ScrollSyncPosition,
 	} from '../utils/scrollSync.js';
+	import { asBufferLine, type BufferLine } from '../utils/lineCoordinates.js';
 
 	// Monaco is ~86% of the startup JavaScript (a 4.4 MB chunk, ~360ms of
 	// parse+eval, paid once per window because every window is its own webview)
@@ -1319,7 +1320,10 @@
 		const model = position.section === 'body' ? editor.getModel() : null;
 		if (!model) return position;
 
-		const line = getLineAtVerticalOffset(editor.getScrollTop(), model.getLineCount(), getEditorLineTop);
+		// Monaco counts from the first line of the FILE, so what comes back is a
+		// buffer line. Saying so here is what obliges the preview to convert:
+		// everything it answers with counts from the first line of the body.
+		const line = asBufferLine(getLineAtVerticalOffset(editor.getScrollTop(), model.getLineCount(), getEditorLineTop));
 
 		return Number.isFinite(line) ? { ...position, line } : position;
 	}
@@ -1833,7 +1837,13 @@
 		editor.focus();
 	}
 
-	export function revealHeader(sourceLine: number | null, text: string) {
+	/**
+	 * `sourceLine` is a BUFFER line, and the type is the whole point: the
+	 * outline reads `data-sourcepos`, which counts from the first line of the
+	 * body, and handed it over unshifted for as long as both features existed.
+	 * The caller now has to go through `lineCoordinates` to produce one.
+	 */
+	export function revealHeader(sourceLine: BufferLine | null, text: string) {
 		if (!editor) return;
 		const model = editor.getModel();
 		if (!model) return;

--- a/src/lib/components/Toc.svelte
+++ b/src/lib/components/Toc.svelte
@@ -4,6 +4,8 @@
 	import { settings } from '../stores/settings.svelte.js';
 	import { t } from '../utils/i18n.js';
 	import { activeTocIdForLine, sourceLineOf } from '../utils/tocFollow.js';
+	import { PREVIEW_ANCHOR_OFFSET } from '../utils/previewAnchor.js';
+	import type { RendererLine } from '../utils/lineCoordinates.js';
 
 	let { markdownBody, htmlContent, activeLine = null, onBeforeJump, collapsedHeaders, ontoggleFold, oncopyref, oncontext, onjump, onshowTooltip, onhideTooltip } = $props<{
 		markdownBody: HTMLElement | null;
@@ -13,13 +15,13 @@
 		 * outline should follow the preview alone (the setting is off, or nothing
 		 * is being edited). See `tocFollow.ts`.
 		 */
-		activeLine?: number | null;
+		activeLine?: RendererLine | null;
 		onBeforeJump?: () => void;
 		collapsedHeaders?: Set<string>;
 		ontoggleFold?: (id: string) => void;
 		oncopyref?: (text: string, slug: string) => void;
 		oncontext?: (e: MouseEvent, item: TocItem) => void;
-		onjump?: (id: string, text: string, sourceLine: number | null) => void;
+		onjump?: (id: string, text: string, sourceLine: RendererLine | null) => void;
 		onshowTooltip?: (e: MouseEvent, text: string, shortcut?: string, align?: 'top' | 'right' | 'left' | 'below') => void;
 		onhideTooltip?: () => void;
 	}>();
@@ -31,7 +33,7 @@
 		isBlock: boolean;
 		hasChildren?: boolean;
 		/** Where this entry starts in the source, for following the editor. */
-		line: number | null;
+		line: RendererLine | null;
 	}
 
 	let items = $state<TocItem[]>([]);
@@ -306,7 +308,7 @@
 
 			const containerRect = markdownBody.getBoundingClientRect();
 			const elRect = el.getBoundingClientRect();
-			const targetScrollTop = elRect.top - containerRect.top + markdownBody.scrollTop - 60;
+			const targetScrollTop = elRect.top - containerRect.top + markdownBody.scrollTop - PREVIEW_ANCHOR_OFFSET;
 			markdownBody.scrollTo({ top: targetScrollTop, behavior: 'smooth' });
 
 			// release lock after scroll settles

--- a/src/lib/utils/lineCoordinates.ts
+++ b/src/lib/utils/lineCoordinates.ts
@@ -1,0 +1,125 @@
+/**
+ * The two line numberings, and the single place the shift between them lives.
+ *
+ * A line has two names in this app. The BUFFER line is what the editor holds:
+ * line 1 is the first line of the file, front matter included. The RENDERER
+ * line is what the preview knows: `renderMarkdownPreview` hands comrak
+ * `getMarkdownBodyWithoutFrontMatter(raw)`, so every `data-sourcepos` — and
+ * everything built out of one, which is the outline, the tab's reading position
+ * and both halves of scroll sync — counts from the first line of the BODY.
+ *
+ * The difference is `frontMatterLineOffset(raw)` and it is invisible in any
+ * document without front matter, which is most documents and was every fixture.
+ * That is what made it a bug that could be introduced over and over: the shift
+ * was applied by hand at each of the five places the two numberings meet, both
+ * numbers were `number`, and a crossing that forgot it compiled and passed.
+ *
+ * So the two are different TYPES here. They are still numbers at run time —
+ * the brands below have no representation — but a `RendererLine` is not
+ * assignable to a `BufferLine` or the other way round, which means a crossing
+ * that forgets to convert is a type error rather than a document that scrolls
+ * to the wrong place. The conversion itself exists once, in `lineCoordinates`,
+ * and the front-matter offset is read there and nowhere else.
+ *
+ * The pixel end of the mapping stays where it already was: Monaco answers for
+ * the editor (`getLineAtVerticalOffset` in scrollSync.ts) and the descent
+ * answers for the preview (previewAnchor.ts). What this module adds is the
+ * preview pair in BUFFER lines, because that is the crossing the viewer's
+ * scroll sync makes on every scroll event — and the crossing whose glue the
+ * tests used to re-implement rather than import.
+ */
+
+import { frontMatterLineOffset } from './frontMatter.js';
+import {
+	getPreviewOffsetForSourceLine,
+	getSourceLineAtPreviewOffset,
+	type AnchorNode,
+	type LineRange,
+	type MeasureAnchorBox,
+} from './previewAnchor.js';
+
+/**
+ * A line number in the editor's buffer: line 1 is the first line of the file.
+ *
+ * The brand is a phantom property. Nothing ever writes it and nothing can read
+ * it, so a `BufferLine` is a `number` in every way that matters at run time —
+ * arithmetic, comparison and JSON all behave exactly as before. What it buys is
+ * that a plain `number` cannot be passed where one of these is wanted without
+ * saying which of the two it is.
+ */
+export type BufferLine = number & { readonly __lineSpace: 'buffer' };
+
+/** A line number as `data-sourcepos` writes it: line 1 is the first line of the body. */
+export type RendererLine = number & { readonly __lineSpace: 'renderer' };
+
+/** `LineRange` moved onto the buffer's numbering — what the editor can be aimed with. */
+export type BufferLineRange = {
+	startLine: BufferLine;
+	endLine: BufferLine;
+};
+
+/**
+ * The escape hatches, for the two places a number arrives from outside this
+ * type system: Monaco (buffer lines) and `data-sourcepos` (renderer lines).
+ * They are deliberately verbose to write, because every use of one is a claim
+ * about which numbering a bare number was in, and a wrong claim is the bug
+ * these types exist to prevent.
+ */
+export function asBufferLine(line: number): BufferLine {
+	return line as BufferLine;
+}
+
+export function asRendererLine(line: number): RendererLine {
+	return line as RendererLine;
+}
+
+export type LineCoordinates = {
+	/** How many buffer lines sit above the body; `0` without front matter. */
+	readonly frontMatterLines: number;
+	toBufferLine(line: RendererLine): BufferLine;
+	toRendererLine(line: BufferLine): RendererLine;
+	/**
+	 * A range read off `data-sourcepos` (the context menu's selection, an
+	 * outline entry) moved onto the buffer, which is the only numbering the
+	 * editor can be aimed with.
+	 */
+	toBufferRange(range: LineRange): BufferLineRange;
+	/**
+	 * The buffer line rendered at `offset` in the preview's scroll content, and
+	 * its inverse. Both are the preview's own mapping with the shift applied, so
+	 * a caller holding a buffer line never has to know there was one.
+	 */
+	bufferLineAtPreviewOffset(root: AnchorNode, offset: number, measure: MeasureAnchorBox): BufferLine | null;
+	previewOffsetForBufferLine(root: AnchorNode, line: BufferLine, measure: MeasureAnchorBox): number | null;
+};
+
+/**
+ * The coordinate systems of one document.
+ *
+ * `rawContent` is the buffer, not the render — measuring the render would
+ * answer 0 forever, since the render is what the front matter was stripped out
+ * of. Cheap enough to derive on every content change, which is what the viewer
+ * does: the offset is one `parseFrontMatter` and the rest is closures.
+ */
+export function lineCoordinates(rawContent: string): LineCoordinates {
+	const frontMatterLines = frontMatterLineOffset(rawContent);
+
+	const toBufferLine = (line: RendererLine): BufferLine => asBufferLine(line + frontMatterLines);
+	const toRendererLine = (line: BufferLine): RendererLine => asRendererLine(line - frontMatterLines);
+
+	return {
+		frontMatterLines,
+		toBufferLine,
+		toRendererLine,
+		toBufferRange: (range) => ({
+			startLine: toBufferLine(asRendererLine(range.startLine)),
+			endLine: toBufferLine(asRendererLine(range.endLine)),
+		}),
+		bufferLineAtPreviewOffset: (root, offset, measure) => {
+			const line = getSourceLineAtPreviewOffset(root, offset, measure);
+			return line === null ? null : toBufferLine(line);
+		},
+		previewOffsetForBufferLine: (root, line, measure) =>
+			getPreviewOffsetForSourceLine(root, toRendererLine(line), measure),
+	};
+}

--- a/src/lib/utils/previewAnchor.ts
+++ b/src/lib/utils/previewAnchor.ts
@@ -28,6 +28,8 @@
  * on a 1,700-line one).
  */
 
+import type { RendererLine } from './lineCoordinates.js';
+
 /** Inclusive source line range, as written in `data-sourcepos`. */
 export type LineRange = {
 	startLine: number;
@@ -61,7 +63,16 @@ export type AnchorBox = {
 	height: number;
 };
 
-type MeasureAnchorBox = (node: AnchorNode) => AnchorBox;
+export type MeasureAnchorBox = (node: AnchorNode) => AnchorBox;
+
+/**
+ * Every line number in this file is a RENDERER line, because every one of them
+ * came out of a `data-sourcepos` and that attribute counts from the first line
+ * of the body. `lineCoordinates.ts` holds the shift onto the editor's
+ * numbering; this is the one place a number is declared to be on this side of
+ * it. Imported as a type, so nothing here depends on that module at run time.
+ */
+const rendererLine = (line: number) => line as RendererLine;
 
 /**
  * The layout API `measureAnchorBox` reads, declared structurally for the same
@@ -579,7 +590,7 @@ export function getSourceLineAtPreviewOffset(
 	root: AnchorNode,
 	offset: number,
 	measure: MeasureAnchorBox,
-): number | null {
+): RendererLine | null {
 	if (!Number.isFinite(offset)) return null;
 
 	const samples = collectLineSamples(root);
@@ -592,17 +603,17 @@ export function getSourceLineAtPreviewOffset(
 	if (next) {
 		const nextTop = measure(next.element).top;
 		const span = nextTop - previousTop;
-		if (!Number.isFinite(span) || span <= 0) return previous.line;
+		if (!Number.isFinite(span) || span <= 0) return rendererLine(previous.line);
 
 		const progress = Math.max(0, Math.min(1, (offset - previousTop) / span));
-		return previous.line + progress * (next.line - previous.line);
+		return rendererLine(previous.line + progress * (next.line - previous.line));
 	}
 
 	// Past the last sample: its own height is all there is to go on, and a
 	// height of one rendered line is worth one source line.
 	const height = measure(previous.element).height;
-	if (!Number.isFinite(height) || height <= 0) return previous.line;
-	return previous.line + Math.max(0, (offset - previousTop) / height);
+	if (!Number.isFinite(height) || height <= 0) return rendererLine(previous.line);
+	return rendererLine(previous.line + Math.max(0, (offset - previousTop) / height));
 }
 
 /**
@@ -615,7 +626,7 @@ export function getSourceLineAtPreviewOffset(
  */
 export function getPreviewOffsetForSourceLine(
 	root: AnchorNode,
-	line: number,
+	line: RendererLine,
 	measure: MeasureAnchorBox,
 ): number | null {
 	if (!Number.isFinite(line)) return null;

--- a/src/lib/utils/scrollSync.ts
+++ b/src/lib/utils/scrollSync.ts
@@ -36,16 +36,24 @@
 // line in each pane. `PREVIEW_ANCHOR_OFFSET` is a separate decision about a
 // separate feature — where to put a line the reader is being *returned* to.
 
+import type { BufferLine } from './lineCoordinates.js';
+
 export type ScrollSyncPosition = {
 	section: 'frontmatter' | 'body';
 	ratio: number;
 	/**
-	 * Fractional source line at the sending pane's anchor. Absent when the
+	 * Fractional BUFFER line at the sending pane's anchor. Absent when the
 	 * sender could not resolve one — front matter (which renders as a panel with
 	 * no source range at all, so only `section`/`ratio` can carry it) or a
 	 * document with no annotated block. The receiver falls back to the ratio.
+	 *
+	 * Buffer, because the editor is the only pane that can produce one and the
+	 * buffer is all it knows. The preview's own numbering starts at the first
+	 * line of the body, so its half of this crossing goes through
+	 * `lineCoordinates` — and the type is what says so, rather than a comment
+	 * the next crossing can be written without reading.
 	 */
-	line?: number;
+	line?: BufferLine;
 };
 
 function clampScrollRatio(value: number) {

--- a/src/lib/utils/tocFollow.ts
+++ b/src/lib/utils/tocFollow.ts
@@ -18,13 +18,22 @@
  * disagree while both are live: the last entry at or above the position, and
  * the first entry when the position is above all of them.
  */
+import { asRendererLine, type RendererLine } from './lineCoordinates.js';
+
 export type TocLineEntry = {
 	id: string;
 	/** `null` for an entry the renderer gave no source range (a block anchor). */
-	line: number | null;
+	line: RendererLine | null;
 };
 
-export function activeTocIdForLine(entries: readonly TocLineEntry[], line: number): string | null {
+/**
+ * Renderer lines throughout: the outline is built out of `data-sourcepos`, so
+ * both the entries and the position they are compared against count from the
+ * first line of the body. The editor's answer is a buffer line and has to go
+ * through `lineCoordinates` on the way in — which the types now insist on,
+ * because that conversion was missing for as long as the outline existed.
+ */
+export function activeTocIdForLine(entries: readonly TocLineEntry[], line: RendererLine): string | null {
 	if (!Number.isFinite(line) || entries.length === 0) return null;
 
 	// Above the first heading the first entry is the active one — what the
@@ -38,7 +47,7 @@ export function activeTocIdForLine(entries: readonly TocLineEntry[], line: numbe
 }
 
 /** The start line of a rendered block, from the `data-sourcepos` comrak wrote. */
-export function sourceLineOf(sourcepos: string | null | undefined): number | null {
+export function sourceLineOf(sourcepos: string | null | undefined): RendererLine | null {
 	const line = Number(sourcepos?.match(/^(\d+):/)?.[1]);
-	return Number.isInteger(line) && line > 0 ? line : null;
+	return Number.isInteger(line) && line > 0 ? asRendererLine(line) : null;
 }


### PR DESCRIPTION
**Stack 3/5.** Base: `refactor/split-lib-rs`.

"Where does this line appear on screen?" involved four coordinate systems, all typed `number`, so nothing stopped one being used as another:

```
source line ──(minus front-matter lines)──▶ renderer line ──(DOM probe)──▶ pixel y
     ▲                                            │
     └────────(plus front-matter lines)◀──────────┘
```

The front-matter offset had to be applied by hand at five crossings, and was not applied at all of them. `toBufferLine` / `toRendererLine` / `toBufferRange` lived as locals inside `MarkdownViewer.svelte`, called from `:1229`, `:1241`, `:1287`, `:1841` and the template at `:3831`.

### What this adds
`src/lib/utils/lineCoordinates.ts` owns all four systems. Phantom branded types (`BufferLine`, `RendererLine`) separate the two line spaces at zero runtime cost — the arithmetic is unchanged.

The offset is now read in exactly one place, and that is asserted.

**Branding is applied to destinations, not sources.** `ScrollSyncPosition.line` is a `BufferLine`, `tocFollow` and `Toc.activeLine` are `RendererLine`, `Editor.revealHeader` takes a `BufferLine` — which makes each of the five crossings a compile error if skipped. `LineRange`, `findAnchorElement` and `getAnchorScrollTop` were deliberately *not* branded: no conversion happens there, and branding them would have cost ~30 `asRendererLine(3)` wrappers in existing tests for no protection. That asymmetry is what keeps call sites readable.

`previewAnchor.ts` was not split. It is already a deep module and only gained types on its two line-mapping entry points.

### The three copies of `60`
`PREVIEW_ANCHOR_OFFSET` (`previewAnchor.ts`), `MarkdownViewer.scrollToAnchor` and `Toc.svelte:jumpTo` each hardcoded it. Collapsed onto the existing constant; `grep '\- 60'` over the three files is now empty.

### The tests could not see this bug
`scrollSyncBlockMapping.test.ts` is ~1,350 lines and passed `frontMatterEnd = 0` in every call — and it *restated* the viewer's glue rather than importing it. `toRendererLine`'s only assertion was a regex on source text in `tocFollowsEditor.test.ts:114`, which passed if the function was wrong and failed if the line was reformatted.

Now: `previewPositionAt` / `previewScrollTopFor` call the real module, and a new section drives the same stress document with 6 lines of YAML and a 180px panel.

> **converted drift 0.0 body lines · unconverted control 6.0**

`scripts/lineCoordinates.test.ts` adds 7 round-trip tests at non-zero offset, including fractional lines, CRLF and the pixel→line→pixel trip.

### Verification
- `npm test` 993 pass / 0 fail
- `npm run check` 708 files / 0 errors / 0 warnings

### Known gap
`tab.anchorLine` is still a plain `number` in the tab store (it is a renderer line). Out of this PR's file boundary; filed for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
