### PR TITLE
fix(folds): measure a fold from its layout height, not its scrollable extent

### DIFF
--- a/scripts/foldMeasurementBatching.test.ts
+++ b/scripts/foldMeasurementBatching.test.ts
@@ -2,8 +2,8 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 // `--fold-content-height` is resolved into `height` by styles.css, so writing it
-// invalidates layout and any `scrollHeight` read that follows forces a
-// synchronous reflow. Measuring one wrapper at a time therefore costs one
+// invalidates layout and any measurement that follows forces a synchronous
+// reflow. Measuring one wrapper at a time therefore costs one
 // full-document reflow per foldable heading. There is no DOM here to time a
 // real reflow, so these tests drive the real `observeFoldLayout` through a
 // recording stand-in for the DOM and lock the structural property that makes
@@ -27,9 +27,9 @@ function createFoldRoot(specs: { id: string; height: number | null }[]) {
 			height === null
 				? null
 				: {
-						get scrollHeight() {
+						getBoundingClientRect() {
 							events.push({ type: 'read', id });
-							return height;
+							return { height };
 						},
 					};
 
@@ -130,7 +130,15 @@ test('each wrapper is measured at its natural height, not at its stale published
 	assert.deepEqual(cleared, ['outer:--fold-content-height', 'inner:--fold-content-height']);
 });
 
-test('measured heights are published rounded up, then committed by one reflow', async () => {
+// The published height used to be `Math.ceil(content.scrollHeight)`. Both
+// halves of that were wrong for maths: `scrollHeight` is the scrollable extent,
+// which KaTeX's negative margins push several pixels past the height `auto`
+// resolves to, and the rounding then threw away what precision survived. A
+// wrapper an integer taller than its content moves everything below it on every
+// keystroke, because `{@html}` rebuilds the wrapper unpublished each time.
+//
+// So a fractional measurement must reach the style property unrounded.
+test('measured heights are published at the precision they were measured', async () => {
 	const events = await runFoldLayout([
 		{ id: 'outer', height: 300 },
 		{ id: 'inner', height: 120.4 },
@@ -140,7 +148,7 @@ test('measured heights are published rounded up, then committed by one reflow', 
 		events.filter((event) => event.type === 'write'),
 		[
 			{ type: 'write', id: 'outer', value: '--fold-content-height:300px' },
-			{ type: 'write', id: 'inner', value: '--fold-content-height:121px' },
+			{ type: 'write', id: 'inner', value: '--fold-content-height:120.4px' },
 		],
 	);
 

--- a/scripts/singleImplementationConvention.test.ts
+++ b/scripts/singleImplementationConvention.test.ts
@@ -71,6 +71,14 @@ const RULES: Rule[] = [
 		allowed: [],
 	},
 	{
+		name: 'a fold height is measured from layout, not from the scrollable extent',
+		why:
+			'KaTeX stacks a display formula with negative margins and vertical-align, so its glyphs reach past the box that lays them out and `scrollHeight` reports several pixels more than `height: auto` resolves to. Writing that number into `--fold-content-height` made the wrapper taller than its content, and `{@html}` rebuilds the wrapper without the property on every keystroke — so the section paints at `auto` and then jumps. Measured on katex-stress.md at devicePixelRatio 2: prose -0.188px, a `\\mathrm` row -0.227px, grown delimiters +5.539px, nested fractions +7.133px. `getBoundingClientRect().height` takes every one of them to +0.000px.',
+		marker: /\.scrollHeight/g,
+		allowed: [],
+		dir: 'src/lib/utils',
+	},
+	{
 		name: 'YouTube links never become embedded frames',
 		why: 'The app dropped frame-src from its CSP and renders YouTube as a thumbnail anchor that opens the browser; an iframe path is the pre-fix version and cannot load.',
 		marker: /createElement\((['"])iframe\1\)/g,

--- a/src/lib/utils/foldLayout.ts
+++ b/src/lib/utils/foldLayout.ts
@@ -37,10 +37,37 @@ function updateFoldHeights(root: HTMLElement) {
 
 	if (pending.length === 0) return;
 
-	// Read pass: the first `scrollHeight` commits the cleared heights with a
-	// single reflow, and the remaining reads hit that same clean layout. No
-	// paint happens mid-task, so the cleared state is never visible.
-	const heights = pending.map(({ content }) => Math.ceil(content.scrollHeight));
+	// Read pass: the first measurement commits the cleared heights with a single
+	// reflow, and the remaining reads hit that same clean layout. No paint
+	// happens mid-task, so the cleared state is never visible.
+	//
+	// The measurement is the *layout* height, not `scrollHeight`. They are not
+	// the same number for maths. KaTeX stacks a display formula with negative
+	// margins and vertical-align, so its glyphs reach past the box that lays
+	// them out: `scrollHeight` reports the scrollable extent it needs, which is
+	// several pixels taller than the height `auto` resolves to. Writing that
+	// number back made the wrapper taller than the content it wraps.
+	//
+	// That is a visible defect, not a rounding artefact, and it fired on every
+	// keystroke: `{@html}` rebuilds the wrapper with no inline property, so it
+	// paints at `auto`, and the next frame writes the larger number and pushes
+	// everything below it down. Measured against `katex-stress.md`'s own
+	// formulas, at devicePixelRatio 2:
+	//
+	//     prose (control)               51.188 auto → 51  scrollHeight  -0.188px
+	//     `\mathrm`/`\mathit` row       25.227 auto → 25                -0.227px
+	//     grown delimiters              46.461 auto → 52                +5.539px
+	//     nested \frac + \sqrt + x^y^z  74.867 auto → 82                +7.133px
+	//
+	// which is exactly the shape of the report: the prose and short-formula
+	// sections sat still and the one with stacked fractions moved. Reading
+	// `getBoundingClientRect().height` instead takes every row to +0.000px,
+	// and keeps the sub-pixel precision `scrollHeight` rounds away.
+	//
+	// Nothing is clipped by the smaller number: both the wrapper and
+	// `.content-inner` are `overflow: visible` while expanded, and a collapsed
+	// wrapper takes `height: 0` from the more specific rule either way.
+	const heights = pending.map(({ content }) => content.getBoundingClientRect().height);
 
 	// Write pass 2: publish the measured heights without reading anything back.
 	pending.forEach(({ wrapper }, index) => {


### PR DESCRIPTION
`updateFoldHeights` published `Math.ceil(content.scrollHeight)`. Both halves of that are wrong for maths.

KaTeX stacks a display formula with negative margins and vertical-align, so its glyphs reach past the box that lays them out. **`scrollHeight` reports the scrollable extent that needs, which is several pixels more than the height `auto` resolves to** — and the rounding then discarded whatever precision had survived. The wrapper ended up taller than the content it wraps.

That is visible on **every keystroke**, because `{@html}` rebuilds the wrapper with no inline property: the section paints at `auto`, the next frame writes the larger number, and everything below it moves.

### Measured, against katex-stress.md's own formulas

Real Chromium, `devicePixelRatio: 2`, the exact CSS rules `styles.css` and `foldLayout.ts` rely on:

| content | `auto` | published | shift today | with the fix |
|---|---|---|---|---|
| prose (control) | 51.188 | 51 | −0.188px | **+0.000px** |
| a `\mathrm` / `\mathit` row | 25.227 | 25 | −0.227px | **+0.000px** |
| grown `\left(…\right)` delimiters | 46.461 | 52 | **+5.539px** | **+0.000px** |
| nested `\frac` + `\sqrt` + `x^{y^z}` | 74.867 | 82 | **+7.133px** | **+0.000px** |

That is exactly the shape of the report this came from: *"sections 2 and 3 don't jitter, section 4 does"*. Section 4 is the one with stacked fractions and grown delimiters; the prose and short-formula sections move by a fifth of a pixel and nobody sees it.

Cumulative over one document's wrappers: **17.9px today, 0.0px with the fix.**

### Nothing gets clipped

The wrapper and `.content-inner` are both `overflow: visible` while expanded, and a collapsed wrapper takes `height: 0` from the more specific `.is-collapsed` rule regardless.

### Tests

`foldMeasurementBatching.test.ts` drives the real `observeFoldLayout` through a recording DOM stand-in, and that stand-in only answered `scrollHeight` — **so it went red the moment the read changed**, which is the test doing its job. It now answers `getBoundingClientRect()` and asserts that a fractional measurement (`120.4`) reaches the style property unrounded instead of as `121px`.

A `singleImplementationConvention` row keeps `.scrollHeight` out of `src/lib/utils`, so the pre-fix form cannot come back. Falsified: reverting the measurement turns that rule red.

### Verification
- `npm test` 964 pass / 0 fail
- `npm run check` 769 files / 0 errors / 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
