### PR TITLE
perf(preview): debounce the rebuild against a pause, not against a keystroke

### DIFF
--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -2636,11 +2636,28 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			// dropped by the revision check below, several ran at once and all of
 			// the work was done regardless.
 			//
-			// 120ms sits above the burst interval, so a word typed at speed costs
-			// one render rather than five, and below the pause someone takes to
-			// look at what they wrote — the preview catches up about an eighth of a
-			// second after the last key. Much larger reads as the preview lagging
-			// the cursor; much smaller is the 16ms case again.
+			// 500ms, and the reason is not throughput — it is that a rebuilt
+			// preview is not pixel-identical to the one it replaces.
+			//
+			// `{@html}` destroys and recreates the whole article. Everything that
+			// settles afterwards — inline maths through KaTeX's auto-renderer,
+			// font metrics, the ResizeObserver remeasuring every fold — settles a
+			// frame or two later, and any of them can leave the text a pixel or
+			// two from where it was. Cacheing the expensive renderers and fixing
+			// the fold measurement each removed one source; neither could remove
+			// the last one, because the source is the rebuild itself.
+			//
+			// So the debounce is chosen against a *pause*, not against the gap
+			// between two keystrokes. At 120ms the preview rebuilt several times
+			// inside one sentence and the reader watched it resettle each time.
+			// At 500ms a sentence typed without stopping is one rebuild, and it
+			// lands when they have already stopped to read it.
+			//
+			// This is a mitigation and should be read as one: it makes the
+			// rebuild rare rather than making it stable. The fix that removes it
+			// is block-level patching — reusing the DOM of blocks whose rendered
+			// HTML did not change — at which point this number can come back
+			// down.
 			const timer = setTimeout(() => {
 				renderMarkdownPreview(rawContent, tab.path, tab.foldOverrides)
 					.then((processed) => {
@@ -2655,7 +2672,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 						tick().then(renderRichContent);
 					})
 					.catch(console.error);
-			}, 120);
+			}, 500);
 
 			return () => clearTimeout(timer);
 		}


### PR DESCRIPTION
A stopgap, and labelled as one in the code.

### Why the number moved

The preview rebuild is **not pixel-identical** to the render it replaces, and that — not its cost — is what the reader sees.

`{@html}` destroys and recreates the whole article. Everything that settles afterwards settles a frame or two later: inline maths through KaTeX's auto-renderer, font metrics, the `ResizeObserver` remeasuring every fold. Any of them can leave the text a pixel or two from where it was.

#614 cached the expensive renderers and #617 corrected the fold measurement. Each removed one source of movement. Neither could remove the last one, **because the source is the rebuild itself** — a freshly built tree is not obliged to settle identically, and chasing the causes one at a time does not converge.

### 120ms → 500ms

The interval is now chosen against a **pause**, not against the gap between two keystrokes.

At 120ms the preview rebuilt several times inside one sentence and the reader watched it resettle each time. At 500ms a sentence typed without stopping is one rebuild, and it lands once they have already stopped to read it.

### What this is not

It makes the rebuild **rare**, not **stable**. The fix that removes the jitter is block-level patching — reusing the DOM of blocks whose rendered HTML did not change — after which this number can come back down.

The code comment says all of this, so the next person to see `500` does not read it as a tuned throughput value.

### Verification
- `npm test` 963 pass / 0 fail
- `npm run check` 769 files / 0 errors / 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
