### PR TITLE
fix(settings): give theme, zoom and preview width the persistence every other setting has

### DIFF
--- a/scripts/exportContentWidth.test.ts
+++ b/scripts/exportContentWidth.test.ts
@@ -376,6 +376,6 @@ test('the exporter is handed the preview\'s own derived width', () => {
 	// And `previewContentWidth` is the same derived value the live preview
 	// renders with, which is what makes "one source of truth" true rather than
 	// merely intended. (previewWidth.test.ts holds the other end of this.)
-	assert.match(viewerSource, /previewContentWidth = \$derived\(getPreviewContentWidth\(settings\.previewMaxWidth, isFullWidth\)\)/);
+	assert.match(viewerSource, /previewContentWidth = \$derived\(getPreviewContentWidth\(settings\.previewMaxWidth, settings\.previewFullWidth\)\)/);
 	assert.match(viewerSource, /--preview-max-width: \{previewContentWidth === null \? '100%' : `\$\{previewContentWidth\}px`\}/);
 });

--- a/scripts/keymapHarness.ts
+++ b/scripts/keymapHarness.ts
@@ -217,12 +217,12 @@ const FUZZ_KEYS: Array<{ keyCode: number; key: string; code: string }> = [
  * the handler's real branch structure rather than a description of it.
  *
  * ASSIGNMENTS ARE RECORDED TOO, as `name=value`. Several branches do their work
- * by writing a component variable rather than by calling anything —
- * `showSettings = true` for Mod+`,` and `zoomLevel = …` for the zoom chords —
- * and a call-only recorder reported those chords as dead. They were not; the
- * harness simply could not see them, which is the empty-iteration failure mode
- * one level down. `set` on the scope proxy used to return `true` and discard the
- * write.
+ * by writing a variable rather than by calling anything — `showSettings = true`
+ * for Mod+`,` and `settings.previewFullWidth = false` for the preview-width
+ * chords — and a call-only recorder reported those chords as dead. They were
+ * not; the harness simply could not see them, which is the empty-iteration
+ * failure mode one level down. `set` on the scope proxy used to return `true`
+ * and discard the write.
  */
 export function documentKeymap(osType: string): Map<Chord, string[]> {
 	const source = functionSource(readSource('src/lib/MarkdownViewer.svelte'), 'handleKeyDown');
@@ -250,19 +250,32 @@ export function documentKeymap(osType: string): Map<Chord, string[]> {
 
 	const known: Record<string, unknown> = {
 		// `has: () => true` below means the scope claims EVERY identifier, globals
-		// included, so `Math` has to be handed back deliberately or the zoom
-		// branches assign a recording stub instead of a number and the value they
-		// wrote becomes unreadable.
+		// included, so `Math` has to be handed back deliberately rather than
+		// answered with a recording stub.
 		Math,
 		mode: 'app',
-		settings: new Proxy({ osType }, { get: (t, k) => (k === 'osType' ? osType : record(`settings.${String(k)}`)) }),
+		// Writes to the store are recorded as well as calls: several branches do
+		// their work by assigning a settings field (`settings.previewFullWidth =
+		// false` for the preview-width chords), and without the `set` trap those
+		// chords come back as firing nothing at all — the same blind spot the
+		// scope proxy's own `set` trap fixed one level up. The trap does not write
+		// through: `get` keeps answering with a fresh stub, so nothing a chord
+		// assigns can leak into the next chord's starting state.
+		settings: new Proxy(
+			{ osType },
+			{
+				get: (t, k) => (k === 'osType' ? osType : record(`settings.${String(k)}`)),
+				set: (t, k, value) => {
+					fired.push(`settings.${String(k)}=${typeof value === 'object' ? '{…}' : String(value)}`);
+					return true;
+				},
+			},
+		),
 		showSettings: false,
 		showHome: false,
 		isEditing: false,
 		modalState: { show: false },
 		promptModal: { show: false },
-		zoomLevel: 100,
-		isFullWidth: false,
 		editorPaneEl: null,
 		document: { activeElement: null },
 		tabManager: new Proxy(

--- a/scripts/localFileLinks.test.ts
+++ b/scripts/localFileLinks.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { resolveLocalFileLinkPath } from '../src/lib/utils/localFileLinks.js';
-import { offsetOf, readSource, sliceBetween } from './sourceTree.js';
+import { functionSource, offsetOf, readSource } from './sourceTree.js';
 
 /*
  * `[data](./data.csv)` did nothing on macOS and Linux, and opened a dead page
@@ -90,7 +90,11 @@ test('a markdown link still resolves to a path, so branch order is what keeps it
 // --- wiring ------------------------------------------------------------------
 
 const viewer = readSource('src/lib/MarkdownViewer.svelte');
-const handler = sliceBetween(viewer, 'async function handleDocumentClick', 'let zoomLevel');
+// Extracted by name rather than by an anchor pair: the closing anchor used to be
+// `'let zoomLevel'`, the next declaration in the file, and it vanished the day
+// zoom moved into the settings store — an anchor whose only qualification is
+// being the next thing down is an anchor that moves for unrelated reasons.
+const handler = functionSource(viewer, 'handleDocumentClick');
 
 test('markdown targets are still claimed before the local-file branch', () => {
 	const markdown = offsetOf(handler, 'getRelativeMarkdownTarget(rawHref)');

--- a/scripts/previewWidth.test.ts
+++ b/scripts/previewWidth.test.ts
@@ -65,7 +65,7 @@ test('settings load, persist, and reset the preview width through one normalizer
 });
 
 test('preview layout derives width and ToC geometry from the same preference', () => {
-	assert.match(viewerSource, /getPreviewContentWidth\(settings\.previewMaxWidth, isFullWidth\)/);
+	assert.match(viewerSource, /getPreviewContentWidth\(settings\.previewMaxWidth, settings\.previewFullWidth\)/);
 	// The gutter arithmetic moved to `tocOverlay.ts` with #176, which added the
 	// question the inline expression could not answer: whether the pane under
 	// the outline is the preview at all. Both halves still feed on this same
@@ -89,13 +89,24 @@ test('preview width keyboard shortcuts avoid editable controls and app modals', 
 	assert.match(viewerSource, /showSettings \|\| modalState\.show \|\| promptModal\.show \|\| showHome/);
 	assert.match(viewerSource, /closest\('input, textarea, select, \[contenteditable="true"\], \[role="textbox"\]'\)/);
 	assert.match(viewerSource, /cmdOrCtrl && e\.altKey && !e\.shiftKey && \(code === 'BracketLeft' \|\| code === 'BracketRight'\)/);
-	assert.match(viewerSource, /isFullWidth = false/);
+	assert.match(viewerSource, /settings\.previewFullWidth = false/);
 	assert.match(viewerSource, /settings\.previewMaxWidth = adjustPreviewMaxWidth\(settings\.previewMaxWidth, code === 'BracketLeft' \? -40 : 40\)/);
 });
 
 test('preview full-width state migrates from the legacy localStorage key', () => {
-	assert.match(viewerSource, /localStorage\.getItem\('preview\.fullWidth'\)/);
-	assert.match(viewerSource, /localStorage\.getItem\('isFullWidth'\)/);
-	assert.match(viewerSource, /localStorage\.setItem\('preview\.fullWidth', String\(isFullWidth\)\)/);
-	assert.match(viewerSource, /localStorage\.removeItem\('isFullWidth'\)/);
+	// The pair the migration is made of, asserted on the function rather than on
+	// its call site: `??` is what makes the new key win once it exists.
+	assert.equal(getStoredPreviewFullWidth('true', null), true);
+	assert.equal(getStoredPreviewFullWidth(null, 'true'), true, 'the legacy key still decides while the new one is absent');
+	assert.equal(getStoredPreviewFullWidth('false', 'true'), false, 'the new key wins outright, it is not OR-ed with the old one');
+	assert.equal(getStoredPreviewFullWidth(null, null), false);
+
+	// It is a persisted setting like every other one now, which is what gets it
+	// cross-window sync — the viewer used to read and write `preview.fullWidth`
+	// with bare localStorage calls and no `storage` listener, so a second window
+	// only noticed after a restart. See scripts/settingsPersistence.test.ts.
+	assert.match(settingsSource, /key: 'preview\.fullWidth'/);
+	assert.match(settingsSource, /read: \(s\) => String\(s\.previewFullWidth\)/);
+	assert.match(settingsSource, /getStoredPreviewFullWidth\(raw, readStoredKey\(LEGACY_PREVIEW_FULL_WIDTH_KEY\)\)/);
+	assert.match(settingsSource, /const LEGACY_PREVIEW_FULL_WIDTH_KEY = 'isFullWidth';/);
 });

--- a/scripts/settingsPersistence.spec.ts
+++ b/scripts/settingsPersistence.spec.ts
@@ -38,6 +38,7 @@ setNavigatorLanguage('en-US');
 const settingsModule = await import('../src/lib/stores/settings.svelte.js');
 const {
 	CODE_FONT_SIZE_RANGE,
+	DEFAULT_PRE_ZEN_STATE,
 	EDITOR_FONT_SIZE_RANGE,
 	EDITOR_MAX_WIDTH_RANGE,
 	PREVIEW_FONT_SIZE_RANGE,
@@ -49,6 +50,7 @@ const {
 	isSupportedLanguage,
 	isThemeSetting,
 	isWithinRange,
+	normalizePreZenState,
 	parseStoredNumber,
 	resolveLanguageTag,
 	resolveTheme,
@@ -685,6 +687,149 @@ test('the open effect neither reads the app version nor re-enters itself', () =>
 	// so they must not be reactive.
 	assert.match(componentSource, /\n\tlet loaded = false;/);
 	assert.match(componentSource, /\n\tlet previousActiveElement: HTMLElement \| null = null;/);
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * Task 6 — the zen-mode snapshot is validated like every other stored value.
+ *
+ * `editor.preZenState` was the one entry in the table that trusted what it
+ * found: a bare `JSON.parse` straight onto the field, with a `console.error`
+ * for the only failure it considered possible. Its neighbours all validate —
+ * `normalizeEditorToolbarOrder`, `parseStoredNumber`, `isSupportedLanguage`,
+ * `raw === 'left' || raw === 'right'` — and this is the entry whose unchecked
+ * value is copied back onto six other settings the moment zen mode ends.
+ * ---------------------------------------------------------------------------
+ */
+
+/** A snapshot whose six values all differ from the store's defaults. */
+const USER_SNAPSHOT = {
+	renderLineHighlight: 'none',
+	showTabs: false,
+	statusBar: false,
+	minimap: true,
+	lineNumbers: 'off',
+	showToc: true,
+};
+
+/** Every way a stored snapshot can be unusable, as it appears in localStorage. */
+const CORRUPT_SNAPSHOTS: Record<string, string> = {
+	'a field of the wrong type': '{"renderLineHighlight":"none","showTabs":"yes","statusBar":true,"minimap":false,"lineNumbers":"on","showToc":false}',
+	'a missing field': '{"renderLineHighlight":"none","statusBar":true,"minimap":false,"lineNumbers":"on","showToc":false}',
+	'not an object': '"showTabs"',
+	'unparseable JSON': '{"showTabs":',
+};
+
+test('a stored zen snapshot is accepted only whole', () => {
+	assert.deepEqual(normalizePreZenState({ ...USER_SNAPSHOT }), USER_SNAPSHOT);
+	// Fields nobody declared are dropped rather than carried onto the store.
+	assert.deepEqual(normalizePreZenState({ ...USER_SNAPSHOT, wordWrap: 'off' }), USER_SNAPSHOT);
+
+	// One field wrong is the whole record wrong: a snapshot this version cannot
+	// read comes from a version whose other five fields it cannot vouch for
+	// either, and a half-applied restore is a state the user never had.
+	assert.equal(normalizePreZenState({ ...USER_SNAPSHOT, showTabs: 'yes' }), null);
+	assert.equal(normalizePreZenState({ ...USER_SNAPSHOT, showTabs: 1 }), null);
+	assert.equal(normalizePreZenState({ ...USER_SNAPSHOT, lineNumbers: 0 }), null);
+	assert.equal(normalizePreZenState({ ...USER_SNAPSHOT, showToc: null }), null);
+	const { showTabs, ...missingShowTabs } = USER_SNAPSHOT;
+	assert.equal(normalizePreZenState(missingShowTabs), null);
+	assert.equal(normalizePreZenState({}), null);
+
+	// And nothing that is not an object gets that far.
+	for (const value of [null, undefined, 42, 'showTabs', true, [USER_SNAPSHOT]]) {
+		assert.equal(normalizePreZenState(value), null, `${JSON.stringify(value)} is not a snapshot`);
+	}
+});
+
+test('a corrupt zen snapshot never reaches the settings it would restore', () => {
+	for (const [description, stored] of Object.entries(CORRUPT_SNAPSHOTS)) {
+		resetStorage({ 'editor.preZenState': stored });
+		const store = new SettingsStore();
+		assert.equal(store.preZenState, null, description);
+		// The store's own fields are untouched: the record was rejected before
+		// anything could be copied out of it.
+		assert.equal(store.showTabs, true, description);
+		assert.equal(store.statusBar, true, description);
+	}
+
+	resetStorage({ 'editor.preZenState': JSON.stringify(USER_SNAPSHOT) });
+	assert.deepEqual(new SettingsStore().preZenState, USER_SNAPSHOT, 'a good snapshot still survives a restart');
+});
+
+test('the tab bar comes back on leaving zen mode even when the snapshot is unusable', () => {
+	// THE BUG, end to end. Zen mode had already hidden the tab bar and written
+	// `editor.showTabs=false`; the snapshot that says how to put it back is one
+	// this version cannot read.
+	//
+	// Unvalidated, the missing-field case restored `showTabs = undefined`, whose
+	// write effect stored the *string* `"undefined"` — and `raw === 'true'` is
+	// false forever after, so the tab bar was gone on every later launch too,
+	// with only the settings dialog to bring it back.
+	for (const [description, stored] of Object.entries(CORRUPT_SNAPSHOTS)) {
+		resetStorage({
+			'editor.zenMode': 'true',
+			'editor.showTabs': 'false',
+			'editor.statusBar': 'false',
+			'editor.lineNumbers': 'off',
+			'editor.preZenState': stored,
+		});
+		const store = new SettingsStore();
+		flushSync();
+		assert.equal(store.zenMode, true, description);
+		assert.equal(store.showTabs, false, description);
+
+		store.toggleZenMode();
+		flushSync();
+
+		assert.equal(store.zenMode, false, description);
+		assert.equal(store.showTabs, true, `${description}: the tab bar is back`);
+		assert.equal(store.statusBar, true, description);
+		assert.equal(store.lineNumbers, 'on', description);
+		assert.equal(store.renderLineHighlight, 'line', description);
+		assert.equal(store.showToc, false, description);
+
+		// What was persisted is a boolean's spelling, not "undefined"...
+		assert.equal(localStorage.getItem('editor.showTabs'), 'true', description);
+		assert.equal(localStorage.getItem('editor.preZenState'), null, `${description}: the bad record is gone`);
+		// ...so the next launch keeps the tab bar instead of reading it back as false.
+		assert.equal(new SettingsStore().showTabs, true, `${description}: and it is still there after a restart`);
+	}
+});
+
+test('a good snapshot still restores what the user had, not the defaults', () => {
+	// The other half: the fallback must not be reached while there is a record
+	// to honour, or leaving zen mode would reset six settings every time.
+	resetStorage();
+	const store = new SettingsStore();
+	Object.assign(store, USER_SNAPSHOT);
+	flushSync();
+
+	store.toggleZenMode();
+	flushSync();
+	assert.equal(store.showTabs, false);
+	assert.equal(store.minimap, false, 'zen mode flattens everything, including what was already off');
+
+	// Through localStorage and a restart, the way a real session gets there.
+	const restarted = new SettingsStore();
+	assert.deepEqual(restarted.preZenState, USER_SNAPSHOT);
+	restarted.toggleZenMode();
+	assert.equal(restarted.zenMode, false);
+	for (const [field, value] of Object.entries(USER_SNAPSHOT)) {
+		assert.equal(Reflect.get(restarted, field), value, `${field} came back as the user left it`);
+	}
+	assert.equal(restarted.preZenState, null, 'the snapshot is spent once it has been restored');
+});
+
+test('the zen fallback is each setting own default', () => {
+	// DEFAULT_PRE_ZEN_STATE spells out six values the store already declares in
+	// its field initializers. This is what stops the two copies drifting.
+	resetStorage();
+	const fresh = new SettingsStore();
+	for (const [field, value] of Object.entries(DEFAULT_PRE_ZEN_STATE)) {
+		assert.equal(Reflect.get(fresh, field), value, `${field} default differs from the zen fallback`);
+	}
+	assert.equal(Object.keys(DEFAULT_PRE_ZEN_STATE).length, 6);
 });
 
 /*

--- a/scripts/settingsPersistence.spec.ts
+++ b/scripts/settingsPersistence.spec.ts
@@ -42,13 +42,16 @@ const {
 	EDITOR_MAX_WIDTH_RANGE,
 	PREVIEW_FONT_SIZE_RANGE,
 	SettingsStore,
+	ZOOM_LEVEL_RANGE,
 	clampToRange,
 	createSettingsPersistence,
 	detectSystemLanguage,
 	isSupportedLanguage,
+	isThemeSetting,
 	isWithinRange,
 	parseStoredNumber,
 	resolveLanguageTag,
+	resolveTheme,
 	stepWithinRange,
 	writeStoredSetting,
 } = settingsModule;
@@ -381,6 +384,189 @@ test('numeric setting inputs are one-way bound and commit through the clamp', ()
 		assert.match(input, /onkeydown=\{\(e\) => handleNumberKeydown\(/, `${id} does not clamp on Enter`);
 	}
 	assert.match(componentSource, /function commitNumberInput[\s\S]{0,400}input\.value = String\(next\)/);
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * Task 3b — the three values that used to write localStorage on their own.
+ *
+ * `theme`, `zoomLevel` and `preview.fullWidth` each had their own `$state` in
+ * MarkdownViewer.svelte with a bare `localStorage.setItem` beside it. What that
+ * cost is asserted below, one property per test; that no such write can come
+ * back is asserted by the `localStorage is written through one function` rule in
+ * singleImplementationConvention.test.ts.
+ * ---------------------------------------------------------------------------
+ */
+
+test('a theme picked in one window reaches the others without a restart', () => {
+	// THE BUG. Every other switch in the appearance panel synced live, because
+	// every other switch was a persisted entry and got the `storage` listener for
+	// free. The theme <select> sat in the same panel and did not: it wrote
+	// `localStorage` directly, and nothing in the app listened for `theme`.
+	resetStorage();
+	storageListeners.length = 0;
+	const store = new SettingsStore();
+	assert.equal(storageListeners.length, 1);
+	const onStorage = storageListeners[0];
+	assert.equal(store.theme, 'system');
+
+	localStorageShim.setItem('theme', 'dark');
+	onStorage({ key: 'theme', newValue: 'dark', storageArea: localStorageShim });
+	assert.equal(store.theme, 'dark');
+
+	localStorageShim.setItem('theme', 'vscode:Ayu Dark');
+	onStorage({ key: 'theme', newValue: 'vscode:Ayu Dark', storageArea: localStorageShim });
+	assert.equal(store.theme, 'vscode:Ayu Dark');
+
+	// And the arriving value is not echoed back at the window that sent it.
+	const entry = createSettingsPersistence().find((item) => item.key === 'theme') as PersistedEntry;
+	assert.equal(writeStoredSetting(entry.key, entry.read(store)), false);
+});
+
+test('the persisted theme key is the one app.html paints from', () => {
+	// The first-paint script in src/app.html reads `theme` before the bundle
+	// loads and picks the background from it; renaming the key (to
+	// `editor.theme`, say, matching its neighbours) brings back the white flash
+	// that script exists to prevent, and nothing else in the app would notice.
+	const keys = createSettingsPersistence().map((entry) => entry.key);
+	assert.ok(keys.includes('theme'), 'the theme is persisted');
+	const appHtml = readSource(new URL('../src/app.html', import.meta.url));
+	assert.match(appHtml, /localStorage\.getItem\('theme'\)/);
+});
+
+test('the startup background is told the appearance, not the theme name', () => {
+	// The fourth reader of this one setting, and the one that cannot see
+	// localStorage at all: `app.rs` paints a window's background before the
+	// webview exists, reading `theme.txt`. Its vocabulary is "dark", "light" and
+	// "anything else means ask the OS" — so every `vscode:` name fell into that
+	// last arm, and a dark VS Code theme on a light desktop flashed white on
+	// every launch. Whether such a theme is dark is inside its own JSON, which
+	// only the frontend parses, so the resolved answer is what gets sent.
+	const viewerSource = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
+	assert.match(viewerSource, /function saveStartupAppearance\(appearance: 'system' \| 'light' \| 'dark'\)/);
+	assert.match(viewerSource, /invoke\('save_theme', \{ theme: appearance \}\)/);
+	assert.equal(
+		(viewerSource.match(/invoke\('save_theme'/g) ?? []).length,
+		1,
+		'save_theme has one caller, so nothing can send it a raw theme name',
+	);
+	// The VS Code branch answers only after the parse, because that is when the
+	// appearance becomes knowable.
+	assert.match(
+		viewerSource,
+		/await parseAndApplyVscodeTheme\(json, name\);[\s\S]{0,300}?saveStartupAppearance\(document\.documentElement\.dataset\.themeType === 'dark' \? 'dark' : 'light'\)/,
+	);
+	// The viewer keeps no theme of its own beside the store's.
+	assert.doesNotMatch(viewerSource, /let theme = \$state/);
+
+	// Both words are literals in two languages with no compiler between them.
+	const appRs = readSource('src-tauri/src/app.rs');
+	assert.match(appRs, /"dark" => Some\(tauri::window::Color/);
+	assert.match(appRs, /"light" => Some\(tauri::window::Color/);
+});
+
+test('an unusable stored theme falls back rather than being applied', () => {
+	assert.equal(resolveTheme('dark'), 'dark');
+	assert.equal(resolveTheme('vscode:Ayu Dark'), 'vscode:Ayu Dark');
+	assert.equal(resolveTheme(null), 'system');
+	assert.equal(resolveTheme('midnight'), 'system');
+	// A bare `vscode:` names no theme; `theme.replace('vscode:', '')` would ask
+	// Rust to read the file called "".
+	assert.equal(resolveTheme('vscode:'), 'system');
+	assert.equal(isThemeSetting('vscode:'), false);
+	assert.equal(isThemeSetting(42), false);
+
+	resetStorage({ theme: 'midnight' });
+	assert.equal(new SettingsStore().theme, 'system');
+	resetStorage({ theme: 'vscode:Ayu Dark' });
+	assert.equal(new SettingsStore().theme, 'vscode:Ayu Dark');
+});
+
+test('a corrupt stored zoom level loads as 100, not as NaN', () => {
+	// THE BUG. The viewer read this key with `parseInt(… || '100', 10)` and no
+	// validation, so any value that is not a number became NaN — and NaN is a
+	// trap, not a glitch: the preview renders `zoom: NaN`, and both ways out
+	// (`Math.min(NaN + 10, 500)` on the wheel and on Mod+=) are NaN as well. Only
+	// the reset button could recover the app.
+	for (const stored of ['banana', 'null', '', '   ', 'NaN', 'Infinity']) {
+		resetStorage({ zoomLevel: stored });
+		const store = new SettingsStore();
+		assert.equal(store.zoomLevel, ZOOM_LEVEL_RANGE.default, `zoomLevel=${JSON.stringify(stored)}`);
+		assert.ok(Number.isFinite(store.zoomLevel));
+	}
+
+	resetStorage({ zoomLevel: '250' });
+	assert.equal(new SettingsStore().zoomLevel, 250, 'a good value still survives a restart');
+	resetStorage({ zoomLevel: '9000' });
+	assert.equal(new SettingsStore().zoomLevel, ZOOM_LEVEL_RANGE.max, 'and one out of range is clamped, not dropped');
+});
+
+test('the zoom operations are bounded by one range, and recover a corrupt level', () => {
+	// The 25/500 pair used to be written out three times (the viewer's wheel
+	// handler, its keyboard chords, and the editor's own wheel handler) beside a
+	// `100` in three more. These are the operations all of them call now.
+	assert.deepEqual(
+		{ min: ZOOM_LEVEL_RANGE.min, max: ZOOM_LEVEL_RANGE.max, step: ZOOM_LEVEL_RANGE.step, default: ZOOM_LEVEL_RANGE.default },
+		{ min: 25, max: 500, step: 10, default: 100 },
+	);
+
+	resetStorage();
+	const store = new SettingsStore();
+	store.zoomIn();
+	assert.equal(store.zoomLevel, 110);
+	store.zoomOut();
+	store.zoomOut();
+	assert.equal(store.zoomLevel, 90);
+	store.resetZoom();
+	assert.equal(store.zoomLevel, ZOOM_LEVEL_RANGE.default);
+
+	store.zoomLevel = ZOOM_LEVEL_RANGE.max;
+	store.zoomIn();
+	assert.equal(store.zoomLevel, ZOOM_LEVEL_RANGE.max, 'zooming in at the top is a no-op, not 510');
+	store.zoomLevel = ZOOM_LEVEL_RANGE.min;
+	store.zoomOut();
+	assert.equal(store.zoomLevel, ZOOM_LEVEL_RANGE.min);
+
+	// The other half of the NaN trap: a level that is already corrupt has to be
+	// escapable with the wheel, not only with the reset button.
+	store.zoomLevel = Number.NaN;
+	store.zoomIn();
+	assert.equal(store.zoomLevel, ZOOM_LEVEL_RANGE.default + ZOOM_LEVEL_RANGE.step);
+});
+
+test('zoom and preview width follow the other windows too', () => {
+	resetStorage();
+	storageListeners.length = 0;
+	const store = new SettingsStore();
+	const onStorage = storageListeners[0];
+
+	localStorageShim.setItem('zoomLevel', '150');
+	onStorage({ key: 'zoomLevel', newValue: '150', storageArea: localStorageShim });
+	assert.equal(store.zoomLevel, 150);
+
+	// Including garbage another window somehow published: the load path is the
+	// same one the constructor uses, so it validates the same way.
+	localStorageShim.setItem('zoomLevel', 'banana');
+	onStorage({ key: 'zoomLevel', newValue: 'banana', storageArea: localStorageShim });
+	assert.equal(store.zoomLevel, ZOOM_LEVEL_RANGE.default);
+
+	localStorageShim.setItem('preview.fullWidth', 'true');
+	onStorage({ key: 'preview.fullWidth', newValue: 'true', storageArea: localStorageShim });
+	assert.equal(store.previewFullWidth, true);
+	store.togglePreviewFullWidth();
+	assert.equal(store.previewFullWidth, false);
+});
+
+test('the legacy full-width key is honoured once and then superseded', () => {
+	resetStorage({ isFullWidth: 'true' });
+	assert.equal(new SettingsStore().previewFullWidth, true, 'an install upgrading from the old key keeps its setting');
+
+	// The old key is left in place rather than deleted — `read` touches one field
+	// and so cannot remove a second key — and the new one takes precedence from
+	// the first write onwards, which is how `editor.openFileMode` and
+	// `editor.autoSaveEdits` treat theirs.
+	resetStorage({ isFullWidth: 'true', 'preview.fullWidth': 'false' });
+	assert.equal(new SettingsStore().previewFullWidth, false);
 });
 
 /*

--- a/scripts/settingsPersistence.spec.ts
+++ b/scripts/settingsPersistence.spec.ts
@@ -404,18 +404,20 @@ test('a theme picked in one window reaches the others without a restart', () => 
 	// free. The theme <select> sat in the same panel and did not: it wrote
 	// `localStorage` directly, and nothing in the app listened for `theme`.
 	resetStorage();
-	storageListeners.length = 0;
 	const store = new SettingsStore();
-	assert.equal(storageListeners.length, 1);
-	const onStorage = storageListeners[0];
+	// The `storage` listener is only wired up once the effects flush.
+	flushSync();
 	assert.equal(store.theme, 'system');
 
-	localStorageShim.setItem('theme', 'dark');
-	onStorage({ key: 'theme', newValue: 'dark', storageArea: localStorageShim });
+	// A real `storage` event through the real `window`, so what is exercised is
+	// the listener the store actually registered — not a callback this test
+	// captured and called itself.
+	localStorage.setItem('theme', 'dark');
+	dispatchStorage('theme', 'dark');
 	assert.equal(store.theme, 'dark');
 
-	localStorageShim.setItem('theme', 'vscode:Ayu Dark');
-	onStorage({ key: 'theme', newValue: 'vscode:Ayu Dark', storageArea: localStorageShim });
+	localStorage.setItem('theme', 'vscode:Ayu Dark');
+	dispatchStorage('theme', 'vscode:Ayu Dark');
 	assert.equal(store.theme, 'vscode:Ayu Dark');
 
 	// And the arriving value is not echoed back at the window that sent it.
@@ -430,7 +432,7 @@ test('the persisted theme key is the one app.html paints from', () => {
 	// that script exists to prevent, and nothing else in the app would notice.
 	const keys = createSettingsPersistence().map((entry) => entry.key);
 	assert.ok(keys.includes('theme'), 'the theme is persisted');
-	const appHtml = readSource(new URL('../src/app.html', import.meta.url));
+	const appHtml = readSource('src/app.html');
 	assert.match(appHtml, /localStorage\.getItem\('theme'\)/);
 });
 
@@ -442,7 +444,7 @@ test('the startup background is told the appearance, not the theme name', () => 
 	// last arm, and a dark VS Code theme on a light desktop flashed white on
 	// every launch. Whether such a theme is dark is inside its own JSON, which
 	// only the frontend parses, so the resolved answer is what gets sent.
-	const viewerSource = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
+	const viewerSource = readSource('src/lib/MarkdownViewer.svelte');
 	assert.match(viewerSource, /function saveStartupAppearance\(appearance: 'system' \| 'light' \| 'dark'\)/);
 	assert.match(viewerSource, /invoke\('save_theme', \{ theme: appearance \}\)/);
 	assert.equal(
@@ -536,22 +538,21 @@ test('the zoom operations are bounded by one range, and recover a corrupt level'
 
 test('zoom and preview width follow the other windows too', () => {
 	resetStorage();
-	storageListeners.length = 0;
 	const store = new SettingsStore();
-	const onStorage = storageListeners[0];
+	flushSync();
 
-	localStorageShim.setItem('zoomLevel', '150');
-	onStorage({ key: 'zoomLevel', newValue: '150', storageArea: localStorageShim });
+	localStorage.setItem('zoomLevel', '150');
+	dispatchStorage('zoomLevel', '150');
 	assert.equal(store.zoomLevel, 150);
 
 	// Including garbage another window somehow published: the load path is the
 	// same one the constructor uses, so it validates the same way.
-	localStorageShim.setItem('zoomLevel', 'banana');
-	onStorage({ key: 'zoomLevel', newValue: 'banana', storageArea: localStorageShim });
+	localStorage.setItem('zoomLevel', 'banana');
+	dispatchStorage('zoomLevel', 'banana');
 	assert.equal(store.zoomLevel, ZOOM_LEVEL_RANGE.default);
 
-	localStorageShim.setItem('preview.fullWidth', 'true');
-	onStorage({ key: 'preview.fullWidth', newValue: 'true', storageArea: localStorageShim });
+	localStorage.setItem('preview.fullWidth', 'true');
+	dispatchStorage('preview.fullWidth', 'true');
 	assert.equal(store.previewFullWidth, true);
 	store.togglePreviewFullWidth();
 	assert.equal(store.previewFullWidth, false);

--- a/scripts/shortcutRegistry.test.ts
+++ b/scripts/shortcutRegistry.test.ts
@@ -218,27 +218,42 @@ test('the native accelerator the registry defers to is the one the Rust menu cla
 	assert.equal(checked, 2, 'Quit and Settings are the two entries the native menu also claims');
 });
 
-test('zoom in raises the level, zoom out lowers it, and reset returns to the default', () => {
-	// All three zoom chords work by assigning `zoomLevel`, so the contract test
-	// above can only prove they reach the zoom code — not that + and − are the
-	// right way round. The harness records the value written, which is what
-	// tells them apart.
+test('each zoom chord reaches its own zoom operation, not just the zoom code', () => {
+	// All three zoom chords land in the same three lines of `handleKeyDown`, so
+	// the contract test above can only prove they reach the zoom code — not that
+	// + and − are the right way round. What tells them apart is which store
+	// method each one calls.
+	//
+	// This used to read the number the chord assigned to a local `zoomLevel`,
+	// because the arithmetic lived in the handler. It lives in the store now, so
+	// the two halves of the claim are checked where each one is: that zoomIn
+	// really raises the level and resetZoom really returns to ZOOM_LEVEL_RANGE's
+	// default is asserted against the real store in settingsPersistence.test.ts,
+	// and what is left here — which chord asks for which — is the half only the
+	// keymap can answer.
+	const operations: Array<[string, string]> = [
+		['view-zoom-in', 'settings.zoomIn'],
+		['view-zoom-out', 'settings.zoomOut'],
+		['view-zoom-reset', 'settings.resetZoom'],
+	];
+
 	for (const platform of PLATFORMS) {
 		const keymap = documentKeymap(platform.osType);
-		const modifier = platform.mac ? 'Meta' : 'Ctrl';
-		const valueOf = (id: string): number => {
+		for (const [id, operation] of operations) {
 			const entry = SHORTCUTS.find((e) => e.id === id)!;
 			const fired = keymap.get(toMonacoLabel(entry.chords[0], platform.mac));
 			assert.ok(fired, `${id} answers on ${platform.name}`);
-			const write = fired.find((call) => call.startsWith('zoomLevel='));
-			assert.ok(write, `${id} writes zoomLevel on ${platform.name}; recorded ${fired.join(', ')}`);
-			return Number(write.slice('zoomLevel='.length));
-		};
-
-		// The harness starts every chord from zoomLevel = 100.
-		assert.ok(valueOf('view-zoom-in') > 100, `${modifier}+= zooms in on ${platform.name}`);
-		assert.ok(valueOf('view-zoom-out') < 100, `${modifier}+- zooms out on ${platform.name}`);
-		assert.equal(valueOf('view-zoom-reset'), 100, `${modifier}+0 resets zoom on ${platform.name}`);
+			assert.ok(
+				fired.includes(operation),
+				`${id} must run ${operation}() on ${platform.name}; recorded ${fired.join(', ')}`,
+			);
+			// And nothing else: a chord that called two of the three would satisfy
+			// its own row above while quietly undoing another one.
+			for (const [, other] of operations) {
+				if (other === operation) continue;
+				assert.ok(!fired.includes(other), `${id} also runs ${other}() on ${platform.name}`);
+			}
+		}
 	}
 });
 
@@ -471,10 +486,16 @@ function commandOf(call: string): string {
 /**
  * Commands the document handler can reach that are deliberately not advertised.
  *
- * Empty today, and that is the point: everything the keyboard can reach is in
- * the panel. A new branch has to be listed here with a reason, or shown.
+ * One entry, and it is a second write inside a branch that IS advertised rather
+ * than a chord of its own: everything the keyboard can *reach* is in the panel.
+ * A new branch has to be listed here with a reason, or shown.
  */
-const DOCUMENT_NOT_ADVERTISED: Record<string, string> = {};
+const DOCUMENT_NOT_ADVERTISED: Record<string, string> = {
+	'settings.previewFullWidth=':
+		'The preview-width chords (view-preview-width) turn full-width off before they narrow or widen ' +
+		'the preview, so this write is half of that one shortcut. No chord toggles full width on its own; ' +
+		'the title bar button does.',
+};
 
 /** Native menu accelerators deliberately not advertised. Also empty today. */
 const NATIVE_NOT_ADVERTISED: Record<string, string> = {};

--- a/scripts/singleImplementationConvention.test.ts
+++ b/scripts/singleImplementationConvention.test.ts
@@ -191,6 +191,28 @@ const RULES: Rule[] = [
 		allowed: ['src/lib/utils/foldState.ts'],
 	},
 	{
+		name: 'localStorage is written through one function',
+		why: "Every window is a separate webview over one shared localStorage, so a persisted value needs compare-and-set on write and a `storage` listener to fold in what the other windows did — `writeStoredSetting` and `installPersistedSettings` in settings.svelte.ts are both. Three values were written with a bare `setItem` outside that: `theme` (changed in one window's settings panel, ignored by every other window until restart, while every switch beside it in the same panel synced live), `zoomLevel` (read back with a bare `parseInt`, so a corrupt key rendered `zoom: NaN` and `Math.min(NaN + 10, 500)` left the wheel and the chords unable to recover it), and `preview.fullWidth`. A bare `setItem` IS the defect: it is the write that no listener answers and no range validates.",
+		// The call, so the `typeof localStorage.setItem === 'function'` guards do
+		// not match. `utils/recentFiles.ts` is deliberately absent rather than
+		// allowed: it keeps its own read-modify-write and its own `storage`
+		// listener — correct, because the recent list is a collection every window
+		// appends to rather than a scalar preference — but its write already goes
+		// through `writeStoredSetting`, so it does not match this marker at all.
+		marker: /localStorage\.setItem\s*\(/g,
+		allowed: [
+			'src/lib/stores/settings.svelte.ts',
+			// KNOWN GAP, not an exemption. `editor.splitScrollSync` is a scalar
+			// preference like any other and belongs in `createSettingsPersistence`;
+			// it is listed only because collecting it means editing the tab store,
+			// which was out of the blast radius of the change that added this rule.
+			// It has the milder half of the same defect: one key, one write, so it
+			// cannot clobber its neighbours, but no listener, so a second window
+			// keeps its own answer until it restarts. Delete this line when it moves.
+			'src/lib/stores/tabs.svelte.ts',
+		],
+	},
+	{
 		name: 'this suite reads a file through one function',
 		why: "A test that reads source with its own readFileSync gets the bytes Git checked out, and on Windows `core.autocrlf` makes those CRLF. Every `\\n` in a pattern then matches nothing and every anchor containing one is 'not found' — fifteen files were red on the maintainer's Windows checkout while cutting v2.7.0 and were hand-patched assertion by assertion (#452). `readSource` in sourceTree.ts decides the line ending once, on read, so the assertions stay written against `\\n` and a new test cannot re-open the hole by accident. Read the file with `readSource(path)` from './sourceTree.js' — it takes a cwd-relative string or a `new URL(…, import.meta.url)` — and write the assertion against `\\n`.",
 		// The call, not the import: `import { readFileSync }` on its own reads

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -187,6 +187,12 @@ pub fn run() {
             let theme_pref =
                 fs::read_to_string(theme_path).unwrap_or_else(|_| "system".to_string());
 
+            // An APPEARANCE, written by `save_theme` — see the note there. It
+            // used to be the raw theme setting, which meant every `vscode:<name>`
+            // theme landed in the fallback arm below and asked the OS instead: a
+            // dark VS Code theme on a light desktop flashed a white window on
+            // every launch. A file left over from that older format still lands
+            // there, and self-corrects as soon as the frontend applies its theme.
             let bg_color = match theme_pref.as_str() {
                 "dark" => Some(tauri::window::Color(24, 24, 24, 255)),
                 "light" => Some(tauri::window::Color(253, 253, 253, 255)),

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -369,6 +369,15 @@ pub async fn watch_file(
     .unwrap_or_else(|e| Err(e.to_string()))
 }
 
+/// Records what colour the NEXT window should be painted before it has a webview.
+///
+/// The argument is an appearance — `"dark"`, `"light"` or `"system"` — and not
+/// the theme the user picked. The theme itself is a frontend setting that lives
+/// in `localStorage`, and one of its forms, `vscode:<name>`, is dark or light
+/// according to a `type` field inside an imported JSON file. Resolving that here
+/// would mean a second theme parser in Rust; the frontend has already parsed the
+/// file by the time it applies the theme, so it sends the answer instead.
+/// `app.rs` is the only reader — see the background colour it picks at startup.
 #[tauri::command]
 pub fn save_theme(app: AppHandle, theme: String) -> Result<(), String> {
     let config_dir = app.path().app_config_dir().map_err(|e| e.to_string())?;

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -102,14 +102,14 @@ import {
 	import HomePage from './components/HomePage.svelte';
 import { tabManager, type Tab } from './stores/tabs.svelte.js';
 import { snapshotTab } from './utils/tabTransfer.js';
-import { adjustPreviewMaxWidth, getPreviewContentWidth, getStoredPreviewFullWidth } from './utils/previewWidth.js';
+import { adjustPreviewMaxWidth, getPreviewContentWidth } from './utils/previewWidth.js';
 import { isTocOverhanging } from './utils/tocOverlay.js';
 import {
 	getScrollSyncPositionFromPixels,
 	getScrollTopForSyncPosition,
 	type ScrollSyncPosition,
 } from './utils/scrollSync.js';
-import { settings, TOC_WIDTH_RANGE } from './stores/settings.svelte.js';
+import { resolveTheme, settings, TOC_WIDTH_RANGE } from './stores/settings.svelte.js';
 import { t } from './utils/i18n.js';
 import { formatChord } from './utils/shortcuts.js';
 import { createWindowSession } from './sessions/windowSession.svelte.js';
@@ -320,10 +320,6 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	let isAtBottom = $state(false);
 
 	let showHome = $state(false);
-	let isFullWidth = $state(getStoredPreviewFullWidth(
-		localStorage.getItem('preview.fullWidth'),
-		localStorage.getItem('isFullWidth'),
-	));
 	let viewerWidth = $state(0);
 	// The bounds come from TOC_WIDTH_RANGE, the same object settings.setTocWidth
 	// clamps against, so the handle cannot offer a width persistence would shrink.
@@ -333,23 +329,18 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	let isTocResizing = $state(false);
 	let tocWrapperEl = $state<HTMLElement | null>(null);
 	let tocToggleEl = $state<HTMLElement | null>(null);
-	let previewContentWidth = $derived(getPreviewContentWidth(settings.previewMaxWidth, isFullWidth));
+	let previewContentWidth = $derived(getPreviewContentWidth(settings.previewMaxWidth, settings.previewFullWidth));
 	let isOverhanging = $derived(
 		isTocOverhanging({
 			isEditing,
 			isSplit,
 			tocSide: settings.tocSide,
-			isFullWidth,
+			isFullWidth: settings.previewFullWidth,
 			viewerWidth,
 			previewContentWidth,
 			tocWidth: settings.tocWidth,
 		}),
 	);
-
-	$effect(() => {
-		localStorage.setItem('preview.fullWidth', String(isFullWidth));
-		localStorage.removeItem('isFullWidth');
-	});
 
 	/**
 	 * Reaching past a floating outline to touch what it is covering is a request
@@ -375,19 +366,31 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 
 	import { parseAndApplyVscodeTheme, clearVscodeTheme } from './utils/theme';
 
-	// Theme State
-	let theme = $state<string>('system');
-
 	onMount(() => {
-		const storedTheme = localStorage.getItem('theme');
-		if (storedTheme) theme = storedTheme;
 		// Clear the forced background color from app.html
 		document.documentElement.style.removeProperty('background-color');
 	});
 
+	/**
+	 * What Rust should paint the next window's background before any webview
+	 * exists — the appearance, not the theme.
+	 *
+	 * `theme.txt` is read in exactly one place (`app.rs`, at window creation) and
+	 * for exactly one purpose, and its vocabulary there is "dark", "light" and
+	 * "anything else means ask the OS". A `vscode:` name fell into that last
+	 * branch, so choosing a dark VS Code theme on a light desktop flashed a white
+	 * window on every launch. Whether such a theme is dark is knowable only after
+	 * its JSON has been parsed — which happens here — so the resolved answer is
+	 * what gets stored, instead of a name Rust would have to learn to parse.
+	 */
+	function saveStartupAppearance(appearance: 'system' | 'light' | 'dark') {
+		invoke('save_theme', { theme: appearance }).catch(console.error);
+	}
+
 	$effect(() => {
-		localStorage.setItem('theme', theme);
-		invoke('save_theme', { theme }).catch(console.error);
+		// Persistence and cross-window sync belong to the settings store; this
+		// effect is only the part that cannot: applying the theme to the document.
+		const theme = settings.theme;
 
 		if (theme === 'system' || theme === 'light' || theme === 'dark') {
 			if (theme === 'system') {
@@ -398,19 +401,23 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 				document.documentElement.dataset.themeType = theme;
 			}
 			clearVscodeTheme();
+			saveStartupAppearance(theme);
 			const monaco = (window as any).monaco;
 			if (monaco && monaco.editor) {
 				const isSystemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 				const effectiveTheme = theme === 'system' ? (isSystemDark ? 'dark' : 'light') : theme;
 				monaco.editor.setTheme(effectiveTheme === 'dark' ? 'vs-dark' : 'vs');
 			}
-		} else if (theme.startsWith('vscode:')) {
+		} else {
 			const name = theme.replace('vscode:', '');
-			invoke('read_vscode_theme', { name }).then((json: any) => {
-				parseAndApplyVscodeTheme(json, name);
+			invoke('read_vscode_theme', { name }).then(async (json: any) => {
+				await parseAndApplyVscodeTheme(json, name);
+				// `parseAndApplyVscodeTheme` decides dark vs. light from the theme's
+				// own `type` field and publishes it here.
+				saveStartupAppearance(document.documentElement.dataset.themeType === 'dark' ? 'dark' : 'light');
 			}).catch(e => {
 				console.error("Failed to load vscode theme", e);
-				theme = 'system';
+				settings.theme = 'system';
 			});
 		}
 
@@ -1062,7 +1069,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 
 	function currentMermaidTheme() {
 		return resolveMermaidTheme({
-			theme,
+			theme: settings.theme,
 			datasetThemeType: document.documentElement.dataset.themeType,
 			systemPrefersDark: window.matchMedia('(prefers-color-scheme: dark)').matches,
 		});
@@ -2598,18 +2605,12 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		}
 	}
 
-	let zoomLevel = $state(parseInt(localStorage.getItem('zoomLevel') || '100', 10));
-
-	$effect(() => {
-		localStorage.setItem('zoomLevel', String(zoomLevel));
-	});
-
 	function handleWheel(e: WheelEvent) {
 		if (e.ctrlKey || e.metaKey) {
 			if (e.deltaY < 0) {
-				zoomLevel = Math.min(zoomLevel + 10, 500);
+				settings.zoomIn();
 			} else {
-				zoomLevel = Math.max(zoomLevel - 10, 25);
+				settings.zoomOut();
 			}
 		}
 	}
@@ -2731,7 +2732,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		if (cmdOrCtrl && e.altKey && !e.shiftKey && (code === 'BracketLeft' || code === 'BracketRight')) {
 			if (!canUsePreviewWidthShortcut(e.target, !!isSplit)) return;
 			e.preventDefault();
-			isFullWidth = false;
+			settings.previewFullWidth = false;
 			settings.previewMaxWidth = adjustPreviewMaxWidth(settings.previewMaxWidth, code === 'BracketLeft' ? -40 : 40);
 			return;
 		}
@@ -2856,15 +2857,15 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		}
 		if (cmdOrCtrl && (key === '=' || key === '+')) {
 			e.preventDefault();
-			zoomLevel = Math.min(zoomLevel + 10, 500);
+			settings.zoomIn();
 		}
 		if (cmdOrCtrl && key === '-') {
 			e.preventDefault();
-			zoomLevel = Math.max(zoomLevel - 10, 25);
+			settings.zoomOut();
 		}
 		if (cmdOrCtrl && key === '0') {
 			e.preventDefault();
-			zoomLevel = 100;
+			settings.resetZoom();
 		}
 		if (cmdOrCtrl && key === ',') {
 			e.preventDefault();
@@ -3444,7 +3445,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		{liveMode}
 		windowTitle="Markpad"
 		showHome={false}
-		{zoomLevel}
+		zoomLevel={settings.zoomLevel}
 		onselectFile={selectFile}
 		onnewFile={handleNewFile}
 		onopenFile={selectFile}
@@ -3463,11 +3464,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		{isEditing}
 		ondetach={handleDetach}
 		ontabclick={() => (showHome = false)}
-		onresetZoom={() => (zoomLevel = 100)}
-		{isFullWidth}
-		ontoggleFullWidth={() => (isFullWidth = !isFullWidth)}
-		{theme}
-		onSetTheme={(t) => (theme = t)}
+		onresetZoom={() => settings.resetZoom()}
+		isFullWidth={settings.previewFullWidth}
+		ontoggleFullWidth={() => settings.togglePreviewFullWidth()}
+		theme={settings.theme}
+		onSetTheme={(t: string) => (settings.theme = resolveTheme(t))}
 		onopenSettings={() => (showSettings = true)}
 		onfind={triggerFindAction}
 		oncloseTab={closeTabAndWindowIfLast} />
@@ -3484,7 +3485,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		{liveMode}
 		{windowTitle}
 		{showHome}
-		{zoomLevel}
+		zoomLevel={settings.zoomLevel}
 		onselectFile={selectFile}
 		onnewFile={handleNewFile}
 		onopenFile={selectFile}
@@ -3504,13 +3505,13 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		{isEditing}
 		ondetach={handleDetach}
 		ontabclick={() => (showHome = false)}
-		onresetZoom={() => (zoomLevel = 100)}
+		onresetZoom={() => settings.resetZoom()}
 		{isScrollSynced}
 		ontoggleSync={() => tabManager.activeTabId && tabManager.toggleScrollSync(tabManager.activeTabId)}
-		{isFullWidth}
-		ontoggleFullWidth={() => (isFullWidth = !isFullWidth)}
-		{theme}
-		onSetTheme={(t) => (theme = t)}
+		isFullWidth={settings.previewFullWidth}
+		ontoggleFullWidth={() => settings.togglePreviewFullWidth()}
+		theme={settings.theme}
+		onSetTheme={(t: string) => (settings.theme = resolveTheme(t))}
 		onopenSettings={() => (showSettings = true)}
 		onfind={triggerFindAction}
 		canGoBack={canGoBackInFileHistory}
@@ -3519,7 +3520,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		onforward={() => navigateFileHistory('forward')}
 		oncloseTab={closeTabAndWindowIfLast} />
 
-	<Settings show={showSettings} {theme} onSetTheme={(t) => (theme = t)} onclose={() => (showSettings = false)} />
+	<Settings show={showSettings} theme={settings.theme} onSetTheme={(t) => (settings.theme = t)} onclose={() => (showSettings = false)} />
 
 	{#if activeExternalChangeConflict && !showHome}
 		<div class="external-change-bar" role="status">
@@ -3536,7 +3537,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	{#if tabManager.activeTab && !isHomePath(tabManager.activeTab.path) && !showHome}
 			<div
 				class="markdown-container"
-				style="zoom: {isEditing && !isSplit ? 1 : zoomLevel / 100}; --code-font: {settings.codeFont}, monospace; --code-font-size: {settings.codeFontSize}px; --highlight-color: {highlightColorMap[settings.highlightColor] || highlightColorMap.yellow};"
+				style="zoom: {isEditing && !isSplit ? 1 : settings.zoomLevel / 100}; --code-font: {settings.codeFont}, monospace; --code-font-size: {settings.codeFontSize}px; --highlight-color: {highlightColorMap[settings.highlightColor] || highlightColorMap.yellow};"
 				onwheel={handleWheel}
 				role="presentation">
 				<div class="layout-container" 
@@ -3578,9 +3579,9 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 								bind:this={editorPane}
 								value={tabManager.activeTab.rawContent}
 								language={editorLanguage}
-								{theme}
+								theme={settings.theme}
 								onsave={saveContent}
-								bind:zoomLevel
+								zoomLevel={settings.zoomLevel}
 								onnew={handleNewFile}
 								onopen={selectFile}
 								onclose={closeFile}
@@ -3622,7 +3623,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 								<article
 									bind:this={markdownBody}
 									contenteditable="false"
-									class="markdown-body {isFullWidth ? 'full-width' : ''} {settings.showToc ? 'toc-active' : ''}"
+									class="markdown-body {settings.previewFullWidth ? 'full-width' : ''} {settings.showToc ? 'toc-active' : ''}"
 									onscroll={handleScroll}
 									onclick={handleLinkClick}
 									onchange={handleTaskCheckboxChange}

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -60,7 +60,10 @@
 		onprevTab,
 		onundoClose,
 		onscrollsync,
-		zoomLevel = $bindable(100),
+		// Read-only now: the wheel handler below changes the zoom through the
+		// settings store, which is what persists it and syncs it across windows,
+		// so there is no longer a value for the parent to bind back to.
+		zoomLevel = 100,
 		theme = "system",
 	} = $props<{
 		value: string;
@@ -549,9 +552,9 @@
 				e.preventDefault();
 				e.stopPropagation();
 				if (e.deltaY < 0) {
-					zoomLevel = Math.min(zoomLevel + 10, 500);
+					settings.zoomIn();
 				} else {
-					zoomLevel = Math.max(zoomLevel - 10, 25);
+					settings.zoomOut();
 				}
 			}
 		};

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -7,6 +7,7 @@
 		clampToRange,
 		isWithinRange,
 		parseStoredNumber,
+		resolveTheme,
 		stepWithinRange,
 		CODE_FONT_SIZE_RANGE,
 		DEFAULT_FONTS,
@@ -15,6 +16,7 @@
 		PREVIEW_FONT_SIZE_RANGE,
 		type NumericSettingRange,
 		type OSType,
+		type ThemeSetting,
 	} from '../stores/settings.svelte.js';
 	import { updateStore } from '../stores/update.svelte.js';
 	import { fade, scale, fly } from 'svelte/transition';
@@ -35,7 +37,7 @@
 		theme = 'system',
 		onSetTheme,
 		onclose,
-	} = $props<{ show?: boolean; theme?: string; onSetTheme?: (t: string) => void; onclose: () => void }>();
+	} = $props<{ show?: boolean; theme?: ThemeSetting; onSetTheme?: (t: ThemeSetting) => void; onclose: () => void }>();
 
 	let activeCategory = $state<'editor' | 'preview' | 'appearance' | 'toolbars' | 'files' | 'shortcuts'>('editor');
 	let highlightMenuOpen = $state(false);
@@ -671,10 +673,10 @@
 		if (!themeImportUrl) return;
 		importingTheme = true;
 		try {
-			const name = await invoke('fetch_vscode_theme', { url: themeImportUrl });
+			const name = await invoke<string>('fetch_vscode_theme', { url: themeImportUrl });
 			themeImportUrl = '';
 			await loadVscodeThemes();
-			onSetTheme?.(`vscode:${name}` as any);
+			onSetTheme?.(`vscode:${name}`);
 		} catch (e) {
 			console.error('Failed to import theme:', e);
 			alert(`Failed to import theme: ${e}`);
@@ -1251,7 +1253,7 @@
 						<div class="setting-item">
 							<label for="appearance-theme">{t('settings.theme', settings.language)}</label>
 							<div class="select-wrapper">
-								<select id="appearance-theme" value={theme} onchange={(e) => onSetTheme?.(e.currentTarget.value as any)}>
+								<select id="appearance-theme" value={theme} onchange={(e) => onSetTheme?.(resolveTheme(e.currentTarget.value))}>
 									<option value="system">{t('settings.themeFollowSystem', settings.language)}</option>
 									<option value="light">{t('settings.themeDefaultLight', settings.language)}</option>
 									<option value="dark">{t('settings.themeDefaultDark', settings.language)}</option>

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -29,6 +29,7 @@ import {
 } from '../utils/titlebarToolbar.js';
 import {
 	DEFAULT_PREVIEW_MAX_WIDTH,
+	getStoredPreviewFullWidth,
 	normalizePreviewMaxWidth,
 } from '../utils/previewWidth.js';
 import { getSupportedLanguages, type LanguageCode } from '../utils/i18n.js';
@@ -36,6 +37,34 @@ import { getSupportedLanguages, type LanguageCode } from '../utils/i18n.js';
 export type OSType = 'macos' | 'windows' | 'linux' | 'unknown';
 
 export type { LanguageCode };
+
+/**
+ * Everything the appearance `<select>` can be set to: the three built-ins plus
+ * one entry per imported VS Code theme, whose names are user data and so cannot
+ * be enumerated here.
+ *
+ * A union rather than `string` for the same reason {@link LanguageCode} is one —
+ * `theme` crosses four modules (the viewer's effect, the title bar menu, the
+ * settings dialog and `save_theme`), and while it was a bare `string` the
+ * dialog needed two `as any` casts to hand a value back.
+ */
+export type ThemeSetting = 'system' | 'light' | 'dark' | `vscode:${string}`;
+
+export const DEFAULT_THEME: ThemeSetting = 'system';
+
+export function isThemeSetting(value: unknown): value is ThemeSetting {
+	if (value === 'system' || value === 'light' || value === 'dark') return true;
+	return typeof value === 'string' && value.startsWith('vscode:') && value.length > 'vscode:'.length;
+}
+
+/**
+ * Coerces a raw string — from localStorage, from a `<select>`, from a sibling
+ * window's `storage` event — to a theme. Anything unrecognised is the default
+ * rather than an error: a theme the app cannot apply must not stop it starting.
+ */
+export function resolveTheme(value: unknown): ThemeSetting {
+	return isThemeSetting(value) ? value : DEFAULT_THEME;
+}
 
 /**
  * The codes `isSupportedLanguage` will accept out of persisted storage, taken
@@ -174,6 +203,14 @@ export const PREVIEW_FONT_SIZE_RANGE: NumericSettingRange = { min: 12, max: 48, 
 export const CODE_FONT_SIZE_RANGE: NumericSettingRange = { min: 10, max: 48, step: 1, default: 14 };
 export const EDITOR_MAX_WIDTH_RANGE: NumericSettingRange = { min: 20, max: 500, step: 10, default: 80 };
 export const TOC_WIDTH_RANGE: NumericSettingRange = { min: 180, max: 420, step: 1, default: 240 };
+// The preview zoom factor, as a percentage. The 25/500 pair used to be written
+// out three times — the wheel handler and the keyboard chords in
+// MarkdownViewer.svelte and the editor's own wheel handler — beside a `100` in
+// three more places, and the stored value was read with a bare `parseInt` that
+// let a corrupt key through as NaN. `Math.min(NaN + 10, 500)` is NaN too, so
+// once that happened neither the wheel nor the chords could get back out; the
+// preview rendered `zoom: NaN` until the reset button was found.
+export const ZOOM_LEVEL_RANGE: NumericSettingRange = { min: 25, max: 500, step: 10, default: 100 };
 
 /** True when `value` is a finite number the user is allowed to commit as-is. */
 export function isWithinRange(value: unknown, range: NumericSettingRange): boolean {
@@ -206,6 +243,7 @@ export function stepWithinRange(current: unknown, delta: number, range: NumericS
 }
 
 const LEGACY_START_IN_EDITOR_KEY = 'editor.startInEditor';
+const LEGACY_PREVIEW_FULL_WIDTH_KEY = 'isFullWidth';
 const LEGACY_AUTO_SAVE_KEY = 'editor.autoSave';
 const LEGACY_CONFIRM_BEFORE_SAVE_KEY = 'editor.confirmBeforeSave';
 
@@ -356,6 +394,11 @@ export class SettingsStore {
 	showRecentFiles = $state(true);
 	editorMaxWidth = $state(80);
 	previewMaxWidth = $state(DEFAULT_PREVIEW_MAX_WIDTH);
+	// Preview ignores previewMaxWidth and fills the pane.
+	previewFullWidth = $state(false);
+	// Preview zoom, in percent. See ZOOM_LEVEL_RANGE.
+	zoomLevel = $state(ZOOM_LEVEL_RANGE.default);
+	theme = $state<ThemeSetting>(DEFAULT_THEME);
 	pinnedToc = $state(false);
 	tocSide = $state<'left' | 'right'>('left');
 	tocWidth = $state(240);
@@ -605,6 +648,27 @@ export class SettingsStore {
 		this.previewMaxWidth = DEFAULT_PREVIEW_MAX_WIDTH;
 	}
 
+	togglePreviewFullWidth() {
+		this.previewFullWidth = !this.previewFullWidth;
+	}
+
+	// The three zoom operations live here rather than at the four keyboard and
+	// wheel handlers that used to spell them out, so ZOOM_LEVEL_RANGE is the only
+	// place the bounds and the neutral factor exist. `stepWithinRange` also
+	// re-clamps the *current* value, which is what makes a corrupt zoomLevel
+	// recoverable by any of them instead of only by the reset button.
+	zoomIn() {
+		this.zoomLevel = stepWithinRange(this.zoomLevel, ZOOM_LEVEL_RANGE.step, ZOOM_LEVEL_RANGE);
+	}
+
+	zoomOut() {
+		this.zoomLevel = stepWithinRange(this.zoomLevel, -ZOOM_LEVEL_RANGE.step, ZOOM_LEVEL_RANGE);
+	}
+
+	resetZoom() {
+		this.zoomLevel = ZOOM_LEVEL_RANGE.default;
+	}
+
 	async initOSType() {
 		try {
 			const osType = await invoke<string>('get_os_type');
@@ -714,6 +778,21 @@ export function createSettingsPersistence(): PersistedSetting<SettingsStore>[] {
 			read: (s) => String(s.previewMaxWidth),
 			load: (s, savedPreviewMaxWidth) => { s.previewMaxWidth = normalizePreviewMaxWidth(savedPreviewMaxWidth); },
 		},
+		{
+			key: 'preview.fullWidth',
+			read: (s) => String(s.previewFullWidth),
+			// The second key is read, never written: it is the name this setting
+			// had before, and it is what an existing install still has on the
+			// first launch after the upgrade. The write effect seeds the new key
+			// immediately, and `??` prefers it, so the legacy one stops being
+			// consulted after that — the same treatment `editor.openFileMode` and
+			// `editor.autoSaveEdits` give theirs. It used to be deleted here
+			// instead, which a `read` that touches one field cannot do.
+			load: (s, raw) => {
+				s.previewFullWidth = getStoredPreviewFullWidth(raw, readStoredKey(LEGACY_PREVIEW_FULL_WIDTH_KEY));
+			},
+		},
+		numberSetting('zoomLevel', ZOOM_LEVEL_RANGE, (s) => s.zoomLevel, (s, v) => { s.zoomLevel = v; }),
 		booleanSetting('editor.pinnedToc', (s) => s.pinnedToc, (s, v) => { s.pinnedToc = v; }),
 		{
 			key: 'editor.tocSide',
@@ -735,6 +814,15 @@ export function createSettingsPersistence(): PersistedSetting<SettingsStore>[] {
 					s.language = raw;
 				}
 			},
+		},
+		{
+			// Unprefixed, because that is the key `src/app.html` reads in its
+			// first-paint script to pick a background colour before the bundle
+			// loads. Renaming it would reintroduce the white flash that script
+			// exists to prevent.
+			key: 'theme',
+			read: (s) => s.theme,
+			load: (s, raw) => { s.theme = resolveTheme(raw); },
 		},
 		booleanSetting('editor.showEditorToolbar', (s) => s.showEditorToolbar, (s, v) => { s.showEditorToolbar = v; }),
 		{

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -273,6 +273,60 @@ function parseStoredRecord(value: string | null): Record<string, unknown> | null
 }
 
 /**
+ * The six settings zen mode flattens, as they were the moment it was entered.
+ * `null` means "no snapshot": either zen mode is off, or the stored one could
+ * not be trusted.
+ */
+export interface PreZenState {
+	renderLineHighlight: string;
+	showTabs: boolean;
+	statusBar: boolean;
+	minimap: boolean;
+	lineNumbers: string;
+	showToc: boolean;
+}
+
+/**
+ * What leaving zen mode restores when there is no snapshot to restore from.
+ *
+ * These are the same six values the store's own field initializers use — pinned
+ * against drift by a test — because "the setting's own default" is the only
+ * answer available once the record of what the user had is gone.
+ */
+export const DEFAULT_PRE_ZEN_STATE: PreZenState = {
+	renderLineHighlight: 'line',
+	showTabs: true,
+	statusBar: true,
+	minimap: false,
+	lineNumbers: 'on',
+	showToc: false,
+};
+
+/**
+ * Validates a parsed `editor.preZenState`, the way every other entry in
+ * {@link createSettingsPersistence} validates its own raw value.
+ *
+ * All six fields or none. A snapshot missing a field, or carrying one of the
+ * wrong type, comes from a version of Markpad this one cannot interpret, and
+ * half-applying it produces a state the user never had — so it is rejected
+ * whole and zen mode leaves through {@link DEFAULT_PRE_ZEN_STATE} instead.
+ *
+ * The unvalidated `JSON.parse` this replaces is how the tab bar could vanish
+ * for good: a snapshot with no `showTabs` restored `showTabs = undefined`, the
+ * write effect stored the string `"undefined"`, and every later launch read
+ * that back as `false` with no way out but the settings dialog.
+ */
+export function normalizePreZenState(value: unknown): PreZenState | null {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+	const record = value as Record<string, unknown>;
+	const { renderLineHighlight, showTabs, statusBar, minimap, lineNumbers, showToc } = record;
+	if (typeof renderLineHighlight !== 'string' || typeof lineNumbers !== 'string') return null;
+	if (typeof showTabs !== 'boolean' || typeof statusBar !== 'boolean') return null;
+	if (typeof minimap !== 'boolean' || typeof showToc !== 'boolean') return null;
+	return { renderLineHighlight, showTabs, statusBar, minimap, lineNumbers, showToc };
+}
+
+/**
  * One persisted localStorage entry.
  *
  * `read` must touch **exactly one** field of the target. That is not a style
@@ -378,14 +432,7 @@ export class SettingsStore {
 	restoreStateOnReopen = $state(true);
 	zenMode = $state(false);
 	showToc = $state(false);
-	preZenState = $state<{
-		renderLineHighlight: string;
-		showTabs: boolean;
-		statusBar: boolean;
-		minimap: boolean;
-		lineNumbers: string;
-		showToc: boolean;
-	} | null>(null);
+	preZenState = $state<PreZenState | null>(null);
 	occurrencesHighlight = $state(false);
 	showWhitespace = $state(false);
 	stickyScroll = $state(true);
@@ -520,15 +567,19 @@ export class SettingsStore {
 			this.lineNumbers = 'off';
 			this.showToc = false;
 		} else {
-			if (this.preZenState) {
-				this.renderLineHighlight = this.preZenState.renderLineHighlight;
-				this.showTabs = this.preZenState.showTabs;
-				this.statusBar = this.preZenState.statusBar;
-				this.minimap = this.preZenState.minimap;
-				this.lineNumbers = this.preZenState.lineNumbers;
-				this.showToc = this.preZenState.showToc;
-				this.preZenState = null;
-			}
+			// Leaving zen mode always un-hides the six things entering it hid,
+			// snapshot or no snapshot. The old `if (this.preZenState)` made "no
+			// snapshot" mean "stay flattened", which is the state a rejected or
+			// missing record leaves behind — tab bar, status bar and line numbers
+			// gone with nothing in the UI saying zen mode was ever involved.
+			const restored = this.preZenState ?? DEFAULT_PRE_ZEN_STATE;
+			this.renderLineHighlight = restored.renderLineHighlight;
+			this.showTabs = restored.showTabs;
+			this.statusBar = restored.statusBar;
+			this.minimap = restored.minimap;
+			this.lineNumbers = restored.lineNumbers;
+			this.showToc = restored.showToc;
+			this.preZenState = null;
 		}
 	}
 
@@ -873,17 +924,11 @@ export function createSettingsPersistence(): PersistedSetting<SettingsStore>[] {
 		{
 			key: 'editor.preZenState',
 			read: (s) => (s.preZenState ? JSON.stringify(s.preZenState) : null),
-			load: (s, raw) => {
-				if (raw === null) {
-					s.preZenState = null;
-					return;
-				}
-				try {
-					s.preZenState = JSON.parse(raw);
-				} catch (e) {
-					console.error('Failed to parse preZenState', e);
-				}
-			},
+			// Same two steps as `titlebar.toolbarPlacement`: parse to a record
+			// (unparseable, non-object and array all become `null` there), then
+			// validate the shape. Nothing here can throw, and nothing reaches the
+			// field that the field's type does not describe.
+			load: (s, raw) => { s.preZenState = normalizePreZenState(parseStoredRecord(raw)); },
 		},
 	];
 }

--- a/src/lib/utils/shortcuts.ts
+++ b/src/lib/utils/shortcuts.ts
@@ -244,14 +244,16 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 		labelKey: 'settings.previewMaxWidth',
 		// One row, two chords: `[` narrows and `]` widens, the same pair the
 		// settings stepper offers. Both run the same branch, which turns full-width
-		// off before it adjusts — that write is what the harness records.
+		// off before it adjusts the width; the width write is the one this row
+		// names, and the full-width write is accounted for in
+		// DOCUMENT_NOT_ADVERTISED as part of this same shortcut.
 		chords: ['Mod+Alt+[', 'Mod+Alt+]'],
 		group: 'view',
-		documentCall: 'isFullWidth=',
+		documentCall: 'settings.previewMaxWidth=',
 	},
-	{ id: 'view-zoom-in', labelKey: 'menu.zoomIn', chords: ['Mod+='], group: 'view', documentCall: 'zoomLevel=' },
-	{ id: 'view-zoom-out', labelKey: 'menu.zoomOut', chords: ['Mod+-'], group: 'view', documentCall: 'zoomLevel=' },
-	{ id: 'view-zoom-reset', labelKey: 'menu.resetZoom', chords: ['Mod+0'], group: 'view', documentCall: 'zoomLevel=' },
+	{ id: 'view-zoom-in', labelKey: 'menu.zoomIn', chords: ['Mod+='], group: 'view', documentCall: 'settings.zoomIn' },
+	{ id: 'view-zoom-out', labelKey: 'menu.zoomOut', chords: ['Mod+-'], group: 'view', documentCall: 'settings.zoomOut' },
+	{ id: 'view-zoom-reset', labelKey: 'menu.resetZoom', chords: ['Mod+0'], group: 'view', documentCall: 'settings.resetZoom' },
 
 	// -------------------------------------------------------------- window
 	{


### PR DESCRIPTION
`settings.svelte.ts` has a `PersistedSetting` mechanism: one `$effect` per key, compare-and-set to stop the echo, and a `storage` listener for the other windows. Its comment says why — Markpad opens multiple windows, each webview gets its own store instance, and they share one localStorage.

**Three values were never wired into it** and wrote localStorage by hand.

### The bug you can see

Open two windows and change the theme in one. Every other switch in that same appearance panel reaches the other window live. The theme `<select>`, sitting in the same panel, does not — the second window stays on the old theme until it restarts.

### The bug you can't see yet

`zoomLevel` was read with `parseInt(localStorage.getItem('zoomLevel') || '100', 10)` and never validated. One corrupt value gives `NaN`, which renders as `style="zoom: NaN"` — and `Math.min(NaN + 10, 500)` is also `NaN`, so **neither the wheel nor the shortcuts can get out of it**. Only the reset button could.

The repo already had the cure: `parseStoredNumber` / `clampToRange` / `stepWithinRange`, used by all five font and width settings. `Settings.svelte:47-60` even records the bug they were written for (an empty input becoming `font-size: nullpx`).

### What changed

All three are now ordinary `PersistedSetting` entries — same shape as the ~35 already there, no parallel mechanism.

| | key | notes |
|---|---|---|
| `theme` | `theme` | unprefixed on purpose: `src/app.html:8` reads that exact key in its first-paint script |
| `zoomLevel` | `zoomLevel` | `numberSetting(…, ZOOM_LEVEL_RANGE, …)`, plus `zoomIn()` / `zoomOut()` / `resetZoom()` on the store |
| `isFullWidth` | `preview.fullWidth` | legacy key read through `readStoredKey`, never written — how `editor.openFileMode` already handles its own |

**Duplicated constants collapsed:** `25`/`500` from **3 copies to 1** (`ZOOM_LEVEL_RANGE`); reset-to-`100` from **3 copies to 1**. `Editor.svelte`'s `zoomLevel` stopped being `$bindable` — nothing writes it back any more.

**Both `as any` are gone.** `ThemeSetting = 'system' | 'light' | 'dark' | \`vscode:${string}\`` plus `resolveTheme()`. The two casts in `Settings.svelte` existed only because `theme` was a bare `string`.

### The VS Code theme startup flash, fixed without touching Rust

`app.rs` reads `theme.txt` to pick the window's background before the webview paints, and its vocabulary is `"dark"` / `"light"` / everything else. Every `vscode:*` theme fell into the last arm and followed the system appearance — so a dark VS Code theme on a light system flashed white at startup.

`save_theme` now receives the **resolved appearance** rather than the theme name, read from the `dataset.themeType` that `parseAndApplyVscodeTheme` already publishes from the theme's own `type` field. **No Rust logic changed** — `app.rs` already matched those two strings. An old-format `theme.txt` lands in the fallback arm and self-corrects on the first theme application.

### The guardrail

A `singleImplementationConvention` row: **`localStorage.setItem` may only appear in `settings.svelte.ts`**, which defines `writeStoredSetting`.

- `recentFiles.ts` was checked and is **deliberately not exempted**. Its read-modify-write and its own `storage` listener are justified — the recent list is a collection every window appends to, not a scalar — but its write already goes through `writeStoredSetting`, so it does not match the marker and needs no exception.
- `tabs.svelte.ts` is listed and **labelled a known gap, not an exemption**. `editor.splitScrollSync` has the milder half of the same defect: one key, one write, so nothing clobbers — but no listener, so a sibling window stays stale until restart. It is allowed only because it sat outside this change's boundary. Filed as follow-up.

### Falsification

Removing the three entries and putting `localStorage.setItem('theme', theme)` back, with the tests untouched:

```
✖ a theme picked in one window reaches the others without a restart
✖ the persisted theme key is the one app.html paints from
✖ an unusable stored theme falls back rather than being applied
✖ a corrupt stored zoom level loads as 100, not as NaN
✖ zoom and preview width follow the other windows too
✖ the legacy full-width key is honoured once and then superseded
✖ single implementation: localStorage is written through one function
   pass 51 / fail 7
```

Restored: all green.

### Rebased onto #615

This branch was written before the vitest pilot landed, so its new `settingsPersistence` tests were rewritten onto that runner: the hand-rolled `localStorageShim` and captured `storageListeners` became jsdom's real `localStorage` and a real dispatched `StorageEvent`, `flushSync()` after construction (the listener is installed inside an `$effect`), and `readSource` switched to the cwd-relative form because `import.meta.url` is `http:` under vitest.

### Verification
- `npm test` 964 pass / 0 fail
- `npm run test:vitest` 62 pass / 0 fail
- `npm run check` 769 files / 0 errors / 0 warnings
- `cargo test` 145 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
