### PR TITLE
refactor(markdown): collapse the grammar data the two languages duplicate

### DIFF
--- a/scripts/exportHtml.test.ts
+++ b/scripts/exportHtml.test.ts
@@ -9,6 +9,7 @@ import {
 	resolveExportImagePath,
 	rewriteMarkdownHrefForExport,
 } from '../src/lib/utils/exportHtml.js';
+import { resolveMarkdownTargetPath } from '../src/lib/utils/markdownLinks.js';
 
 test('normalizeAssetPath decodes Tauri asset URLs for Windows drive paths and UNC paths', () => {
 	assert.equal(
@@ -64,6 +65,38 @@ test('resolveExportImagePath preserves remote/data images and resolves local pat
 	assert.equal(resolveExportImagePath('img/a%20b.png', 'C:\\Docs\\note.md'), 'C:/Docs/img/a b.png');
 	assert.equal(resolveExportImagePath('./img/a.png', '/home/daniel/docs/note.md'), '/home/daniel/docs/img/a.png');
 	assert.equal(resolveExportImagePath('/home/daniel/assets/a.png', '/home/daniel/docs/note.md'), '/home/daniel/assets/a.png');
+});
+
+test('the path resolver for documents and the one for hrefs differ on purpose', () => {
+	// Two functions called `resolvePath` used to sit in markdown.ts and
+	// markdownLinks.ts. They are NOT copies that drifted, and collapsing them
+	// would have silently changed one caller or the other, so they are named
+	// apart now and their three differences are pinned here — through the public
+	// entry points, since the href one is private to its module.
+	//
+	// The image side is `resolveDocumentRelativePath` (via resolveExportImagePath),
+	// the link side `resolveHrefRelativePath` (via resolveMarkdownTargetPath).
+	const target = (path: string) => ({ path, hash: '' });
+
+	// 1. `\` in the relative half. An image path is a filesystem path: a Windows
+	//    author's `img\a.png` names a directory. An href is a URL: `\` is an
+	//    ordinary character and the name must survive intact.
+	assert.equal(resolveExportImagePath('img\\a.png', '/notes/index.md'), '/notes/img/a.png');
+	assert.equal(
+		resolveMarkdownTargetPath('/notes/index.md', target('sub\\other.md')),
+		'/notes/sub\\other.md',
+	);
+
+	// 2. Empty segments. A path is bytes for the OS; an href gets tidied.
+	assert.equal(resolveExportImagePath('a//b.png', '/notes/index.md'), '/notes/a//b.png');
+	assert.equal(resolveMarkdownTargetPath('/notes/index.md', target('a//b.md')), '/notes/a/b.md');
+
+	// 3. A base with no separator. The href side would answer `/other.md` — the
+	//    filesystem root, a real and wrong directory — so its caller refuses the
+	//    empty base outright. The document side answers relatively and lets
+	//    resolveLocalFileLinkPath do the refusing (see localFileLinks.test.ts).
+	assert.equal(resolveExportImagePath('a.png', ''), 'a.png');
+	assert.equal(resolveMarkdownTargetPath('', target('other.md')), null);
 });
 
 test('rewriteMarkdownHrefForExport rewrites local Markdown links and preserves query/hash', () => {

--- a/scripts/fileAssociations.test.ts
+++ b/scripts/fileAssociations.test.ts
@@ -21,9 +21,9 @@ test('installer advertises only Markdown file associations', () => {
 // extensions by hand and `.txt` was reachable only via "All Files".
 test('the Open dialog offers every extension Markpad treats as a document', () => {
 	const viewer = readSource('src/lib/MarkdownViewer.svelte');
-	const sanitize = readSource('src/lib/utils/sanitize.ts');
+	const links = readSource('src/lib/utils/markdownLinks.ts');
 
-	assert.match(sanitize, /MARKDOWN_LINK_EXTENSIONS = \[[^\]]*'txt'/);
+	assert.match(links, /MARKDOWN_LINK_EXTENSIONS = \[[^\]]*'txt'/);
 	assert.match(viewer, /\{ name: 'Markdown', extensions: MARKDOWN_LINK_EXTENSIONS \}/);
 	// A literal list is how the two drifted apart in the first place.
 	assert.doesNotMatch(viewer, /extensions: \['md/);

--- a/scripts/localFileLinks.test.ts
+++ b/scripts/localFileLinks.test.ts
@@ -70,7 +70,7 @@ test('an in-page anchor is not a file', () => {
 });
 
 test('an unsaved buffer has nothing to resolve a relative link against', () => {
-	// `resolvePath('', './data.csv')` yields `data.csv`, which the OS would
+	// `resolveDocumentRelativePath('', './data.csv')` yields `data.csv`, which the OS would
 	// open relative to the process's working directory — some arbitrary file,
 	// or none. Refusing is the only honest answer.
 	assert.equal(resolveLocalFileLinkPath('./data.csv', ''), null);

--- a/scripts/mathDelimiterContract.test.ts
+++ b/scripts/mathDelimiterContract.test.ts
@@ -4,7 +4,7 @@
  * Correctness of the math pipeline rests on one invariant that lives in two
  * languages at once:
  *
- *     the spans `src-tauri/src/lib.rs` hides from comrak
+ *     the spans `src-tauri/src/markdown.rs` hides from comrak
  *   ≡ the spans `src/lib/utils/markdown.ts` renders with KaTeX
  *
  *   backend ⊂ frontend → comrak rewrites the formula before KaTeX ever sees

--- a/scripts/mathDelimiterCorpus.json
+++ b/scripts/mathDelimiterCorpus.json
@@ -1,7 +1,7 @@
 {
 	"$comment": [
 		"Shared math-delimiter corpus. Read by BOTH sides of the render pipeline:",
-		"  src-tauri/src/lib.rs  -> the_backend_recognises_exactly_the_math_the_contract_lists",
+		"  src-tauri/src/markdown.rs  -> the_backend_recognises_exactly_the_math_the_contract_lists",
 		"  scripts/mathDelimiterContract.test.ts -> the frontend's own decision",
 		"",
 		"The invariant it pins: the set of spans the BACKEND hides from comrak must",
@@ -276,6 +276,67 @@
 				{
 					"kind": "display",
 					"source": "\\mathbf{Accuracy: 100\\%}"
+				}
+			]
+		},
+		{
+			"name": "an even backslash run still refuses the dollar",
+			"markdown": "A \\\\$x\\\\$ here.\n",
+			"html": "<p data-sourcepos=\"1:1-1:33\">A \\\\$x\\\\$ here.</p>\n",
+			"math": []
+		},
+		{
+			"name": "an odd backslash run refuses it the same way",
+			"markdown": "A \\\\\\$x\\\\\\$ here.\n",
+			"html": "<p data-sourcepos=\"1:1-1:33\">A \\\\\\$x\\\\\\$ here.</p>\n",
+			"math": []
+		},
+		{
+			"name": "a tilde fence hides its dollars too",
+			"markdown": "~~~\n$x_1$\n~~~\n",
+			"html": "<pre data-sourcepos=\"1:1-3:3\"><code>$x_1$\n</code></pre>\n",
+			"math": []
+		},
+		{
+			"name": "two display blocks separated by a blank line",
+			"markdown": "$$\nx_1\n$$\n\n$$\ny_1\n$$\n",
+			"html": "<p data-sourcepos=\"1:1-3:12\">$$<br data-sourcepos=\"1:13-1:13\" />\nx_1<br data-sourcepos=\"2:13-2:13\" />\n$$</p>\n<p data-sourcepos=\"5:1-7:12\">$$<br data-sourcepos=\"5:13-5:13\" />\ny_1<br data-sourcepos=\"6:13-6:13\" />\n$$</p>\n",
+			"math": [
+				{
+					"kind": "display",
+					"source": "x_1"
+				},
+				{
+					"kind": "display",
+					"source": "y_1"
+				}
+			]
+		},
+		{
+			"name": "two stray display delimiters may not pair across a hard break",
+			"markdown": "A $$ opener not alone\nand $$ later.\n",
+			"html": "<p data-sourcepos=\"1:1-2:13\">A $$ opener not alone<br data-sourcepos=\"1:22-1:22\" />\nand $$ later.</p>\n",
+			"math": []
+		},
+		{
+			"name": "math after a code span and a fence",
+			"markdown": "`$a$` then\n\n```\n$b$\n```\n\nand $c_1$.\n",
+			"html": "<p data-sourcepos=\"1:1-1:10\"><code data-sourcepos=\"1:1-1:5\">$a$</code> then</p>\n<pre data-sourcepos=\"3:1-5:3\"><code>$b$\n</code></pre>\n<p data-sourcepos=\"7:1-7:17\">and $c_1$.</p>\n",
+			"math": [
+				{
+					"kind": "inline",
+					"source": "c_1"
+				}
+			]
+		},
+		{
+			"name": "a formula in a block quote",
+			"markdown": "> Quoted $x_1$ math.\n",
+			"html": "<blockquote data-sourcepos=\"1:1-1:27\">\n<p data-sourcepos=\"1:3-1:27\">Quoted $x_1$ math.</p>\n</blockquote>\n",
+			"math": [
+				{
+					"kind": "inline",
+					"source": "x_1"
 				}
 			]
 		}

--- a/scripts/wikilinkFileTargets.test.ts
+++ b/scripts/wikilinkFileTargets.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import { readRustBackend, readSource } from './sourceTree.js';
 
 import {
+	MARKDOWN_LINK_EXTENSIONS,
 	getMarkdownLinkTarget,
 	hasMarkdownLinkExtension,
 	resolveMarkdownTargetPath,
@@ -74,10 +75,21 @@ test('non-markdown wikilink targets are left literal rather than emitted as link
 });
 
 test('the extension list the rewriter mirrors still matches markdownLinks.ts', () => {
+	// The last cross-language copy of this list. Every TypeScript reader — the
+	// sanitizer's URI pattern, the export's `.md` -> `.html` rewrite, the Open
+	// dialog filter — now imports MARKDOWN_LINK_EXTENSIONS from markdownLinks.ts,
+	// so a drift between two of them is no longer expressible. Rust cannot
+	// import it, so the drift is caught here instead, by reading the array back
+	// out of the source and comparing the two *sets*: a third-party extension
+	// added to either side alone fails, in whichever direction it was added.
 	const declared = rustSource.match(/const MARKDOWN_LINK_EXTENSIONS: \[&str; \d+\] = \[([^\]]*)\]/);
-	assert.notEqual(declared, null, 'MARKDOWN_LINK_EXTENSIONS disappeared from lib.rs');
+	assert.notEqual(declared, null, 'MARKDOWN_LINK_EXTENSIONS disappeared from the Rust backend');
 	const extensions = [...declared![1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
-	assert.deepEqual(extensions, ['md', 'markdown', 'mdown', 'mkd', 'txt']);
+	assert.deepEqual(
+		[...extensions].sort(),
+		[...MARKDOWN_LINK_EXTENSIONS].sort(),
+		'the Rust and TypeScript extension lists disagree — add the extension to both',
+	);
 	for (const extension of extensions) {
 		assert.equal(hasMarkdownLinkExtension(`file.${extension}`), true, extension);
 	}

--- a/src/lib/utils/exportHtml.ts
+++ b/src/lib/utils/exportHtml.ts
@@ -1,7 +1,7 @@
 import { getFrontMatterListItems, type FrontMatterParseResult } from './frontMatter.js';
 import { resolvePath } from './markdown.js';
+import { MARKDOWN_LINK_EXTENSION_PATTERN } from './markdownLinks.js';
 
-const localMarkdownExtensionPattern = /\.(?:md|markdown|mdown|mkd|txt)$/i;
 const windowsDrivePathPattern = /^[a-zA-Z]:[\\/]/;
 
 export function escapeHtml(value: string): string {
@@ -112,9 +112,9 @@ export function rewriteMarkdownHrefForExport(href: string): string {
 	if (!trimmed || hasNonFileScheme(trimmed)) return href;
 
 	const { base, suffix } = splitUrlSuffix(trimmed);
-	if (!localMarkdownExtensionPattern.test(base)) return href;
+	if (!MARKDOWN_LINK_EXTENSION_PATTERN.test(base)) return href;
 
-	return base.replace(localMarkdownExtensionPattern, '.html') + suffix;
+	return base.replace(MARKDOWN_LINK_EXTENSION_PATTERN, '.html') + suffix;
 }
 
 export function renderStaticFrontMatterPanel(frontMatter: FrontMatterParseResult): string {

--- a/src/lib/utils/exportHtml.ts
+++ b/src/lib/utils/exportHtml.ts
@@ -1,5 +1,5 @@
 import { getFrontMatterListItems, type FrontMatterParseResult } from './frontMatter.js';
-import { resolvePath } from './markdown.js';
+import { resolveDocumentRelativePath } from './markdown.js';
 import { MARKDOWN_LINK_EXTENSION_PATTERN } from './markdownLinks.js';
 
 const windowsDrivePathPattern = /^[a-zA-Z]:[\\/]/;
@@ -77,6 +77,12 @@ export function normalizeAssetPath(src: string): string | null {
 	}
 }
 
+/**
+ * Not a third path resolver: everything above the last line decides *which
+ * kind* of reference `src` is — asset URL, `file:`, remote scheme, absolute
+ * path — and only the relative case is a resolution at all, which it delegates
+ * to `resolveDocumentRelativePath`.
+ */
 export function resolveExportImagePath(src: string, tabPath: string): string | null {
 	const trimmed = src.trim();
 	if (!trimmed) return null;
@@ -104,7 +110,7 @@ export function resolveExportImagePath(src: string, tabPath: string): string | n
 		return decoded.replace(/\\/g, '/');
 	}
 
-	return resolvePath(tabPath, decoded);
+	return resolveDocumentRelativePath(tabPath, decoded);
 }
 
 export function rewriteMarkdownHrefForExport(href: string): string {

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -16,7 +16,30 @@ const alertIcons: Record<string, string> = {
 	example: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list"><line x1="8" x2="21" y1="6" y2="6"/><line x1="8" x2="21" y1="12" y2="12"/><line x1="8" x2="21" y1="18" y2="18"/><line x1="3" x2="3.01" y1="6" y2="6"/><line x1="3" x2="3.01" y1="12" y2="12"/><line x1="3" x2="3.01" y1="18" y2="18"/></svg>',
 };
 
-export function resolvePath(basePath: string, relativePath: string): string {
+/**
+ * Resolves a **filesystem path** an author wrote in a document — an image
+ * `src`, a local file link — against the document holding it.
+ *
+ * Deliberately not the same function as `resolveHrefRelativePath` in
+ * ./markdownLinks.ts, which resolves an *href*. The two were named alike and
+ * differ in three ways that are each right for one caller and wrong for the
+ * other, so `three path resolvers stay three` in scripts/exportHtml.test.ts
+ * pins the differences rather than papering over them:
+ *
+ *   - `\` separates here, in the relative half too: a Windows author writes
+ *     `![](img\a.png)` and means a directory. In an href `\` is an ordinary
+ *     character and must survive.
+ *   - Empty segments survive (`a//b` stays `a//b`), because a path is bytes
+ *     the OS will be handed, not a URL to tidy up.
+ *   - A base with no separator at all — an unsaved buffer's `""`, a bare
+ *     `note.md` — yields a *relative* result rather than one rooted at `/`.
+ *     Callers that cannot use a relative answer refuse it themselves;
+ *     `resolveLocalFileLinkPath` is the one that does.
+ */
+export function resolveDocumentRelativePath(
+	basePath: string,
+	relativePath: string,
+): string {
 	if (relativePath.match(/^[a-zA-Z]:/) || relativePath.startsWith("/"))
 		return relativePath;
 	const parts = basePath.split(/[/\\]/);
@@ -552,7 +575,9 @@ export function processMarkdownHtml(
 		if (src && !src.startsWith("http") && !src.startsWith("data:")) {
 			try {
 				const decodedSrc = decodeURIComponent(src);
-				finalSrc = convertFileSrc(resolvePath(filePath, decodedSrc));
+				finalSrc = convertFileSrc(
+					resolveDocumentRelativePath(filePath, decodedSrc),
+				);
 				img.setAttribute("src", finalSrc);
 			} catch (e) {
 				console.error("Failed to decode/resolve image src:", src, e);

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -23,8 +23,9 @@ const alertIcons: Record<string, string> = {
  * Deliberately not the same function as `resolveHrefRelativePath` in
  * ./markdownLinks.ts, which resolves an *href*. The two were named alike and
  * differ in three ways that are each right for one caller and wrong for the
- * other, so `three path resolvers stay three` in scripts/exportHtml.test.ts
- * pins the differences rather than papering over them:
+ * other, so `the path resolver for documents and the one for hrefs differ on
+ * purpose` in scripts/exportHtml.test.ts pins the differences rather than
+ * papering over them:
  *
  *   - `\` separates here, in the relative half too: a Windows author writes
  *     `![](img\a.png)` and means a directory. In an href `\` is an ordinary
@@ -167,7 +168,8 @@ function extractDisplayMathBlock(element: Element): string | null {
  * That in turn is why `\$` arrives here still escaped. comrak would have
  * resolved it, and then `\$\$x\$\$` and `$$x$$` would be the same eight bytes
  * and the reader's literal dollars would be typeset. `mask_math_spans` in
- * src-tauri/src/lib.rs hides the escape from comrak for exactly this moment.
+ * src-tauri/src/markdown.rs hides the escape from comrak for exactly this
+ * moment.
  */
 function convertInlineMathDelimiters(text: string): string {
 	const parts: string[] = [];

--- a/src/lib/utils/markdownLinks.ts
+++ b/src/lib/utils/markdownLinks.ts
@@ -3,6 +3,26 @@ export type MarkdownLinkTarget = {
 	hash: string;
 };
 
+// The one list of extensions Markpad treats as a document, and the lowest-level
+// module that can hold it: everything that needs it — the link resolver below,
+// the sanitizer's URI pattern (./sanitize.ts), the export's `.md` -> `.html`
+// rewrite (./exportHtml.ts) and the Open dialog filter — imports it from here.
+// Three hand-written copies of these five names used to exist, one of them
+// documented as a copy and pinned by a test; a list is cheaper to share than to
+// police.
+//
+// The Rust renderer keeps the sixth copy, in `MARKDOWN_LINK_EXTENSIONS` in
+// src-tauri/src/markdown.rs, because no import crosses that boundary. It is
+// pinned against this one by `the extension list the rewriter mirrors still
+// matches markdownLinks.ts` in scripts/wikilinkFileTargets.test.ts.
+export const MARKDOWN_LINK_EXTENSIONS = ['md', 'markdown', 'mdown', 'mkd', 'txt'];
+
+/** `.md`, `.markdown`, … anchored at the end of a path. Also used to replace it. */
+export const MARKDOWN_LINK_EXTENSION_PATTERN = new RegExp(
+	`\\.(?:${MARKDOWN_LINK_EXTENSIONS.map((ext) => ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})$`,
+	'i',
+);
+
 export function decodeLinkPath(path: string): string {
 	try {
 		return decodeURIComponent(path);
@@ -12,7 +32,7 @@ export function decodeLinkPath(path: string): string {
 }
 
 export function hasMarkdownLinkExtension(path: string): boolean {
-	return /\.(md|markdown|mdown|mkd|txt)$/i.test(path);
+	return MARKDOWN_LINK_EXTENSION_PATTERN.test(path);
 }
 
 function isAbsoluteMarkdownPath(path: string): boolean {

--- a/src/lib/utils/markdownLinks.ts
+++ b/src/lib/utils/markdownLinks.ts
@@ -54,7 +54,22 @@ export function getMarkdownLinkTarget(href: string): MarkdownLinkTarget | null {
 	};
 }
 
-export function resolvePath(base: string, relative: string): string {
+/**
+ * Resolves the **href** of a markdown link against the document holding it.
+ *
+ * An href is URL-shaped even when it names a local file, which is what makes
+ * this a different function from `resolveDocumentRelativePath` in ./markdown.ts
+ * rather than a copy of it — see that function's comment for the three
+ * differences and scripts/exportHtml.test.ts for the test that pins them. Here:
+ * only `/` separates in the relative half (a `\` in a URL is a character, and
+ * `sub\note.md` names one file), empty segments collapse (`a//b.md` is
+ * `a/b.md`), and the base is normalized to `/` before its directory is taken.
+ *
+ * Not exported: `resolveMarkdownTargetPath` is the only caller, and it is what
+ * refuses the degenerate bases — a base with no `/` at all would come back
+ * rooted at `/`, which is a real directory and the wrong one.
+ */
+function resolveHrefRelativePath(base: string, relative: string): string {
 	if (relative.startsWith('/') || /^[a-z]:/i.test(relative)) return relative;
 
 	const normalizedBase = base.replace(/\\/g, '/');
@@ -73,7 +88,7 @@ export function resolvePath(base: string, relative: string): string {
 export function resolveMarkdownTargetPath(currentFile: string, target: MarkdownLinkTarget): string | null {
 	if (isAbsoluteMarkdownPath(target.path)) return target.path;
 	if (!currentFile) return null;
-	return resolvePath(currentFile, target.path);
+	return resolveHrefRelativePath(currentFile, target.path);
 }
 
 export function isOpenInNewTabMarkdownTarget(href: string, currentFile: string): boolean {

--- a/src/lib/utils/sanitize.ts
+++ b/src/lib/utils/sanitize.ts
@@ -1,5 +1,7 @@
 import DOMPurify from 'dompurify';
 
+import { MARKDOWN_LINK_EXTENSIONS } from './markdownLinks.js';
+
 // The Rust renderer runs comrak with `render.unsafe_ = true`, so whatever raw
 // HTML a document author wrote survives into the rendered output verbatim. A
 // `.md` file is untrusted input — it can arrive by download, by shared folder,
@@ -9,11 +11,12 @@ import DOMPurify from 'dompurify';
 // to drift apart, because a payload that is invisible on screen but live in an
 // exported file is worse than one the user can see.
 
-// Mirrors the extension set `hasMarkdownLinkExtension` accepts in
-// ./markdownLinks.ts. It lives here as data (not as that predicate) because the
-// sanitizer needs to splice the extensions into a URI pattern; a test pins the
-// two lists against each other so they cannot drift.
-export const MARKDOWN_LINK_EXTENSIONS = ['md', 'markdown', 'mdown', 'mkd', 'txt'];
+// The extension set `hasMarkdownLinkExtension` accepts, spliced into a URI
+// pattern rather than called as a predicate — DOMPurify takes a regexp, not a
+// function. Re-exported because MarkdownViewer.svelte reads the same list for
+// the Open dialog's file filter and imports it from the sanitizer; the list
+// itself is defined once, in ./markdownLinks.ts.
+export { MARKDOWN_LINK_EXTENSIONS };
 
 const markdownLinkExtensionPattern = MARKDOWN_LINK_EXTENSIONS
 	.map((ext) => ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))


### PR DESCRIPTION
Base: `master`. Was stack 6/6 — the other five merged while this one was blocked, so it stands alone.

The markdown grammar is implemented twice — Rust emits HTML, then `markdown.ts` re-parses it and decides the same syntax questions again. This PR does **not** attempt that migration. It collapses three concrete, verifiable duplications and leaves the rest alone.

### 1. The markdown extension list had four frontend copies, not two

`markdownLinks.ts`, `sanitize.ts`, `exportHtml.ts`, and — worst — `wikilinkFileTargets.test.ts:80`, where the guard compared Rust against a *literal restatement* of the list, so a TS-only addition failed nothing.

The list now lives once in `markdownLinks.ts` (lowest module, no deps). The Rust boundary genuinely cannot share the data, so the guard now reads the array out of `markdown.rs` and asserts **set equality** against the TS constant — adding an extension on either side alone goes red, in either direction.

`TitleBar.svelte:323` has a fifth copy, outside this PR's file boundary. Filed.

### 2. The two `resolvePath` functions genuinely differ — so they were not merged

Brute-forcing 128 (base, relative) pairs: **40 disagree**, on three real axes.

| input | `markdown.ts` | `markdownLinks.ts` |
|---|---|---|
| `('/notes/index.md', 'sub\other.md')` | `/notes/sub/other.md` | `/notes/sub\other.md` |
| `('/notes/index.md', 'a//b.md')` | `/notes/a//b.md` | `/notes/a/b.md` |
| `('note.md', 'other.md')` | `other.md` | `/other.md` |

Each is right for its own caller. An image `src` is a filesystem path, where a Windows author's `img\a.png` names a directory. An href is a URL, where `\` is an ordinary character and `sub\note.md` names one POSIX file. The third row is the sharper one: the href version returns `''` from `lastIndexOf('/') === -1`, so the result roots at `/` — a real and wrong directory — and is only safe because its single caller refuses an empty `currentFile` first.

So: renamed to `resolveDocumentRelativePath` and `resolveHrefRelativePath`, the latter made private (nothing outside its module imported it). **The shared name was the only thing making them look interchangeable.** Each carries a comment naming the three differences, and a new test pins all three through the public entry points.

`resolveExportImagePath` is not a third resolver — everything above its last line classifies the reference and only the relative case resolves, by delegating. Documented, no code moved.

### 3. The math-delimiter corpus was already bidirectional

`scripts/mathDelimiterCorpus.json` is already the single contract both sides read — Rust via `include_str!`, TS via `readSource`. Nothing structural was needed.

Added 7 cases, each verified to give the identical answer on both sides before being written down: even backslash run, odd run, tilde fence, two display blocks across a blank line, two stray `$$` that may not pair across a hard break, math after a code span + fence, and a formula in a block quote.

One real divergence was found and **deliberately not papered over**: inside a four-space indented code block the backend recognises `$x_1$` as math and the frontend does not, because `code_region_ranges` only knows fences. Benign today, so adding the case would just make the suite red. Tracked separately.

### Verification
- `npm test` 1006 pass / 0 fail
- `npm run check` 710 files / 0 errors / 0 warnings
- `cargo test` 145 pass / 0 fail

### Note on the convention table
`singleImplementationConvention.test.ts` was **not** touched — 0 rows deleted. None of its 17 rows covered the extension list or path resolution; the extension copies were policed by two other tests, and the duplicate `resolvePath` was policed by nothing at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
