### PR TITLE
ci: one release build at a time, and no runner it names can move on its own

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,28 @@ on:
 permissions:
   contents: write
 
+# One release build at a time, per version.
+#
+# Dispatching twice used to give two runs writing to the same draft release, and
+# that is not hypothetical: publish-packages.yml records markpad-app 2.7.2 going
+# to Chocolatey at 15:37 UTC on 2026-08-07 from run 31192564528 -- a run that
+# then failed on Linux and produced no release -- while the release users got
+# came out of a different run three hours later. #561 moved the package pushes
+# out of the matrix, which fixed the irreversible half. This is the other half.
+#
+# Keyed on the ref rather than on the version, because the version is read from
+# package.json inside `create-release` and is not available to a concurrency
+# group, which is evaluated before any job starts. A release is always dispatched
+# from master, so in practice the two are the same key.
+#
+# `cancel-in-progress: false` deliberately. The second dispatch waits instead of
+# killing the first: a half-cancelled run leaves a draft release holding some
+# platforms' assets and not others, which looks exactly like a build that has not
+# finished yet.
+concurrency:
+  group: build-and-release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   create-release:
     runs-on: ubuntu-24.04
@@ -357,7 +379,11 @@ jobs:
 
   generate-update-feed:
     needs: [create-release, build]
-    runs-on: ubuntu-latest
+    # Pinned like every other runner that this pipeline names. This job only runs
+    # `gh` and `jq`, so the version buys little on its own -- what it buys is that
+    # `ubuntu-latest` moving is a thing that happens to us with a commit rather
+    # than without one.
+    runs-on: ubuntu-24.04
     # The updater feed must describe a complete release. Do not publish an
     # update if any platform build failed or was cancelled.
     if: ${{ always() && needs.create-release.result == 'success' && needs.build.result == 'success' }}

--- a/scripts/releaseWorkflow.test.ts
+++ b/scripts/releaseWorkflow.test.ts
@@ -449,3 +449,29 @@ test('the Chocolatey job skips a version that is already on the feed', () => {
 	const pack = sliceFrom(publishWorkflow, '- name: Pack and publish');
 	assert.match(pack, /if: steps\.already\.outputs\.published != 'true'/);
 });
+
+test('one release build runs at a time, and none of its runners drift', () => {
+	// Dispatching twice gave two runs writing to the same draft release.
+	// publish-packages.yml records what that cost: markpad-app 2.7.2 reached
+	// Chocolatey at 15:37 UTC on 2026-08-07 from a run that then failed on Linux
+	// and produced no release, while the release users got came from a different
+	// run three hours later. #561 took the package pushes out of the build
+	// matrix, which fixed the irreversible half of that. This is the other half.
+	//
+	// `cancel-in-progress: false` is the part worth asserting rather than the
+	// group: cancelling the first run mid-flight leaves a draft holding some
+	// platforms' assets and not others, which is indistinguishable from a build
+	// that has not finished.
+	const concurrency = sliceBetween(workflow, '\nconcurrency:', '\njobs:');
+	assert.match(concurrency, /group:/, 'the release build can be dispatched twice into the same draft');
+	assert.match(concurrency, /cancel-in-progress:\s*false/);
+
+	// And every runner it names is a version, not a moving label. `ubuntu-latest`
+	// on generate-update-feed was the last one that could change without a commit.
+	const drifting = workflow
+		.split('\n')
+		.filter((line) => !/^\s*#/.test(line))
+		.filter((line) => /runs-on:\s*(ubuntu|macos|windows)-latest/.test(line))
+		.filter((line) => !/matrix\./.test(line));
+	assert.deepEqual(drifting, [], 'a release job runs on a moving runner label');
+});


### PR DESCRIPTION
Two things in `build.yml`, both about the release build being the one workflow nothing else guards — it is `workflow_dispatch` only, so nothing exercises it until a release is cut.

## It had no `concurrency` at all

```
test.yml            concurrency ✅
test_build.yml      concurrency ✅
publish-packages    concurrency ✅  keyed on the tag, cancel-in-progress: false
build.yml           ✗
```

Dispatch twice and two runs write to the same draft release. **Not hypothetical** — `publish-packages.yml` records what it cost, in its own comment:

> Chocolatey's `markpad-app` 2.7.2 was published at 15:37 UTC on 2026-08-07 by run 31192564528 — a run that then failed on Linux and produced no release. The release users actually got came out of a different run three hours later. Nothing can un-push a Chocolatey version.

#561 moved the package pushes out of the build matrix, which fixed the *irreversible* half of that story. **This is the other half**: two runs for one version, which is what put a Chocolatey package and a release out of step in the first place.

**Keyed on the ref, not the version.** The version is read from `package.json` inside `create-release`, and a concurrency group is evaluated before any job starts, so it cannot see it. A release is always dispatched from `master`, so the two are the same key in practice.

**`cancel-in-progress: false`, deliberately.** The second dispatch waits rather than killing the first. A half-cancelled run leaves a draft holding some platforms' assets and not others — which looks exactly like a build that has not finished yet, and RELEASING.md step 5 is a human comparing that asset list against an expected one.

## And one runner could still move without a commit

`generate-update-feed` ran on `ubuntu-latest` while every other runner in the pipeline is pinned. It only runs `gh` and `jq`, so the version buys little on its own. What it buys is that the image moving becomes something that happens to us **with** a commit rather than without one — which is the distinction the whole `ubuntu-24.04` unification was about.

`macos-latest` and `windows-latest` in the build matrix stay as they are: those artifacts do not bundle system libraries the way the AppImage does, and the assertion skips matrix lines for that reason.

## Tests

Both halves checked by mutation, each failing alone:

```
cancel-in-progress: false → true          ✖ one release build runs at a time…
ubuntu-24.04 → ubuntu-latest on the feed   ✖ (same, "a release job runs on a moving runner label")
```

The assertion is on `cancel-in-progress: false` rather than on the group string, because that is the part carrying the reasoning; a group can be renamed without changing what it protects.

`npm test` — 1006 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)