### PR TITLE
refactor(tabs): derive isDirty, and give a keystroke one route to the document

### DIFF
--- a/scripts/editorPdfExport.test.ts
+++ b/scripts/editorPdfExport.test.ts
@@ -354,7 +354,7 @@ test('the refresh is skipped when the DOM already matches the buffer', () => {
 	// Reading mode is rendered by loadMarkdown from this same buffer, and
 	// re-rendering it would discard the scroll, fold and find state on screen.
 	assert.match(body_, /if \(!tab \|\| !\(tab\.isEditing \|\| tab\.isSplit\)\) return;/);
-	assert.match(body_, /_lastRenderedRawContent === rawContent\) return;/);
+	assert.match(body_, /previewedRawContent === rawContent\) return;/);
 });
 
 test('the refresh actually lands before the print', () => {

--- a/scripts/editorWritesThroughTheStore.test.ts
+++ b/scripts/editorWritesThroughTheStore.test.ts
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import ts from 'typescript';
+
+import { callbackBodies, readSource } from './sourceTree.js';
+
+/*
+ * A keystroke reaches the document by ONE route, and the dirty flag is not a
+ * flag.
+ *
+ * THE DEFECT. Typing used to write the buffer twice. `MarkdownViewer` passed
+ * the editor `bind:value={tabManager.activeTab.rawContent}`, so Svelte's
+ * assignment put the new text on the tab; the same listener then called
+ * `tabManager.updateTabRawContent`, which put it there again and recomputed
+ * `isDirty` from it. Both writes carried the same text, so the app worked — and
+ * it worked *because* Svelte's assignment happened to run first. Delete the
+ * store call and the editor still edited, the preview still re-rendered, and
+ * nothing maintained `isDirty`: no dirty dot, no auto-save, no unsaved-changes
+ * prompt on close, and no type error anywhere to say so.
+ *
+ * WHAT IT IS NOW. `value` is a plain prop — a getter over the parent's
+ * `tabManager.activeTab.rawContent` — and the listener's call to the store is
+ * the only write. Remove it and the editor stops editing the document, which is
+ * a failure you can see; these tests are the ones that see it first.
+ *
+ * `isDirty` went the same way: a getter on the tab, exactly
+ * `rawContent !== originalContent`, so nothing can hold an opinion about
+ * "changed?" that its two buffers do not support.
+ *
+ * WHAT RUNS HERE. The component's own `onDidChangeModelContent` listener,
+ * lifted out of Editor.svelte and evaluated against the REAL `TabManager`. Only
+ * Monaco is a fake, and only the two methods the listener touches.
+ */
+
+// ---------------------------------------------------------------- environment
+// Svelte runes and the Tauri bridge, faked as the other lifting tests do, so
+// `tabs.svelte.ts` imports under plain node.
+
+const g = globalThis as any;
+const runeEffect = (fn: () => void) => {
+	void fn;
+};
+runeEffect.root = (fn: () => unknown) => fn();
+g.$state = (value: unknown) => value;
+g.$state.raw = (value: unknown) => value;
+g.$state.snapshot = (value: unknown) => value;
+g.$derived = (value: unknown) => value;
+g.$derived.by = (fn: () => unknown) => fn();
+g.$effect = runeEffect;
+g.window = g.window ?? {};
+
+const localStore = new Map<string, string>();
+g.localStorage = {
+	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
+	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
+	removeItem: (key: string) => void localStore.delete(key),
+	clear: () => localStore.clear(),
+};
+g.window.__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+
+// ------------------------------------------------- the component, as written
+
+const EDITOR = 'src/lib/components/Editor.svelte';
+const source = readSource(EDITOR);
+
+const contentChangeBody = (() => {
+	const bodies = callbackBodies(source, 'editor.onDidChangeModelContent');
+	assert.equal(bodies.length, 1, `expected exactly one model-content listener in ${EDITOR}, found ${bodies.length}`);
+	return bodies[0];
+})();
+
+/**
+ * The lifted body is TypeScript and `new Function` only parses JavaScript, so
+ * it goes through `tsc` first, as undoHistoryPerTab.test.ts and
+ * imageUndoKeepsFile.test.ts already do. Types are erased, nothing else: the
+ * statements that run are the component's.
+ */
+const factorySource = ts.transpileModule(
+	`const __component = (tabManager, editor) => {
+		// The status bar readings. Stubbed rather than lifted because they are
+		// the listener's other errand and have their own tests; what is under
+		// test here is where the text goes.
+		const syncStatusFromModel = () => {};
+		return { contentChanged: () => ${contentChangeBody} };
+	};`,
+	{ compilerOptions: { target: ts.ScriptTarget.ES2022 } },
+).outputText;
+
+/**
+ * The `value` prop, modelled as what Svelte compiles a dynamic prop to: a
+ * getter over the parent's expression, `value={tabManager.activeTab.rawContent}`.
+ * Modelling it as a local copy would be re-introducing the second buffer this
+ * whole change removed.
+ *
+ * A null-prototype object so `with` captures this one name and not
+ * `toString`, `constructor` and the rest of Object.prototype.
+ */
+const propsScope = Object.defineProperty(Object.create(null), 'value', {
+	get: () => tabManager.activeTab?.rawContent ?? '',
+});
+
+function editorShowing(text: string) {
+	let onScreen = text;
+	const editor = { getValue: () => onScreen };
+	const factory = new Function(
+		'__props',
+		`with (__props) { ${factorySource}\nreturn __component; }`,
+	)(propsScope) as (tabManager: unknown, editor: unknown) => { contentChanged: () => void };
+	const component = factory(tabManager, editor);
+
+	return {
+		/** A keystroke: Monaco's buffer changes, then it fires the listener. */
+		type: (next: string) => {
+			onScreen = next;
+			component.contentChanged();
+		},
+	};
+}
+
+function activeTab() {
+	const tab = tabManager.activeTab;
+	assert.ok(tab, 'precondition: a tab is active');
+	return tab!;
+}
+
+// ------------------------------------------------------------------ the tests
+
+test('a keystroke reaches the document, and the document knows it is unsaved', () => {
+	tabManager.closeAll();
+	tabManager.addTab('/notes/a.md', 'saved text');
+	const editor = editorShowing('saved text');
+
+	assert.equal(activeTab().isDirty, false, 'precondition: a freshly opened tab is clean');
+
+	editor.type('saved text and more');
+
+	assert.equal(
+		activeTab().rawContent,
+		'saved text and more',
+		'the keystroke never reached the document: the editor is writing to something else, or to nothing',
+	);
+	assert.equal(
+		activeTab().isDirty,
+		true,
+		'the document has unsaved edits and does not say so — no dirty dot, no auto-save, no prompt on close',
+	);
+});
+
+test('typing the saved text back makes the tab clean again, with nobody clearing a flag', () => {
+	// The point of deriving it. Undo, or retyping what was deleted, leaves a
+	// buffer that IS the saved text — and the only thing that has to happen for
+	// the tab to say so is that the two buffers agree.
+	tabManager.closeAll();
+	tabManager.addTab('/notes/b.md', 'saved text');
+	const editor = editorShowing('saved text');
+
+	editor.type('saved text!');
+	assert.equal(activeTab().isDirty, true);
+
+	editor.type('saved text');
+	assert.equal(activeTab().isDirty, false, 'the buffer is the saved text and the tab still reads dirty');
+});
+
+test('following a link does not leave the tab dirty against the file it just left', () => {
+	// `navigate` repoints the tab at another file before the load lands, so for
+	// that window `path` is the new file and `rawContent` is the old document.
+	// A tab left dirty there arms the auto-save effect, which writes the
+	// document the reader left into the file they opened.
+	tabManager.closeAll();
+	tabManager.addTab('/notes/c.md', 'saved text');
+	const editor = editorShowing('saved text');
+	editor.type('unsaved edits');
+
+	tabManager.navigate(activeTab().id, '/notes/linked.md');
+
+	assert.equal(activeTab().path, '/notes/linked.md');
+	assert.equal(activeTab().isDirty, false, 'the tab claims unsaved edits to a document it no longer holds');
+});

--- a/scripts/imageUndoKeepsFile.test.ts
+++ b/scripts/imageUndoKeepsFile.test.ts
@@ -249,7 +249,6 @@ type Component = {
  */
 const factorySource = ts.transpileModule(
 	`const __component = (invoke, settings, tabManager, monaco, editor, lineEndingLabel) => {
-		let value = '';
 		let wordCount = 0;
 		let currentLanguage = 'markdown';
 		let lineEnding = 'LF';
@@ -291,6 +290,14 @@ const factorySource = ts.transpileModule(
 const unmodelledScope = new Proxy(Object.create(null), {
 	has: (_target, key) => typeof key === 'string' && !(key in globalThis),
 	get: (_target, key) => {
+		// The `value` prop, modelled as what Svelte compiles a dynamic prop to:
+		// a getter over the parent's expression, which is
+		// `value={tabManager.activeTab.rawContent}`. A local copy would be a
+		// second buffer with its own staleness — the very thing the component
+		// stopped keeping when `bind:value` went — and the listener's
+		// `value !== newValue` guard would then mean "changed since this copy
+		// was last assigned" instead of "the editor changed the document".
+		if (key === 'value') return tabManager.activeTab?.rawContent ?? '';
 		if (typeof key !== 'string') return undefined;
 		throw new Error(
 			`the editor reads component state \`${String(key)}\` that this harness does not model. ` +

--- a/scripts/oneWritePerTabInFlight.test.ts
+++ b/scripts/oneWritePerTabInFlight.test.ts
@@ -270,3 +270,49 @@ test('closing a tab mid-write does not leave the older snapshot on disk', async 
 	assert.equal(sawOverlap, false);
 	assert.equal(disk.get('/notes/e.md'), 'B', 'the closed tab’s newest text must be what is left on disk');
 });
+
+// ------------------------------------------ what "saved" means for the buffer
+//
+// `isDirty` is `rawContent !== originalContent` read off the tab, so the only
+// way a save can report itself is by moving `originalContent` to the text it
+// actually wrote. These two used to be assertions about the *shape* of that
+// code — that `documentSession` still contained a particular assignment — which
+// stopped being expressible once the flag became a getter nobody assigns. They
+// run here instead, where a live session already writes to a fake disk.
+
+test('a keystroke that misses the Save As write is still unsaved when it returns', async () => {
+	// The baseline is the snapshot that reached the file, never the buffer as it
+	// stands afterwards: the write is awaited, and anything typed while it
+	// drains is not in the file. Marking the tab clean there is silent data
+	// loss with a clean dirty dot on top of it.
+	reset();
+	const session = makeSession();
+	const tabId = await openDirtyTab(session, '/notes/f.md', 'A');
+	writeDurationsMs = [30];
+	nextSaveTarget = '/notes/copy-f.md';
+
+	const saveAs = session.saveContentAs();
+	// Past the dialog and the snapshot, still inside the write.
+	await new Promise((resolve) => setTimeout(resolve, 5));
+	tabManager.updateTabRawContent(tabId, 'AB');
+
+	assert.equal(await saveAs, true);
+	assert.equal(disk.get('/notes/copy-f.md'), 'A', 'the copy holds the snapshot the save took');
+	const tab = tabManager.tabs.find((item) => item.id === tabId)!;
+	assert.equal(tab.isDirty, true, 'the keystroke the copy does not contain was reported as saved');
+});
+
+test('discarding at the close prompt puts the last saved text back', async () => {
+	reset();
+	settings.autoSave = false;
+	const session = makeSession();
+	const tabId = await openDirtyTab(session, '/notes/g.md', 'edited');
+
+	// `askClose` answers 'discard'.
+	assert.equal(await session.canCloseTab(tabId), true);
+
+	const tab = tabManager.tabs.find((item) => item.id === tabId)!;
+	assert.equal(tab.rawContent, 'original', 'the buffer kept the edits the user chose to discard');
+	assert.equal(tab.isDirty, false, 'the discarded tab still reads dirty, so closing it asks again');
+	assert.equal(disk.get('/notes/g.md'), 'original', 'discarding wrote to the file');
+});

--- a/scripts/taskToggleLineEndings.test.ts
+++ b/scripts/taskToggleLineEndings.test.ts
@@ -213,7 +213,7 @@ test('LF: two blank lines above the list', async () => {
 // ---------------------------------------------- the toggle does not re-render
 //
 // Ticking a checkbox writes the buffer, and MarkdownViewer's render effect
-// re-renders whenever the buffer stops matching `_lastRenderedRawContent`. It
+// re-renders whenever the buffer stops matching `previewedRawContent`. It
 // would rebuild the whole article to arrive at the DOM already on screen — the
 // browser has drawn the native checkbox and the caller has added `task-done` —
 // and rebuilding drops the reader's scroll position, which in a long document
@@ -237,11 +237,7 @@ test('a toggle tells the preview it is already up to date', async () => {
 
 	await session.toggleTaskCheckbox(3, true);
 
-	assert.equal(
-		(tab as unknown as Record<string, unknown>)._lastRenderedRawContent,
-		tab.rawContent,
-		'the render effect has nothing to do',
-	);
+	assert.equal(tab.previewedRawContent, tab.rawContent, 'the render effect has nothing to do');
 });
 
 test('it is marked before anything can be awaited', () => {
@@ -249,7 +245,7 @@ test('it is marked before anything can be awaited', () => {
 	// checks the field BEFORE that — so marking after an `await` would be too
 	// late to prevent the render it has already scheduled.
 	const fn = sliceBetween(sessionSource, 'async function toggleTaskCheckbox(', '\n\tasync function ');
-	const marked = fn.indexOf('markPreviewMatchesBuffer');
+	const marked = fn.indexOf('tab.previewedRawContent = updated;');
 	const awaited = fn.indexOf('await saveContent');
 	assert.ok(marked > 0, 'the toggle marks the preview');
 	assert.ok(marked < awaited, 'marked before the first await after the write');

--- a/scripts/undoHistoryPerTab.test.ts
+++ b/scripts/undoHistoryPerTab.test.ts
@@ -319,9 +319,6 @@ type Component = {
 	undo: () => void;
 	acquireTabModel: (tabId: string, seed: string, language: string) => FakeModel | null;
 	setLanguage: (language: string) => void;
-	/** Svelte's `bind:value={tabManager.activeTab.rawContent}`, by hand. */
-	syncBoundValue: () => void;
-	value: () => string;
 	currentTabId: () => string | null;
 	currentLanguage: () => string;
 	wordCount: () => number;
@@ -335,7 +332,6 @@ type Component = {
  */
 const factorySource = ts.transpileModule(
 	`const __component = (tabManager, monaco, editor, getTabModel, tabModelUri, lineEndingLabel) => {
-		let value = '';
 		let currentTabId = null;
 		let language = 'markdown';
 		let currentLanguage = 'markdown';
@@ -355,8 +351,6 @@ const factorySource = ts.transpileModule(
 			undo,
 			acquireTabModel,
 			setLanguage: (next) => { language = next; },
-			syncBoundValue: () => { value = tabManager.activeTab ? tabManager.activeTab.rawContent : ''; },
-			value: () => value,
 			currentTabId: () => currentTabId,
 			currentLanguage: () => currentLanguage,
 			wordCount: () => wordCount,
@@ -365,8 +359,26 @@ const factorySource = ts.transpileModule(
 	{ compilerOptions: { target: ts.ScriptTarget.ES2022 } },
 ).outputText;
 
+/**
+ * The `value` prop, modelled as what Svelte compiles a dynamic prop to: a
+ * getter over the parent's expression, which is
+ * `value={tabManager.activeTab.rawContent}`. It used to be `bind:value`, and
+ * this harness used to mirror it with a local the tests re-synced by hand —
+ * which is the same second copy of the buffer, and the same chance for the two
+ * to disagree, that the component itself no longer keeps.
+ *
+ * A null-prototype object so `with` captures this one name and not
+ * `toString`, `constructor` and the rest of Object.prototype.
+ */
+const propsScope = Object.defineProperty(Object.create(null), 'value', {
+	get: () => tabManager.activeTab?.rawContent ?? '',
+});
+
 function createComponent(editor: Editor): Component {
-	const factory = new Function(`${factorySource}\nreturn __component;`)() as (
+	const factory = new Function(
+		'__props',
+		`with (__props) { ${factorySource}\nreturn __component; }`,
+	)(propsScope) as (
 		tabManager: unknown,
 		monaco: unknown,
 		editor: unknown,
@@ -403,7 +415,6 @@ function setup(): Harness {
 
 	const show = (tabId: string) => {
 		tabManager.setActive(tabId);
-		component.syncBoundValue();
 		component.activate();
 	};
 
@@ -534,7 +545,6 @@ test('a buffer replaced behind the editor still clears undo', () => {
 	h.type('1');
 
 	tabManager.setTabRawContent(a, 'from disk');
-	h.component.syncBoundValue();
 	h.component.activate();
 
 	assert.equal(h.text(), 'from disk', 'the external write did not reach the editor');
@@ -553,7 +563,6 @@ test('a tab pointed at another document does not carry its undo history across',
 
 	tabManager.navigate(a, '/docs/linked.md');
 	tabManager.setTabRawContent(a, 'linked');
-	h.component.syncBoundValue();
 	h.component.activate();
 
 	h.component.undo();
@@ -570,7 +579,6 @@ test('renaming a tab keeps the undo history, because the document did not change
 	h.type('1');
 
 	tabManager.renameTab(a, '/docs/renamed.md');
-	h.component.syncBoundValue();
 	h.component.activate();
 
 	h.component.undo();
@@ -590,7 +598,6 @@ test('a tab that follows a link into another file type re-languages its model', 
 
 	tabManager.navigate(a, '/docs/script.ts');
 	h.component.setLanguage('typescript');
-	h.component.syncBoundValue();
 	h.component.activate();
 
 	assert.equal(h.modelOf(a)?.getLanguageId(), 'typescript', 'the model kept the language of the previous document');

--- a/scripts/viewModeWithoutSaving.test.ts
+++ b/scripts/viewModeWithoutSaving.test.ts
@@ -162,7 +162,6 @@ function buildHarness(fakes: Fakes, isEditing: boolean): Harness {
 			if (fakes.typeDuringSave) tab.rawContent = snapshot + fakes.typeDuringSave;
 			fakes.disk.set(tab.path, snapshot);
 			tab.originalContent = snapshot;
-			tab.isDirty = tab.rawContent !== snapshot;
 			return true;
 		},
 		cancelPendingAutoSave: () => {},

--- a/scripts/windowClosePerTab.test.ts
+++ b/scripts/windowClosePerTab.test.ts
@@ -161,10 +161,12 @@ test('the untitled save dialog prefills the numbered tab title', () => {
 	assert.match(scope, /defaultPath: tab\.title/);
 });
 
-test('save-as keeps snapshot-based dirty tracking in documentSession', () => {
+test('save-as writes a snapshot rather than the buffer as it stands', () => {
+	// The other half — that a keystroke landing during that write is still
+	// unsaved afterwards — is `isDirty` reading the two buffers, and it runs
+	// for real in oneWritePerTabInFlight.test.ts.
 	const fn = sliceFrom(documentSession, 'async function saveContentAs');
 	assert.match(fn, /const snapshot = tab\.rawContent;/);
-	assert.match(fn, /tab\.isDirty = tab\.rawContent !== snapshot;/);
 });
 
 test('the restore-on-reopen branch persists window state via the shared helper', () => {

--- a/scripts/windowStateRestore.test.ts
+++ b/scripts/windowStateRestore.test.ts
@@ -24,7 +24,6 @@ const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 const tabs = readSource('src/lib/stores/tabs.svelte.ts');
 const viewer = readSource('src/lib/MarkdownViewer.svelte');
 const session = readSource('src/lib/sessions/windowSession.svelte.ts');
-const documentSession = readSource('src/lib/sessions/documentSession.svelte.ts');
 
 // Session restore persists WINDOW state only: which files are open, the
 // active tab, and per-tab UI (edit mode, split, scroll). Document content
@@ -138,12 +137,6 @@ test('startup restore reads content from disk, not from the snapshot', () => {
 	// 'HOME' sentinel (homeSentinelSnapshot.test.ts)
 	assert.match(restore, /if \(!hasRealFilePath\(tab\.path\)\) \{\s*\n\s*options\.dropRestoredTab\(tab\.id\);/);
 	assert.match(viewer, /await windowSession\.restore\(\);/);
-});
-
-test('the discard choice reverts the tab to its last saved content', () => {
-	const fn = sliceBetween(documentSession, 'async function canCloseTab', 'return { loadMarkdown');
-	assert.match(fn, /tab\.rawContent = tab\.originalContent;/);
-	assert.match(fn, /tab\.isDirty = false;/);
 });
 
 test('the close flow resolves dirty tabs before serializing window state', () => {

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -579,8 +579,12 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		applyRestoredContent: async (tabId, raw) => {
 			const tab = tabManager.tabs.find((item) => item.id === tabId);
 			if (!tab) return;
-			tab.rawContent = raw;
-			tab.originalContent = raw;
+			// Through the store, not by assigning the two buffers here: this is
+			// a whole file read from disk, so it also settles `isTruncated` —
+			// and a tab whose earlier restore attempt was deferred arrives here
+			// carrying `true` from `markTabContentUnavailable`, which would have
+			// gone on refusing every save of a buffer that is now complete.
+			tabManager.setTabRawContent(tabId, raw);
 			const processed = await renderMarkdownPreview(raw, tab.path, tab.collapsedHeaders);
 			if (isDisposed) return;
 			tabManager.updateTabContent(tab.id, processed);
@@ -840,10 +844,10 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		return processMarkdownHtml(html, filePath, folds);
 	}
 
-	async function renderTabPreviewFromRaw(tab: { id: string; path: string; rawContent: string; collapsedHeaders: Set<string>; [key: string]: any }) {
+	async function renderTabPreviewFromRaw(tab: Tab) {
 		const processed = await renderMarkdownPreview(tab.rawContent, tab.path, tab.collapsedHeaders);
 		tabManager.updateTabContent(tab.id, processed);
-		tab._lastRenderedRawContent = tab.rawContent;
+		tab.previewedRawContent = tab.rawContent;
 		await tick();
 		renderRichContent();
 	}
@@ -2128,13 +2132,13 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		const tabId = tab.id;
 		const rawContent = tab.rawContent;
 		if (rawContent === undefined) return;
-		if ((tab as any)._lastRenderedRawContent === rawContent) return;
+		if (tab.previewedRawContent === rawContent) return;
 		try {
 			const processed = await renderMarkdownPreview(rawContent, tab.path, tab.collapsedHeaders);
 			const current = tabManager.activeTab;
 			if (tabManager.activeTabId !== tabId || current?.rawContent !== rawContent) return;
 			tabManager.updateTabContent(tabId, processed);
-			(current as any)._lastRenderedRawContent = rawContent;
+			current.previewedRawContent = rawContent;
 			await tick();
 			// Awaited, unlike the on-screen path: Mermaid, KaTeX and
 			// highlight.js all replace nodes asynchronously, and the diagram
@@ -2645,7 +2649,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		if (tab && (tab.isSplit || (isEditing && settings.showToc)) && tab.rawContent !== undefined) {
 			const tabId = tab.id;
 			const rawContent = tab.rawContent;
-			if ((tab as any)._lastRenderedRawContent === rawContent) return;
+			if (tab.previewedRawContent === rawContent) return;
 
 			const timer = setTimeout(() => {
 				renderMarkdownPreview(rawContent, tab.path, tab.collapsedHeaders)
@@ -2657,7 +2661,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 							currentTab?.rawContent !== rawContent
 						) return;
 						tabManager.updateTabContent(tabId, processed);
-						(currentTab as any)._lastRenderedRawContent = rawContent;
+						currentTab.previewedRawContent = rawContent;
 						tick().then(renderRichContent);
 					})
 					.catch(console.error);

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -3582,7 +3582,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 							{/if}
 							<Editor
 								bind:this={editorPane}
-								bind:value={tabManager.activeTab.rawContent}
+								value={tabManager.activeTab.rawContent}
 								language={editorLanguage}
 								{theme}
 								onsave={saveContent}

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -45,7 +45,7 @@
 	import { invoke } from "@tauri-apps/api/core";
 
 	let {
-		value = $bindable(),
+		value,
 		language = "markdown",
 		onsave,
 		onnew,
@@ -498,13 +498,24 @@
 
 		editor.focus();
 
+		// The one route from a keystroke to the document. `value` is a plain
+		// prop — it reads the active tab's `rawContent` and nothing here writes
+		// it back — so this call is not a second opinion about the buffer, it is
+		// the only opinion. It used to be a `bind:value` writing the field
+		// directly PLUS this call, and the tab only stayed dirty-tracked because
+		// Svelte's assignment happened to run first: deleting this line left the
+		// text on screen correct and the dirty flag, the auto-save trigger and
+		// the close prompt silently dead. Delete it now and the editor stops
+		// editing the document at all, which is a bug you can see.
+		//
+		// The guard is what stops the loop: the effect below pushes an external
+		// buffer replacement in with `setValue`, which fires this listener with
+		// text `value` already holds, and writing that back to the store would
+		// be a write the user did not make.
 		editor.onDidChangeModelContent(() => {
 			const newValue = editor.getValue();
-			if (value !== newValue) {
-				value = newValue;
-				if (tabManager.activeTabId) {
-					tabManager.updateTabRawContent(tabManager.activeTabId, newValue);
-				}
+			if (value !== newValue && tabManager.activeTabId) {
+				tabManager.updateTabRawContent(tabManager.activeTabId, newValue);
 			}
 
 			syncStatusFromModel();

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -64,22 +64,6 @@ type DocumentSessionOptions = {
 };
 
 /**
- * Record that the rendered preview already matches `rawContent`.
- *
- * `_lastRenderedRawContent` is MarkdownViewer's bookkeeping: its render effect
- * compares the field against the buffer and re-renders when they differ. A
- * caller that has updated the preview DOM by hand has to say so, or the effect
- * rebuilds the article to reach the state already on screen — and takes the
- * reader's scroll position with it.
- *
- * Declared here rather than inlined so the cast lives in one place and the
- * reason is written once.
- */
-function markPreviewMatchesBuffer(tab: Tab, rawContent: string) {
-	(tab as unknown as Record<string, unknown>)._lastRenderedRawContent = rawContent;
-}
-
-/**
  * Which heading sections the tab being loaded has folded, read at render time
  * rather than captured up front. A large file is rendered twice — the 5MB
  * preview, then the whole document once the background read lands — and the
@@ -765,13 +749,13 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		// entirely, which is worse than the missing render would be.
 		//
 		// In the same synchronous block as the write, deliberately. The render
-		// effect reads `_lastRenderedRawContent` and, if it does not match,
-		// arms a 16ms timer BEFORE anything can be awaited — so marking this
-		// after an `await` would be too late to stop the render it schedules.
-		// The field is MarkdownViewer's, and this is the one place outside it
-		// that may claim the preview is current, because this is the one place
-		// that knows the DOM was updated by hand.
-		markPreviewMatchesBuffer(tab, updated);
+		// effect reads `previewedRawContent` and, if it does not match, arms a
+		// 16ms timer BEFORE anything can be awaited — so marking this after an
+		// `await` would be too late to stop the render it schedules. This is
+		// the one place outside the viewer that may claim the preview is
+		// current, because it is the one place that knows the DOM was updated
+		// by hand.
+		tab.previewedRawContent = updated;
 		await saveContent(tab.id);
 		return true;
 	}

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -636,8 +636,10 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 					tabManager.updateTabPath(tab.id, targetPath, targetKey);
 					options.saveRecentFile(targetPath);
 				}
+				// The baseline is the text that reached the file, not the buffer:
+				// anything typed while the write was in flight is still unsaved,
+				// and `isDirty` reads that off these two by itself.
 				tab.originalContent = snapshot;
-				tab.isDirty = tab.rawContent !== snapshot;
 				return true;
 			} catch (error) {
 				clearSelfWrite(targetPath);
@@ -713,8 +715,9 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 				// lines below set on purpose.
 				tab.isTruncated = false;
 				options.saveRecentFile(selected);
+				// Same as the ordinary save: the baseline is what was written,
+				// and edits made during the write stay dirty against it.
 				tab.originalContent = snapshot;
-				tab.isDirty = tab.rawContent !== snapshot;
 				// Said after the write rather than before the dialog: nothing is lost
 				// by proceeding, and a reader who came here to rescue unsaved text
 				// still has to know that what landed on disk stops where the load did.
@@ -788,7 +791,7 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		if (response === 'save') {
 			return saveContent(tabId);
 		}
-		// Kept, but not because the timer would otherwise fire: the three lines
+		// Kept, but not because the timer would otherwise fire: the two lines
 		// below are synchronous, so nothing can run between them, and the
 		// auto-save effect drops the timer on its own once `isDirty` is false.
 		// That route rests on the effect flushing ahead of a pending macrotask
@@ -798,7 +801,6 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		// to do it on this path's behalf.
 		options.cancelPendingAutoSave(tabId);
 		tab.rawContent = tab.originalContent;
-		tab.isDirty = false;
 		return true;
 	}
 

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -30,12 +30,13 @@ export interface Tab {
 	 * Anything that reads or changes the user's text wants this one.
 	 *
 	 * `originalContent` is that same buffer as it last came off, or last went
-	 * onto, disk. It exists only to answer "changed?": `isDirty` is literally
-	 * `rawContent !== originalContent` (`updateTabRawContent` below), and
-	 * discarding edits is `rawContent = originalContent` (`canCloseTab`). Write
-	 * it to a file and you save the last-saved text over the user's unsaved
-	 * edits; overwrite it and the edits stop even looking unsaved, which is why
-	 * `resolveExternalChange` refuses to reload a dirty tab.
+	 * onto, disk. It exists only to answer "changed?": `isDirty` IS
+	 * `rawContent !== originalContent` — a getter, not a field, so the two
+	 * cannot disagree — and discarding edits is `rawContent = originalContent`
+	 * (`canCloseTab`). Write it to a file and you save the last-saved text over
+	 * the user's unsaved edits; overwrite it and the edits stop even looking
+	 * unsaved, which is why `resolveExternalChange` refuses to reload a dirty
+	 * tab.
 	 *
 	 * `content` is not Markdown at all. It is the rendered preview HTML, cached
 	 * per tab and re-sanitized at the sink (`sanitizedHtml`). It is allowed to
@@ -44,12 +45,8 @@ export interface Tab {
 	 * repair. So it answers "what is on screen", never "what does the document
 	 * say", and it must never reach a file.
 	 *
-	 * Two things that are easy to assume and are not true. Assigning
-	 * `rawContent` directly does NOT update `isDirty` — go through
-	 * `updateTabRawContent` (edits) or `setTabRawContent` (a fresh read), or
-	 * maintain the flag yourself as `saveContent` does. And a clean tab is not
-	 * necessarily a copy of its file: a partial or failed read puts the same
-	 * prefix — or `''` — in BOTH buffers and clears `isDirty`, so "not dirty"
+	 * A clean tab is not necessarily a copy of its file: a partial or failed
+	 * read puts the same prefix — or `''` — in BOTH buffers, so "not dirty"
 	 * means "no unsaved edits", not "matches disk". See `isTruncated`.
 	 */
 	content: string;
@@ -57,7 +54,21 @@ export interface Tab {
 	originalContent: string;
 	/** Preview pixels — the coarsest of three position fields. See `scrollPercentage`. */
 	scrollTop: number;
-	isDirty: boolean;
+	/**
+	 * Derived, never assigned: exactly `rawContent !== originalContent`, read
+	 * off the two buffers every time. Each construction site below spells it as
+	 * a getter, which is why this is `readonly` — `tab.isDirty = false` is now
+	 * a compile error rather than a fourth opinion about what "changed" means.
+	 *
+	 * It used to be a plain field that nine sites maintained by hand, in three
+	 * different ways, and every one of them was really saying one of two
+	 * things: "this text is the saved text now" (`originalContent = rawContent`,
+	 * which the navigation routes below still say) or nothing at all, because
+	 * the buffers already agreed. A flag that can be set independently of the
+	 * buffers it summarises can be wrong about them, and the tab close dialog,
+	 * the auto-save trigger and the reload guard all believe it.
+	 */
+	readonly isDirty: boolean;
 	isEditing: boolean;
 	/**
 	 * Back/forward navigation, not undo — despite sitting next to three text
@@ -310,7 +321,9 @@ class TabManager {
 					rawContent: '',
 					originalContent: '',
 					scrollTop: typeof saved.scrollTop === 'number' ? saved.scrollTop : 0,
-					isDirty: false,
+					get isDirty() {
+						return this.rawContent !== this.originalContent;
+					},
 					isEditing: saved.isEditing === true,
 					history: fileHistory.history,
 					historyIndex: fileHistory.historyIndex,
@@ -447,7 +460,9 @@ class TabManager {
 			rawContent,
 			originalContent: rawContent,
 			scrollTop: 0,
-			isDirty: false,
+			get isDirty() {
+				return this.rawContent !== this.originalContent;
+			},
 			isEditing: false,
 			history: fileHistory.history,
 			historyIndex: fileHistory.historyIndex,
@@ -482,7 +497,9 @@ class TabManager {
 			rawContent: content,
 			originalContent: content,
 			scrollTop: 0,
-			isDirty: false,
+			get isDirty() {
+				return this.rawContent !== this.originalContent;
+			},
 			isEditing: settings.newFileDefaultMode,
 			history: [content],
 			historyIndex: 0,
@@ -517,7 +534,9 @@ class TabManager {
 			rawContent: '',
 			originalContent: '',
 			scrollTop: 0,
-			isDirty: false,
+			get isDirty() {
+				return this.rawContent !== this.originalContent;
+			},
 			isEditing: false,
 			history: [],
 			historyIndex: 0,
@@ -629,7 +648,6 @@ class TabManager {
 		const tab = this.tabs.find((t) => t.id === id);
 		if (tab) {
 			tab.rawContent = raw;
-			tab.isDirty = tab.rawContent !== tab.originalContent;
 		}
 	}
 
@@ -649,7 +667,6 @@ class TabManager {
 		if (tab) {
 			tab.rawContent = raw;
 			tab.originalContent = raw;
-			tab.isDirty = false;
 			tab.isTruncated = isTruncated;
 		}
 	}
@@ -832,7 +849,13 @@ class TabManager {
 			tab.path = path;
 			tab.pathKey = pathKey;
 			tab.title = path.split(/[/\\]/).pop() || 'Untitled';
-			tab.isDirty = false;
+			// The buffer is not touched here, so nothing about "changed?" changed
+			// either. This used to clear a dirty flag by hand, which was only ever
+			// right because both callers reach here mid-save and set
+			// `originalContent` to the text they just wrote a line later — and
+			// wrong in the window between, where a keystroke landing during the
+			// write would have been marked saved. The other caller repoints an
+			// untitled, empty, already-clean tab at the file it is about to load.
 			const fileHistory = replaceCurrentHistoryEntry({
 				currentPath: tab.path,
 				targetPath: path,
@@ -878,9 +901,10 @@ class TabManager {
 	 * this trigger — both doc comments below used to open by restating it, which
 	 * is what an unnamed shared concept looks like. This is its name.
 	 *
-	 * Not the buffer: `rawContent`, `originalContent` and `content` are
-	 * overwritten by the load that follows, not cleared here. This is only the
-	 * state that describes a document without being it.
+	 * Not the buffer's TEXT: `rawContent`, `originalContent` and `content` are
+	 * overwritten by the load that follows, not cleared here. Only the saved
+	 * baseline moves, and only so the tab stops reading dirty — see
+	 * `clearUnsavedEdits` below.
 	 *
 	 * Only a change of DOCUMENT gets here. Save As and rename (`updateTabPath`,
 	 * `renameTab`) change the tab's path while the text on screen stays put: the
@@ -888,8 +912,27 @@ class TabManager {
 	 * it. Tests guard both directions.
 	 */
 	private forgetPreviousDocument(tab: Tab) {
+		this.clearUnsavedEdits(tab);
 		this.clearReadingPosition(tab);
 		this.clearCollapsedHeaders(tab);
+	}
+
+	/**
+	 * The tab no longer holds the document its buffer came from, so it has no
+	 * unsaved edits to that document any more — and it must not look as if it
+	 * has, because `path` is already the NEW file. The auto-save effect arms on
+	 * `isDirty && path !== ''`, so a tab left dirty across a navigation would
+	 * write the document it just left into the file it just moved to, during
+	 * the await before the load lands.
+	 *
+	 * Moving the baseline rather than the text: the load that follows replaces
+	 * both buffers within the same user action, and clearing `rawContent` here
+	 * would blank the editor for that frame. This is what the three navigation
+	 * routes were each saying with `isDirty = false` while it was still a field
+	 * anyone could assign — one place now, because they ask one question.
+	 */
+	private clearUnsavedEdits(tab: Tab) {
+		tab.originalContent = tab.rawContent;
 	}
 
 	/**
@@ -966,7 +1009,6 @@ class TabManager {
 			tab.path = path;
 			tab.pathKey = pathKey;
 			tab.title = path.split(/[/\\]/).pop() || 'Untitled';
-			tab.isDirty = false;
 			this.forgetPreviousDocument(tab);
 		}
 	}
@@ -998,7 +1040,6 @@ class TabManager {
 			tab.path = path;
 			tab.pathKey = undefined;
 			tab.title = path.split(/[/\\]/).pop() || 'Untitled';
-			tab.isDirty = false;
 			this.forgetPreviousDocument(tab);
 			return path;
 		}
@@ -1017,7 +1058,6 @@ class TabManager {
 			tab.path = path;
 			tab.pathKey = undefined;
 			tab.title = path.split(/[/\\]/).pop() || 'Untitled';
-			tab.isDirty = false;
 			this.forgetPreviousDocument(tab);
 			return path;
 		}

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -25,8 +25,9 @@ export interface Tab {
 	 * document, and picking the wrong one loses the user's work.
 	 *
 	 * `rawContent` IS the document — the Markdown as it stands right now. The
-	 * editor two-way binds to it, the preview and the HTML export render from
-	 * it, and it is the exact string `saveContent` hands to `save_file_content`.
+	 * editor shows it and writes every keystroke back through
+	 * `updateTabRawContent`, the preview and the HTML export render from it,
+	 * and it is the exact string `saveContent` hands to `save_file_content`.
 	 * Anything that reads or changes the user's text wants this one.
 	 *
 	 * `originalContent` is that same buffer as it last came off, or last went

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -154,6 +154,26 @@ export interface Tab {
 	 */
 	isTruncated?: boolean;
 	/**
+	 * The `rawContent` the preview in `content` was rendered from — the answer
+	 * to "is what is on screen still this document?".
+	 *
+	 * Its whole job is to let the render effect skip work: a re-render rebuilds
+	 * the article and takes the reader's scroll position, fold state and find
+	 * highlights with it, so the effect renders only when this does not match
+	 * `rawContent`. Which also makes it a claim anyone may make on the
+	 * preview's behalf: `toggleTaskCheckbox` updates the DOM by hand and then
+	 * says so here, and that is the one place outside the viewer allowed to.
+	 *
+	 * Not the same question as `content !== ''`. `content` is the rendered
+	 * HTML and is allowed to lag; this says whether it lags.
+	 *
+	 * Optional, and absent is the safe direction: "nothing has been rendered
+	 * from this buffer", which costs one render. It lived on the tab as an
+	 * undeclared `_lastRenderedRawContent` reached through `as any` from two
+	 * files, which is the same field with nothing to check the spelling of it.
+	 */
+	previewedRawContent?: string;
+	/**
 	 * `rawContent` was decoded with U+FFFD substitutions because NO encoding
 	 * could read the file: a truncated multi-byte tail, or bytes that are not
 	 * text at all. Not merely "not UTF-8" — a legacy codepage is detected and

--- a/src/lib/utils/tabTransfer.ts
+++ b/src/lib/utils/tabTransfer.ts
@@ -27,6 +27,12 @@ export interface TransferableTab {
 	title: string;
 	rawContent: string;
 	originalContent: string;
+	/**
+	 * Redundant with the two buffers above, and kept anyway: it is the wire
+	 * format, the strict validator on the receiving side requires it, and the
+	 * window on the other end of the broker can be running an older build that
+	 * still reads it. `buildTransferredTab` derives its own answer.
+	 */
 	isDirty: boolean;
 	isEditing: boolean;
 	isSplit: boolean;
@@ -185,7 +191,13 @@ export function buildTransferredTab(
 		rawContent: snap.rawContent,
 		originalContent: snap.originalContent,
 		scrollTop: snap.scrollTop,
-		isDirty: snap.isDirty,
+		// Recomputed from the two buffers that just arrived, not copied from
+		// `snap.isDirty`: the payload can only be believed about what it
+		// carries, and the answer is a function of what it carries. The wire
+		// field stays — see `TransferableTab.isDirty`.
+		get isDirty() {
+			return this.rawContent !== this.originalContent;
+		},
 		isEditing: snap.isEditing,
 		history: [...snap.history],
 		historyIndex: snap.historyIndex,


### PR DESCRIPTION
**Stack 4/5.** Base: `refactor/line-coordinate-module`.

Over the last six weeks, **57% of all `fix` commits touched this set of files.** This PR goes after why.

### The defect
One keystroke reached `tab.rawContent` through two channels, and only one of them maintained the dirty flag:

```
a keystroke
   ├─▶ bind:value={tabManager.activeTab.rawContent}   ← writes the field, no isDirty
   └─▶ tabManager.updateTabRawContent(id, newValue)   ← re-derives isDirty
```

It worked only because Svelte's `bind:` assignment happens to run first. **Deleting the explicit call killed dirty tracking silently** — nothing type-checked it.

Underneath that, `isDirty` was an assignable field with three different formulas across nine write sites in two modules.

### What this changes

**1. `isDirty` is a read-only derivation.** `readonly` in the interface, a getter at every construction site. `tab.isDirty = …` is now a compile error.

All nine write points are gone. Six were redundant (the statement above them already said it). The three navigation routes collapsed into one `clearUnsavedEdits`, called from `forgetPreviousDocument` — and *not* deleting them outright matters: `navigate` sets the new path before the load lands, and auto-save arms on `isDirty && path !== ''`, so a tab left dirty across a navigation would write the document the reader left into the file they just opened.

**2. One route from a keystroke to the document.** `bind:value` became a plain prop; `updateTabRawContent` is the only writer. A dynamic Svelte prop compiles to a getter over the parent expression, so `value` still reads the store's current text — which keeps the `value !== newValue` guard meaningful.

**3. `_lastRenderedRawContent` → `Tab.previewedRawContent`.** All five casts gone — three `as any`, one `as unknown as Record<string, unknown>` helper, and an `[key: string]: any` escape hatch.

Drive-by: `applyRestoredContent` now goes through `setTabRawContent`, so it settles `isTruncated` — which matters for a tab a previous restore pass deferred, since it arrives carrying `true` and would go on refusing to save a buffer that is now complete.

### Falsification, run twice
`scripts/editorWritesThroughTheStore.test.ts` lifts the real `onDidChangeModelContent` listener out of `Editor.svelte` and runs it against the real `TabManager`.

> Deleting the `updateTabRawContent` line turns **2 of its 3 tests red**. Restored: 3/3 green.

Two source-shape assertions became real runs (`windowClosePerTab`, `windowStateRestore` → `oneWritePerTabInFlight`). Two lifted-editor harnesses (`undoHistoryPerTab`, `imageUndoKeepsFile`) modelled `value` as a hand-resynced local — literally the second copy of the buffer this PR removes — and now model it as a getter.

### Verification
- `npm test` 997 pass / 0 fail
- `npm run check` 709 files / 0 errors / 0 warnings

### Scope, stated plainly
This is **not** a full `Document` module. That would be a rewrite. This is the surgical version: one owner for the dirty question, one route for the buffer, no cast fields. `readonly` prevents assignment but not initialisation — a `Tab` literal could still write `isDirty: false` and typecheck. Closing that needs a factory over five construction sites, judged to be more machinery than the remaining hole is worth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
