### PR TITLE
refactor(folds): give heading and callout folds one owner

### DIFF
--- a/scripts/exportFoldParity.test.ts
+++ b/scripts/exportFoldParity.test.ts
@@ -297,7 +297,7 @@ test('the HTML export renders every heading fold open', () => {
 	// the Set it passes is the fold state that render is given. An empty one is
 	// what makes every section expanded.
 	assert.match(exportSource, /processMarkdownHtml\(safeHtml, ctx\.tabPath, new Set\(\)\)/);
-	assert.doesNotMatch(exportSource, /processMarkdownHtml\([^)]*collapsedHeaders/);
+	assert.doesNotMatch(exportSource, /processMarkdownHtml\([^)]*foldOverrides/);
 });
 
 test('a callout collapsed in the source is still readable in an exported file', () => {

--- a/scripts/fileDropRouting.test.ts
+++ b/scripts/fileDropRouting.test.ts
@@ -94,6 +94,6 @@ test('the viewer routes both panes through it, and acts on all three answers', (
 	// to say.
 	assert.match(
 		viewerSource,
-		/function reportUnsupportedDrop\(path: string\)[\s\S]{0,300}?t\('toast\.unsupportedFile', uiLanguage\)/,
+		/function reportUnsupportedDrop\(path: string\)[\s\S]{0,300}?t\('toast\.unsupportedFile', settings\.language\)/,
 	);
 });

--- a/scripts/foldKeys.test.ts
+++ b/scripts/foldKeys.test.ts
@@ -2,11 +2,11 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { installShimDom, parseHtml, type ShimElement } from './renderProtocolDom.ts';
-import { readSource } from './sourceTree.js';
 
 installShimDom();
 
 const { processMarkdownHtml } = await import('../src/lib/utils/markdown.ts');
+const { foldKeyOf } = await import('../src/lib/utils/foldState.ts');
 
 // Fold state is keyed by `h.id || textContent`. comrak emits the deduplicated
 // heading id ("setup", "setup-1", …) on an empty inner <a class="anchor">, not
@@ -82,12 +82,59 @@ test('a heading that already carries an id keeps it', () => {
 	assert.equal(heading.getAttribute('id'), 'hand-written');
 });
 
-test('the preview reads the heading id before falling back to text', () => {
-	// Kept as a source-shape assertion on purpose: the consumer lives in a
-	// Svelte component, which this runner cannot import. The anchor is the
-	// keying convention itself — the producer above is only useful if every
-	// consumer prefers the id — so it is a contract, not an internal call site.
-	const viewer = readSource('src/lib/MarkdownViewer.svelte');
-	assert.match(viewer, /foldableHeader\.id \|\| foldableHeader\.textContent/, 'preview chevron keys by heading id first');
-	assert.match(viewer, /\[id="\$\{CSS\.escape\(key\)\}"\]\.foldable-header/, 'toggleFold resolves the heading by id');
+// This used to be a source-shape assertion — the preview and the outline were
+// each grepped for their own copy of `id || textContent`, because the two
+// consumers live in Svelte components this runner cannot import. That is the
+// wrong shape of check for a rule about agreement: three spellings of one
+// expression pass it happily, right up until one of them is edited.
+//
+// There is one spelling now. `assignFoldKey` computes the key while the markup
+// is built and leaves it on the element, so every consumer reads the answer
+// instead of recomputing it, and this file can check the producer by running it.
+
+test('the key a fold is stored under is written onto the markup', () => {
+	const root = parseHtml(processMarkdownHtml(DUPLICATE_TITLES, '/doc.md', new Set()));
+	const [first, second] = root.querySelectorAll('h2') as unknown as ShimElement[];
+
+	assert.equal(foldKeyOf(first as unknown as Element), 'setup');
+	assert.equal(foldKeyOf(second as unknown as Element), 'setup-1', 'the deduplicated id, not the shared text');
+});
+
+test('a foldable callout is named too, and two with the same title fold apart', () => {
+	// Callouts have no id and no slug, so before they were keyed at all their
+	// fold state had nowhere to live — the title toggled two classes and the
+	// next render put them back. Keyed by title, in a namespace of their own.
+	const html = processMarkdownHtml(
+		[
+			'<blockquote><p>[!note]- Details<br>first body</p></blockquote>',
+			'<blockquote><p>[!note]- Details<br>second body</p></blockquote>',
+		].join('\n'),
+		'/doc.md',
+		new Set(['callout:Details']),
+	);
+	const root = parseHtml(html);
+	const [first, second] = root.querySelectorAll('.callout-foldable') as unknown as ShimElement[];
+
+	assert.equal(foldKeyOf(first as unknown as Element), 'callout:Details');
+	assert.equal(foldKeyOf(second as unknown as Element), 'callout:Details~1');
+
+	// `[!note]-` opens folded, and the set holds the folds the reader flipped —
+	// so the first callout, whose key is in the set, is the OPEN one.
+	assert.equal(first.classList.contains('is-collapsed'), false, 'the flipped callout is open');
+	assert.equal(second.classList.contains('is-collapsed'), true, 'its same-titled sibling keeps the source default');
+});
+
+test('a callout key cannot collide with a heading that reads the same', () => {
+	const root = parseHtml(
+		processMarkdownHtml(
+			'<h2>Details</h2>\n<blockquote><p>[!note]+ Details<br>body</p></blockquote>',
+			'/doc.md',
+			new Set(),
+		),
+	);
+	const heading = root.querySelector('h2') as unknown as ShimElement;
+	const callout = root.querySelector('.callout-foldable') as unknown as ShimElement;
+
+	assert.equal(foldKeyOf(heading as unknown as Element), 'Details');
+	assert.equal(foldKeyOf(callout as unknown as Element), 'callout:Details');
 });

--- a/scripts/foldStatePerDocument.test.ts
+++ b/scripts/foldStatePerDocument.test.ts
@@ -1,5 +1,6 @@
 /**
- * Heading folds belong to the document, not to the window.
+ * Folds belong to the document, not to the window — and every driver of a fold
+ * writes them.
  *
  * The fold key `processMarkdownHtml` writes and reads is the heading's id —
  * comrak's slug — falling back to its text. That identifies a heading WITHIN a
@@ -16,14 +17,22 @@
  * second half of this file drives those three routes, and the routes that
  * change only the path and must leave the folds alone.
  *
- * These tests run the REAL `toggleFold` and `handleLinkClick` out of
- * MarkdownViewer.svelte, the REAL `visibleItems` out of Toc.svelte and the REAL
- * `processMarkdownHtml`, against the REAL TabManager. Nothing here asserts on
- * the text of an implementation file: what is checked is what a second document
- * renders as.
+ * The third section is a different failure with the same cause. A fold has
+ * three drivers — the preview's own control, the outline's fold button, and
+ * find opening whatever hides a match — and one of them used to skip the
+ * bookkeeping entirely: a callout's title toggled `is-collapsed` on two
+ * elements and wrote nothing down, so a folded callout sprang open on the next
+ * render, which in split view is the next keystroke. Nothing keyed callouts at
+ * all, so there was nowhere to write it down even in principle.
+ *
+ * These tests run the REAL `toggleFold`, `revealFold` and `handleLinkClick` out
+ * of MarkdownViewer.svelte, the REAL `revealFoldsAround` out of FindBar.svelte,
+ * the REAL `visibleItems` out of Toc.svelte and the REAL `processMarkdownHtml`,
+ * against the REAL TabManager. Nothing here asserts on the text of an
+ * implementation file: what is checked is what a second render comes back as.
  *
  * The rune declarations are plucked too, not restated, because the whole fix
- * lives in one of them — whether `collapsedHeaders` is component state or a
+ * lives in one of them — whether `foldOverrides` is component state or a
  * read of the active tab. Restating it here would be restating the answer.
  */
 
@@ -65,9 +74,11 @@ installShimDom();
 
 const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 const { processMarkdownHtml } = await import('../src/lib/utils/markdown.ts');
+const foldState = await import('../src/lib/utils/foldState.ts');
 
 const viewer = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
 const toc = readSource(new URL('../src/lib/components/Toc.svelte', import.meta.url));
+const findBar = readSource(new URL('../src/lib/components/FindBar.svelte', import.meta.url));
 const session = readSource(new URL('../src/lib/sessions/documentSession.svelte.ts', import.meta.url));
 
 // ------------------------------------------------------------ source plucking
@@ -158,6 +169,18 @@ const DOC_B = docHtml('Beta body.');
 
 const FOLD_KEY = 'introduction';
 
+/**
+ * A callout the reader can fold, inside the section above it. comrak renders
+ * `> [!tip]+ Hint` as a blockquote whose first line carries the marker; `+`
+ * means "foldable, and open to begin with", so anything folded about it
+ * afterwards is the reader's doing and nobody else's.
+ */
+const DOC_WITH_CALLOUT =
+	docHtml('Alpha body.') +
+	'<blockquote data-sourcepos="5:1-6:12"><p>[!tip]+ Hint<br>the hidden text</p></blockquote>\n';
+
+const CALLOUT_KEY = 'callout:Hint';
+
 function render(html: string, path: string, folds: Set<string>): ShimElement {
 	return parseHtml(processMarkdownHtml(html, path, folds)).body;
 }
@@ -171,8 +194,10 @@ function isSectionCollapsed(body: ShimElement): boolean {
 type Viewer = {
 	/** The table of contents' fold button, and the keyboard route. */
 	toggleFold: (key: string) => void;
-	/** The preview chevron — also what FindBar clicks to reveal a match. */
-	clickChevron: (icon: ShimElement) => Promise<void>;
+	/** What find asks for on its way to a match it cannot show. */
+	revealFold: (key: string) => void;
+	/** The preview's own fold control: a heading chevron, or a callout title. */
+	clickChevron: (control: ShimElement) => Promise<void>;
 	/** The set the viewer would hand `processMarkdownHtml` right now. */
 	foldsOnScreen: () => Set<string>;
 	/** Point the viewer at a rendered document, as `bind:this={markdownBody}` does. */
@@ -180,16 +205,17 @@ type Viewer = {
 };
 
 function buildViewer(): Viewer {
-	const names = ['NO_COLLAPSED_HEADERS', 'activeTab', 'collapsedHeaders'];
+	const names = ['NO_FOLD_OVERRIDES', 'activeTab', 'foldOverrides'];
 	const declarations = names
 		.map((name) => ({ name, offset: declarationOffset(viewer, name) }))
 		.sort((a, b) => a.offset - b.offset)
-		.map(({ name }) => pluckDeclaration(viewer, name, name === 'collapsedHeaders'))
+		.map(({ name }) => pluckDeclaration(viewer, name, name === 'foldOverrides'))
 		.filter((declaration): declaration is Declaration => declaration !== null);
 
 	const source = [
-		pluckFunction(viewer, 'setCollapsedHeaders', false),
+		pluckFunction(viewer, 'setFoldOverrides', false),
 		pluckFunction(viewer, 'toggleFold'),
+		pluckFunction(viewer, 'revealFold'),
 		pluckFunction(viewer, 'handleLinkClick'),
 	]
 		.filter(Boolean)
@@ -205,43 +231,37 @@ function buildViewer(): Viewer {
 	).outputText;
 
 	// `markdownBody` is the component's `bind:this` on the preview article, and
-	// `document` is how `handleLinkClick` reaches the fold wrapper. Both are
-	// injected so the plucked source runs unmodified.
-	let preview: ShimElement | null = null;
+	// the foldState helpers are its imports. Both are injected so the plucked
+	// source runs unmodified.
 	const factory = new Function(
 		'deps',
 		`"use strict";
-		const { tabManager, CSS, document } = deps;
+		const { tabManager, applyFold, flipFold, foldRegionAt, foldRegionByKey, isFoldCollapsed } = deps;
 		let markdownBody = null;
 		${js}
 		return {
 			setBody: (body) => { markdownBody = body; },
 			toggleFold: (key) => { refresh(); return toggleFold(key); },
+			revealFold: (key) => { refresh(); return revealFold(key); },
 			handleLinkClick: (event) => { refresh(); return handleLinkClick(event); },
-			folds: () => { refresh(); return collapsedHeaders; },
+			folds: () => { refresh(); return foldOverrides; },
 		};`,
 	);
 
-	const bound = factory({
-		tabManager,
-		CSS: { escape: (value: string) => value },
-		document: {
-			getElementById: (id: string) => preview?.querySelector(`[id="${id}"]`) ?? null,
-		},
-	});
+	const bound = factory({ tabManager, ...foldState });
 
 	return {
 		toggleFold: bound.toggleFold,
-		clickChevron: (icon) =>
+		revealFold: bound.revealFold,
+		clickChevron: (control) =>
 			bound.handleLinkClick({
-				target: icon,
+				target: control,
 				detail: 1,
 				preventDefault: () => {},
 				stopPropagation: () => {},
 			}),
 		foldsOnScreen: bound.folds,
 		showDocument: (body) => {
-			preview = body;
 			bound.setBody(body);
 		},
 	};
@@ -254,9 +274,9 @@ function buildTocFilter() {
 	const open = offsetOf(toc, '{', start + marker.length);
 	const body = toc.slice(open, matchBrace(toc, open) + 1);
 	const js = ts.transpileModule(body, { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText;
-	return new Function('items', 'collapsedHeaders', `"use strict";\n${js}`) as (
+	return new Function('items', 'foldOverrides', `"use strict";\n${js}`) as (
 		items: unknown[],
-		collapsedHeaders: Set<string>,
+		foldOverrides: Set<string>,
 	) => Array<{ id: string }>;
 }
 
@@ -266,7 +286,7 @@ const tocVisibleItems = buildTocFilter();
  * The real `foldsForTab` out of documentSession — the set the LOAD path hands
  * the renderer, looked up at render time.
  *
- * The viewer's `collapsedHeaders` derived (above) is what the outline and the
+ * The viewer's `foldOverrides` derived (above) is what the outline and the
  * live preview DOM read; this is what decides which sections the incoming
  * HTML is built with `is-collapsed` already on. They are different readers of
  * the same field and both are exercised below, because a fold leak shows up in
@@ -281,9 +301,11 @@ const foldsForTab = (() => {
 	) => Set<string>;
 })();
 
+// `foldKey` is what the outline now reads off the rendered heading rather than
+// rebuilding out of `id || text` — see `TocItem` in Toc.svelte.
 const TOC_ITEMS = [
-	{ id: FOLD_KEY, text: 'Introduction', level: 2, isBlock: false, hasChildren: true },
-	{ id: 'details', text: 'Details', level: 3, isBlock: false, hasChildren: false },
+	{ id: FOLD_KEY, foldKey: FOLD_KEY, text: 'Introduction', level: 2, isBlock: false, hasChildren: true },
+	{ id: 'details', foldKey: 'details', text: 'Details', level: 3, isBlock: false, hasChildren: false },
 ];
 
 // ------------------------------------------------------------------ the tests
@@ -526,7 +548,7 @@ test('going forward renders that document with its own fold state', () => {
 });
 
 test('the tab gets a new set rather than the old one emptied', () => {
-	// `Tab.collapsedHeaders` is replaced, never mutated: the viewer's derived
+	// `Tab.foldOverrides` is replaced, never mutated: the viewer's derived
 	// holds the Set itself, and Svelte cannot see a `.clear()` of a Set it is
 	// already holding — the outline would keep hiding the section.
 	reset();
@@ -584,4 +606,172 @@ test('a link that resolves to the file already open is not a navigation', () => 
 	tabManager.navigate(id, '/notes/a.md');
 
 	assert.equal(isSectionCollapsed(render(DOC_A, '/notes/a.md', foldsForTab(id))), true);
+});
+
+// ------------------------------------------------- the drivers of a fold
+//
+// Three affordances fold things, and until now only one of them wrote anything
+// down. The heading chevron updated the tab; the callout title toggled two
+// classes; find fired a synthetic click at the chevron and hoped the viewer's
+// delegated handler would treat it as a user. The tests below drive all three
+// against the same tab and re-render after each, because "it looked folded" is
+// exactly what the broken version also achieved.
+
+/** The callout title bar, which is the whole control for a foldable callout. */
+function calloutToggle(body: ShimElement): ShimElement {
+	const toggle = body.querySelector('.callout-toggle');
+	assert.ok(toggle, 'the rendered callout must have a control to click');
+	return toggle;
+}
+
+function isCalloutCollapsed(body: ShimElement): boolean {
+	return body.querySelector('.callout-foldable.is-collapsed') !== null;
+}
+
+/** Open a document with a foldable callout in it and fold the callout by hand. */
+function foldTheCallout() {
+	reset();
+	const app = buildViewer();
+
+	tabManager.addTab('/notes/a.md', DOC_WITH_CALLOUT);
+	const id = tabManager.activeTabId!;
+	const body = render(DOC_WITH_CALLOUT, '/notes/a.md', app.foldsOnScreen());
+	app.showDocument(body);
+	assert.equal(isCalloutCollapsed(body), false, 'precondition: `[!tip]+` opens open');
+
+	return { app, id, body, clicked: app.clickChevron(calloutToggle(body)) };
+}
+
+test('a callout the reader folds is still folded after the next render', async () => {
+	// The defect. Split view re-renders the preview on every keystroke, so a
+	// fold that lives only in the DOM lasts until the next character typed —
+	// and the reader has no way to tell that the callout they closed is the
+	// one that keeps coming back.
+	const { app, id, body, clicked } = await foldTheCallout();
+	await clicked;
+
+	assert.equal(isCalloutCollapsed(body), true, 'the click closes it on screen');
+	assert.equal(
+		isCalloutCollapsed(render(DOC_WITH_CALLOUT, '/notes/a.md', foldsForTab(id))),
+		true,
+		'and the document re-renders with it still closed',
+	);
+	assert.equal(app.foldsOnScreen().has(CALLOUT_KEY), true, 'because the tab was told');
+});
+
+test('a callout folded in one document is not folded in another that has the same one', async () => {
+	// The heading half of this file, one element type over: the key is the
+	// callout's title, which is unique within a document and nowhere else.
+	const { app, clicked } = await foldTheCallout();
+	await clicked;
+
+	tabManager.addTab('/notes/b.md', DOC_WITH_CALLOUT);
+	assert.equal(
+		isCalloutCollapsed(render(DOC_WITH_CALLOUT, '/notes/b.md', app.foldsOnScreen())),
+		false,
+	);
+});
+
+test('opening a callout the source folds shut stays open across a render', async () => {
+	// The mirror image, and the reason the tab stores deviations rather than
+	// closures: `> [!tip]-` renders folded, so a set of "what is closed" cannot
+	// tell a callout the reader OPENED from one they never touched, and the
+	// next render shuts it again.
+	reset();
+	const app = buildViewer();
+	const source = DOC_WITH_CALLOUT.replace('[!tip]+', '[!tip]-');
+
+	tabManager.addTab('/notes/a.md', source);
+	const id = tabManager.activeTabId!;
+	const body = render(source, '/notes/a.md', app.foldsOnScreen());
+	app.showDocument(body);
+	assert.equal(isCalloutCollapsed(body), true, 'precondition: `[!tip]-` opens folded');
+
+	await app.clickChevron(calloutToggle(body));
+
+	assert.equal(isCalloutCollapsed(body), false, 'the click opens it on screen');
+	assert.equal(
+		isCalloutCollapsed(render(source, '/notes/a.md', foldsForTab(id))),
+		false,
+		'and it is still open after a re-render',
+	);
+});
+
+/**
+ * The real `revealFoldsAround` out of FindBar.svelte.
+ *
+ * It used to build a `MouseEvent` and fire it at the fold's control, which is
+ * three modules coupled through a class name and a synthetic event — and a
+ * coupling no test could drive, because the shim DOM has no event dispatch.
+ * Now it asks for a key, so the two halves can be run against each other: the
+ * find bar's ancestor walk, and the viewer's write path.
+ */
+function buildFindReveal(app: Viewer, body: ShimElement) {
+	const js = ts.transpileModule(pluckFunction(findBar, 'revealFoldsAround'), {
+		compilerOptions: { target: ts.ScriptTarget.ES2022 },
+	}).outputText;
+
+	const opened: string[] = [];
+	const reveal = new Function(
+		'deps',
+		`"use strict";
+		const { markdownBody, collapsedFoldsAround, onunfold } = deps;
+		${js}
+		return revealFoldsAround;`,
+	)({
+		markdownBody: body,
+		collapsedFoldsAround: foldState.collapsedFoldsAround,
+		onunfold: (key: string) => {
+			opened.push(key);
+			app.revealFold(key);
+		},
+	}) as (mark: ShimElement) => boolean;
+
+	return { reveal, opened };
+}
+
+test('find opens every fold hiding a match, and the tab keeps them open', async () => {
+	// A match inside a collapsed callout inside a collapsed section: the text is
+	// in the DOM behind `height: 0`, so find counts it and has to reveal it.
+	reset();
+	const app = buildViewer();
+
+	tabManager.addTab('/notes/a.md', DOC_WITH_CALLOUT);
+	const id = tabManager.activeTabId!;
+	const body = render(DOC_WITH_CALLOUT, '/notes/a.md', app.foldsOnScreen());
+	app.showDocument(body);
+
+	await app.clickChevron(calloutToggle(body));
+	app.toggleFold(FOLD_KEY);
+	assert.equal(isCalloutCollapsed(body), true);
+	assert.equal(isSectionCollapsed(body), true);
+
+	// Whatever wraps the buried text is what a find mark would sit inside.
+	const buried = body.querySelector('.markdown-alert-content .content-inner');
+	assert.ok(buried, 'the callout body survives folding — it is hidden, not removed');
+
+	const { reveal, opened } = buildFindReveal(app, body);
+	assert.equal(reveal(buried), true, 'find reports that it had folds to open');
+	assert.deepEqual(opened, [FOLD_KEY, CALLOUT_KEY], 'outermost first');
+
+	assert.equal(isCalloutCollapsed(body), false);
+	assert.equal(isSectionCollapsed(body), false);
+	assert.equal(
+		isCalloutCollapsed(render(DOC_WITH_CALLOUT, '/notes/a.md', foldsForTab(id))),
+		false,
+		'and the next render agrees, rather than hiding the match again',
+	);
+});
+
+test('find leaves a match that is not folded away alone', () => {
+	reset();
+	const app = buildViewer();
+	tabManager.addTab('/notes/a.md', DOC_WITH_CALLOUT);
+	const body = render(DOC_WITH_CALLOUT, '/notes/a.md', app.foldsOnScreen());
+	app.showDocument(body);
+
+	const { reveal, opened } = buildFindReveal(app, body);
+	assert.equal(reveal(body.querySelector('.markdown-alert-content .content-inner')!), false);
+	assert.deepEqual(opened, []);
+	assert.equal(app.foldsOnScreen().size, 0, 'and nothing is written down about a fold nobody touched');
 });

--- a/scripts/issue261EditorPdf.test.ts
+++ b/scripts/issue261EditorPdf.test.ts
@@ -57,8 +57,8 @@ test('the two Monaco entries this app can use survive drawing our own menu', () 
 
 	// Through the app's own translations, which is a gain rather than parity:
 	// Monaco's menu is English whatever language the app is in.
-	assert.match(menu, /t\('menu\.commandPalette', uiLanguage\)/);
-	assert.match(menu, /t\('menu\.changeAllOccurrences', uiLanguage\)/);
+	assert.match(menu, /t\('menu\.commandPalette', settings\.language\)/);
+	assert.match(menu, /t\('menu\.changeAllOccurrences', settings\.language\)/);
 });
 
 test('every label the editor menu asks for exists in every language', () => {
@@ -70,7 +70,7 @@ test('every label the editor menu asks for exists in every language', () => {
 	assert.ok(locales >= 6, `expected at least six locales, found ${locales}`);
 
 	const menu = functionSource(viewer, 'showEditorContextMenu');
-	for (const key of [...menu.matchAll(/t\('menu\.(\w+)', uiLanguage\)/g)].map((m) => m[1])) {
+	for (const key of [...menu.matchAll(/t\('menu\.(\w+)', settings\.language\)/g)].map((m) => m[1])) {
 		assert.equal(
 			(i18n.match(new RegExp(`\\b${key}:`, 'g')) ?? []).length >= locales,
 			true,

--- a/scripts/jumpToSelectedFragment.test.ts
+++ b/scripts/jumpToSelectedFragment.test.ts
@@ -249,7 +249,7 @@ test('the Edit entry resolves its target while the selection still exists', () =
 	// clicked a menu item, and a click is how a selection goes away.
 	const handler = functionSource(viewerSource, 'handleContextMenu');
 	assert.match(handler, /const editSourceTarget = getContextMenuSourceRange\(e\);/);
-	assert.match(handler, /t\('menu\.edit', uiLanguage\), onClick: \(\) => editSourceRange\(editSourceTarget\)/);
+	assert.match(handler, /t\('menu\.edit', settings\.language\), onClick: \(\) => editSourceRange\(editSourceTarget\)/);
 	assert.doesNotMatch(handler, /onClick: \(\) => toggleEdit\(\)/);
 });
 

--- a/scripts/lossyDecodeSaveGuard.test.ts
+++ b/scripts/lossyDecodeSaveGuard.test.ts
@@ -215,7 +215,7 @@ function makeTab(overrides: Partial<Tab> = {}): Tab {
 		isScrollSynced: false,
 		hasReplacementChars: true,
 		encoding: 'UTF-8',
-		collapsedHeaders: new Set<string>(),
+		foldOverrides: new Set<string>(),
 		...overrides,
 	};
 }

--- a/scripts/renderProtocolDom.ts
+++ b/scripts/renderProtocolDom.ts
@@ -107,6 +107,12 @@ export class ShimNode {
 		return (candidate as ShimElement) ?? null;
 	}
 
+	get previousElementSibling(): ShimElement | null {
+		let candidate = this.previousSibling;
+		while (candidate && candidate.nodeType !== NODE_ELEMENT) candidate = candidate.previousSibling;
+		return (candidate as ShimElement) ?? null;
+	}
+
 	get textContent(): string {
 		return this.childNodes.map((child) => child.textContent).join('');
 	}

--- a/scripts/singleImplementationConvention.test.ts
+++ b/scripts/singleImplementationConvention.test.ts
@@ -182,6 +182,15 @@ const RULES: Rule[] = [
 		},
 	},
 	{
+		name: 'a fold is named in one place',
+		why: "The expression that names a fold was written out three times — in the renderer, in the preview's click handler and in the outline — and two of them disagreed: the outline strips a trailing `^block-id` off the heading text before keying by it and the renderer does not, so for those headings the outline's fold button and the preview's chevron addressed different folds. Nothing type-checks a string built the same way in three files. `assignFoldKey` computes it once, while the markup is built, and leaves it on the element for `foldKeyOf` to read back.",
+		// The shape of the defect, not the helper's name: a second site is by
+		// construction one that does NOT call `assignFoldKey`, and what it would
+		// contain instead is this — the id-then-text fallback, spelled out.
+		marker: /id \|\| [A-Za-z.]*textContent/g,
+		allowed: ['src/lib/utils/foldState.ts'],
+	},
+	{
 		name: 'this suite reads a file through one function',
 		why: "A test that reads source with its own readFileSync gets the bytes Git checked out, and on Windows `core.autocrlf` makes those CRLF. Every `\\n` in a pattern then matches nothing and every anchor containing one is 'not found' — fifteen files were red on the maintainer's Windows checkout while cutting v2.7.0 and were hand-patched assertion by assertion (#452). `readSource` in sourceTree.ts decides the line ending once, on read, so the assertions stay written against `\\n` and a new test cannot re-open the hole by accident. Read the file with `readSource(path)` from './sourceTree.js' — it takes a cwd-relative string or a `new URL(…, import.meta.url)` — and write the assertion against `\\n`.",
 		// The call, not the import: `import { readFileSync }` on its own reads

--- a/scripts/tabTransfer.test.ts
+++ b/scripts/tabTransfer.test.ts
@@ -40,7 +40,7 @@ function makeTab(overrides: Partial<Tab> = {}): Tab {
 		isScrollSynced: true,
 		hasReplacementChars: false,
 		encoding: 'UTF-8',
-		collapsedHeaders: new Set<string>(),
+		foldOverrides: new Set<string>(),
 		...overrides,
 	};
 }

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -130,12 +130,6 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 
 	let showSettings = $state(false);
 
-	let uiLanguage = $state(settings.language);
-
-	$effect(() => {
-		uiLanguage = settings.language;
-	});
-
 	let recentFiles = $state<string[]>([]);
 	let isFocused = $state(true);
 	
@@ -226,7 +220,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 
 	function reportUnsupportedDrop(path: string) {
 		const filename = path.split(/[/\\]/).pop() || 'File';
-		addToast(t('toast.unsupportedFile', uiLanguage).replace('{{filename}}', filename), 'error');
+		addToast(t('toast.unsupportedFile', settings.language).replace('{{filename}}', filename), 'error');
 	}
 	let editorPaneEl = $state<HTMLElement>();
 	let viewerPaneEl = $state<HTMLElement>();
@@ -2341,9 +2335,9 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 				// No chord printed beside these three: ⌘X/⌘C/⌘V are the one set of
 				// shortcuts nobody needs told, and the reminder costs a column of
 				// width in every language.
-				{ label: t('menu.cut', uiLanguage), onClick: () => editorPane?.cutToClipboard() },
-				{ label: t('menu.copy', uiLanguage), onClick: () => editorPane?.copyToClipboard() },
-				{ label: t('menu.paste', uiLanguage), onClick: () => editorPane?.pasteFromClipboard() },
+				{ label: t('menu.cut', settings.language), onClick: () => editorPane?.cutToClipboard() },
+				{ label: t('menu.copy', settings.language), onClick: () => editorPane?.copyToClipboard() },
+				{ label: t('menu.paste', settings.language), onClick: () => editorPane?.pasteFromClipboard() },
 				{ separator: true },
 				// The two Monaco put here that this app can actually use, and
 				// that drawing our own menu would otherwise have taken away.
@@ -2354,12 +2348,12 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 				// Translated here, which they were not before: Monaco's menu is
 				// English whatever the app's language is.
 				{
-					label: t('menu.commandPalette', uiLanguage),
+					label: t('menu.commandPalette', settings.language),
 					shortcut: 'F1',
 					onClick: () => editorPane?.runEditorAction('editor.action.quickCommand'),
 				},
 				{
-					label: t('menu.changeAllOccurrences', uiLanguage),
+					label: t('menu.changeAllOccurrences', settings.language),
 					shortcut: chord('Mod+F2'),
 					onClick: () => editorPane?.runEditorAction('editor.action.changeAll'),
 				},
@@ -2424,7 +2418,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		const linkItems: ContextMenuItem[] =
 			linkTarget && resolveMarkdownTargetPath(currentFile, linkTarget)
 				? [
-						{ label: t('menu.openInNewTab', uiLanguage), onClick: () => openMarkdownTargetInNewTab(linkTarget) },
+						{ label: t('menu.openInNewTab', settings.language), onClick: () => openMarkdownTargetInNewTab(linkTarget) },
 						{ separator: true },
 					]
 				: [];
@@ -2439,7 +2433,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			// nests inside the heading rather than on the heading itself.
 			const slug = heading.id || heading.querySelector('a.anchor')?.id || '';
 			copyRefItem = [
-				{ label: t('menu.copyReference', uiLanguage), onClick: () => copyHeadingReference(text, slug) },
+				{ label: t('menu.copyReference', settings.language), onClick: () => copyHeadingReference(text, slug) },
 				{ separator: true },
 			];
 		}
@@ -2448,7 +2442,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		let mediaItems: any[] = [];
 		if (img) {
 			mediaItems = [
-				{ label: t('menu.saveImageAs', uiLanguage), onClick: () => saveImageAs(img.src) },
+				{ label: t('menu.saveImageAs', settings.language), onClick: () => saveImageAs(img.src) },
 				{ separator: true }
 			];
 		}
@@ -2461,7 +2455,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		const mermaidDiag = (e.target as HTMLElement).closest('.mermaid-diagram');
 		if (mermaidDiag) {
 			mediaItems = [
-				{ label: t('menu.saveDiagramAsSvg', uiLanguage), onClick: () => saveDiagramAs(mermaidDiag as HTMLElement) },
+				{ label: t('menu.saveDiagramAsSvg', settings.language), onClick: () => saveDiagramAs(mermaidDiag as HTMLElement) },
 				{ separator: true }
 			];
 		}
@@ -2474,11 +2468,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 				...linkItems,
 				...copyRefItem,
 				...mediaItems,
-				...(hasSelection ? [{ label: t('menu.copy', uiLanguage), onClick: () => {
+				...(hasSelection ? [{ label: t('menu.copy', settings.language), onClick: () => {
 					const selection = window.getSelection()?.toString();
 					if (selection) invoke('clipboard_write_text', { text: selection });
 				} }] : []),
-				{ label: t('menu.selectAll', uiLanguage), onClick: () => {
+				{ label: t('menu.selectAll', settings.language), onClick: () => {
 					if (!markdownBody) return;
 					const range = document.createRange();
 					range.selectNodeContents(markdownBody);
@@ -2487,10 +2481,10 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 					selection?.addRange(range);
 				} },
 				{ separator: true },
-				{ label: t('menu.openLocation', uiLanguage), onClick: openFileLocation, disabled: !currentFile },
-				{ label: t('menu.edit', uiLanguage), onClick: () => editSourceRange(editSourceTarget) },
+				{ label: t('menu.openLocation', settings.language), onClick: openFileLocation, disabled: !currentFile },
+				{ label: t('menu.edit', settings.language), onClick: () => editSourceRange(editSourceTarget) },
 				{ separator: true },
-				{ label: t('menu.closeFile', uiLanguage), onClick: closeFile },
+				{ label: t('menu.closeFile', settings.language), onClick: closeFile },
 			],
 		};
 	}
@@ -3819,7 +3813,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 												y: e.clientY,
 												items: [
 													{ 
-														label: t('menu.copyReference', uiLanguage),
+														label: t('menu.copyReference', settings.language),
 														onClick: () => {
 															copyHeadingReference(item.text, item.id);
 															docContextMenu.show = false;
@@ -3917,14 +3911,14 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 				{#if isSplit || isEditing}
 					<div class="drag-zone editor-zone" class:active={dragTarget === 'editor'}>
 								<div class="drag-message">
-									<span>{t('dragAndDrop.embed', uiLanguage)}</span>
+									<span>{t('dragAndDrop.embed', settings.language)}</span>
 								</div>
 							</div>
 				{/if}
 				{#if isSplit || !isEditing}
 					<div class="drag-zone viewer-zone" class:active={dragTarget === 'preview'}>
 								<div class="drag-message">
-									<span>{t('dragAndDrop.open', uiLanguage)}</span>
+									<span>{t('dragAndDrop.open', settings.language)}</span>
 								</div>
 							</div>
 				{/if}

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -37,6 +37,13 @@ import {
 	type RichContentLibraries,
 } from './utils/richContent.js';
 import { observeFoldLayout } from './utils/foldLayout.js';
+import {
+	applyFold,
+	flipFold,
+	foldRegionAt,
+	foldRegionByKey,
+	isFoldCollapsed,
+} from './utils/foldState.js';
 import { routeDroppedFile, type DropPane } from './utils/fileDrop.js';
 import { headingReference, preferredReferenceStyle } from './utils/headingReference.js';
 import {
@@ -270,16 +277,16 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	let zoomData = $state<{ src?: string; html?: string } | null>(null);
 
 	// What a document with no tab behind it has folded. Never written to — every
-	// write goes through `setCollapsedHeaders`, which needs an active tab.
-	const NO_COLLAPSED_HEADERS = new Set<string>();
+	// write goes through `setFoldOverrides`, which needs an active tab.
+	const NO_FOLD_OVERRIDES = new Set<string>();
 
 	// derived from tab manager
 	let activeTab = $derived(tabManager.activeTab);
 	// Fold state belongs to the document, so it lives on the tab (see
-	// `Tab.collapsedHeaders`). Reading it through a derived is what makes a tab
+	// `Tab.foldOverrides`). Reading it through a derived is what makes a tab
 	// switch swap the whole set: the preview render, the table of contents and
 	// find all see the folds of the document on screen and no other document's.
-	let collapsedHeaders = $derived(activeTab?.collapsedHeaders ?? NO_COLLAPSED_HEADERS);
+	let foldOverrides = $derived(activeTab?.foldOverrides ?? NO_FOLD_OVERRIDES);
 	let isEditing = $derived(activeTab?.isEditing ?? false);
 	let rawContent = $derived(activeTab?.rawContent ?? '');
 	let isSplit = $derived(activeTab?.isSplit ?? false);
@@ -585,7 +592,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			// carrying `true` from `markTabContentUnavailable`, which would have
 			// gone on refusing every save of a buffer that is now complete.
 			tabManager.setTabRawContent(tabId, raw);
-			const processed = await renderMarkdownPreview(raw, tab.path, tab.collapsedHeaders);
+			const processed = await renderMarkdownPreview(raw, tab.path, tab.foldOverrides);
 			if (isDisposed) return;
 			tabManager.updateTabContent(tab.id, processed);
 			if (tabManager.activeTabId === tab.id) tick().then(renderRichContent);
@@ -845,7 +852,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	}
 
 	async function renderTabPreviewFromRaw(tab: Tab) {
-		const processed = await renderMarkdownPreview(tab.rawContent, tab.path, tab.collapsedHeaders);
+		const processed = await renderMarkdownPreview(tab.rawContent, tab.path, tab.foldOverrides);
 		tabManager.updateTabContent(tab.id, processed);
 		tab.previewedRawContent = tab.rawContent;
 		await tick();
@@ -1377,43 +1384,38 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	}
 
 	// The one place fold state is written. It goes to the tab the user is
-	// looking at, which is the document the fold is a fold OF — both toggle
-	// paths below act on the preview or the table of contents of that tab.
-	function setCollapsedHeaders(next: Set<string>) {
-		if (tabManager.activeTabId) tabManager.setTabCollapsedHeaders(tabManager.activeTabId, next);
+	// looking at, which is the document the fold is a fold OF — every toggle
+	// path below acts on the preview or the table of contents of that tab.
+	function setFoldOverrides(next: Set<string>) {
+		if (tabManager.activeTabId) tabManager.setTabFoldOverrides(tabManager.activeTabId, next);
 	}
 
+	/**
+	 * The single write path for a fold, whichever of the three drivers asked:
+	 * the preview chevron and the callout title (`handleLinkClick`), the
+	 * outline's fold button, and find opening what hides a match (`revealFold`).
+	 *
+	 * Both halves happen here, and that is the point. The stored deviation is
+	 * what the NEXT render reads; the two class writes are what the current DOM
+	 * shows. A driver that did only the second — which is what the callout title
+	 * used to do — folds something that springs open again on the next
+	 * keystroke, and there is nothing on screen to say why.
+	 *
+	 * The state is flipped even when the fold is not in the DOM (the preview is
+	 * hidden in editor-only mode, and the outline is still there to click), so
+	 * the fold is honoured by the render that brings it back.
+	 */
 	function toggleFold(key: string) {
-		const isCurrentlyCollapsed = collapsedHeaders.has(key);
+		setFoldOverrides(flipFold(foldOverrides, key));
 
-		if (isCurrentlyCollapsed) {
-			const next = new Set(collapsedHeaders);
-			next.delete(key);
-			setCollapsedHeaders(next);
-		} else {
-			setCollapsedHeaders(new Set([...collapsedHeaders, key]));
-		}
+		const region = markdownBody ? foldRegionByKey(markdownBody, key) : null;
+		if (region) applyFold(region, !isFoldCollapsed(region));
+	}
 
-		if (!markdownBody) return;
-
-		let h = markdownBody.querySelector(`[id="${CSS.escape(key)}"].foldable-header`) as HTMLElement | null;
-		if (!h) {
-			const allHeaders = markdownBody.querySelectorAll('.foldable-header');
-			for (const el of Array.from(allHeaders)) {
-				if ((el.textContent?.trim() || '') === key) {
-					h = el as HTMLElement;
-					break;
-				}
-			}
-		}
-		if (!h) return;
-
-		const wrapId = h.getAttribute('data-fold-target');
-		const wrapper = wrapId ? document.getElementById(wrapId) : null;
-		if (!wrapper) return;
-
-		h.classList.toggle('is-collapsed', !isCurrentlyCollapsed);
-		wrapper.classList.toggle('is-collapsed', !isCurrentlyCollapsed);
+	/** Open this fold if it is shut — what FindBar asks for on the way to a match. */
+	function revealFold(key: string) {
+		const region = markdownBody ? foldRegionByKey(markdownBody, key) : null;
+		if (region && isFoldCollapsed(region)) toggleFold(key);
 	}
 
 	function scrollToAnchor(anchor: string, options: { pushHistory?: boolean } = {}) {
@@ -1482,40 +1484,16 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	async function handleLinkClick(e: MouseEvent) {
 		const target = e.target as HTMLElement;
 
-		// header fold toggle
-		const foldIcon = target.closest('.header-fold-icon');
-		const foldableHeader = foldIcon ? foldIcon.closest('.foldable-header') as HTMLElement : null;
-		if (foldableHeader) {
+		// Fold toggle: the heading's chevron, or a foldable callout's whole title
+		// bar. One branch for both, because they are one feature — the callout's
+		// own branch used to toggle the classes and stop there, so a folded
+		// callout re-opened on the next render while a folded heading did not.
+		const foldControl = target.closest('.header-fold-icon, .callout-toggle');
+		if (foldControl) {
 			if (e.detail > 1) e.preventDefault(); // prevent double-click selection
 			e.stopPropagation();
-			const key = foldableHeader.id || foldableHeader.textContent?.trim() || '';
-			const wrapId = foldableHeader.getAttribute('data-fold-target');
-			const wrapper = wrapId ? document.getElementById(wrapId) : null;
-			if (wrapper) {
-				const isCollapsed = foldableHeader.classList.toggle('is-collapsed');
-				wrapper.classList.toggle('is-collapsed', isCollapsed);
-				if (isCollapsed) {
-					setCollapsedHeaders(new Set([...collapsedHeaders, key]));
-				} else {
-					const next = new Set(collapsedHeaders);
-					next.delete(key);
-					setCollapsedHeaders(next);
-				}
-			}
-			return;
-		}
-
-		// callout fold toggle
-		const calloutToggle = target.closest('.callout-toggle');
-		if (calloutToggle) {
-			if (e.detail > 1) e.preventDefault(); // prevent double-click selection
-			e.stopPropagation();
-			const alert = calloutToggle.closest('.callout-foldable');
-			const content = alert?.querySelector('.markdown-alert-content');
-			if (alert && content) {
-				alert.classList.toggle('is-collapsed');
-				content.classList.toggle('is-collapsed');
-			}
+			const region = foldRegionAt(foldControl);
+			if (region) toggleFold(region.key);
 			return;
 		}
 
@@ -2134,7 +2112,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		if (rawContent === undefined) return;
 		if (tab.previewedRawContent === rawContent) return;
 		try {
-			const processed = await renderMarkdownPreview(rawContent, tab.path, tab.collapsedHeaders);
+			const processed = await renderMarkdownPreview(rawContent, tab.path, tab.foldOverrides);
 			const current = tabManager.activeTab;
 			if (tabManager.activeTabId !== tabId || current?.rawContent !== rawContent) return;
 			tabManager.updateTabContent(tabId, processed);
@@ -2652,7 +2630,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			if (tab.previewedRawContent === rawContent) return;
 
 			const timer = setTimeout(() => {
-				renderMarkdownPreview(rawContent, tab.path, tab.collapsedHeaders)
+				renderMarkdownPreview(rawContent, tab.path, tab.foldOverrides)
 					.then((processed) => {
 						const currentTab = tabManager.activeTab;
 						if (
@@ -3625,6 +3603,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 							bind:this={findBar}
 							bind:open={findOpen}
 							{markdownBody}
+							onunfold={revealFold}
 							language={settings.language} />
 
 							<div class="viewer-content">
@@ -3811,7 +3790,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 										{markdownBody} 
 										htmlContent={sanitizedHtml}
 										onBeforeJump={pushScrollHistory} 
-										{collapsedHeaders} 
+										{foldOverrides} 
 										ontoggleFold={toggleFold} 
 										oncopyref={(text: string, slug: string) => copyHeadingReference(text, slug)}
 										onjump={(id: string, text: string, sourceLine: RendererLine | null) => {

--- a/src/lib/components/FindBar.svelte
+++ b/src/lib/components/FindBar.svelte
@@ -3,15 +3,25 @@
 	import { tick } from 'svelte';
 	import { t } from '../utils/i18n.js';
 	import type { LanguageCode } from '../utils/i18n.js';
+	import { collapsedFoldsAround } from '../utils/foldState.js';
 
 	let {
 		open = $bindable(false),
 		markdownBody,
-		language = 'en' as LanguageCode,
+		onunfold,
+		language,
 	} = $props<{
 		open: boolean;
 		markdownBody: HTMLElement | null;
-		language?: LanguageCode;
+		/** Open the fold with this key. Only the owner of the fold state can. */
+		onunfold?: (key: string) => void;
+		/**
+		 * Required, and deliberately without a default. `= 'en'` here was a
+		 * caller that forgot the prop silently rendering an English find bar in
+		 * a Chinese window — the compiler's one chance to catch that, given
+		 * away for a default nobody wants.
+		 */
+		language: LanguageCode;
 	}>();
 
 	const FIND_MARK_CLASS = 'markpad-find-match';
@@ -27,8 +37,7 @@
 	// (content the browser cannot reveal, `display: none`, is not matched at
 	// all). So the matches stay in the count and the fold opens on the way to
 	// them.
-	const FOLD_CONTENT_SELECTOR =
-		'.foldable-content-wrapper.is-collapsed, .markdown-alert-content.is-collapsed';
+	//
 	// styles.css animates the fold height for 0.25s.
 	const FOLD_TRANSITION_MS = 300;
 
@@ -67,44 +76,29 @@
 	}
 
 	/**
-	 * The control a user would click to open this fold.
+	 * Opens every collapsed fold between `mark` and the preview root.
 	 *
-	 * Expanding by clearing `is-collapsed` here would work for exactly one
-	 * frame: MarkdownViewer owns `collapsedHeaders`, re-applies the class on
-	 * every re-render and hands the same set to the table of contents. Going
-	 * through the affordance keeps that bookkeeping the single source of
-	 * truth — the same reason Chrome fires `beforematch` before it reveals
-	 * `hidden=until-found` content.
+	 * Clearing `is-collapsed` here would work for exactly one frame: the fold
+	 * state belongs to the tab, the render re-applies the class from it, and
+	 * the outline reads the same set. Asking its owner is what keeps that
+	 * bookkeeping the single source of truth — the same reason Chrome fires
+	 * `beforematch` before it reveals `hidden=until-found` content.
+	 *
+	 * This used to say so by building a `MouseEvent` and firing it at the
+	 * chevron, so that the viewer's delegated click handler would treat find
+	 * like a user. That coupled three modules through a class name and a
+	 * synthetic event: the fold key is a string now, and `onunfold` is a
+	 * function.
 	 */
-	function foldToggleFor(container: Element, root: HTMLElement): HTMLElement | null {
-		if (container.classList.contains('foldable-content-wrapper')) {
-			const header = container.id
-				? root.querySelector(`.foldable-header[data-fold-target="${CSS.escape(container.id)}"]`)
-				: null;
-			return (header?.querySelector('.header-fold-icon') as HTMLElement | null) ?? null;
-		}
-		return (container.closest('.callout-foldable')?.querySelector('.callout-toggle') as HTMLElement | null) ?? null;
-	}
-
-	/** Opens every collapsed fold between `mark` and the preview root. */
 	function revealFoldsAround(mark: HTMLElement): boolean {
 		const root = markdownBody as HTMLElement | null;
 		if (!root) return false;
 
-		const collapsed: Element[] = [];
-		let curr: Element | null = mark.parentElement;
-		while (curr && curr !== root) {
-			if (curr.matches(FOLD_CONTENT_SELECTOR)) collapsed.push(curr);
-			curr = curr.parentElement;
-		}
-		if (collapsed.length === 0) return false;
-
-		// Collected innermost first; open the outermost fold first so a nested
-		// one is already on screen by the time its own toggle fires.
-		for (const container of collapsed.reverse()) {
-			foldToggleFor(container, root)?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-		}
-		return true;
+		// Outermost first, so a nested fold is already on screen by the time its
+		// own height is measured.
+		const folds = collapsedFoldsAround(mark, root);
+		for (const fold of folds) onunfold?.(fold.key);
+		return folds.length > 0;
 	}
 
 	export function clearHighlights() {

--- a/src/lib/components/Toc.svelte
+++ b/src/lib/components/Toc.svelte
@@ -4,10 +4,11 @@
 	import { settings } from '../stores/settings.svelte.js';
 	import { t } from '../utils/i18n.js';
 	import { activeTocIdForLine, sourceLineOf } from '../utils/tocFollow.js';
+	import { foldKeyOf } from '../utils/foldState.js';
 	import { PREVIEW_ANCHOR_OFFSET } from '../utils/previewAnchor.js';
 	import type { RendererLine } from '../utils/lineCoordinates.js';
 
-	let { markdownBody, htmlContent, activeLine = null, onBeforeJump, collapsedHeaders, ontoggleFold, oncopyref, oncontext, onjump, onshowTooltip, onhideTooltip } = $props<{
+	let { markdownBody, htmlContent, activeLine = null, onBeforeJump, foldOverrides, ontoggleFold, oncopyref, oncontext, onjump, onshowTooltip, onhideTooltip } = $props<{
 		markdownBody: HTMLElement | null;
 		htmlContent: string;
 		/**
@@ -17,8 +18,8 @@
 		 */
 		activeLine?: RendererLine | null;
 		onBeforeJump?: () => void;
-		collapsedHeaders?: Set<string>;
-		ontoggleFold?: (id: string) => void;
+		foldOverrides?: Set<string>;
+		ontoggleFold?: (key: string) => void;
 		oncopyref?: (text: string, slug: string) => void;
 		oncontext?: (e: MouseEvent, item: TocItem) => void;
 		onjump?: (id: string, text: string, sourceLine: RendererLine | null) => void;
@@ -32,6 +33,15 @@
 		level: number;
 		isBlock: boolean;
 		hasChildren?: boolean;
+		/**
+		 * How the fold state names this heading — read off the rendered heading,
+		 * never recomputed. The outline used to build its own `id || text`, which
+		 * is not the renderer's answer for a heading whose text carries a block
+		 * id: the outline strips the `^id` suffix and the renderer does not, so
+		 * the two disagreed for exactly the headings nobody tests. `''` for a
+		 * block anchor, which is not a fold.
+		 */
+		foldKey: string;
 		/** Where this entry starts in the source, for following the editor. */
 		line: RendererLine | null;
 	}
@@ -58,7 +68,7 @@
 				const anchor = h.querySelector('a.anchor') as HTMLElement | null;
 				const id = h.id || (anchor ? anchor.id : '');
 				if (id) {
-					result.push({ id, text: text.trim(), level: parseInt(h.tagName[1], 10), isBlock: false, line: sourceLineOf(h.dataset.sourcepos) });
+					result.push({ id, text: text.trim(), foldKey: foldKeyOf(h), level: parseInt(h.tagName[1], 10), isBlock: false, line: sourceLineOf(h.dataset.sourcepos) });
 				}
 			}
 
@@ -66,7 +76,7 @@
 			for (const el of Array.from(blockAnchors)) {
 				const id = el.id;
 				const label = el.getAttribute('data-label') || id;
-				result.push({ id, text: label, level: 0, isBlock: true, line: sourceLineOf(el.dataset.sourcepos) });
+				result.push({ id, text: label, foldKey: '', level: 0, isBlock: true, line: sourceLineOf(el.dataset.sourcepos) });
 			}
 
 			const allIds = new Map<string, number>();
@@ -128,15 +138,13 @@
 			if (item.level <= hideUntilLevel) {
 				hideUntilLevel = 99;
 				result.push(item);
-				const key = item.id || item.text || '';
-				if (collapsedHeaders?.has(key)) {
+				if (foldOverrides?.has(item.foldKey)) {
 					hideUntilLevel = item.level;
 				}
 			} else {
 				if (hideUntilLevel === 99) {
 					result.push(item);
-					const key = item.id || item.text || '';
-					if (collapsedHeaders?.has(key)) {
+					if (foldOverrides?.has(item.foldKey)) {
 						hideUntilLevel = item.level;
 					}
 				}
@@ -377,7 +385,7 @@
 					</button>
 					{:else}
 						<div class="toc-link-wrapper level-{item.level}">
-							<button aria-label={t('tooltip.toggleFold', settings.language)} class="toc-fold-btn {collapsedHeaders?.has(item.id || item.text || '') ? 'collapsed' : ''}" style={item.hasChildren ? '' : 'visibility: hidden'} onclick={(e) => { e.stopPropagation(); ontoggleFold?.(item.id || item.text || ''); }}>
+							<button aria-label={t('tooltip.toggleFold', settings.language)} class="toc-fold-btn {foldOverrides?.has(item.foldKey) ? 'collapsed' : ''}" style={item.hasChildren ? '' : 'visibility: hidden'} onclick={(e) => { e.stopPropagation(); ontoggleFold?.(item.foldKey); }}>
 								<svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
 							</button>
 							<button

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -41,7 +41,7 @@ type DocumentSessionOptions = {
 	setShowHome: (value: boolean) => void;
 	currentFile: () => string;
 	resetScrollHistory: () => void;
-	renderMarkdown: (raw: string, path: string, collapsedHeaders: Set<string>) => Promise<string>;
+	renderMarkdown: (raw: string, path: string, foldOverrides: Set<string>) => Promise<string>;
 	afterLoad: () => Promise<unknown>;
 	saveRecentFile: (path: string) => void;
 	deleteRecentFile: (path: string) => void;
@@ -64,15 +64,15 @@ type DocumentSessionOptions = {
 };
 
 /**
- * Which heading sections the tab being loaded has folded, read at render time
- * rather than captured up front. A large file is rendered twice — the 5MB
- * preview, then the whole document once the background read lands — and the
- * user can fold something in between; the second render has to honour that.
- * An unknown tab folds nothing, which is what a load of a tab that has since
- * been closed should hand a renderer.
+ * Which folds the tab being loaded has flipped from the opening position its
+ * own source asks for, read at render time rather than captured up front. A
+ * large file is rendered twice — the 5MB preview, then the whole document once
+ * the background read lands — and the user can fold something in between; the
+ * second render has to honour that. An unknown tab flips nothing, which is what
+ * a load of a tab that has since been closed should hand a renderer.
  */
 function foldsForTab(tabId: string): Set<string> {
-	return tabManager.tabs.find((item) => item.id === tabId)?.collapsedHeaders ?? new Set<string>();
+	return tabManager.tabs.find((item) => item.id === tabId)?.foldOverrides ?? new Set<string>();
 }
 
 export function createDocumentSession(options: DocumentSessionOptions) {

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -116,12 +116,19 @@ export interface Tab {
 	splitRatio: number;
 	isScrollSynced: boolean;
 	/**
-	 * Which heading sections are folded shut in THIS document. The entries are
-	 * the fold keys `processMarkdownHtml` writes and reads: the heading's id
-	 * (comrak's slug), falling back to its trimmed text.
+	 * Which folds in THIS document the reader has changed their mind about.
+	 * The entries are the fold keys `foldState.ts` assigns while the preview
+	 * markup is built — a heading's id (comrak's slug) falling back to its
+	 * trimmed text, and `callout:<title>` for a foldable callout.
 	 *
-	 * Per tab, not per window, because that key only identifies a heading
-	 * WITHIN a document. Every file with an `## Introduction` gets the key
+	 * Deviations, not closures. A heading always starts open, so for headings
+	 * the two readings are the same set. A callout does not: `> [!note]-` opens
+	 * folded, and a set of "what is closed" cannot tell a callout the reader
+	 * OPENED from one they never touched — the next render would shut it again.
+	 * `isFolded` is the one place the two are combined.
+	 *
+	 * Per tab, not per window, because a fold key only identifies a fold WITHIN
+	 * a document. Every file with an `## Introduction` gets the key
 	 * `introduction`, so a single window-wide set folded that section in all of
 	 * them at once, kept the key after the document it was folded in was
 	 * closed, and pre-folded the next document to contain that heading with
@@ -143,7 +150,7 @@ export interface Tab {
 	 * Required, like `hasReplacementChars`: every consumer calls `.has()` on
 	 * it, so a construction site that forgot it would hand them `undefined`.
 	 */
-	collapsedHeaders: Set<string>;
+	foldOverrides: Set<string>;
 	/**
 	 * True while `rawContent` holds only the leading slice of a large file
 	 * (the >5MB preview read) instead of the whole document. Such a buffer
@@ -269,7 +276,7 @@ class TabManager {
 	 * permanently unreadable phantom tab — or, when the home tab was the only
 	 * one, a window that came back empty.
 	 *
-	 * `collapsedHeaders` is deliberately NOT in here. Every other field written
+	 * `foldOverrides` is deliberately NOT in here. Every other field written
 	 * below describes the window and survives whatever happened to the file
 	 * while Markpad was closed; a fold key describes a heading in a particular
 	 * revision of the document. The restore reads the file fresh from disk, so
@@ -355,7 +362,7 @@ class TabManager {
 					splitRatio: typeof saved.splitRatio === 'number' ? saved.splitRatio : 0.5,
 					isScrollSynced: saved.isScrollSynced === true,
 					// Not persisted — see serializeState.
-					collapsedHeaders: new Set<string>(),
+					foldOverrides: new Set<string>(),
 					isTruncated: false,
 					hasReplacementChars: false,
 					encoding: 'UTF-8'
@@ -493,7 +500,7 @@ class TabManager {
 			isSplit: false,
 			splitRatio: 0.5,
 			isScrollSynced: false,
-			collapsedHeaders: new Set<string>(),
+			foldOverrides: new Set<string>(),
 			isTruncated: false,
 			hasReplacementChars: false,
 			encoding: 'UTF-8',
@@ -530,7 +537,7 @@ class TabManager {
 			isSplit: false,
 			splitRatio: 0.5,
 			isScrollSynced: false,
-			collapsedHeaders: new Set<string>(),
+			foldOverrides: new Set<string>(),
 			isTruncated: false,
 			hasReplacementChars: false,
 			encoding: 'UTF-8'
@@ -567,7 +574,7 @@ class TabManager {
 			isSplit: false,
 			splitRatio: 0.5,
 			isScrollSynced: false,
-			collapsedHeaders: new Set<string>(),
+			foldOverrides: new Set<string>(),
 			isTruncated: false,
 			hasReplacementChars: false,
 			encoding: 'UTF-8'
@@ -786,13 +793,13 @@ class TabManager {
 	}
 
 	/**
-	 * Replace this tab's folded-heading set. Callers build a NEW set rather
-	 * than mutating the old one — see `Tab.collapsedHeaders`.
+	 * Replace this tab's fold overrides. Callers build a NEW set rather
+	 * than mutating the old one — see `Tab.foldOverrides`.
 	 */
-	setTabCollapsedHeaders(id: string, collapsedHeaders: Set<string>) {
+	setTabFoldOverrides(id: string, foldOverrides: Set<string>) {
 		const tab = this.tabs.find((t) => t.id === id);
 		if (tab) {
-			tab.collapsedHeaders = collapsedHeaders;
+			tab.foldOverrides = foldOverrides;
 		}
 	}
 
@@ -935,7 +942,7 @@ class TabManager {
 	private forgetPreviousDocument(tab: Tab) {
 		this.clearUnsavedEdits(tab);
 		this.clearReadingPosition(tab);
-		this.clearCollapsedHeaders(tab);
+		this.clearFoldOverrides(tab);
 	}
 
 	/**
@@ -986,10 +993,10 @@ class TabManager {
 	}
 
 	/**
-	 * The folded-heading set of the document this tab has just left. Called only
+	 * The fold overrides of the document this tab has just left. Called only
 	 * from `forgetPreviousDocument`.
 	 *
-	 * A fold key is a heading slug (see `Tab.collapsedHeaders`), which is only
+	 * A fold key is a heading slug or a callout title (see `Tab.foldOverrides`), which is only
 	 * unique WITHIN a document, so carrying the set across means the incoming
 	 * document is rendered with any section whose slug happens to match already
 	 * shut. `loadMarkdown` reads the set on the line after the `navigate` call,
@@ -1002,8 +1009,8 @@ class TabManager {
 	 * viewer holds it through a `$derived`, and Svelte cannot see a `.clear()`
 	 * of a Set it is already holding.
 	 */
-	private clearCollapsedHeaders(tab: Tab) {
-		tab.collapsedHeaders = new Set<string>();
+	private clearFoldOverrides(tab: Tab) {
+		tab.foldOverrides = new Set<string>();
 	}
 
 	navigate(id: string, path: string, pathKey?: string) {

--- a/src/lib/utils/foldState.ts
+++ b/src/lib/utils/foldState.ts
@@ -1,0 +1,189 @@
+/**
+ * Who owns a fold.
+ *
+ * A fold is one thing with three drivers: the chevron in the preview, the
+ * outline's fold button, and find opening whatever is hiding a match. Each of
+ * them used to reach the state by a different route, and the routes disagreed.
+ *
+ * - The heading chevron wrote `tab.collapsedHeaders`; the callout title wrote
+ *   `classList.toggle('is-collapsed')` and nothing else, so a folded callout
+ *   sprang open again on the next render — which is every keystroke in split
+ *   view. Two affordances that look identical, one of them amnesiac.
+ * - Find had no way to say "open this", so it built a `MouseEvent` and fired
+ *   it at the chevron, hoping the viewer's delegated click handler would pick
+ *   it up. Three modules coupled through a class name and a synthetic event.
+ * - The key that identifies a fold was spelled out three times — in the
+ *   renderer, in the preview's click handler and in the outline — and the
+ *   outline's spelling did not match the other two for a heading whose text
+ *   carries a block id.
+ *
+ * So the key is computed exactly once, by `assignFoldKey`, while the markup is
+ * being built, and written into that markup as `data-fold-key`. Every later
+ * reader asks the element (`foldKeyOf`) instead of recomputing, which is why
+ * there is no second algorithm left to drift. Everything else here is about
+ * getting from something the user pointed at — a chevron, a key from the
+ * outline, a search hit buried in a collapsed section — to the pair of
+ * elements that wear `is-collapsed`.
+ *
+ * What the tab stores is deliberately NOT "the folds that are closed": it is
+ * the folds whose state differs from the one the document asks for. Headings
+ * always start open, so for them the two readings are the same set — which is
+ * why the stored field survived this change unaltered in meaning for every
+ * heading. Callouts do not: `> [!note]-` starts closed. Storing "closed" would
+ * make a callout the reader OPENED indistinguishable from one they never
+ * touched, and the next render would shut it again — symptom A over, with the
+ * sign flipped. Storing the deviation costs one `!==` and answers both.
+ */
+
+/** Where `assignFoldKey` leaves its answer for every later reader. */
+export const FOLD_KEY_ATTR = 'data-fold-key';
+
+const HEADING_HEAD_CLASS = 'foldable-header';
+const HEADING_CONTENT_CLASS = 'foldable-content-wrapper';
+const CALLOUT_CONTENT_CLASS = 'markdown-alert-content';
+const COLLAPSED_CLASS = 'is-collapsed';
+
+/**
+ * The two elements a fold toggles, and the key its state is stored under.
+ *
+ * `head` is what the reader clicks and what the chevron rotates with; `content`
+ * is the box whose height animates. Both carry `is-collapsed` because the CSS
+ * needs it in both places, and keeping them in one object is what stops a
+ * caller from setting one and forgetting the other.
+ */
+export interface FoldRegion {
+	key: string;
+	head: Element;
+	content: Element;
+}
+
+/**
+ * Name this fold, once, and leave the name on it.
+ *
+ * `taken` is the keys already handed out in this render, so that two callouts
+ * with the same title — or two headings with the same text and no id — get
+ * keys of their own rather than folding as one. It is the same guarantee
+ * comrak gives heading ids, applied to the things comrak does not name.
+ *
+ * Keys only have to be unique within a document and stable across re-renders of
+ * it. Both fall out of keying by content in document order: an edit somewhere
+ * else leaves this fold's key alone.
+ */
+export function assignFoldKey(head: Element, taken: Set<string>): string {
+	// A heading's id is comrak's slug, already deduplicated, and it is what the
+	// outline and every `#anchor` link name the heading by. Text is the fallback
+	// for a heading the renderer gave no id. A callout has neither, so it is
+	// keyed by its title, in a namespace of its own so that a callout titled
+	// "Notes" and an id-less heading reading "Notes" stay two folds.
+	const base = head.classList.contains(HEADING_HEAD_CLASS)
+		? head.id || head.textContent?.trim() || ''
+		: `callout:${head.querySelector('.callout-title-inner')?.textContent?.trim() ?? ''}`;
+
+	let key = base;
+	for (let n = 1; taken.has(key); n += 1) key = `${base}~${n}`;
+	taken.add(key);
+	head.setAttribute(FOLD_KEY_ATTR, key);
+	return key;
+}
+
+/** The key the renderer wrote on this element, or `''` if it is not a fold head. */
+export function foldKeyOf(head: Element | null | undefined): string {
+	return head?.getAttribute(FOLD_KEY_ATTR) ?? '';
+}
+
+/**
+ * Is this fold closed, for a tab that has these deviations recorded?
+ *
+ * `foldedInSource` is what the document asks for — `> [!note]-` for a callout,
+ * always `false` for a heading. See the note at the top of this file for why
+ * the stored set is deviations rather than closures.
+ */
+export function isFolded(
+	overrides: ReadonlySet<string>,
+	key: string,
+	foldedInSource = false,
+): boolean {
+	return overrides.has(key) !== foldedInSource;
+}
+
+/**
+ * The same set with this key's deviation flipped.
+ *
+ * A NEW set, never a mutation: the viewer holds the tab's set through a
+ * `$derived`, and Svelte cannot see an `add` or a `delete` on a Set it is
+ * already holding — see `Tab.foldOverrides`.
+ */
+export function flipFold(overrides: ReadonlySet<string>, key: string): Set<string> {
+	const next = new Set(overrides);
+	if (!next.delete(key)) next.add(key);
+	return next;
+}
+
+function regionOfHead(head: Element): FoldRegion | null {
+	const key = foldKeyOf(head);
+	if (!key) return null;
+
+	// The heading's wrapper is the sibling the renderer inserts right after it
+	// (`renderProtocol.test.ts` pins that), so the pairing needs no id lookup
+	// and no document to look ids up in. A callout encloses its own content.
+	const content = head.classList.contains(HEADING_HEAD_CLASS)
+		? head.nextElementSibling
+		: head.querySelector(`.${CALLOUT_CONTENT_CLASS}`);
+	const contentClass = head.classList.contains(HEADING_HEAD_CLASS)
+		? HEADING_CONTENT_CLASS
+		: CALLOUT_CONTENT_CLASS;
+
+	return content?.classList.contains(contentClass) ? { key, head, content } : null;
+}
+
+/** The fold whose control the reader just clicked — a chevron, or a callout title. */
+export function foldRegionAt(control: Element): FoldRegion | null {
+	const head = control.closest(`.${HEADING_HEAD_CLASS}, .callout-foldable`);
+	return head ? regionOfHead(head) : null;
+}
+
+/**
+ * The fold this key names, in the document currently on screen.
+ *
+ * A scan rather than an attribute selector: a callout key is its title, which
+ * is arbitrary user text, and building a selector out of it means escaping it
+ * correctly for the exact question `getAttribute` answers directly.
+ */
+export function foldRegionByKey(root: Element, key: string): FoldRegion | null {
+	for (const head of Array.from(root.querySelectorAll(`[${FOLD_KEY_ATTR}]`))) {
+		if (foldKeyOf(head) === key) return regionOfHead(head);
+	}
+	return null;
+}
+
+export function isFoldCollapsed(region: FoldRegion): boolean {
+	return region.content.classList.contains(COLLAPSED_CLASS);
+}
+
+/** Put a fold's two elements in the given state. The stored deviation is the caller's. */
+export function applyFold(region: FoldRegion, collapsed: boolean): void {
+	region.head.classList.toggle(COLLAPSED_CLASS, collapsed);
+	region.content.classList.toggle(COLLAPSED_CLASS, collapsed);
+}
+
+/**
+ * Every collapsed fold between `el` and the preview root, outermost first.
+ *
+ * Find calls this to learn what is hiding a match. Outermost first so that a
+ * nested fold is already on screen by the time its own height is measured.
+ */
+export function collapsedFoldsAround(el: Element, root: Element): FoldRegion[] {
+	const folds: FoldRegion[] = [];
+	for (let curr = el.parentElement; curr && curr !== root; curr = curr.parentElement) {
+		if (!curr.classList.contains(COLLAPSED_CLASS)) continue;
+
+		const head = curr.classList.contains(HEADING_CONTENT_CLASS)
+			? curr.previousElementSibling
+			: curr.classList.contains(CALLOUT_CONTENT_CLASS)
+				? curr.parentElement
+				: null;
+		const region = head ? regionOfHead(head) : null;
+		if (region) folds.unshift(region);
+	}
+	return folds;
+}

--- a/src/lib/utils/foldState.ts
+++ b/src/lib/utils/foldState.ts
@@ -5,7 +5,7 @@
  * outline's fold button, and find opening whatever is hiding a match. Each of
  * them used to reach the state by a different route, and the routes disagreed.
  *
- * - The heading chevron wrote `tab.collapsedHeaders`; the callout title wrote
+ * - The heading chevron wrote the tab's fold set; the callout title wrote
  *   `classList.toggle('is-collapsed')` and nothing else, so a folded callout
  *   sprang open again on the next render — which is every keystroke in split
  *   view. Two affordances that look identical, one of them amnesiac.
@@ -31,8 +31,8 @@
  * why the stored field survived this change unaltered in meaning for every
  * heading. Callouts do not: `> [!note]-` starts closed. Storing "closed" would
  * make a callout the reader OPENED indistinguishable from one they never
- * touched, and the next render would shut it again — symptom A over, with the
- * sign flipped. Storing the deviation costs one `!==` and answers both.
+ * touched, and the next render would shut it again — the callout defect above,
+ * with the sign flipped. Storing the deviation costs one `!==` and answers both.
  */
 
 /** Where `assignFoldKey` leaves its answer for every later reader. */

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -1,4 +1,5 @@
 import { convertFileSrc } from "@tauri-apps/api/core";
+import { assignFoldKey, isFolded } from "./foldState.js";
 import { parseSourceposLineRange } from "./previewAnchor.js";
 import { carrySourcepos } from "./richContent.js";
 
@@ -536,10 +537,14 @@ function processSoftLineAnchors(root: Element, doc: Document) {
 export function processMarkdownHtml(
 	html: string,
 	filePath: string,
-	collapsedHeaders: Set<string>,
+	foldOverrides: Set<string>,
 ): string {
 	const parser = new DOMParser();
 	const doc = parser.parseFromString(html, "text/html");
+
+	// The keys handed out in THIS render, shared by the callout pass and the
+	// heading pass below so that neither can hand out a key the other used.
+	const foldKeys = new Set<string>();
 
 	for (const img of doc.querySelectorAll("img")) {
 		const src = img.getAttribute("src");
@@ -732,9 +737,17 @@ export function processMarkdownHtml(
 			if (contentInner.childNodes.length === 0) {
 				container.classList.add("callout-title-only");
 			} else {
-				if (fold === "-") {
-					contentWrapper.classList.add("is-collapsed");
-					container.classList.add("is-collapsed");
+				// A callout the reader folds is remembered exactly like a
+				// heading, and `> [!note]-` is the document's opening position
+				// rather than a state of its own — see `foldState.ts`. A
+				// title-only callout hides nothing and so is not a fold at all,
+				// which is why the key is assigned in this branch.
+				if (isFoldable) {
+					const key = assignFoldKey(container, foldKeys);
+					if (isFolded(foldOverrides, key, fold === "-")) {
+						contentWrapper.classList.add("is-collapsed");
+						container.classList.add("is-collapsed");
+					}
 				}
 				container.appendChild(contentWrapper);
 			}
@@ -755,11 +768,11 @@ export function processMarkdownHtml(
 	let nextFoldId = 0;
 	for (const h of headings) {
 		// comrak puts the deduplicated heading id ("title", "title-1", ...)
-		// on an empty inner <a class="anchor">, so h.id is empty and every
-		// consumer that keys folds by `h.id || textContent` falls back to
-		// the heading text — which collides for duplicate titles and never
-		// matches the ToC's id-based keys. Promote the id onto the heading
-		// itself (and off the anchor, so the document keeps unique ids).
+		// on an empty inner <a class="anchor">, so h.id is empty and the fold
+		// key falls all the way back to the heading text — which collides for
+		// duplicate titles and never matches an id-based anchor link. Promote
+		// the id onto the heading itself (and off the anchor, so the document
+		// keeps unique ids). See `assignFoldKey`.
 		const headingAnchor = h.querySelector("a.anchor");
 		if (headingAnchor && headingAnchor.id && !h.id) {
 			h.id = headingAnchor.id;
@@ -796,8 +809,8 @@ export function processMarkdownHtml(
 		h.setAttribute("data-fold-target", mappingId);
 		wrapper.id = mappingId;
 
-		const key = h.id || h.textContent?.trim() || "";
-		if (collapsedHeaders.has(key)) {
+		const key = assignFoldKey(h, foldKeys);
+		if (isFolded(foldOverrides, key)) {
 			h.classList.add("is-collapsed");
 			wrapper.classList.add("is-collapsed");
 		}

--- a/src/lib/utils/tabTransfer.ts
+++ b/src/lib/utils/tabTransfer.ts
@@ -14,8 +14,8 @@ import { nextUntitledTitle } from './untitledTitle.js';
  * Excluded on purpose:
  * - `content` (rendered HTML): regenerated at the destination.
  * - `editorViewState`: a live Monaco object, not serializable.
- * - `collapsedHeaders`: the destination re-renders the document from source,
- *   and it re-renders it with everything open. Before fold state was per tab
+ * - `foldOverrides`: the destination re-renders the document from source, so
+ *   every fold arrives at the position that source asks for. Before fold state was per tab
  *   the arriving document inherited whatever the DESTINATION window happened
  *   to have folded, which is the bleed this field exists to stop; starting
  *   open is the honest version of "this was rendered fresh here". Carrying it
@@ -207,7 +207,7 @@ export function buildTransferredTab(
 		isSplit: snap.isSplit,
 		splitRatio: snap.splitRatio,
 		isScrollSynced: snap.isScrollSynced,
-		collapsedHeaders: new Set<string>(),
+		foldOverrides: new Set<string>(),
 		hasReplacementChars: snap.hasReplacementChars,
 		encoding: snap.encoding,
 	};


### PR DESCRIPTION
**Stack 5/5.** Base: `refactor/document-owns-its-buffer`.

### The user-visible bug
**Folding a callout did not survive the next render.** `handleLinkClick` toggled `is-collapsed` on the DOM and never wrote to the tab, so every collapsed callout sprang open as soon as the document re-rendered. Heading folds persisted; callout folds did not.

That was one symptom of three, all from the same missing owner:

- **`FindBar` drove folds by forging a click.** It queried `.foldable-header[data-fold-target=…]` — markup owned by `markdown.ts` — then `dispatchEvent(new MouseEvent('click', { bubbles: true }))` and relied on the viewer's own handler catching the bubble. Three modules coupled through a class name and a synthetic event.
- **The fold key was computed in three places** (`markdown.ts`, `MarkdownViewer.svelte`, `Toc.svelte`), each spelling `id || textContent?.trim() || ''` by hand.

### What this adds
`src/lib/utils/foldState.ts` (~180 lines) owns fold state for headings and callouts alike. `FoldRegion = { key, head, content }` keeps the two elements that wear `is-collapsed` in one object, so a caller cannot set one and forget the other. The viewer has one write path; the click handler, the outline and find all route through it.

The key is computed once at render by `assignFoldKey`, stamped as `data-fold-key`, and read back by everyone else. A new `singleImplementationConvention` rule pins that — it immediately caught a stale comment in `markdown.ts`.

### Storage semantics changed on purpose
`Tab.collapsedHeaders` → `Tab.foldOverrides`, holding folds whose state *differs from what the source asks for*.

Headings are always open in source, so the set is identical and behaviour is unchanged. Callouts are not: `[!note]-` starts shut, and storing "shut" cannot distinguish a callout the reader *opened* from one they never touched — the same bug with the sign flipped. Costs one `!==`.

**Snapshot compatibility: verified, not assumed.** `serializeState` already excludes fold state (there is a comment saying why) and `tabTransfer.ts` builds a fresh empty set on arrival. No snapshot field was added, renamed or read — old and new snapshots are byte-identical in this area.

### Falsification, run twice
1. Deleting the shared `setFoldOverrides(flipFold(...))` line → **14 of 20** tests in `foldStatePerDocument.test.ts` red. Proves persistence, but not callouts specifically.
2. Narrower — reverting the callout render to `if (fold === "-")` → **exactly the callout tests** red: *"a callout the reader folds is still folded after the next render"* and *"opening a callout the source folds shut stays open across a render"*. Restored: 20/20 green.

`FindBar`'s synthetic event is gone; a new test plucks the real `revealFoldsAround` out of it, runs it against a match buried in a collapsed callout inside a collapsed section, and asserts outermost-first order plus that the next render keeps them open.

### Also in this PR
- `FindBar`'s `language = 'en'` prop default removed — the same latent defect class as stack 1/5.
- The viewer's `uiLanguage` mirror deleted; 17 sites (20 after rebasing onto stack 1/5) read `settings.language`. One value, one source.
- Side effect: the outline strips a trailing `^block-id` from heading text and the renderer did not, so for those headings the outline's fold button used to address a fold that did not exist. It works now.

### Verification
- `npm test` 1005 pass / 0 fail
- `npm run check` 710 files / 0 errors / 0 warnings

### Not done, deliberately
The render pipeline was **not** extracted. `renderMarkdownPreview` is 3 lines and `renderTabPreviewFromRaw` is 6 — the weight already sits in `markdown.ts` and `richContent.ts`. Moving the remainder would mean editing the `renderPipelineConvention` allowlist that pins `invoke('render_markdown')` to the viewer (a rule change deserving its own decision) and passing five callbacks for `markdownBody` / `richLibraries` / mermaid theme / clipboard. That is ceremony, not decoupling.

**Known ceiling:** a callout is keyed by its title text, so editing the title loses that callout's fold. Headings without an id have always had the same property. Duplicate titles get `~1`, `~2` in document order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
