### PR TITLE
fix(settings): validate the zen-mode snapshot before restoring six settings from it

### DIFF
--- a/scripts/settingsPersistence.spec.ts
+++ b/scripts/settingsPersistence.spec.ts
@@ -38,6 +38,7 @@ setNavigatorLanguage('en-US');
 const settingsModule = await import('../src/lib/stores/settings.svelte.js');
 const {
 	CODE_FONT_SIZE_RANGE,
+	DEFAULT_PRE_ZEN_STATE,
 	EDITOR_FONT_SIZE_RANGE,
 	EDITOR_MAX_WIDTH_RANGE,
 	PREVIEW_FONT_SIZE_RANGE,
@@ -49,6 +50,7 @@ const {
 	isSupportedLanguage,
 	isThemeSetting,
 	isWithinRange,
+	normalizePreZenState,
 	parseStoredNumber,
 	resolveLanguageTag,
 	resolveTheme,
@@ -685,6 +687,149 @@ test('the open effect neither reads the app version nor re-enters itself', () =>
 	// so they must not be reactive.
 	assert.match(componentSource, /\n\tlet loaded = false;/);
 	assert.match(componentSource, /\n\tlet previousActiveElement: HTMLElement \| null = null;/);
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * Task 6 — the zen-mode snapshot is validated like every other stored value.
+ *
+ * `editor.preZenState` was the one entry in the table that trusted what it
+ * found: a bare `JSON.parse` straight onto the field, with a `console.error`
+ * for the only failure it considered possible. Its neighbours all validate —
+ * `normalizeEditorToolbarOrder`, `parseStoredNumber`, `isSupportedLanguage`,
+ * `raw === 'left' || raw === 'right'` — and this is the entry whose unchecked
+ * value is copied back onto six other settings the moment zen mode ends.
+ * ---------------------------------------------------------------------------
+ */
+
+/** A snapshot whose six values all differ from the store's defaults. */
+const USER_SNAPSHOT = {
+	renderLineHighlight: 'none',
+	showTabs: false,
+	statusBar: false,
+	minimap: true,
+	lineNumbers: 'off',
+	showToc: true,
+};
+
+/** Every way a stored snapshot can be unusable, as it appears in localStorage. */
+const CORRUPT_SNAPSHOTS: Record<string, string> = {
+	'a field of the wrong type': '{"renderLineHighlight":"none","showTabs":"yes","statusBar":true,"minimap":false,"lineNumbers":"on","showToc":false}',
+	'a missing field': '{"renderLineHighlight":"none","statusBar":true,"minimap":false,"lineNumbers":"on","showToc":false}',
+	'not an object': '"showTabs"',
+	'unparseable JSON': '{"showTabs":',
+};
+
+test('a stored zen snapshot is accepted only whole', () => {
+	assert.deepEqual(normalizePreZenState({ ...USER_SNAPSHOT }), USER_SNAPSHOT);
+	// Fields nobody declared are dropped rather than carried onto the store.
+	assert.deepEqual(normalizePreZenState({ ...USER_SNAPSHOT, wordWrap: 'off' }), USER_SNAPSHOT);
+
+	// One field wrong is the whole record wrong: a snapshot this version cannot
+	// read comes from a version whose other five fields it cannot vouch for
+	// either, and a half-applied restore is a state the user never had.
+	assert.equal(normalizePreZenState({ ...USER_SNAPSHOT, showTabs: 'yes' }), null);
+	assert.equal(normalizePreZenState({ ...USER_SNAPSHOT, showTabs: 1 }), null);
+	assert.equal(normalizePreZenState({ ...USER_SNAPSHOT, lineNumbers: 0 }), null);
+	assert.equal(normalizePreZenState({ ...USER_SNAPSHOT, showToc: null }), null);
+	const { showTabs, ...missingShowTabs } = USER_SNAPSHOT;
+	assert.equal(normalizePreZenState(missingShowTabs), null);
+	assert.equal(normalizePreZenState({}), null);
+
+	// And nothing that is not an object gets that far.
+	for (const value of [null, undefined, 42, 'showTabs', true, [USER_SNAPSHOT]]) {
+		assert.equal(normalizePreZenState(value), null, `${JSON.stringify(value)} is not a snapshot`);
+	}
+});
+
+test('a corrupt zen snapshot never reaches the settings it would restore', () => {
+	for (const [description, stored] of Object.entries(CORRUPT_SNAPSHOTS)) {
+		resetStorage({ 'editor.preZenState': stored });
+		const store = new SettingsStore();
+		assert.equal(store.preZenState, null, description);
+		// The store's own fields are untouched: the record was rejected before
+		// anything could be copied out of it.
+		assert.equal(store.showTabs, true, description);
+		assert.equal(store.statusBar, true, description);
+	}
+
+	resetStorage({ 'editor.preZenState': JSON.stringify(USER_SNAPSHOT) });
+	assert.deepEqual(new SettingsStore().preZenState, USER_SNAPSHOT, 'a good snapshot still survives a restart');
+});
+
+test('the tab bar comes back on leaving zen mode even when the snapshot is unusable', () => {
+	// THE BUG, end to end. Zen mode had already hidden the tab bar and written
+	// `editor.showTabs=false`; the snapshot that says how to put it back is one
+	// this version cannot read.
+	//
+	// Unvalidated, the missing-field case restored `showTabs = undefined`, whose
+	// write effect stored the *string* `"undefined"` — and `raw === 'true'` is
+	// false forever after, so the tab bar was gone on every later launch too,
+	// with only the settings dialog to bring it back.
+	for (const [description, stored] of Object.entries(CORRUPT_SNAPSHOTS)) {
+		resetStorage({
+			'editor.zenMode': 'true',
+			'editor.showTabs': 'false',
+			'editor.statusBar': 'false',
+			'editor.lineNumbers': 'off',
+			'editor.preZenState': stored,
+		});
+		const store = new SettingsStore();
+		flushSync();
+		assert.equal(store.zenMode, true, description);
+		assert.equal(store.showTabs, false, description);
+
+		store.toggleZenMode();
+		flushSync();
+
+		assert.equal(store.zenMode, false, description);
+		assert.equal(store.showTabs, true, `${description}: the tab bar is back`);
+		assert.equal(store.statusBar, true, description);
+		assert.equal(store.lineNumbers, 'on', description);
+		assert.equal(store.renderLineHighlight, 'line', description);
+		assert.equal(store.showToc, false, description);
+
+		// What was persisted is a boolean's spelling, not "undefined"...
+		assert.equal(localStorage.getItem('editor.showTabs'), 'true', description);
+		assert.equal(localStorage.getItem('editor.preZenState'), null, `${description}: the bad record is gone`);
+		// ...so the next launch keeps the tab bar instead of reading it back as false.
+		assert.equal(new SettingsStore().showTabs, true, `${description}: and it is still there after a restart`);
+	}
+});
+
+test('a good snapshot still restores what the user had, not the defaults', () => {
+	// The other half: the fallback must not be reached while there is a record
+	// to honour, or leaving zen mode would reset six settings every time.
+	resetStorage();
+	const store = new SettingsStore();
+	Object.assign(store, USER_SNAPSHOT);
+	flushSync();
+
+	store.toggleZenMode();
+	flushSync();
+	assert.equal(store.showTabs, false);
+	assert.equal(store.minimap, false, 'zen mode flattens everything, including what was already off');
+
+	// Through localStorage and a restart, the way a real session gets there.
+	const restarted = new SettingsStore();
+	assert.deepEqual(restarted.preZenState, USER_SNAPSHOT);
+	restarted.toggleZenMode();
+	assert.equal(restarted.zenMode, false);
+	for (const [field, value] of Object.entries(USER_SNAPSHOT)) {
+		assert.equal(Reflect.get(restarted, field), value, `${field} came back as the user left it`);
+	}
+	assert.equal(restarted.preZenState, null, 'the snapshot is spent once it has been restored');
+});
+
+test('the zen fallback is each setting own default', () => {
+	// DEFAULT_PRE_ZEN_STATE spells out six values the store already declares in
+	// its field initializers. This is what stops the two copies drifting.
+	resetStorage();
+	const fresh = new SettingsStore();
+	for (const [field, value] of Object.entries(DEFAULT_PRE_ZEN_STATE)) {
+		assert.equal(Reflect.get(fresh, field), value, `${field} default differs from the zen fallback`);
+	}
+	assert.equal(Object.keys(DEFAULT_PRE_ZEN_STATE).length, 6);
 });
 
 /*

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -273,6 +273,60 @@ function parseStoredRecord(value: string | null): Record<string, unknown> | null
 }
 
 /**
+ * The six settings zen mode flattens, as they were the moment it was entered.
+ * `null` means "no snapshot": either zen mode is off, or the stored one could
+ * not be trusted.
+ */
+export interface PreZenState {
+	renderLineHighlight: string;
+	showTabs: boolean;
+	statusBar: boolean;
+	minimap: boolean;
+	lineNumbers: string;
+	showToc: boolean;
+}
+
+/**
+ * What leaving zen mode restores when there is no snapshot to restore from.
+ *
+ * These are the same six values the store's own field initializers use — pinned
+ * against drift by a test — because "the setting's own default" is the only
+ * answer available once the record of what the user had is gone.
+ */
+export const DEFAULT_PRE_ZEN_STATE: PreZenState = {
+	renderLineHighlight: 'line',
+	showTabs: true,
+	statusBar: true,
+	minimap: false,
+	lineNumbers: 'on',
+	showToc: false,
+};
+
+/**
+ * Validates a parsed `editor.preZenState`, the way every other entry in
+ * {@link createSettingsPersistence} validates its own raw value.
+ *
+ * All six fields or none. A snapshot missing a field, or carrying one of the
+ * wrong type, comes from a version of Markpad this one cannot interpret, and
+ * half-applying it produces a state the user never had — so it is rejected
+ * whole and zen mode leaves through {@link DEFAULT_PRE_ZEN_STATE} instead.
+ *
+ * The unvalidated `JSON.parse` this replaces is how the tab bar could vanish
+ * for good: a snapshot with no `showTabs` restored `showTabs = undefined`, the
+ * write effect stored the string `"undefined"`, and every later launch read
+ * that back as `false` with no way out but the settings dialog.
+ */
+export function normalizePreZenState(value: unknown): PreZenState | null {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+	const record = value as Record<string, unknown>;
+	const { renderLineHighlight, showTabs, statusBar, minimap, lineNumbers, showToc } = record;
+	if (typeof renderLineHighlight !== 'string' || typeof lineNumbers !== 'string') return null;
+	if (typeof showTabs !== 'boolean' || typeof statusBar !== 'boolean') return null;
+	if (typeof minimap !== 'boolean' || typeof showToc !== 'boolean') return null;
+	return { renderLineHighlight, showTabs, statusBar, minimap, lineNumbers, showToc };
+}
+
+/**
  * One persisted localStorage entry.
  *
  * `read` must touch **exactly one** field of the target. That is not a style
@@ -378,14 +432,7 @@ export class SettingsStore {
 	restoreStateOnReopen = $state(true);
 	zenMode = $state(false);
 	showToc = $state(false);
-	preZenState = $state<{
-		renderLineHighlight: string;
-		showTabs: boolean;
-		statusBar: boolean;
-		minimap: boolean;
-		lineNumbers: string;
-		showToc: boolean;
-	} | null>(null);
+	preZenState = $state<PreZenState | null>(null);
 	occurrencesHighlight = $state(false);
 	showWhitespace = $state(false);
 	stickyScroll = $state(true);
@@ -520,15 +567,19 @@ export class SettingsStore {
 			this.lineNumbers = 'off';
 			this.showToc = false;
 		} else {
-			if (this.preZenState) {
-				this.renderLineHighlight = this.preZenState.renderLineHighlight;
-				this.showTabs = this.preZenState.showTabs;
-				this.statusBar = this.preZenState.statusBar;
-				this.minimap = this.preZenState.minimap;
-				this.lineNumbers = this.preZenState.lineNumbers;
-				this.showToc = this.preZenState.showToc;
-				this.preZenState = null;
-			}
+			// Leaving zen mode always un-hides the six things entering it hid,
+			// snapshot or no snapshot. The old `if (this.preZenState)` made "no
+			// snapshot" mean "stay flattened", which is the state a rejected or
+			// missing record leaves behind — tab bar, status bar and line numbers
+			// gone with nothing in the UI saying zen mode was ever involved.
+			const restored = this.preZenState ?? DEFAULT_PRE_ZEN_STATE;
+			this.renderLineHighlight = restored.renderLineHighlight;
+			this.showTabs = restored.showTabs;
+			this.statusBar = restored.statusBar;
+			this.minimap = restored.minimap;
+			this.lineNumbers = restored.lineNumbers;
+			this.showToc = restored.showToc;
+			this.preZenState = null;
 		}
 	}
 
@@ -873,17 +924,11 @@ export function createSettingsPersistence(): PersistedSetting<SettingsStore>[] {
 		{
 			key: 'editor.preZenState',
 			read: (s) => (s.preZenState ? JSON.stringify(s.preZenState) : null),
-			load: (s, raw) => {
-				if (raw === null) {
-					s.preZenState = null;
-					return;
-				}
-				try {
-					s.preZenState = JSON.parse(raw);
-				} catch (e) {
-					console.error('Failed to parse preZenState', e);
-				}
-			},
+			// Same two steps as `titlebar.toolbarPlacement`: parse to a record
+			// (unparseable, non-object and array all become `null` there), then
+			// validate the shape. Nothing here can throw, and nothing reaches the
+			// field that the field's type does not describe.
+			load: (s, raw) => { s.preZenState = normalizePreZenState(parseStoredRecord(raw)); },
 		},
 	];
 }


### PR DESCRIPTION
**Stacked on #618** (`fix/persist-theme-and-zoom`), which this needs for the vitest-based `settingsPersistence.spec.ts` it adds tests to.

### The chain, reproduced rather than reasoned about

`preZenState` was the one entry in `createSettingsPersistence` that did not validate what it read — `JSON.parse(raw)` straight into the field, with `console.error` in the catch. Every sibling validates: `normalizeEditorToolbarOrder`, `parseStoredNumber`, `isSupportedLanguage`, `raw === 'left' || raw === 'right'`.

An instrumented probe run reproduced what each corrupt form actually does:

| stored record | after load | written back | next launch |
|---|---|---|---|
| `{"showTabs":"yes"}` | `showTabs = "yes"` | `"yes"` | `raw === 'true'` → **false** |
| missing `showTabs` | `showTabs = undefined` | **`"undefined"`** | → **false** |
| not an object | same as missing | `"undefined"` | → **false** |
| unparseable JSON | `null` | — | (the old catch already handled this one) |

So one bad record hid the tab bar **permanently**: the string `"undefined"` reads as false on every future launch, and the user has to find the switch in settings to get it back.

### What changed

`normalizePreZenState(value: unknown): PreZenState | null`, exported beside `resolveTheme` / `isSupportedLanguage`. Rejects non-objects, `null`, arrays and primitives; requires `renderLineHighlight` / `lineNumbers` to be strings and `showTabs` / `statusBar` / `minimap` / `showToc` to be booleans; **all six or nothing**; drops unknown extras.

The entry now reads exactly like `titlebar.toolbarPlacement` two entries above it. `parseStoredRecord` already absorbs unparseable JSON and non-objects, so the `try`/`catch` is gone rather than replaced.

**Failure means `null` — "there is no snapshot".** Partial repair was the alternative and is worse: a record this version cannot read comes from a version whose other five fields it also cannot vouch for, so mixing kept fields with invented ones restores a state the user never had. One rule instead — either the snapshot is the user's, or there isn't one.

### `toggleZenMode` had to change with it

With the normalizer returning `null`, the old `if (this.preZenState)` guard turned "no snapshot" into "stay flattened" — validated garbage would still have left the tab bar, status bar and line numbers hidden. It now restores from `this.preZenState ?? DEFAULT_PRE_ZEN_STATE` unconditionally.

That branch is only reachable with `zenMode === true`, and entering zen always writes a snapshot, so a `null` there *is* the corrupt-or-missing case. Nothing that was working is touched. A test pins `DEFAULT_PRE_ZEN_STATE` against the six field initializers so the duplication cannot drift.

### Falsified twice, each half separately

1. Bare `JSON.parse` restored → 2 tests red.
2. Validation kept, `?? DEFAULT_PRE_ZEN_STATE` reverted to `if (!restored) return;` → the end-to-end test red on its own.

Case 1 alone does not cover unparseable JSON and case 2 alone does not cover the others, which is how both halves are shown to carry weight.

### The narrow multi-window race — deliberately not addressed

A window entering zen inside the gap between a sibling's `showTabs=false` and its `preZenState` snapshots a *well-formed* `false`. No shape check can tell it from a genuine one, and no structure was changed for it — it needs a keypress inside a millisecond window.

Its ceiling did drop, though: the poisoned value is now an ordinary `false` that the settings dialog fixes and that persists correctly afterwards, rather than a `"undefined"` string that reads as false on every future launch.

### Verification
- `npm test` 964 pass / 0 fail
- `npm run test:vitest` 67 pass / 0 fail (baseline 62)
- `npm run check` 769 files / 0 errors / 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
