### PR TITLE
fix(front-matter): key the edit errors by document, like their four siblings

### DIFF
--- a/scripts/frontMatterFieldStateScope.test.ts
+++ b/scripts/frontMatterFieldStateScope.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { readSource } from './sourceTree.js';
+
+// The front-matter panel keeps five per-field state tables side by side, and
+// every one of them has to be keyed by document *and* field. Four were;
+// `frontMatterEditErrors` was keyed by the bare field name, so a validation
+// error raised while editing `date` in one document was still on screen —
+// under the same field — after switching to another document, and stayed
+// there until that field was edited successfully in the second document.
+//
+// Nothing caught it. The four siblings established a convention, the fifth
+// quietly did not follow it, and a convention is not a seam: no type, no test
+// and no comment said the key had to carry the document.
+//
+// This is a source-shape assertion because the panel lives inside
+// MarkdownViewer.svelte, which the Node test runner cannot import. What it
+// pins is deliberately narrow — that this one table is never indexed by a bare
+// `field.key` — rather than the spelling of any particular line.
+
+const VIEWER = 'src/lib/MarkdownViewer.svelte';
+
+/** The scoped key helper the four correct tables already went through. */
+const SCOPED_KEY = 'frontMatterFieldStateKey(field)';
+
+test('the front-matter error table is never keyed by a bare field name', () => {
+	const viewer = readSource(VIEWER);
+
+	// Every read and write of the table, with whatever sits in the brackets.
+	const indexed = [...viewer.matchAll(/frontMatterEditErrors\[([^\]]+)\]/g)].map(
+		(match) => match[1],
+	);
+	assert.ok(
+		indexed.length > 0,
+		`${VIEWER} no longer indexes frontMatterEditErrors — has the panel moved?`,
+	);
+
+	const unscoped = indexed.filter((expression) => /\bfield\.key\b/.test(expression));
+	assert.deepEqual(
+		unscoped,
+		[],
+		`frontMatterEditErrors must be keyed by ${SCOPED_KEY}, not by the field name alone — ` +
+			'a bare field name carries one document\'s error into every other document',
+	);
+
+	// The assignment sites spread the old table and add one entry, so the key
+	// they mint has to carry the document too.
+	const minted = [...viewer.matchAll(/\n\t+\[([^\]]+)\]: String\(error\),/g)].map(
+		(match) => match[1],
+	);
+	assert.ok(minted.length > 0, 'no front-matter error is recorded any more — has the catch moved?');
+	assert.deepEqual(
+		minted,
+		minted.map(() => SCOPED_KEY),
+		`every front-matter error must be recorded under ${SCOPED_KEY}`,
+	);
+});
+
+test('all five per-field front-matter tables agree on their key', () => {
+	const viewer = readSource(VIEWER);
+
+	// The four that were already right, plus the one this test exists for. If a
+	// sixth table joins the cluster it has to be added here, which is the point:
+	// the list is the convention, written down where it can fail.
+	const TABLES = [
+		'frontMatterEditErrors',
+		'frontMatterTagDrafts',
+		'frontMatterTagEditIndexes',
+		'frontMatterTagEditDrafts',
+	];
+
+	for (const table of TABLES) {
+		const indexed = [...viewer.matchAll(new RegExp(`${table}\\[([^\\]]+)\\]`, 'g'))].map(
+			(match) => match[1],
+		);
+		assert.ok(indexed.length > 0, `${table} is no longer indexed — has it been removed?`);
+		for (const expression of indexed) {
+			assert.match(
+				expression,
+				/frontMatterFieldStateKey\(|^key$/,
+				`${table} is indexed by \`${expression}\`, which does not carry the document`,
+			);
+		}
+	}
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -879,7 +879,8 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		};
 	}
 
-	function clearFrontMatterEditError(key: string) {
+	function clearFrontMatterEditError(field: FrontMatterField) {
+		const key = frontMatterFieldStateKey(field);
 		if (!frontMatterEditErrors[key]) return;
 		const next = { ...frontMatterEditErrors };
 		delete next[key];
@@ -901,12 +902,12 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			const nextValue = parseFrontMatterEditableValue(field, value);
 			const nextRaw = updateFrontMatterField(tab.rawContent, field.key, nextValue);
 			tabManager.updateTabRawContent(tab.id, nextRaw);
-			clearFrontMatterEditError(field.key);
+			clearFrontMatterEditError(field);
 			await renderTabPreviewFromRaw(tab);
 		} catch (error) {
 			frontMatterEditErrors = {
 				...frontMatterEditErrors,
-				[field.key]: String(error),
+				[frontMatterFieldStateKey(field)]: String(error),
 			};
 		}
 	}
@@ -920,7 +921,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			...frontMatterTagDrafts,
 			[frontMatterFieldStateKey(field)]: value,
 		};
-		clearFrontMatterEditError(field.key);
+		clearFrontMatterEditError(field);
 	}
 
 	function clearFrontMatterTagDraft(field: FrontMatterField) {
@@ -945,7 +946,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			...frontMatterTagEditDrafts,
 			[frontMatterFieldStateKey(field)]: value,
 		};
-		clearFrontMatterEditError(field.key);
+		clearFrontMatterEditError(field);
 	}
 
 	function startFrontMatterTagEdit(field: FrontMatterField, index: number, value: string) {
@@ -958,7 +959,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			...frontMatterTagEditDrafts,
 			[key]: value,
 		};
-		clearFrontMatterEditError(field.key);
+		clearFrontMatterEditError(field);
 	}
 
 	function clearFrontMatterTagEdit(field: FrontMatterField) {
@@ -983,12 +984,12 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		try {
 			const nextRaw = updateFrontMatterField(tab.rawContent, field.key, nextItems);
 			tabManager.updateTabRawContent(tab.id, nextRaw);
-			clearFrontMatterEditError(field.key);
+			clearFrontMatterEditError(field);
 			await renderTabPreviewFromRaw(tab);
 		} catch (error) {
 			frontMatterEditErrors = {
 				...frontMatterEditErrors,
-				[field.key]: String(error),
+				[frontMatterFieldStateKey(field)]: String(error),
 			};
 		}
 	}
@@ -3704,8 +3705,8 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 															{:else}
 																<code>{field.displayValue}</code>
 															{/if}
-															{#if frontMatterEditErrors[field.key]}
-																<div class="frontmatter-field-error" role="status">{frontMatterEditErrors[field.key]}</div>
+															{#if frontMatterEditErrors[frontMatterFieldStateKey(field)]}
+																<div class="frontmatter-field-error" role="status">{frontMatterEditErrors[frontMatterFieldStateKey(field)]}</div>
 															{/if}
 														</div>
 													{/each}


### PR DESCRIPTION
The front-matter panel keeps five per-field state tables side by side. Four are keyed by `frontMatterFieldStateKey(field)` — the document's panel key plus the field name. `frontMatterEditErrors` was keyed by the field name alone.

```
frontMatterCollapsedByKey    key = document path        ✓
frontMatterEditErrors        key = field.key            ✗
frontMatterTagDrafts         key = path:field           ✓
frontMatterTagEditIndexes    key = path:field           ✓
frontMatterTagEditDrafts     key = path:field           ✓
```

### The bug

Type an invalid value into `date` in one document, switch to another — that document's `date` field is wearing the first document's error, and keeps wearing it until the field is edited successfully there.

The error text belongs to a document. The key did not say so.

### Why nothing caught it

Four siblings established a convention and the fifth quietly did not follow it. **A convention is not a seam**: no type, no test and no comment required the key to carry the document, so there was nothing for a reviewer or a compiler to check against.

### The fix

`clearFrontMatterEditError` now takes the `FrontMatterField` rather than a key string, and computes the scoped key itself — which is what the four correct tables already do. Five call sites, two write sites and the template read follow.

The new test pins two things: that this table is never indexed by a bare `field.key`, and that the whole cluster agrees on one key. The second half means a sixth table joining the cluster has to be added to the list — the list *is* the convention, written where it can fail.

**Falsified:** reverting the fix turns both tests red; restoring turns them green.

### Verification
- `npm test` 1009 pass / 0 fail
- `npm run check` 711 files / 0 errors / 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
