### PR TITLE
test: run the runes-module tests through the compiler that owns runes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,12 @@ jobs:
       - name: run frontend behavior tests
         run: npm test
 
+      # The `scripts/*.spec.ts` half of the suite: the tests whose subject is a
+      # runes module or needs a DOM, which `node --test` cannot load at all. Two
+      # non-overlapping globs, so a file is run by exactly one of these steps.
+      - name: run frontend behavior tests (vitest)
+        run: npm run test:vitest
+
       - name: run cargo test
         run: |
           cd src-tauri

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,13 +155,60 @@ All file operations go through Rust commands - never use Node.js fs APIs.
 ## Testing
 
 - **Rust**: `cargo test` in `src-tauri/` directory
-- **Frontend**: `npm test` runs `scripts/*.test.ts` (`node --test --import tsx`). Two kinds
-  live there: behavior tests, which import and run the real modules, and source-shape
-  assertions, which match the source text for a contract the compiler cannot check — a Tauri
-  command name, an i18n key, a second copy of a fixed behavior. A green run is not a claim
-  that every behavior is covered; a source-shape assertion passes as long as the line it
-  matches is still spelled that way.
-- **CI**: Runs `npm audit`, `npm run check`, `npm test` and `cargo test` on PRs
+- **Frontend**: two runners, split by glob so a file belongs to exactly one.
+  - `npm test` runs `scripts/*.test.ts` (`node --test --import tsx`).
+  - `npm run test:vitest` runs `scripts/*.spec.ts` (vitest, jsdom, Svelte plugin).
+- **CI**: Runs `npm audit`, `npm run check`, `npm test`, `npm run test:vitest` and
+  `cargo test` on PRs
+
+Two kinds of assertion live in this suite: behavior tests, which import and run the real
+modules, and source-shape assertions, which match the source text for a contract the
+compiler cannot check — a Tauri command name, an i18n key, a second copy of a fixed
+behavior. A green run is not a claim that every behavior is covered; a source-shape
+assertion passes as long as the line it matches is still spelled that way.
+
+### Which runner a test belongs to
+
+**Write it as `*.spec.ts` (vitest) when the subject is a `.svelte.ts` runes module, or when
+it needs a real DOM.** `node --test` cannot load either. A runes module reached from
+`node --test` only runs because the test installs `$state`/`$derived`/`$effect` onto
+`globalThis` itself, and a hand-written rune is not the compiler's: it misses `$derived`'s
+laziness, `$state`'s deep proxying, the private-field backing the compiler generates for
+each `$state`, and — the expensive one — `$effect` never re-runs, so an assertion about
+what an effect writes cannot fail. Under vitest the module is compiled for real and
+`flushSync()` from `svelte` runs the pending effects.
+
+**Leave it as `*.test.ts` (`node --test`) otherwise.** Plain TypeScript modules run fine
+there, the runner is already configured, and moving a passing file buys nothing.
+
+**Do not migrate `.svelte` component tests.** Mounting a component here means jsdom
+standing in for Monaco, mermaid and KaTeX, and the assertion it earns — "the handler is
+wired up" — is weaker than the source-shape assertion it replaced, not stronger.
+
+### What must never be migrated
+
+Two categories are correct *because* they are text assertions, and a runtime test cannot
+express them at all:
+
+- **Cross-language contracts.** A `#[tauri::command]` name, an event name, a config key: one
+  side is Rust and the other is TypeScript, and nothing but the spelling connects them.
+  Running the TypeScript proves the TypeScript.
+- **Single-implementation conventions.** "There is exactly one copy of this behavior", "no
+  other caller passes this flag", "this constant is not hard-coded a second time". These are
+  claims about the *absence* of a second implementation. Executing the one implementation
+  that exists cannot observe a second one; only reading the source can.
+
+### Migrating a file
+
+Rename `*.test.ts` to `*.spec.ts`, change `import test from 'node:test'` to
+`import { test } from 'vitest'`, and delete the rune shim. `node:assert/strict` works
+unchanged. Two things bite:
+
+- `resolve.conditions: ['browser']` in `vitest.config.ts` is load-bearing. Without it Svelte
+  resolves to its SSR build and `$effect` never flushes — the runes go quietly back to
+  behaving like the shims.
+- `readSource(new URL('…', import.meta.url))` throws under vitest, which serves test files
+  over `http://`. Use the cwd-relative string form.
 
 ## Notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,11 +29,13 @@
 				"@sveltejs/vite-plugin-svelte": "^5.1.1",
 				"@tauri-apps/cli": "^2.11.4",
 				"@types/node": "^26.2.0",
+				"jsdom": "^30.0.1",
 				"svelte": "^5.56.8",
 				"svelte-check": "^4.7.5",
 				"tsx": "^4.23.12",
 				"typescript": "^5.9.3",
-				"vite": "^6.4.3"
+				"vite": "^6.4.3",
+				"vitest": "^4.1.10"
 			}
 		},
 		"node_modules/@antfu/install-pkg": {
@@ -49,17 +51,203 @@
 				"url": "https://github.com/sponsors/antfu"
 			}
 		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "6.0.7",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+			"integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/css-calc": "^3.3.0",
+				"@csstools/css-color-parser": "^4.1.10",
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0",
+				"lru-cache": "^11.5.2"
+			},
+			"engines": {
+				"node": "^22.13.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/dom-selector": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+			"integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bidi-js": "^1.0.3",
+				"css-tree": "^3.2.1",
+				"is-potential-custom-element-name": "^1.0.1",
+				"lru-cache": "^11.5.2"
+			},
+			"engines": {
+				"node": "^22.13.0 || >=24.0.0"
+			}
+		},
 		"node_modules/@braintree/sanitize-url": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
 			"integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
 			"license": "MIT"
 		},
+		"node_modules/@bramus/specificity": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+			"integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"css-tree": "^3.0.0"
+			},
+			"bin": {
+				"specificity": "bin/cli.js"
+			}
+		},
 		"node_modules/@chevrotain/types": {
 			"version": "11.1.2",
 			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
 			"integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
 			"license": "Apache-2.0"
+		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+			"integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+			"integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+			"integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/color-helpers": "^6.1.0",
+				"@csstools/css-calc": "^3.3.0"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+			"integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"peerDependencies": {
+				"css-tree": "^3.2.1"
+			},
+			"peerDependenciesMeta": {
+				"css-tree": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.25.12",
@@ -501,6 +689,24 @@
 			],
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@exodus/bytes": {
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+			"integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@noble/hashes": "^1.8.0 || ^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@noble/hashes": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@iconify/types": {
@@ -1333,6 +1539,17 @@
 				"@tauri-apps/api": "^2.10.1"
 			}
 		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
 		"node_modules/@types/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -1562,6 +1779,13 @@
 				"@types/d3-selection": "*"
 			}
 		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1602,6 +1826,119 @@
 				"d3-transition": "^3.0.1"
 			}
 		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+			"integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+			"integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.10",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+			"integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+			"integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.10",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+			"integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+			"integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+			"integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.10",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.18.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
@@ -1624,6 +1961,16 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/axobject-query": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -1632,6 +1979,26 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/bidi-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"require-from-string": "^2.0.2"
+			}
+		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/chokidar": {
@@ -1675,6 +2042,13 @@
 			"integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
 			"license": "MIT"
 		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/cookie": {
 			"version": "0.7.2",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -1692,6 +2066,20 @@
 			"license": "MIT",
 			"dependencies": {
 				"layout-base": "^1.0.0"
+			}
+		},
+		"node_modules/css-tree": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
 			}
 		},
 		"node_modules/cytoscape": {
@@ -2202,6 +2590,35 @@
 				"lodash-es": "^4.17.21"
 			}
 		},
+		"node_modules/data-urls": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+			"integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/data-urls/node_modules/whatwg-url": {
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.11.0",
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
 		"node_modules/dayjs": {
 			"version": "1.11.21",
 			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
@@ -2225,6 +2642,13 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/deepmerge": {
 			"version": "4.3.1",
@@ -2260,6 +2684,26 @@
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
 			}
+		},
+		"node_modules/entities": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+			"integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/es-toolkit": {
 			"version": "1.50.0",
@@ -2339,6 +2783,26 @@
 				}
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+			"integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
 		"node_modules/fdir": {
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2392,6 +2856,19 @@
 			"resolved": "https://registry.npmjs.org/highlightjs-svelte/-/highlightjs-svelte-1.0.6.tgz",
 			"integrity": "sha512-aXuBPz8df3sOXg90q8rRcBLyxIR8ozPU39a6tJ2rpJUjjd9brRIr55aC0IccW4gsPhQxZ+B3rFugdXsg9/ckDw=="
 		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.6.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
 		"node_modules/iconv-lite": {
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -2413,6 +2890,13 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/is-reference": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -2421,6 +2905,47 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.6"
+			}
+		},
+		"node_modules/jsdom": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+			"integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/css-color": "^6.0.5",
+				"@asamuzakjp/dom-selector": "^8.3.0",
+				"@bramus/specificity": "^2.4.2",
+				"@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+				"@exodus/bytes": "^1.15.1",
+				"css-tree": "^3.2.1",
+				"data-urls": "^7.0.0",
+				"decimal.js": "^10.6.0",
+				"html-encoding-sniffer": "^6.0.0",
+				"is-potential-custom-element-name": "^1.0.1",
+				"lru-cache": "^11.5.2",
+				"parse5": "^8.0.1",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^6.0.2",
+				"undici": "^8.9.0",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^8.0.1",
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^17.1.0",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.2.3"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/katex": {
@@ -2473,6 +2998,16 @@
 			"integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
 			"license": "MIT"
 		},
+		"node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2494,6 +3029,13 @@
 			"engines": {
 				"node": ">= 18"
 			}
+		},
+		"node_modules/mdn-data": {
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"dev": true,
+			"license": "CC0-1.0"
 		},
 		"node_modules/mermaid": {
 			"version": "11.16.1",
@@ -2628,11 +3170,38 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/obug": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+			"integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
 		"node_modules/package-manager-detector": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
 			"integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
 			"license": "MIT"
+		},
+		"node_modules/parse5": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+			"integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^8.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
 		},
 		"node_modules/path-data-parser": {
 			"version": "0.1.0",
@@ -2722,6 +3291,16 @@
 				"node": "^10 || ^12 || >=14"
 			}
 		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/readdirp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -2734,6 +3313,16 @@
 			"funding": {
 				"type": "individual",
 				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/robust-predicates": {
@@ -2824,12 +3413,32 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"license": "MIT"
 		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
+			}
+		},
 		"node_modules/set-cookie-parser": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
 			"integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/sirv": {
 			"version": "3.0.2",
@@ -2855,6 +3464,20 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+			"integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/stylis": {
 			"version": "4.3.6",
@@ -2915,6 +3538,20 @@
 				"typescript": "^5.0.0 || ^6.0.0"
 			}
 		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/tinyexec": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -2941,6 +3578,36 @@
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
+		"node_modules/tinyrainbow": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+			"integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tldts": {
+			"version": "7.4.10",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+			"integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^7.4.10"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "7.4.10",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+			"integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/totalist": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -2949,6 +3616,32 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+			"integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tldts": "^7.0.5"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/ts-dedent": {
@@ -3483,6 +4176,16 @@
 			"integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
 			"license": "MIT"
 		},
+		"node_modules/undici": {
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+			"integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
 		"node_modules/undici-types": {
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
@@ -3597,6 +4300,178 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/vitest": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+			"integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.10",
+				"@vitest/mocker": "4.1.10",
+				"@vitest/pretty-format": "4.1.10",
+				"@vitest/runner": "4.1.10",
+				"@vitest/snapshot": "4.1.10",
+				"@vitest/spy": "4.1.10",
+				"@vitest/utils": "4.1.10",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.10",
+				"@vitest/browser-preview": "4.1.10",
+				"@vitest/browser-webdriverio": "4.1.10",
+				"@vitest/coverage-istanbul": "4.1.10",
+				"@vitest/coverage-v8": "4.1.10",
+				"@vitest/ui": "4.1.10",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "17.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+			"integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.15.1",
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.14.0 || >=24.0.0"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/yaml": {
 			"version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"build": "vite build",
 		"preview": "vite preview",
 		"test": "node --test --import tsx 'scripts/*.test.ts'",
+		"test:vitest": "vitest run",
 		"test:frontmatter": "node --test --import tsx scripts/frontMatter.test.ts scripts/frontMatterProseBlock.test.ts",
 		"test:workflows": "node --test --import tsx scripts/exportHtml.test.ts scripts/exportOpenPrompt.test.ts scripts/editorToolbar.test.ts scripts/titlebarToolbar.test.ts",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
@@ -39,11 +40,13 @@
 		"@sveltejs/vite-plugin-svelte": "^5.1.1",
 		"@tauri-apps/cli": "^2.11.4",
 		"@types/node": "^26.2.0",
+		"jsdom": "^30.0.1",
 		"svelte": "^5.56.8",
 		"svelte-check": "^4.7.5",
 		"tsx": "^4.23.12",
 		"typescript": "^5.9.3",
-		"vite": "^6.4.3"
+		"vite": "^6.4.3",
+		"vitest": "^4.1.10"
 	},
 	"overrides": {
 		"cookie": "0.7.2",

--- a/scripts/reopenDirtyDocument.spec.ts
+++ b/scripts/reopenDirtyDocument.spec.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+import { test } from 'vitest';
 
 import { readSource, sliceBetween } from './sourceTree.js';
 
@@ -15,32 +15,15 @@ import { readSource, sliceBetween } from './sourceTree.js';
 // ("Reload from disk", the external-change "Reload"), never a side effect of
 // asking to see a file.
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
-
-const localStore = new Map<string, string>();
-g.localStorage = {
-	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
-	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
-	removeItem: (key: string) => void localStore.delete(key),
-	clear: () => localStore.clear(),
-};
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity. Only
+// the Tauri backend, which jsdom cannot provide, is stubbed.
 
 // What the file says right now, and every read the session performed.
 const disk = new Map<string, string>();
 const reads: string[] = [];
 
-g.window.__TAURI_INTERNALS__ = {
+(window as any).__TAURI_INTERNALS__ = {
 	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (cmd: string, args: any) => {
 		if (cmd === 'read_file_content_checked') {
@@ -59,7 +42,8 @@ g.window.__TAURI_INTERNALS__ = {
 const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
 
-const viewer = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
+// Cwd-relative, not `import.meta.url`: see the note on `readSource`.
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
 function makeSession() {
 	return createDocumentSession({
@@ -87,7 +71,7 @@ function makeSession() {
 function reset() {
 	tabManager.closeAll();
 	tabManager.recentlyClosed.length = 0;
-	localStore.clear();
+	localStorage.clear();
 	disk.clear();
 	reads.length = 0;
 }

--- a/scripts/settingsPersistence.spec.ts
+++ b/scripts/settingsPersistence.spec.ts
@@ -1,87 +1,39 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
 
+import { flushSync } from 'svelte';
 import { parse } from 'svelte/compiler';
+import { test } from 'vitest';
 
 import { callbackBodies, readSource, sliceBetween } from './sourceTree.js';
 // Plain TypeScript, no runes: safe to import statically, unlike the store below.
 import { getSupportedLanguages, translations } from '../src/lib/utils/i18n.js';
 
 /*
- * `settings.svelte.ts` is a runes module, so it cannot be imported the way the
- * other suites import plain utils. Node's test runner gives every file its own
- * process, so shimming the runes and the browser globals here cannot leak into
- * any other suite.
+ * `settings.svelte.ts` is a runes module, and this file runs under vitest so
+ * that it is compiled by the Svelte plugin: `$state` is a real proxy, `$effect`
+ * really tracks what it reads, and `flushSync()` really runs the pending ones.
  *
- * The shims are deliberately dumb: `$state` is identity and `$effect` runs its
- * callback once and records it. That is enough to assert the *shape* of the
- * persistence layer (how many effects exist, which fields each one reads),
- * which is the property that actually decides the multi-window behaviour. No
- * assertion below depends on the shims re-running anything.
+ * That matters here more than anywhere else in the suite. The property this
+ * file exists to guard — "changing one setting rewrites one localStorage key" —
+ * IS Svelte's dependency tracking. Under a hand-written `$effect` shim that
+ * only records its callback, the assertions could describe the intended shape
+ * but never exercise the mechanism that delivers it.
+ *
+ * jsdom supplies `window`, `localStorage` and `navigator` for real; only the
+ * Tauri backend is stubbed.
  */
-type EffectFn = () => void | (() => void);
+(window as any).__TAURI_INTERNALS__ = { invoke: async () => 'macos' };
 
-const runes = globalThis as unknown as {
-	$state: unknown;
-	$derived: unknown;
-	$effect: unknown;
-};
+/** jsdom does not fire `storage` for writes made by this same document. */
+function dispatchStorage(key: string | null, newValue: string | null) {
+	window.dispatchEvent(new StorageEvent('storage', { key, newValue, storageArea: localStorage }));
+}
 
-const registeredEffects: EffectFn[] = [];
+function setNavigatorLanguage(language: string) {
+	Object.defineProperty(globalThis, 'navigator', { value: { language }, configurable: true });
+}
 
-const identity = (value: unknown) => value;
-const stateRune = Object.assign(identity, { raw: identity, snapshot: identity });
-const effectRune = Object.assign(
-	(fn: EffectFn) => {
-		registeredEffects.push(fn);
-		fn();
-	},
-	{
-		root: (fn: () => void) => {
-			fn();
-			return () => {};
-		},
-		pre: (fn: EffectFn) => {
-			registeredEffects.push(fn);
-			fn();
-		},
-		tracking: () => false,
-	},
-);
-
-runes.$state = stateRune;
-runes.$derived = Object.assign(identity, { by: (fn: () => unknown) => fn() });
-runes.$effect = effectRune;
-
-const storageBacking = new Map<string, string>();
-const storageListeners: ((event: unknown) => void)[] = [];
-
-const localStorageShim = {
-	getItem: (key: string) => (storageBacking.has(key) ? storageBacking.get(key)! : null),
-	setItem: (key: string, value: string) => {
-		storageBacking.set(key, String(value));
-	},
-	removeItem: (key: string) => {
-		storageBacking.delete(key);
-	},
-	clear: () => storageBacking.clear(),
-};
-
-const windowShim = {
-	__TAURI_INTERNALS__: { invoke: async () => 'macos' },
-	addEventListener: (type: string, fn: (event: unknown) => void) => {
-		if (type === 'storage') storageListeners.push(fn);
-	},
-	removeEventListener: (type: string, fn: (event: unknown) => void) => {
-		if (type !== 'storage') return;
-		const index = storageListeners.indexOf(fn);
-		if (index >= 0) storageListeners.splice(index, 1);
-	},
-};
-
-Object.defineProperty(globalThis, 'localStorage', { value: localStorageShim, configurable: true });
-Object.defineProperty(globalThis, 'window', { value: windowShim, configurable: true });
-Object.defineProperty(globalThis, 'navigator', { value: { language: 'en-US' }, configurable: true });
+setNavigatorLanguage('en-US');
 
 const settingsModule = await import('../src/lib/stores/settings.svelte.js');
 const {
@@ -103,12 +55,13 @@ const {
 
 type PersistedEntry = ReturnType<typeof createSettingsPersistence>[number];
 
-const storeSource = readSource(new URL('../src/lib/stores/settings.svelte.ts', import.meta.url));
-const componentSource = readSource(new URL('../src/lib/components/Settings.svelte', import.meta.url));
+// Cwd-relative, not `import.meta.url`: see the note on `readSource`.
+const storeSource = readSource('src/lib/stores/settings.svelte.ts');
+const componentSource = readSource('src/lib/components/Settings.svelte');
 
 function resetStorage(seed: Record<string, string> = {}) {
-	storageBacking.clear();
-	for (const [key, value] of Object.entries(seed)) storageBacking.set(key, value);
+	localStorage.clear();
+	for (const [key, value] of Object.entries(seed)) localStorage.setItem(key, value);
 }
 
 /**
@@ -121,9 +74,12 @@ function createRecordingStore(): { proxy: InstanceType<typeof SettingsStore>; re
 	resetStorage();
 	const real = new SettingsStore();
 	const proxy = new Proxy(real, {
-		get(target, property, receiver) {
+		get(target, property) {
 			if (typeof property === 'string') reads.add(property);
-			return Reflect.get(target, property, receiver);
+			// `target`, not the receiver: the compiler turns `x = $state(…)` into a
+			// getter over a `#x` private field, and a getter invoked with the proxy
+			// as `this` throws — private fields are keyed on the real instance.
+			return Reflect.get(target, property);
 		},
 	});
 	return { proxy, reads };
@@ -185,50 +141,62 @@ test('persisted keys are unique and cover the documented settings surface', () =
 	}
 });
 
-test('persistence installs one effect per key plus the storage listener', () => {
-	// The regression this guards: a single effect that read every field, so any
-	// one change rewrote all ~30 keys from a stale snapshot.
-	resetStorage();
-	storageListeners.length = 0;
-	registeredEffects.length = 0;
-
-	// Constructing the store is what installs the effects; the counts below are
-	// the assertion. `assert.ok(store instanceof SettingsStore)` stood here and
-	// could not fail — a constructor that throws fails the line above it, and
-	// one that returns fails nothing.
-	new SettingsStore();
-
-	const entryCount = createSettingsPersistence().length;
-	assert.equal(registeredEffects.length, entryCount + 1);
-	assert.equal(storageListeners.length, 1);
-});
+/** Every key currently in localStorage, with its value. */
+function storageSnapshot(): Map<string, string> {
+	const out = new Map<string, string>();
+	for (let i = 0; i < localStorage.length; i++) {
+		const key = localStorage.key(i)!;
+		out.set(key, localStorage.getItem(key)!);
+	}
+	return out;
+}
 
 test('changing one setting rewrites only that setting key', () => {
-	const entries = createSettingsPersistence();
+	// The regression this guards: a single effect that read every field, so any
+	// one change rewrote all ~30 keys from a stale snapshot.
+	//
+	// This runs the real effects. `new SettingsStore()` installs them inside an
+	// `$effect.root`, `flushSync()` runs the pending ones, and what lands in
+	// localStorage afterwards is decided by Svelte's dependency tracking — not
+	// by this file's idea of it. Under the hand-written `$effect` shim this
+	// suite used to install, the assertion below could not fail: nothing re-ran.
 	resetStorage();
 	const store = new SettingsStore();
+	flushSync(); // seeds every key from the store's current values
 
-	// Snapshot what each entry's effect last wrote, then re-run only the effects
-	// whose single dependency actually changed — which is what Svelte does.
-	const lastWritten = new Map(entries.map((entry) => [entry.key, entry.read(store)]));
-	const flush = () => {
-		const written: string[] = [];
-		for (const entry of entries) {
-			const next = entry.read(store);
-			if (lastWritten.get(entry.key) === next) continue;
-			lastWritten.set(entry.key, next);
-			if (writeStoredSetting(entry.key, next)) written.push(entry.key);
-		}
-		return written;
+	const written = (change: () => void) => {
+		const before = storageSnapshot();
+		change();
+		flushSync();
+		return [...storageSnapshot()]
+			.filter(([key, value]) => before.get(key) !== value)
+			.map(([key]) => key)
+			.sort();
 	};
 
-	flush();
-	store.minimap = !store.minimap;
-	assert.deepEqual(flush(), ['editor.minimap']);
+	assert.deepEqual(written(() => (store.minimap = !store.minimap)), ['editor.minimap']);
+	assert.deepEqual(
+		written(() => {
+			store.editorFontSize = 30;
+			store.language = 'ja';
+		}),
+		['editor.fontSize', 'editor.language'],
+	);
+	// A write with no state change is not a write at all.
+	assert.deepEqual(written(() => {}), []);
+});
 
-	store.editorFontSize = 30;
-	store.language = 'ja';
-	assert.deepEqual(flush().sort(), ['editor.fontSize', 'editor.language']);
+test('the store installs a storage listener that survives on the real window', () => {
+	// The other half of the multi-window fix, through jsdom's real event
+	// dispatch: `addEventListener('storage', …)` runs inside an `$effect`, so it
+	// is only wired up once the effects flush.
+	resetStorage();
+	const store = new SettingsStore();
+	flushSync();
+
+	localStorage.setItem('editor.fontSize', '30');
+	dispatchStorage('editor.fontSize', '30');
+	assert.equal(store.editorFontSize, 30);
 });
 
 test('a second window no longer clobbers what the first window just changed', () => {
@@ -250,8 +218,8 @@ test('a second window no longer clobbers what the first window just changed', ()
 	const minimapEntry = entries.find((entry) => entry.key === 'editor.minimap') as PersistedEntry;
 	writeStoredSetting(minimapEntry.key, minimapEntry.read(windowB));
 
-	assert.equal(localStorageShim.getItem('editor.fontSize'), '30');
-	assert.equal(localStorageShim.getItem('editor.language'), 'ja');
+	assert.equal(localStorage.getItem('editor.fontSize'), '30');
+	assert.equal(localStorage.getItem('editor.language'), 'ja');
 
 	// And a fresh window (a restart) sees A's changes intact.
 	const restarted = new SettingsStore();
@@ -261,19 +229,17 @@ test('a second window no longer clobbers what the first window just changed', ()
 
 test('storage events fold another window changes into this instance', () => {
 	resetStorage();
-	storageListeners.length = 0;
 	const store = new SettingsStore();
-	assert.equal(storageListeners.length, 1);
-	const onStorage = storageListeners[0];
+	flushSync();
 
 	// Another window wrote the value; localStorage already reflects it when the
 	// event is delivered here.
-	localStorageShim.setItem('editor.fontSize', '30');
-	onStorage({ key: 'editor.fontSize', newValue: '30', storageArea: localStorageShim });
+	localStorage.setItem('editor.fontSize', '30');
+	dispatchStorage('editor.fontSize', '30');
 	assert.equal(store.editorFontSize, 30);
 
-	localStorageShim.setItem('editor.language', 'ja');
-	onStorage({ key: 'editor.language', newValue: 'ja', storageArea: localStorageShim });
+	localStorage.setItem('editor.language', 'ja');
+	dispatchStorage('editor.language', 'ja');
 	assert.equal(store.language, 'ja');
 });
 
@@ -282,13 +248,12 @@ test('a value that arrived from localStorage is not written back', () => {
 	// because compare-and-set finds the value already stored.
 	const entries = createSettingsPersistence();
 	resetStorage();
-	storageListeners.length = 0;
 	const store = new SettingsStore();
-	const onStorage = storageListeners[0];
+	flushSync();
 	const entry = entries.find((item) => item.key === 'editor.fontSize') as PersistedEntry;
 
-	localStorageShim.setItem('editor.fontSize', '30');
-	onStorage({ key: 'editor.fontSize', newValue: '30', storageArea: localStorageShim });
+	localStorage.setItem('editor.fontSize', '30');
+	dispatchStorage('editor.fontSize', '30');
 
 	// This is the follow-up effect run that a naive implementation would use to
 	// echo the value straight back to the other window.
@@ -301,18 +266,18 @@ test('writeStoredSetting is compare-and-set and removes on null', () => {
 	assert.equal(writeStoredSetting('demo.key', 'a'), false);
 	assert.equal(writeStoredSetting('demo.key', 'b'), true);
 	assert.equal(writeStoredSetting('demo.key', null), true);
-	assert.equal(localStorageShim.getItem('demo.key'), null);
+	assert.equal(localStorage.getItem('demo.key'), null);
 	assert.equal(writeStoredSetting('demo.key', null), false);
 });
 
 test('a cleared localStorage is re-read rather than half-applied', () => {
 	resetStorage({ 'editor.fontSize': '30' });
-	storageListeners.length = 0;
 	const store = new SettingsStore();
+	flushSync();
 	assert.equal(store.editorFontSize, 30);
 
-	storageBacking.clear();
-	storageListeners[0]({ key: null, newValue: null, storageArea: localStorageShim });
+	localStorage.clear();
+	dispatchStorage(null, null);
 	assert.equal(store.editorFontSize, EDITOR_FONT_SIZE_RANGE.default);
 });
 
@@ -465,21 +430,21 @@ test('regional variants and unsupported tags resolve predictably', () => {
 });
 
 test('system detection falls back to English for unsupported locales', () => {
-	Object.defineProperty(globalThis, 'navigator', { value: { language: 'ar-EG' }, configurable: true });
+	setNavigatorLanguage('ar-EG');
 	assert.equal(detectSystemLanguage(), 'en');
-	Object.defineProperty(globalThis, 'navigator', { value: { language: 'nb-NO' }, configurable: true });
+	setNavigatorLanguage('nb-NO');
 	assert.equal(detectSystemLanguage(), 'no');
-	Object.defineProperty(globalThis, 'navigator', { value: { language: 'en-US' }, configurable: true });
+	setNavigatorLanguage('en-US');
 });
 
 test('a stored language is validated against the catalogue', () => {
 	resetStorage({ 'editor.language': 'klingon' });
-	Object.defineProperty(globalThis, 'navigator', { value: { language: 'ja-JP' }, configurable: true });
+	setNavigatorLanguage('ja-JP');
 	assert.equal(new SettingsStore().language, 'en'); // unchanged default, not the bogus code
 
 	resetStorage();
 	assert.equal(new SettingsStore().language, 'ja'); // nothing stored -> detect
-	Object.defineProperty(globalThis, 'navigator', { value: { language: 'en-US' }, configurable: true });
+	setNavigatorLanguage('en-US');
 });
 
 test('the validator accepts exactly the languages the dialog offers', () => {

--- a/scripts/sourceTree.ts
+++ b/scripts/sourceTree.ts
@@ -55,6 +55,11 @@ export type SourceFile = { path: string; text: string };
  * `new URL('../src/…', import.meta.url)`, which resolves against the test file
  * rather than the cwd. `readFileSync` takes either, so no call site has to
  * change shape to get normalized.
+ *
+ * The `import.meta.url` spelling only works under `node --test`. Vitest serves
+ * test files through Vite, so `import.meta.url` is an `http://` URL there and
+ * `readFileSync` rejects it with "The URL must be of scheme file". A `*.spec.ts`
+ * file must use the cwd-relative string form.
  */
 export function readSource(path: string | URL): string {
 	return readFileSync(path, 'utf8').replace(/\r\n/g, '\n');

--- a/scripts/tabPathIdentity.spec.ts
+++ b/scripts/tabPathIdentity.spec.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+import { test } from 'vitest';
 
 // A file path identifies a tab. Two tabs on one file are two buffers with two
 // dirty flags and two auto-save timers writing the same file in turn, so
@@ -10,27 +10,10 @@ import test from 'node:test';
 //
 // These tests drive the real TabManager: they assert behaviour, not wording.
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
-
-const localStore = new Map<string, string>();
-g.localStorage = {
-	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
-	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
-	removeItem: (key: string) => void localStore.delete(key),
-	clear: () => localStore.clear(),
-};
-g.window.__TAURI_INTERNALS__ = {
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so `$state`/`$derived`/`$effect` behave here exactly as they do
+// in the app. Only the things jsdom genuinely does not have are stubbed.
+(window as any).__TAURI_INTERNALS__ = {
 	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
 };
@@ -40,7 +23,7 @@ const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 function reset() {
 	tabManager.closeAll();
 	tabManager.recentlyClosed.length = 0;
-	localStore.clear();
+	localStorage.clear();
 }
 
 function tabsFor(path: string) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,7 @@
     ".svelte-kit/types/**/$types.d.ts",
     "vite.config.js",
     "vite.config.ts",
+    "vitest.config.ts",
     "src/**/*.js",
     "src/**/*.ts",
     "src/**/*.svelte",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,30 @@
+import type { UserConfig } from 'vite';
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+import viteConfig from './vite.config.js';
+
+// `vite.config.js` exports an async factory (it reads TAURI_DEV_HOST), so it has
+// to be called before it can be merged.
+const base = (await (viteConfig as unknown as (env: unknown) => Promise<UserConfig>)({
+	command: 'serve',
+	mode: 'test',
+})) as UserConfig;
+
+export default mergeConfig(
+	base,
+	defineConfig({
+		test: {
+			// `*.spec.ts` here, `scripts/*.test.ts` in `npm test`. The two globs do
+			// not overlap, so a file belongs to exactly one runner and moving it
+			// across is a rename.
+			include: ['scripts/**/*.spec.ts'],
+			environment: 'jsdom',
+		},
+		resolve: {
+			// Without this Svelte resolves to its SSR build, where `$effect` never
+			// flushes and `$state` is not a proxy — runes would silently behave
+			// like the hand-written shims these tests exist to delete.
+			conditions: ['browser'],
+		},
+	}),
+);


### PR DESCRIPTION
114 test files carry **678 source-shape assertions** and 88 of them import `scripts/sourceTree.ts`, which reads `src/` as text. The reason is in that file's own header: `node --test` cannot import `.svelte`. Extracting more modules does not move that number — the last round of refactoring moved it by 5.

So this changes the runner, for one specific class of test, as a pilot.

### The class

`.svelte.ts` runes modules — stores, sessions, tab identity, save guards. Real logic that currently cannot be executed at all, so the tests hand-write a `$state` proxy shim onto `globalThis` and hope it matches the compiler.

Three files migrated: `reopenDirtyDocument`, `tabPathIdentity`, `settingsPersistence`. They keep their names but move to `*.spec.ts`, which the existing `scripts/*.test.ts` glob does not match — **two runners, zero overlap, either can be stopped**.

### What the pilot had to prove

**1. The shims come out — 84 lines.** No `.spec.ts` installs `$state` / `$derived` / `$effect` onto `globalThis` any more. The stores compile through the Svelte plugin; jsdom supplies `window` / `localStorage` / `navigator` for real. `settingsPersistence` lost ~62 of the 84 (full rune shim plus `localStorageShim` and `windowShim`).

**2. `$effect` really flushes.** `settingsPersistence.spec.ts` now constructs a real `SettingsStore` — whose constructor installs ~30 effects inside `$effect.root` — calls `flushSync()`, mutates one field, flushes again, and diffs actual `localStorage`. It asserts the changed-key set is exactly `['editor.minimap']`, then exactly `['editor.fontSize','editor.language']`, then `[]` for a no-op.

The old version hand-simulated the flush loop and then asserted on its own simulation, so **it could not fail**. The `registeredEffects.length === entryCount + 1` counting test is gone with it — subsumed, because the behaviour is now observed rather than counted.

*Negative control:* setting `resolve.conditions: []` makes **exactly 5 of 54 fail** — precisely the `$effect`-dependent ones. That is simultaneously proof the trap is real and proof the effects are running.

**3. CI does not get slower.** `npm test` 22.3s → 18.2s (three files left the glob). `npm run test:vitest` 2.8s. Combined 21.0s, marginally under the baseline. vitest's cost is per-process, not per-file, so further migrations add much less than linearly.

### The shims had already drifted, and nobody knew

`createRecordingStore()` forwarded with `Reflect.get(target, prop, receiver)`. The real compiler backs every `$state` with a `#private` field plus a getter, and invoking that getter with the Proxy as `this` throws `Cannot read private member #minimap`. Under the identity shim these were plain properties, so it passed.

This is the concrete form of the concern: **a shim passing is not the same as the code passing.**

### Other potholes, for the next person

- `import.meta.url` is `http://` under vitest (Vite serves the test files), so `readSource(new URL(…, import.meta.url))` dies with *The URL must be of scheme file*. The cwd-relative string form, which `readSource` already documents, works. Noted in its doc comment.
- jsdom does not fire `storage` for same-document writes (correct per spec). Tests now dispatch a real `StorageEvent`, which exercises the store's actual `addEventListener` instead of a captured callback array.
- `vite.config.js` exports an async factory, so `mergeConfig` must call it first. It merges cleanly with `sveltekit()` included — no need to drop to a bare `svelte()` plugin.
- `vitest.config.ts` was invisible to `npm run check` (tsconfig `include` listed `vite.config.*` only). Adding it immediately caught a wrong `UserConfig` import path.

### The boundary is written down, with reasons

`AGENTS.md` gains a rewritten Testing section: `*.spec.ts` when the subject is a `.svelte.ts` runes module or needs a real DOM; `*.test.ts` otherwise, because **moving a passing file buys nothing**; do not migrate `.svelte` component tests, because jsdom standing in for Monaco/mermaid/KaTeX is a swamp and *"the handler is wired up"* is weaker than what it would replace.

Then a **never-migrate** section that gives the reasoning rather than just the list:

- **Cross-language contracts** — the only thing connecting Rust to TS is the spelling; running the TS proves the TS.
- **Single-implementation conventions** — these are claims about the *absence* of a second implementation, and executing the one that exists cannot observe a second.

That is what makes the two-runner split a defensible end state rather than an unfinished migration.

### Known before rolling out further

- **`SettingsStore` discards the disposer `$effect.root` returns**, so every store a test constructs leaks live effects into that file's environment. It did not bite here, but a file that constructs stores and flushes repeatedly could see cross-test writes. The fix belongs in `src/` and should land before file #10.
- **`foldStatePerDocument.test.ts` is not in this class.** It slices functions out of a `.svelte` file with a hand-written brace matcher; a runner swap does not fix that. The subject needs extracting into a `.svelte.ts` module first.

25 files still install rune shims. Each was ~15 minutes once the config was right, and the API delta is one import line.

### Verification
- `npm test` 953 pass / 0 fail
- `npm run test:vitest` 54 pass / 0 fail
- `npm run check` 766 files / 0 errors
- No file under `src/` or `src-tauri/` was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
