### PR TITLE
fix(anchors): convert the rect delta into scroll pixels before adding it (#621)

### DIFF
--- a/scripts/anchorJumpUnderZoom.spec.ts
+++ b/scripts/anchorJumpUnderZoom.spec.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+
+import { test } from 'vitest';
+
+import { anchorScrollTop, previewZoomFactor, PREVIEW_ANCHOR_OFFSET } from '../src/lib/utils/previewAnchor.js';
+
+/*
+ * #621: "Custom viewport zoom bogusly offsets anchor jumps (in preview mode)".
+ * At 150% a link scrolled past its heading, at 50% it stopped short, and at
+ * 100% it was right.
+ *
+ * The preview sets CSS `zoom` on `.markdown-container`, an ANCESTOR of the
+ * scrolling element. `getBoundingClientRect()` reports viewport pixels, which
+ * carry that zoom; `scrollTop` counts the scroller's own pixels, which do not.
+ * Both call sites added one straight to the other, so the error was exactly the
+ * zoom factor — invisible at 100%, and the wrong sign on either side of it.
+ *
+ * jsdom has no layout, so the elements here are stand-ins that report the
+ * geometry a browser would at a given zoom: a rect scaled by the factor, and an
+ * `offsetWidth` that is not. That is the whole relationship under test.
+ */
+
+/** An element whose rect is `zoom`× its layout box, as a zoomed ancestor makes it. */
+function zoomedElement(layoutTop: number, layoutWidth: number, zoom: number) {
+	return {
+		offsetWidth: layoutWidth,
+		getBoundingClientRect: () => ({ top: layoutTop * zoom, width: layoutWidth * zoom }),
+	} as unknown as HTMLElement;
+}
+
+function scroller(zoom: number, scrollTop: number) {
+	const el = zoomedElement(0, 800, zoom) as unknown as { scrollTop: number };
+	el.scrollTop = scrollTop;
+	return el as unknown as HTMLElement;
+}
+
+test('the zoom factor is measured off the container, not read from settings', () => {
+	assert.equal(previewZoomFactor(scroller(1, 0)), 1);
+	assert.equal(previewZoomFactor(scroller(1.5, 0)), 1.5);
+	assert.equal(previewZoomFactor(scroller(0.5, 0)), 0.5);
+});
+
+test('a container with no layout reports 1 rather than a division by zero', () => {
+	const detached = {
+		offsetWidth: 0,
+		scrollTop: 0,
+		getBoundingClientRect: () => ({ top: 0, width: 0 }),
+	} as unknown as HTMLElement;
+	assert.equal(previewZoomFactor(detached), 1);
+	assert.ok(Number.isFinite(anchorScrollTop(detached, detached)));
+});
+
+test('an anchor lands the same distance down the document at every zoom', () => {
+	// The heading sits 1000 layout pixels below the top of the scroller, which
+	// is already scrolled to 200. Wherever the zoom is, the answer is the same
+	// number of the scroller's own pixels.
+	const expected = 200 + 1000 - PREVIEW_ANCHOR_OFFSET;
+
+	for (const zoom of [0.5, 1, 1.5, 2]) {
+		const container = scroller(zoom, 200);
+		const heading = zoomedElement(1000, 400, zoom);
+		assert.equal(
+			anchorScrollTop(container, heading),
+			expected,
+			`zoom ${zoom} must land at ${expected}`,
+		);
+	}
+});
+
+test('the pre-fix arithmetic is what overshot, and by exactly the zoom factor', () => {
+	// Kept as the shape of the defect: rect delta added straight to scrollTop.
+	// It is only correct at 100%, which is why the bug went unseen — and the
+	// error is the factor itself, matching the report's "way past" at 150% and
+	// "way before" at 50%.
+	const preFix = (container: HTMLElement, el: HTMLElement) =>
+		el.getBoundingClientRect().top -
+		container.getBoundingClientRect().top +
+		container.scrollTop -
+		PREVIEW_ANCHOR_OFFSET;
+
+	const correct = 200 + 1000 - PREVIEW_ANCHOR_OFFSET;
+
+	for (const [zoom, sign] of [
+		[1.5, 'past'],
+		[0.5, 'short'],
+	] as const) {
+		const container = scroller(zoom, 200);
+		const heading = zoomedElement(1000, 400, zoom);
+		const old = preFix(container, heading);
+		assert.notEqual(old, correct, `at zoom ${zoom} the old form must be wrong (${sign})`);
+		// The whole error is the un-divided delta.
+		assert.equal(old - correct, 1000 * zoom - 1000);
+		assert.equal(anchorScrollTop(container, heading), correct);
+	}
+
+	// …and identical at 100%, which is why nobody saw it.
+	const container = scroller(1, 200);
+	const heading = zoomedElement(1000, 400, 1);
+	assert.equal(preFix(container, heading), anchorScrollTop(container, heading));
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -54,6 +54,7 @@ import {
 	measureAnchorBox,
 	mergeSourceLineRanges,
 	PREVIEW_ANCHOR_OFFSET,
+	anchorScrollTop,
 	type AnchorBox,
 	type AnchorNode,
 	type LineRange,
@@ -1430,10 +1431,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			(markdownBody?.querySelector(`[name="${CSS.escape(id)}"]`) as HTMLElement | null);
 		if (el && markdownBody) {
 			if (options.pushHistory !== false) pushScrollHistory();
-			const containerRect = markdownBody.getBoundingClientRect();
-			const elRect = el.getBoundingClientRect();
-			const targetScrollTop = elRect.top - containerRect.top + markdownBody.scrollTop - PREVIEW_ANCHOR_OFFSET;
-			markdownBody.scrollTo({ top: targetScrollTop, behavior: 'smooth' });
+			markdownBody.scrollTo({ top: anchorScrollTop(markdownBody, el), behavior: 'smooth' });
 			return true;
 		}
 		return false;

--- a/src/lib/components/Toc.svelte
+++ b/src/lib/components/Toc.svelte
@@ -5,7 +5,7 @@
 	import { t } from '../utils/i18n.js';
 	import { activeTocIdForLine, sourceLineOf } from '../utils/tocFollow.js';
 	import { foldKeyOf } from '../utils/foldState.js';
-	import { PREVIEW_ANCHOR_OFFSET } from '../utils/previewAnchor.js';
+	import { anchorScrollTop } from '../utils/previewAnchor.js';
 	import type { RendererLine } from '../utils/lineCoordinates.js';
 
 	let { markdownBody, htmlContent, activeLine = null, onBeforeJump, foldOverrides, ontoggleFold, oncopyref, oncontext, onjump, onshowTooltip, onhideTooltip } = $props<{
@@ -314,10 +314,7 @@
 			el.classList.add('toc-target-active');
 			activeTargetEl = el;
 
-			const containerRect = markdownBody.getBoundingClientRect();
-			const elRect = el.getBoundingClientRect();
-			const targetScrollTop = elRect.top - containerRect.top + markdownBody.scrollTop - PREVIEW_ANCHOR_OFFSET;
-			markdownBody.scrollTo({ top: targetScrollTop, behavior: 'smooth' });
+			markdownBody.scrollTo({ top: anchorScrollTop(markdownBody, el), behavior: 'smooth' });
 
 			// release lock after scroll settles
 			if (clickLockTimer) clearTimeout(clickLockTimer);

--- a/src/lib/utils/previewAnchor.ts
+++ b/src/lib/utils/previewAnchor.ts
@@ -148,6 +148,49 @@ function isAnchorable(node: AnchorNode): boolean {
  */
 export const PREVIEW_ANCHOR_OFFSET = 60;
 
+/**
+ * The factor between the coordinates `getBoundingClientRect()` reports and the
+ * ones `scrollTop` is measured in, for anything inside `container`.
+ *
+ * The preview sets CSS `zoom` on `.markdown-container`, an ANCESTOR of the
+ * scrolling element. A rect is reported in viewport pixels, which have that
+ * zoom folded in; `scrollTop` counts in the scroller's own pixels, which do
+ * not. The two are the same number only at 100%.
+ *
+ * Measured off the container rather than read from the settings store, so this
+ * module keeps knowing nothing about where the zoom is applied or how many
+ * ancestors apply one. `offsetWidth` is the container's own layout width and
+ * the rect is its rendered width, so the ratio is exactly the accumulated
+ * scale — whatever produced it.
+ *
+ * A container with no layout (display:none, detached) reports `offsetWidth` 0.
+ * There is nothing to scroll in that case; 1 keeps the caller's arithmetic
+ * finite instead of handing it an Infinity to scroll to.
+ */
+export function previewZoomFactor(container: HTMLElement): number {
+	const layoutWidth = container.offsetWidth;
+	if (!layoutWidth) return 1;
+	const renderedWidth = container.getBoundingClientRect().width;
+	if (!renderedWidth) return 1;
+	return renderedWidth / layoutWidth;
+}
+
+/**
+ * Where `container` has to scroll to for `element` to sit
+ * `PREVIEW_ANCHOR_OFFSET` below its top edge.
+ *
+ * This was written out twice — once for an in-document anchor, once for the
+ * outline — and both copies added a rect delta straight to `scrollTop`. At
+ * zoom 150% that overshot the heading by half the distance to it, and at 50%
+ * it stopped half-way short (#621). Dividing by the factor above puts both
+ * terms in the scroller's own pixels before they meet.
+ */
+export function anchorScrollTop(container: HTMLElement, element: HTMLElement): number {
+	const zoom = previewZoomFactor(container);
+	const delta = element.getBoundingClientRect().top - container.getBoundingClientRect().top;
+	return delta / zoom + container.scrollTop - PREVIEW_ANCHOR_OFFSET;
+}
+
 export function parseSourceposLineRange(sourcepos: string | null | undefined): LineRange | null {
 	if (!sourcepos) return null;
 


### PR DESCRIPTION
Fixes #621. An anchor link overshot its heading at zoom 150% and stopped short at 50%.

### The mismatch

CSS `zoom` is set on `.markdown-container`, an **ancestor** of the scrolling element. `getBoundingClientRect()` reports viewport pixels and those carry the zoom; `scrollTop` counts the scroller's own pixels and they do not. Both jump sites added one straight to the other:

```js
elRect.top - containerRect.top + markdownBody.scrollTop - PREVIEW_ANCHOR_OFFSET
```

So the error is exactly the zoom factor — none at 100%, half the distance too far at 150%, half short at 50%.

### The fix

`anchorScrollTop()` divides the rect delta by the factor before adding it. The factor is measured off the container (`getBoundingClientRect().width / offsetWidth`) rather than read from the settings store, so `previewAnchor.ts` needs to know nothing about where a zoom is applied or how many ancestors apply one. A container with no layout answers `1`.

The arithmetic existed twice — once for an in-document anchor, once for the outline — byte-identical, and wrong the same way in both. It now lives next to `PREVIEW_ANCHOR_OFFSET`, which #607 had already collapsed.

### Tests

`scripts/anchorJumpUnderZoom.spec.ts`. jsdom has no layout, so the elements report the geometry a browser would at a given zoom — a rect scaled by the factor, an `offsetWidth` that is not. One test keeps the pre-fix arithmetic beside the new one and asserts the difference is the un-divided delta, and that they agree at 100%.

`npm test` 966 · `npm run test:vitest` 71 · `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
