### PR TITLE
refactor(titlebar): read the markdown extension list, do not restate it

### DIFF
--- a/scripts/singleImplementationConvention.test.ts
+++ b/scripts/singleImplementationConvention.test.ts
@@ -79,6 +79,23 @@ const RULES: Rule[] = [
 		dir: 'src/lib/utils',
 	},
 	{
+		name: 'the markdown extension list has one implementation in src',
+		why:
+			'There were five copies of `md | markdown | mdown | mkd | txt` in the frontend. #611 collapsed four of them into markdownLinks.ts; the fifth was an inline array in TitleBar.svelte deciding whether the outline and full-width buttons belong on the toolbar, which is exactly the kind of copy that goes stale when an extension is added. The Rust renderer keeps its own, pinned against this one by wikilinkFileTargets.test.ts, because no import crosses that boundary.',
+		// `mdown` rather than `md`: it is distinctive enough that prose and other
+		// identifiers cannot match it by accident.
+		//
+		// MarkdownViewer.svelte is allowed because its list answers a different
+		// question. `getLanguage` maps an extension to a *Monaco grammar id*, and
+		// it deliberately leaves `txt` out — a .txt file gets plaintext
+		// highlighting even though this app renders it as Markdown. Folding the
+		// two together would have to pick one of those answers and be wrong about
+		// the other. That table has its own guard, the `return 'plaintext'` rule
+		// below.
+		marker: /['"]mdown['"]/g,
+		allowed: ['src/lib/utils/markdownLinks.ts', 'src/lib/MarkdownViewer.svelte'],
+	},
+	{
 		name: 'YouTube links never become embedded frames',
 		why: 'The app dropped frame-src from its CSP and renders YouTube as a thumbnail anchor that opens the browser; an iframe path is the pre-fix version and cannot load.',
 		marker: /createElement\((['"])iframe\1\)/g,

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -11,6 +11,7 @@
 	import { t } from '../utils/i18n.js';
 	import { getConfiguredTitlebarToolbarIds } from '../utils/titlebarToolbar.js';
 	import { shortcutLabel } from '../utils/shortcuts.js';
+	import { hasMarkdownLinkExtension } from '../utils/markdownLinks.js';
 	import { hasRealFilePath } from '../utils/tabFileActions.js';
 	import { getVersion } from '@tauri-apps/api/app';
 
@@ -319,8 +320,10 @@
 			list.push('forward');
 			if (currentFile) list.push('reload');
 
-			const ext = currentFile ? currentFile.split('.').pop()?.toLowerCase() || '' : 'md';
-			const isMarkdown = ['md', 'markdown', 'mdown', 'mkd', 'txt'].includes(ext);
+			// An unsaved buffer has no name to read an extension off, and is
+			// treated as Markdown — which is what the old inline default of `'md'`
+			// said, spelled as the condition it actually is.
+			const isMarkdown = currentFile ? hasMarkdownLinkExtension(currentFile) : true;
 
 			if (isMarkdown) {
 				list.push('toc');

--- a/src/lib/utils/markdownLinks.ts
+++ b/src/lib/utils/markdownLinks.ts
@@ -11,8 +11,8 @@ export type MarkdownLinkTarget = {
 // documented as a copy and pinned by a test; a list is cheaper to share than to
 // police.
 //
-// The Rust renderer keeps the sixth copy, in `MARKDOWN_LINK_EXTENSIONS` in
-// src-tauri/src/markdown.rs, because no import crosses that boundary. It is
+// The Rust renderer keeps the only other copy, in `MARKDOWN_LINK_EXTENSIONS`
+// in src-tauri/src/markdown.rs, because no import crosses that boundary. It is
 // pinned against this one by `the extension list the rewriter mirrors still
 // matches markdownLinks.ts` in scripts/wikilinkFileTargets.test.ts.
 export const MARKDOWN_LINK_EXTENSIONS = ['md', 'markdown', 'mdown', 'mkd', 'txt'];


### PR DESCRIPTION
#611 collapsed four frontend copies of `md | markdown | mdown | mkd | txt` into `markdownLinks.ts` and left a fifth, because it sat outside that change's boundary: an inline array in `TitleBar.svelte` deciding whether the outline and full-width buttons belong on the toolbar.

Adding an extension would have shown it in the Open dialog, the link resolver and the export path — and not here.

### Behaviour is unchanged, checked case by case

`hasMarkdownLinkExtension` carries the `i` flag, which is what the old `.toLowerCase()` did, and its pattern is anchored:

| input | before | after |
|---|---|---|
| `notes.MD` | true | true |
| `README` (no extension) | false | false |
| `notes.md.bak` | false | false |
| `.md` | true | true |
| unsaved buffer (empty name) | true (inline `'md'` default) | true (explicit) |

The `'md'` default is now spelled as the condition it actually is: a buffer with no name has no extension to read, and is treated as Markdown.

### The guard

A `singleImplementationConvention` rule pins the list, marked on `mdown` — distinctive enough that prose and other identifiers cannot match it by accident. **Falsified**: restoring the inline copy turns it red; removing it again turns it green.

### `MarkdownViewer.svelte` is allowlisted, not folded in

Its list answers a **different question**. `getLanguage` maps an extension to a *Monaco grammar id*, and it deliberately leaves `txt` out — a `.txt` file gets plaintext highlighting even though this app renders it as Markdown.

Merging the two would have to pick one of those answers and be wrong about the other. That is the same reasoning #611 used to rename the two `resolvePath` functions rather than merge them: same-looking data, different questions. That table keeps its own existing guard, the `return 'plaintext'` rule.

The stale comment in `markdownLinks.ts` calling Rust "the sixth copy" is corrected — it is now the only other one.

### Verification
- `npm test` 967 pass / 0 fail
- `npm run check` 769 files / 0 errors / 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
