### PR TITLE
perf(preview): remember what KaTeX and highlight.js drew, and debounce for a typist

### DIFF
--- a/scripts/diagramCache.test.ts
+++ b/scripts/diagramCache.test.ts
@@ -69,10 +69,10 @@ function svgFor(id: string, source: string, theme: string, extra = ''): string {
 function libraries(record: Recorder, extraFor: (source: string, id: string) => string = () => '') {
 	let theme = 'neutral';
 	return {
-		hljs: { highlightElement() {} },
+		hljs: { getLanguage: () => null },
 		// The renderer refuses to run without these; the diagrams are what is
 		// under test, so they do nothing.
-		katex: { render() {} },
+		katex: { renderToString: () => '' },
 		renderMathInElement() {},
 		mermaid: {
 			initialize(config: { theme: string }) {

--- a/scripts/exportContentWidth.test.ts
+++ b/scripts/exportContentWidth.test.ts
@@ -319,8 +319,8 @@ async function exportedFile(contentWidth: number | null): Promise<string> {
 		tabPath: '/documents/notes.md',
 		mermaidTheme: 'neutral',
 		libraries: {
-			hljs: { highlightElement() {} },
-			katex: { render() {} },
+			hljs: { getLanguage: () => null },
+			katex: { renderToString: () => '' },
 			renderMathInElement() {},
 			mermaid: { initialize() {}, async render() { return { svg: '' }; } },
 		} as any,

--- a/scripts/exportRichContent.test.ts
+++ b/scripts/exportRichContent.test.ts
@@ -84,15 +84,15 @@ const KATEX_CSS = `
 function fakeLibraries(record: { mermaidThemes: string[]; mathCalls: string[] }) {
 	return {
 		hljs: {
-			highlightElement(element: any) {
-				element.classList.add('hljs');
-				element.innerHTML = `<span class="hljs-keyword">${element.textContent}</span>`;
+			getLanguage: (name: string) => (name === 'js' ? { name } : null),
+			highlight(code: string, options: { language: string }) {
+				return { value: `<span class="hljs-keyword">${code}</span>`, language: options.language };
 			},
 		},
 		katex: {
-			render(source: string, element: any, options: any) {
+			renderToString(source: string, options: any) {
 				record.mathCalls.push(`${options.displayMode ? 'display' : 'inline'}:${source}`);
-				element.innerHTML = `<span class="katex"><span class="mord mathnormal">${source}</span></span>`;
+				return `<span class="katex"><span class="mord mathnormal">${source}</span></span>`;
 			},
 		},
 		renderMathInElement(root: any) {

--- a/scripts/mermaidDiagramLabels.test.ts
+++ b/scripts/mermaidDiagramLabels.test.ts
@@ -125,7 +125,7 @@ function escapeHtml(value: string): string {
 /** The libraries `renderRichContent` needs, with Mermaid backed by the corpus. */
 function libraries() {
 	return {
-		hljs: { highlightElement() {} },
+		hljs: { getLanguage: () => null },
 		katex: null,
 		renderMathInElement() {},
 		mermaid: {

--- a/scripts/richContentCache.test.ts
+++ b/scripts/richContentCache.test.ts
@@ -1,0 +1,185 @@
+/**
+ * The preview re-renders the whole article on every keystroke and `{@html}`
+ * puts every formula and every code block back as source, so KaTeX and
+ * highlight.js ran over the entire document for one typed character. Measured
+ * in Chromium on `samples/katex-stress.md` (21 display formulas), the
+ * `[data-math]` pass alone was ~17ms per keystroke; with the memo it is ~6ms
+ * and calls KaTeX zero times.
+ *
+ * These tests pin what such a memo can get quietly wrong. It is the same list
+ * `diagramCache.test.ts` works from — a memo that never misses is a
+ * correctness bug and a memo that never evicts is a leak, and neither shows up
+ * as anything on screen — minus the re-identification half, because neither
+ * `katex.renderToString` nor `hljs.highlight` bakes an id into its output.
+ *
+ * What is *not* stood in for is the shape of the call: the fakes here answer to
+ * `renderToString` / `highlight` + `getLanguage`, which is exactly the boundary
+ * the renderer now uses, so a return to the element-mutating entry points
+ * (`katex.render`, `hljs.highlightElement`) fails here rather than silently
+ * costing a render per keystroke again.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { installShimDom } from './renderProtocolDom.ts';
+
+installShimDom();
+(globalThis as any).window = globalThis;
+
+const DOMPurify = (await import('dompurify')).default as any;
+DOMPurify.sanitize = (html: string) => html;
+
+const { renderRichContent } = await import('../src/lib/utils/richContent.ts');
+const { resetRichContentCache } = await import('../src/lib/utils/richContentCache.ts');
+
+interface Recorder {
+	math: string[];
+	code: string[];
+}
+
+function newRecorder(): Recorder {
+	return { math: [], code: [] };
+}
+
+const KNOWN_LANGUAGES = new Set(['js', 'rust', 'python']);
+
+function libraries(record: Recorder, mathOutput = (source: string) => `<span>${source}</span>`) {
+	return {
+		hljs: {
+			getLanguage: (name: string) => (KNOWN_LANGUAGES.has(name) ? { name } : null),
+			highlight(code: string, options: { language: string }) {
+				record.code.push(`${options.language}:${code}`);
+				return { value: `<b>${options.language}</b>${code}`, language: options.language };
+			},
+		},
+		katex: {
+			renderToString(source: string, options: { displayMode: boolean }) {
+				record.math.push(`${options.displayMode ? 'display' : 'inline'}:${source}`);
+				return mathOutput(source);
+			},
+		},
+		renderMathInElement() {},
+		mermaid: { initialize() {}, async render() { return { svg: '' }; } },
+	};
+}
+
+function mathBlock(source: string, mode: 'display' | 'inline' = 'display'): string {
+	return `<p data-math="${mode}" data-math-source="${source}">${source}</p>`;
+}
+
+function codeBlock(language: string, code: string): string {
+	return `<pre><code class="language-${language}">${code}</code></pre>`;
+}
+
+async function render(html: string, record: Recorder, mathOutput?: (source: string) => string) {
+	const root = (globalThis as any).document.createElement('div');
+	root.innerHTML = html;
+	await renderRichContent({
+		root,
+		libraries: libraries(record, mathOutput) as any,
+		mermaidTheme: 'neutral',
+	});
+	return root;
+}
+
+// ------------------------------------------------------------------- tests
+
+test('a second pass over the same document renders nothing again', async () => {
+	resetRichContentCache();
+	const article = `${mathBlock('E = mc^2')}\n${codeBlock('js', 'const a = 1;')}`;
+
+	const first = newRecorder();
+	const before = await render(article, first);
+	assert.deepEqual(first.math, ['display:E = mc^2']);
+	assert.deepEqual(first.code, ['js:const a = 1;']);
+
+	const second = newRecorder();
+	const after = await render(article, second);
+	assert.deepEqual(second.math, [], 'a repeat pass must not call KaTeX at all');
+	assert.deepEqual(second.code, [], 'a repeat pass must not call highlight.js at all');
+	// The same document, not merely the same call count.
+	assert.equal(after.innerHTML, before.innerHTML);
+});
+
+test('typing in one formula re-renders that formula and nothing else', async () => {
+	resetRichContentCache();
+	const warm = newRecorder();
+	await render(`${mathBlock('a + b')}\n${mathBlock('c + d')}`, warm);
+	assert.equal(warm.math.length, 2);
+
+	const typed = newRecorder();
+	await render(`${mathBlock('a + bc')}\n${mathBlock('c + d')}`, typed);
+	assert.deepEqual(typed.math, ['display:a + bc']);
+});
+
+test('the same source typeset both ways is two entries', async () => {
+	resetRichContentCache();
+	const record = newRecorder();
+	await render(`${mathBlock('x^2', 'display')}\n${mathBlock('x^2', 'inline')}`, record);
+	assert.deepEqual(record.math, ['display:x^2', 'inline:x^2']);
+});
+
+test('the same code under a different language is two entries', async () => {
+	resetRichContentCache();
+	const record = newRecorder();
+	await render(`${codeBlock('js', 'let x = 1')}\n${codeBlock('rust', 'let x = 1')}`, record);
+	assert.deepEqual(record.code, ['js:let x = 1', 'rust:let x = 1']);
+});
+
+test('a highlighted block carries the class the stylesheet hangs off', async () => {
+	resetRichContentCache();
+	const root = await render(codeBlock('js', 'const a = 1;'), newRecorder());
+	const code = root.querySelector('code');
+	assert.ok(code.classList.contains('hljs'), 'every hljs- rule in styles.css is scoped to .hljs');
+	assert.equal(code.innerHTML, '<b>js</b>const a = 1;');
+	// The shell and its label are what the copy button and the language caption
+	// are built from, and they are unchanged by the memo.
+	assert.ok(root.querySelector('.code-block-shell'), 'the code block still gets its shell');
+	assert.equal(root.querySelector('.lang-label').textContent, 'js');
+});
+
+test('a language highlight.js does not know is left exactly as it was', async () => {
+	resetRichContentCache();
+	const record = newRecorder();
+	// `hljs.highlightElement` used to answer this itself by falling back to
+	// no-highlight; `hljs.highlight` throws instead, and a throw is the one
+	// result the memo cannot store — so an unknown language must never reach it.
+	const root = await render(codeBlock('admonition', 'note: hello'), record);
+	assert.deepEqual(record.code, []);
+	const code = root.querySelector('code');
+	assert.ok(!code.classList.contains('hljs'));
+	assert.equal(code.textContent, 'note: hello');
+	// The caption still names what the author wrote.
+	assert.equal(root.querySelector('.lang-label').textContent, 'admonition');
+});
+
+test('the memo is bounded by entry count', async () => {
+	resetRichContentCache();
+	// 512 entries is the cap. Fill past it and the first one must be gone.
+	const first = mathBlock('n0');
+	await render(first, newRecorder());
+	for (let i = 1; i <= 512; i++) await render(mathBlock(`n${i}`), newRecorder());
+
+	const evicted = newRecorder();
+	await render(first, evicted);
+	assert.deepEqual(evicted.math, ['display:n0'], 'the oldest entry must have been evicted');
+
+	const kept = newRecorder();
+	await render(mathBlock('n512'), kept);
+	assert.deepEqual(kept.math, []);
+});
+
+test('the memo is bounded by size, not only by count', async () => {
+	resetRichContentCache();
+	// Six 400k-character outputs are six entries but 2.4M characters, which is
+	// over the budget: a handful of enormous formulas must not sit in memory
+	// forever just because they are few.
+	const huge = () => 'x'.repeat(400_000);
+	await render(mathBlock('big0'), newRecorder(), huge);
+	for (let i = 1; i < 6; i++) await render(mathBlock(`big${i}`), newRecorder(), huge);
+
+	const evicted = newRecorder();
+	await render(mathBlock('big0'), evicted, huge);
+	assert.deepEqual(evicted.math, ['display:big0']);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -2623,6 +2623,23 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			const rawContent = tab.rawContent;
 			if (tab.previewedRawContent === rawContent) return;
 
+			// 120ms, and the reason is arithmetic rather than taste. This is a
+			// trailing debounce in front of the whole preview pipeline — one
+			// `render_markdown` round trip to Rust, `processMarkdownHtml`,
+			// DOMPurify, `{@html}` reparsing the article, then KaTeX, highlight.js
+			// and Mermaid over the result — and it arrived at 16ms with the split
+			// view (ef219cf), unexplained. 16ms merges nothing a human types: even
+			// inside a fast burst keystrokes land 60–80ms apart, and at a normal
+			// pace roughly 125ms apart. Every character therefore started its own
+			// pipeline, and since the pipeline is async and only its *result* is
+			// dropped by the revision check below, several ran at once and all of
+			// the work was done regardless.
+			//
+			// 120ms sits above the burst interval, so a word typed at speed costs
+			// one render rather than five, and below the pause someone takes to
+			// look at what they wrote — the preview catches up about an eighth of a
+			// second after the last key. Much larger reads as the preview lagging
+			// the cursor; much smaller is the 16ms case again.
 			const timer = setTimeout(() => {
 				renderMarkdownPreview(rawContent, tab.path, tab.foldOverrides)
 					.then((processed) => {
@@ -2637,7 +2654,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 						tick().then(renderRichContent);
 					})
 					.catch(console.error);
-			}, 16);
+			}, 120);
 
 			return () => clearTimeout(timer);
 		}

--- a/src/lib/utils/richContent.ts
+++ b/src/lib/utils/richContent.ts
@@ -6,6 +6,7 @@ import {
 	templateDiagramSvg,
 } from './diagramCache.js';
 import { rememberDiagramSource } from './mermaidPrint.js';
+import { highlightedCode, renderedMath } from './richContentCache.js';
 
 /**
  * The one implementation of "turn rendered Markdown into the thing the user
@@ -194,6 +195,8 @@ export async function renderRichContent(options: RenderRichContentOptions): Prom
 	const doc = root.ownerDocument ?? document;
 	const idFactory = options.idFactory ?? defaultIdFactory;
 
+	const codeBlocks = Array.from(root.querySelectorAll('pre code'));
+
 	// `htmlLabels: false` is what keeps a diagram's text in the picture. With
 	// Mermaid's default (`true`) every label is an HTML `<div>`/`<span>` inside a
 	// `<foreignObject>`, and `sanitizeDiagramSvg` — like any DOMPurify — deletes
@@ -202,9 +205,20 @@ export async function renderRichContent(options: RenderRichContentOptions): Prom
 	// objects to. Measured against mermaid 11.16.0: this one root-level key is
 	// enough for every diagram type it ships (the per-diagram `htmlLabels` keys
 	// are deprecated in 11.x and the root one takes precedence over them).
-	mermaid.initialize({ startOnLoad: false, theme: options.mermaidTheme, htmlLabels: false });
+	//
+	// Only when there is something to draw: `initialize` deep-merges and installs
+	// a site config, which measures at ~2.5ms in Chromium, and this function runs
+	// once per keystroke. A document with no diagram in it was paying that on
+	// every character. Asking first is one selector over a list already in hand.
+	// Configuring per pass, rather than remembering the last theme, is
+	// deliberate — `mermaidPrint.ts` reconfigures the same singleton to print a
+	// diagram on paper and configures it back, so a remembered theme here would
+	// be a claim about a global another module also writes to.
+	const hasDiagram = codeBlocks.some((block) => block.classList.contains('language-mermaid'));
+	if (hasDiagram) {
+		mermaid.initialize({ startOnLoad: false, theme: options.mermaidTheme, htmlLabels: false });
+	}
 
-	const codeBlocks = Array.from(root.querySelectorAll('pre code'));
 	let diagramIndex = 0;
 	for (const block of codeBlocks) {
 		const codeEl = block as HTMLElement;
@@ -257,19 +271,38 @@ export async function renderRichContent(options: RenderRichContentOptions): Prom
 		}
 
 		// Check if language was explicitly specified BEFORE highlight.js runs
-		const hasExplicitLang = Array.from(codeEl.classList).some((c) => c.startsWith('language-'));
+		const langClass = Array.from(codeEl.classList).find((c) => c.startsWith('language-'));
+		const hasExplicitLang = langClass !== undefined;
+		const language = langClass?.replace('language-', '') ?? '';
 
-		// Only highlight if explicit language is specified
-		if (hasExplicitLang) {
+		// Only highlight if explicit language is specified, and only if it names a
+		// grammar highlight.js has. `highlightElement` used to decide that itself:
+		// for an unknown language its `blockLanguage` falls back to "no-highlight"
+		// and it returns having touched nothing. `hljs.highlight` instead throws,
+		// so the same question has to be asked out here — and asking it is also
+		// what keeps a fenced `admonition` block from throwing an exception on
+		// every keystroke, since a throw is the one result the memo cannot store.
+		if (language && hljs.getLanguage(language)) {
 			try {
-				hljs.highlightElement(codeEl);
+				// `hljs.highlight(code, …)` rather than `hljs.highlightElement(el)`:
+				// the element form has no result to keep, and this pass runs over
+				// every block in the document on every keystroke. What the element
+				// form did around the highlighting itself is done here — the `hljs`
+				// class the stylesheet's rules hang off, and nothing else. It also
+				// added the canonical `language-<name>` for an alias
+				// (`language-js` → `language-javascript`); no stylesheet, export or
+				// test reads that class, and the label below deliberately shows the
+				// name the author wrote.
+				const code = codeEl.textContent || '';
+				codeEl.innerHTML = highlightedCode(language, code, () =>
+					hljs.highlight(code, { language, ignoreIllegals: true }).value,
+				);
+				codeEl.classList.add('hljs');
 			} catch (error) {
 				options.onError?.(error);
 				console.error('Failed to highlight code block:', error);
 			}
 		}
-
-		const langClass = Array.from(codeEl.classList).find((c) => c.startsWith('language-'));
 
 		if (preEl && preEl.tagName === 'PRE') {
 			preEl.querySelectorAll('.lang-label').forEach((l) => l.remove());
@@ -308,10 +341,15 @@ export async function renderRichContent(options: RenderRichContentOptions): Prom
 			const isDisplay = el.getAttribute('data-math') === 'display';
 			const mathSource = el.getAttribute('data-math-source') || el.textContent || '';
 			try {
-				katex.render(mathSource, el as HTMLElement, {
-					displayMode: isDisplay,
-					throwOnError: false,
-				});
+				// `renderToString` rather than `render`, for the memo: the string is
+				// the whole result, and typing a character somewhere else in the
+				// document leaves every formula's source exactly as it was.
+				el.innerHTML = renderedMath(mathSource, isDisplay, () =>
+					katex.renderToString(mathSource, {
+						displayMode: isDisplay,
+						throwOnError: false,
+					}),
+				);
 			} catch (e) {
 				options.onError?.(e);
 				console.error('KaTeX rendering error:', e);

--- a/src/lib/utils/richContentCache.ts
+++ b/src/lib/utils/richContentCache.ts
@@ -1,0 +1,121 @@
+/**
+ * A memo for the two halves of `renderRichContent` that are pure functions of
+ * their input: a KaTeX formula and a highlighted code block.
+ *
+ * Why this exists is the same reason `diagramCache.ts` exists, and the numbers
+ * are the ones the debounce could not hide. The preview re-renders the whole
+ * article on every keystroke — in split mode, and in edit mode with the TOC
+ * open — and `{@html sanitizedHtml}` puts every formula and every code block
+ * back as source, so both libraries ran over the whole document again for one
+ * typed character. Measured in Chromium on `samples/katex-stress.md` (21
+ * display formulas, 31 inline), one pass through `renderRichContent` was
+ * 32–45ms, of which the `[data-math]` loop alone was ~20ms. `diagramCache.ts`
+ * had already taken Mermaid out of that figure; it does nothing for a document
+ * whose maths is the expensive part.
+ *
+ * ## Why this is the easy version of `diagramCache.ts`
+ *
+ * That module cannot hand back the bytes it stored: Mermaid bakes the render id
+ * it was given into the SVG's `<style>` selectors and markers, so a reused
+ * diagram has to be re-identified, and most of that file is about proving when
+ * that is safe. Neither library here has anything of the kind.
+ * `katex.renderToString(source, { displayMode })` and
+ * `hljs.highlight(code, { language })` are functions of their arguments and
+ * nothing else — no ids, no counters, no document — so the cached string is
+ * simply the answer, and the key is simply the arguments.
+ *
+ * That is also why the render sites moved to the string-returning entry points.
+ * `katex.render(source, el)` and `hljs.highlightElement(el)` take an element
+ * and there is no result to keep; `renderToString` / `highlight` return exactly
+ * what the cache stores, and the call site assigns it.
+ *
+ * ## What is deliberately not in here
+ *
+ * Inline maths (`$x$`, which `markdown.ts` mints as `\(x\)`) is rendered by
+ * KaTeX's own `renderMathInElement`, which walks the tree and calls its own
+ * bundled KaTeX. There is no seam to memoise without either re-implementing its
+ * delimiter scanner — the thing `mathDelimiterContract.test.ts` exists to keep
+ * honest — or monkey-patching a library's method. So inline maths still costs
+ * what it always did; on the stress document that is ~11ms of the pass.
+ */
+
+/**
+ * Upper bounds, in the spirit of `diagramCache.ts`: the memo outlives a
+ * document and a tab, because the preview keeps rendering into the same window
+ * as the user switches files, so it needs a ceiling that does not depend on
+ * anyone remembering to clear it.
+ *
+ * 2M characters is roughly 4MB of UTF-16, the same budget the diagram cache
+ * carries. Rendered KaTeX is verbose — a display formula from
+ * `samples/katex-stress.md` comes out at 2–8k characters — so the character
+ * bound is the one that usually bites, and 512 entries is there for the
+ * documents made of hundreds of tiny `$a_i$`-sized fragments, where the entry
+ * count runs out first. Between them they hold a stress document and the one
+ * the user was looking at before it.
+ */
+const MAX_ENTRIES = 512;
+const MAX_CHARS = 2_000_000;
+
+/**
+ * Insertion order is the eviction order, and a hit re-inserts, which makes this
+ * an LRU without a second data structure.
+ */
+const rendered = new Map<string, string>();
+let cachedChars = 0;
+
+function memo(key: string, render: () => string): string {
+	const hit = rendered.get(key);
+	if (hit !== undefined) {
+		rendered.delete(key);
+		rendered.set(key, hit);
+		return hit;
+	}
+
+	// A throw propagates to the caller's own try/catch and nothing is stored: a
+	// formula that failed to render must be retried, not remembered as an error.
+	const html = render();
+
+	// A single entry that would evict everything else is not worth caching.
+	if (html.length > MAX_CHARS / 4) return html;
+
+	rendered.set(key, html);
+	cachedChars += html.length;
+
+	for (const [oldest, value] of rendered) {
+		if (rendered.size <= MAX_ENTRIES && cachedChars <= MAX_CHARS) break;
+		if (oldest === key) break; // never evict what was just asked for
+		rendered.delete(oldest);
+		cachedChars -= value.length;
+	}
+
+	return html;
+}
+
+/**
+ * KaTeX output for one formula. `displayMode` is the only other input KaTeX is
+ * given at the call site, and the same source typeset both ways is two
+ * different drawings, so it is part of the key.
+ */
+export function renderedMath(source: string, displayMode: boolean, render: () => string): string {
+	return memo(`math:${displayMode ? 'd' : 'i'}:${source}`, render);
+}
+
+/**
+ * Highlighted markup for one code block. The language is length-prefixed so a
+ * language name that happens to be a prefix of the code cannot collide with a
+ * shorter name followed by different code — the same trick `diagramCache.ts`
+ * uses for the theme. The two families are separated by their own prefixes,
+ * which are the same length, so no `math:` key can spell a `code:` one.
+ */
+export function highlightedCode(language: string, code: string, render: () => string): string {
+	return memo(`code:${language.length}:${language}${code}`, render);
+}
+
+/**
+ * Test seam, like `resetDiagramCache`: the memo is module-level and therefore
+ * process-wide, while a test wants to start from empty.
+ */
+export function resetRichContentCache(): void {
+	rendered.clear();
+	cachedChars = 0;
+}


### PR DESCRIPTION
In split view — and in edit mode with the outline open — the preview re-rendered the whole article on a 16ms debounce, which is roughly once per keystroke. On a document full of LaTeX that meant re-running KaTeX over every formula for every character typed.

### What each keystroke was doing

```
invoke('render_markdown')  whole article, one IPC round trip
processMarkdownHtml        whole article
sanitizeMarkdownHtml       whole article (DOMPurify)
{@html}                    browser reparses, old subtree destroyed
renderRichContent
  mermaid.initialize()     every pass
  every <pre code>      →  hljs.highlightElement    no cache
  every [data-math]     →  katex.render             no cache
  renderMathInElement      second full-tree text walk
```

`diagramCache.ts` memoises Mermaid and nothing else, so it was no help at all on a maths-heavy document.

### The cache

`src/lib/utils/richContentCache.ts` — one LRU (`Map`, insertion order is eviction order, a hit re-inserts), two typed doors:

- `renderedMath(source, displayMode, render)`
- `highlightedCode(language, code, render)` — length-prefixed key for injectivity, the trick `diagramCache.ts` already uses for the theme
- `resetRichContentCache()` — test seam, mirroring `resetDiagramCache`

`MAX_ENTRIES = 512`, `MAX_CHARS = 2_000_000` (the diagram cache's budget). An entry over `MAX_CHARS / 4` is returned but not stored. **A throw is never stored** — a formula that failed has to be retried, not remembered.

Call sites moved to the string-returning entry points (`katex.renderToString`, `hljs.highlight`), because `katex.render(src, el)` and `hljs.highlightElement(el)` hand back nothing worth keeping. Two behaviours had to be carried by hand: the `hljs` class the stylesheet hangs its rules off, and the unknown-language decision — `highlightElement` fell back internally, `hljs.highlight` throws, so `hljs.getLanguage()` is now checked up front. Without that a fenced ` ```admonition ` would throw once per keystroke, and a throw is uncacheable.

Dropped: the canonical alias class (`language-js` no longer also gets `language-javascript`). No stylesheet, export or test reads it.

### Measured — real Chromium, median of 51 passes, 5 warm-ups discarded

| | before | after |
|---|---|---|
| `[data-math]` pass, katex-stress.md (21 display formulas) | 17.2ms, **21** KaTeX calls | **6.5ms, 0 calls** |
| highlighting pass, stress-test.md (74 code blocks) | 3.4ms, **74** hljs calls | **1.7ms, 0 calls** |
| whole pass, katex-stress.md | 46.6ms | **29.5ms** |
| typing *inside* one formula | 21 of 21 re-rendered | **20/21 hits (95%)** |
| `mermaid.initialize` | 2.4ms every pass | 0 for documents without diagrams |

Wall-clock medians swing ±40% run to run on this machine, so **the call counts are the unambiguous part**; the medians never overlapped between columns. Verified visually after an all-hits pass: 20 KaTeX spans, correct `hljs-keyword`/`hljs-number`/`hljs-comment` markup, unknown-language block untouched, shells and labels unchanged.

The harness is not committed — `diagramCache.ts` sets the precedent of quoting measurements in comments and shipping no bench.

### 16ms → 120ms

16ms merged nothing a human types: keystrokes land 60–80ms apart inside a fast burst and ~125ms apart at a normal pace. Worse, the pipeline is async and only its *result* was dropped by the revision check — several ran concurrently and all the work happened anyway.

120ms sits above the burst interval (a word typed at speed is one render, not five) and below the pause someone takes to read what they just wrote. The 16ms was never tuned: it arrived with split view in `ef219cf` and its commit message gives no reason for the value.

### Still uncached, and why

**Inline maths.** `markdown.ts` turns `$x$` into `\(x\)` text, which KaTeX's own `renderMathInElement` renders by walking the tree and calling *its own bundled copy* of KaTeX. There is no seam to memoise without re-implementing its delimiter scanner — the thing `mathDelimiterContract.test.ts` guards — or monkey-patching a library method. On katex-stress.md this is ~20ms of the remaining 29ms, and it is **the largest single item left**.

### Path to block-level incremental rendering

Not attempted here, but the ground is prepared: comrak already emits `data-sourcepos` on every top-level block, and `carrySourcepos` in `richContent.ts` already keeps it across element replacement. The shape would be to return blocks keyed by `data-sourcepos` plus a hash of the block's source, diff against the previous list, and replace only the changed blocks.

That path also makes inline maths cheap for free (auto-render would run on one block, not the article). The two things that make it a real project: `updateFoldHeights` and the `ResizeObserver` rebuild both assume a fresh tree, and `{@html sanitizedHtml}` is currently the single point where DOMPurify runs — per-block replacement needs the filter applied per block with the same config, which `singleImplementationConvention.test.ts` will rightly have opinions about.

### Verification
- `npm test` 1015 pass / 0 fail
- `npm run check` 712 files / 0 errors / 0 warnings
- `cargo test` 145 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
