### PR TITLE
fix(tabs): keep the untitled buffer out of the path history, and drop three dead interface parts

### DIFF
--- a/scripts/navigationHistory.test.ts
+++ b/scripts/navigationHistory.test.ts
@@ -24,6 +24,31 @@ test('new file tabs start history with their path', () => {
 	});
 });
 
+// Entries exist to be re-opened, and an untitled buffer cannot be. See the
+// behaviour this protects in scripts/tabNavigationHistory.spec.ts.
+test('an untitled tab starts with no history entry at all', () => {
+	assert.deepEqual(createFileHistory(''), {
+		history: [],
+		historyIndex: 0,
+	});
+});
+
+test('navigating out of an untitled tab leaves nothing to go back to', () => {
+	// Both shapes an untitled tab can arrive in: no entry, and — for a tab
+	// transferred from an older window — the `''` its source seeded.
+	for (const history of [[], ['']]) {
+		assert.deepEqual(
+			navigateFileHistory({
+				currentPath: '',
+				targetPath: '/notes/a.md',
+				history,
+				historyIndex: 0,
+			}),
+			{ history: ['/notes/a.md'], historyIndex: 0 }
+		);
+	}
+});
+
 // History is a list of PATHS. `createFileHistory` used to take the tab's
 // initial content as an ignored second parameter, and all three callers passed
 // one — which is how `addNewTab` came to seed a history with a content string
@@ -94,7 +119,7 @@ test('replacing current history entry keeps file history path-based', () => {
 	assert.deepEqual(
 		replaceCurrentHistoryEntry({
 			targetPath: '/notes/saved.md',
-			history: [''],
+			history: [],
 			historyIndex: 0,
 		}),
 		{

--- a/scripts/navigationHistory.test.ts
+++ b/scripts/navigationHistory.test.ts
@@ -15,26 +15,49 @@ import {
 	isOpenInNewTabMarkdownTarget,
 	resolveMarkdownTargetPath,
 } from '../src/lib/utils/markdownLinks.js';
+import { readSource } from './sourceTree.js';
 
-test('new file tabs start history with their path, not initial content', () => {
-	assert.deepEqual(createFileHistory('/notes/a.md', 'body text'), {
+test('new file tabs start history with their path', () => {
+	assert.deepEqual(createFileHistory('/notes/a.md'), {
 		history: ['/notes/a.md'],
 		historyIndex: 0,
 	});
 });
 
-test('untitled tabs keep an empty initial history entry', () => {
-	assert.deepEqual(createFileHistory('', ''), {
-		history: [''],
-		historyIndex: 0,
-	});
+// History is a list of PATHS. `createFileHistory` used to take the tab's
+// initial content as an ignored second parameter, and all three callers passed
+// one — which is how `addNewTab` came to seed a history with a content string
+// in it. A source assertion because that is the whole of what the parameter
+// was: nothing reads it, so no behaviour can fail when it comes back, and
+// `Function.length` cannot see an optional one either.
+test('no caller hands a file history anything but a path', () => {
+	const declaration = readSource('src/lib/utils/tabHistory.ts').match(/export function createFileHistory\([^)]*\)/);
+	assert.ok(declaration);
+	assert.equal(declaration[0], 'export function createFileHistory(path: string)');
+
+	for (const call of readSource('src/lib/stores/tabs.svelte.ts').matchAll(/createFileHistory\([^)]*\)/g)) {
+		assert.doesNotMatch(call[0], /,/, `${call[0]} passes something that is not a path`);
+	}
+});
+
+// `goBackInHistory`/`goForwardInHistory` move an index inside the array they
+// were handed; they never rewrite it. Returning it made both store callers
+// assign `tab.history` back over itself before assigning the index that
+// actually moved.
+test('moving through history returns only the index and the path', () => {
+	assert.deepEqual(Object.keys(goBackInHistory({ history: ['/a.md', '/b.md'], historyIndex: 1 })).sort(), [
+		'historyIndex',
+		'path',
+	]);
+	assert.deepEqual(Object.keys(goForwardInHistory({ history: ['/a.md', '/b.md'], historyIndex: 1 })).sort(), [
+		'historyIndex',
+		'path',
+	]);
 });
 
 test('navigating appends paths and truncates forward entries', () => {
-	const afterBack = goBackInHistory({
-		history: ['/notes/a.md', '/notes/b.md', '/notes/c.md'],
-		historyIndex: 1,
-	});
+	const history = ['/notes/a.md', '/notes/b.md', '/notes/c.md'];
+	const afterBack = goBackInHistory({ history, historyIndex: 1 });
 
 	assert.equal(afterBack.path, '/notes/a.md');
 	assert.equal(afterBack.historyIndex, 0);
@@ -42,7 +65,7 @@ test('navigating appends paths and truncates forward entries', () => {
 	const afterNavigate = navigateFileHistory({
 		currentPath: afterBack.path!,
 		targetPath: '/notes/d.md',
-		history: afterBack.history,
+		history,
 		historyIndex: afterBack.historyIndex,
 	});
 
@@ -64,13 +87,12 @@ test('back and forward stay inside history bounds', () => {
 	const forward = goForwardInHistory(initial);
 	assert.equal(forward.path, '/notes/b.md');
 	assert.equal(forward.historyIndex, 1);
-	assert.equal(canGoForwardInHistory(forward), false);
+	assert.equal(canGoForwardInHistory({ history: initial.history, historyIndex: forward.historyIndex }), false);
 });
 
 test('replacing current history entry keeps file history path-based', () => {
 	assert.deepEqual(
 		replaceCurrentHistoryEntry({
-			currentPath: '',
 			targetPath: '/notes/saved.md',
 			history: [''],
 			historyIndex: 0,

--- a/scripts/tabNavigationHistory.spec.ts
+++ b/scripts/tabNavigationHistory.spec.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+
+// A tab's `history` is a list of PATHS: `goBack` and `goForward` hand an entry
+// back to the caller, which re-opens the file it names. An untitled buffer has
+// no path and no file, so it is not a place the reader can return to — by the
+// time Back could run, `forgetPreviousDocument` and the load that follows have
+// already replaced the text that was in it.
+//
+// It used to get an entry regardless, from two directions: `addNewTab` seeded
+// the history with the new tab's (empty) CONTENT, and `navigateFileHistory`
+// synthesised `[currentPath]` for a tab whose history was empty. Either way the
+// tab ended up at index 1 of `['', '/some/file.md']`, `canGoBack` reported true
+// and lit the button, and `goBack` then rejected the `''` it got as falsy and
+// returned null without even moving the index — a Back button that stayed
+// enabled and did nothing for the rest of the tab's life.
+//
+// These tests drive the real TabManager: they assert behaviour, not wording.
+
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin. Only the things jsdom genuinely does not have are stubbed.
+(window as any).__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+
+function reset() {
+	tabManager.closeAll();
+	tabManager.recentlyClosed.length = 0;
+	localStorage.clear();
+}
+
+function tabWith(id: string) {
+	return tabManager.tabs.find((tab) => tab.id === id)!;
+}
+
+test('a new tab carries no history entry until it points at a file', () => {
+	reset();
+	tabManager.addNewTab();
+
+	assert.deepEqual(tabWith(tabManager.activeTabId!).history, []);
+});
+
+test('following a link out of an untitled tab does not light a Back button that cannot work', () => {
+	reset();
+	tabManager.addNewTab();
+	const id = tabManager.activeTabId!;
+
+	tabManager.navigate(id, '/notes/a.md');
+
+	assert.deepEqual(tabWith(id).history, ['/notes/a.md']);
+	assert.equal(tabManager.canGoBack(id), false);
+	assert.equal(tabManager.goBack(id), null);
+});
+
+test('a tab that gave up its path to another does not keep a dead entry either', () => {
+	reset();
+	tabManager.addTab('/notes/target.md', 'target text');
+	const resident = tabManager.activeTabId!;
+	// Only a DIRTY tab survives losing its path — a clean one is closed.
+	tabManager.updateTabRawContent(resident, 'work in progress');
+	tabManager.addTab('/notes/from.md', 'from text');
+	tabManager.navigate(tabManager.activeTabId!, '/notes/target.md');
+	assert.equal(tabWith(resident).path, '', 'the dirty loser is now untitled');
+
+	tabManager.navigate(resident, '/notes/b.md');
+
+	assert.deepEqual(tabWith(resident).history, ['/notes/b.md']);
+	assert.equal(tabManager.canGoBack(resident), false);
+});
+
+test('back and forward still walk a tab that has actually been somewhere', () => {
+	reset();
+	tabManager.addTab('/notes/a.md', 'a');
+	const id = tabManager.activeTabId!;
+
+	tabManager.navigate(id, '/notes/b.md');
+
+	assert.deepEqual(tabWith(id).history, ['/notes/a.md', '/notes/b.md']);
+	assert.equal(tabManager.canGoBack(id), true);
+	assert.equal(tabManager.goBack(id), '/notes/a.md');
+	assert.equal(tabManager.canGoForward(id), true);
+	assert.equal(tabManager.goForward(id), '/notes/b.md');
+});
+
+// Save As is the other way an untitled tab acquires a path, and it must not
+// leave a second entry behind either: the buffer did not move to another
+// document, it just gained a name for the one it already held.
+test('naming an untitled buffer replaces its entry rather than appending one', () => {
+	reset();
+	tabManager.addNewTab();
+	const id = tabManager.activeTabId!;
+
+	tabManager.updateTabPath(id, '/notes/saved.md');
+
+	assert.deepEqual(tabWith(id).history, ['/notes/saved.md']);
+	assert.equal(tabManager.canGoBack(id), false);
+});

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -483,7 +483,9 @@ class TabManager {
 			// The title still names the file the buffer came from — that is what
 			// makes the tab recognizable, and `saveContent` offers it as the
 			// default filename when the user places it.
-			other.history = [''];
+			// It has no path now, so it has no history entry: the tab is untitled,
+			// and `''` is not somewhere Back can take the reader.
+			other.history = [];
 			other.historyIndex = 0;
 		}
 	}
@@ -570,7 +572,11 @@ class TabManager {
 				return this.rawContent !== this.originalContent;
 			},
 			isEditing: settings.newFileDefaultMode,
-			history: [content],
+			// Empty, as `addHomeTab` below already had it. This used to be
+			// `[content]` — a PATH list seeded with the new buffer's text, which
+			// is `''` and so looked harmless, and was not: see
+			// `navigateFileHistory`.
+			history: [],
 			historyIndex: 0,
 			editorViewState: null,
 			scrollPercentage: 0,

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -19,6 +19,47 @@ import {
 export interface Tab {
 	id: string;
 	path: string;
+	/**
+	 * What the tab strip, the window title and the per-tab close dialog call
+	 * this tab. Derived from `path` at every site that points a tab at a
+	 * document — `addTab`, `restoreState`, `updateTabPath`, `renameTab`,
+	 * `navigate`, `goBack`, `goForward` — as the last segment of the path, and
+	 * chosen by `nextUntitledTitle` when there is no path to take a segment
+	 * from.
+	 *
+	 * Five of those sites spell the derivation `path.split(/[/\\]/).pop() ||
+	 * 'Untitled'`, and that English literal is dead code, not an i18n hole. It
+	 * is there because `Array.prototype.pop` is typed `string | undefined`; the
+	 * arm needs a path that is empty or ends in a separator, and every route
+	 * into those five is guarded against both upstream:
+	 *
+	 * - `navigate` is only ever handed a link target, and `getMarkdownLinkTarget`
+	 *   refuses an href whose path does not end in one of
+	 *   `MARKDOWN_LINK_EXTENSIONS`, so what `resolveMarkdownTargetPath` returns
+	 *   always ends in a filename.
+	 * - `goBack`/`goForward` return on `!result.path` before the title is
+	 *   touched, so an empty entry cannot reach it — and every non-empty entry
+	 *   in `history` was put there by one of the other sites.
+	 * - `renameTab` replaces the last segment of a non-empty `tab.path` with a
+	 *   non-empty typed name, and only runs once `fs::rename` has SUCCEEDED on
+	 *   the result, which a destination ending in a separator cannot do.
+	 * - `updateTabPath` is reached from the Save/Save As dialog, which returns
+	 *   a file the user named, and from `loadMarkdown` — and there only when
+	 *   the active tab is an empty untitled one. The app's one unvalidated path
+	 *   source, `send_markdown_path`, hands back raw argv filtered only on a
+	 *   leading `-`, so `markpad ~/notes/` really does reach `loadMarkdown`
+	 *   with a trailing separator; it cannot reach THIS branch, because
+	 *   untitled tabs are not persisted (`serializeState` filters on
+	 *   `hasRealFilePath`) and so no empty untitled tab exists at startup for
+	 *   argv to repoint. That path lands on `addTab`, which resolves a nameless
+	 *   path through `nextUntitledTitle` and `t('tabs.untitled', …)`.
+	 *
+	 * If a route ever does hand one of them a directory or an empty string, the
+	 * fallback to reach for is `t('tabs.untitled', settings.language)` and NOT
+	 * `nextUntitledTitle`: numbering exists to tell several NEW untitled buffers
+	 * apart, and a tab that got here has a path — calling it "Untitled 3" would
+	 * claim otherwise.
+	 */
 	title: string;
 	/**
 	 * The three buffers. They are the same shape, they usually hold the same

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -381,7 +381,7 @@ class TabManager {
 			for (const saved of data.tabs) {
 				if (!saved || typeof saved.path !== 'string' || !hasRealFilePath(saved.path)) continue;
 				const filename = saved.path.split('\\').pop()?.split('/').pop() || saved.path;
-				const fileHistory = createFileHistory(saved.path, '');
+				const fileHistory = createFileHistory(saved.path);
 				restored.push({
 					id: typeof saved.id === 'string' ? saved.id : crypto.randomUUID(),
 					path: saved.path,
@@ -519,7 +519,7 @@ class TabManager {
 				this.tabs.map((tab) => tab.title),
 				t('tabs.untitled', settings.language),
 			);
-		const fileHistory = createFileHistory(path, rawContent);
+		const fileHistory = createFileHistory(path);
 
 		this.tabs.push({
 			id,
@@ -926,7 +926,6 @@ class TabManager {
 			// write would have been marked saved. The other caller repoints an
 			// untitled, empty, already-clean tab at the file it is about to load.
 			const fileHistory = replaceCurrentHistoryEntry({
-				currentPath: tab.path,
 				targetPath: path,
 				history: tab.history,
 				historyIndex: tab.historyIndex,
@@ -947,7 +946,6 @@ class TabManager {
 			tab.pathKey = pathKey;
 			tab.title = newPath.split(/[/\\]/).pop() || 'Untitled';
 			const fileHistory = replaceCurrentHistoryEntry({
-				currentPath: tab.path,
 				targetPath: newPath,
 				history: tab.history,
 				historyIndex: tab.historyIndex,
@@ -1104,7 +1102,6 @@ class TabManager {
 			// literally; the caller loads the file straight afterwards and
 			// `loadMarkdown` resolves the key then.
 			this.claimPath(path, id);
-			tab.history = result.history;
 			tab.historyIndex = result.historyIndex;
 			tab.path = path;
 			tab.pathKey = undefined;
@@ -1122,7 +1119,6 @@ class TabManager {
 			if (!result.path) return null;
 			const path = result.path;
 			this.claimPath(path, id);
-			tab.history = result.history;
 			tab.historyIndex = result.historyIndex;
 			tab.path = path;
 			tab.pathKey = undefined;

--- a/src/lib/utils/tabHistory.ts
+++ b/src/lib/utils/tabHistory.ts
@@ -1,28 +1,48 @@
+/**
+ * The back/forward history of ONE tab, as a value: the paths it has shown and
+ * where in them it is. Deliberately not part of the store — the arithmetic
+ * below (truncating the forward entries, clamping an index, refusing a move
+ * that would leave the bounds) is the fiddly half of back/forward, and here it
+ * can be tested for what it computes rather than for what it does to a tab.
+ *
+ * Every function returns the next state instead of mutating one, so the store
+ * assigns exactly the two fields that changed and nothing here can reach a tab.
+ * Only what a caller actually reads is returned: `goBackInHistory` and
+ * `goForwardInHistory` move the index within the array they were given, so they
+ * hand back an index and a path and leave `history` alone — the store used to
+ * assign that array back over itself.
+ */
 type FileHistoryState = {
 	history: string[];
 	historyIndex: number;
 };
 
-type FileHistoryNavigationState = FileHistoryState & {
-	currentPath: string;
-};
-
-type FileHistoryNavigationResult = FileHistoryState & {
+type FileHistoryNavigationResult = {
+	historyIndex: number;
 	path: string | null;
 };
 
-export function createFileHistory(path: string, _content = ''): FileHistoryState {
+export function createFileHistory(path: string): FileHistoryState {
 	return {
 		history: [path],
 		historyIndex: 0,
 	};
 }
 
+/**
+ * Re-point the entry the tab is standing on — Save As and rename, which change
+ * the tab's path without moving it to another document.
+ *
+ * Takes no `currentPath`: the entry to overwrite is the one `historyIndex`
+ * names, whatever it currently holds. It used to be in the signature and never
+ * destructured, and both callers passed `tab.path` AFTER assigning the new path
+ * to it, so even reading it would have read the target.
+ */
 export function replaceCurrentHistoryEntry({
 	targetPath,
 	history,
 	historyIndex,
-}: FileHistoryNavigationState & { targetPath: string }): FileHistoryState {
+}: FileHistoryState & { targetPath: string }): FileHistoryState {
 	const nextHistory = history.length > 0 ? [...history] : [targetPath];
 	const nextIndex = Math.max(0, Math.min(historyIndex, nextHistory.length - 1));
 	nextHistory[nextIndex] = targetPath;
@@ -38,7 +58,7 @@ export function navigateFileHistory({
 	targetPath,
 	history,
 	historyIndex,
-}: FileHistoryNavigationState & { targetPath: string }): FileHistoryState {
+}: FileHistoryState & { currentPath: string; targetPath: string }): FileHistoryState {
 	if (currentPath === targetPath) {
 		return { history, historyIndex };
 	}
@@ -63,12 +83,11 @@ export function canGoForwardInHistory({ history, historyIndex }: FileHistoryStat
 
 export function goBackInHistory(state: FileHistoryState): FileHistoryNavigationResult {
 	if (!canGoBackInHistory(state)) {
-		return { history: state.history, historyIndex: state.historyIndex, path: null };
+		return { historyIndex: state.historyIndex, path: null };
 	}
 
 	const historyIndex = state.historyIndex - 1;
 	return {
-		history: state.history,
 		historyIndex,
 		path: state.history[historyIndex],
 	};
@@ -76,12 +95,11 @@ export function goBackInHistory(state: FileHistoryState): FileHistoryNavigationR
 
 export function goForwardInHistory(state: FileHistoryState): FileHistoryNavigationResult {
 	if (!canGoForwardInHistory(state)) {
-		return { history: state.history, historyIndex: state.historyIndex, path: null };
+		return { historyIndex: state.historyIndex, path: null };
 	}
 
 	const historyIndex = state.historyIndex + 1;
 	return {
-		history: state.history,
 		historyIndex,
 		path: state.history[historyIndex],
 	};

--- a/src/lib/utils/tabHistory.ts
+++ b/src/lib/utils/tabHistory.ts
@@ -24,7 +24,9 @@ type FileHistoryNavigationResult = {
 
 export function createFileHistory(path: string): FileHistoryState {
 	return {
-		history: [path],
+		// An untitled tab is opened with `''`, and `''` is not a path — see
+		// `navigateFileHistory` for what an entry nobody can re-open costs.
+		history: path === '' ? [] : [path],
 		historyIndex: 0,
 	};
 }
@@ -64,7 +66,21 @@ export function navigateFileHistory({
 	}
 
 	const baseHistory = history.length > 0 ? history : [currentPath];
-	const nextHistory = baseHistory.slice(0, historyIndex + 1);
+	// Only real paths, because that is the only thing an entry is for: `goBack`
+	// hands its entry to the caller to re-open, and there is no re-opening an
+	// untitled buffer — it has no file, and the load that follows this
+	// navigation has already replaced the text that was in it. Left in, the
+	// tab sits at index 1 of `['', '/target.md']`, `canGoBack` reports true and
+	// enables the button, and `goBack` rejects the `''` it gets as falsy and
+	// returns null without moving the index: enabled and dead, permanently.
+	//
+	// Filtered here, at the one function that GROWS a history, rather than at
+	// each seed. `''` reaches this line from four of them — `addNewTab`, an
+	// untitled `addTab`, the tab that gives up its path in `claimPath`, and the
+	// `[currentPath]` fallback on the line above — and a tab transferred from an
+	// older window arrives carrying whatever its source seeded. The index is
+	// recomputed from the length below, so removing an entry cannot desync it.
+	const nextHistory = baseHistory.slice(0, historyIndex + 1).filter((entry) => entry !== '');
 	nextHistory.push(targetPath);
 
 	return {


### PR DESCRIPTION
Three backlog items in the tab store. One of them turned out not to be a bug.

---

### ① The five hardcoded `'Untitled'` fallbacks — not a bug

`tab.title = path.split(/[/\\]/).pop() || 'Untitled'` appears five times, bypassing both `nextUntitledTitle()` and i18n. It looks like #605's defect class.

**The arm is unreachable at all five sites.** It exists only because `pop()` is typed `string | undefined`; firing it needs a path that is empty or ends in a separator.

| site | what stops it |
|---|---|
| `navigate` | `getMarkdownLinkTarget` returns `null` unless the href matches `\.(md\|markdown\|mdown\|mkd\|txt)$`, so the path always ends in a filename |
| `goBack` / `goForward` | `if (!result.path) return null` fires before the title assignment |
| `renameTab` | the rename regex preserves the separator, and it runs only after `fs::rename` succeeded — which fails with `ENOTDIR` onto a trailing slash |
| `updateTabPath` | Save/Save-As names a file; the `loadMarkdown` caller is reached only for an empty untitled tab |

No mechanism added. A doc comment on `Tab.title` records the four guarantees, and notes that a future route breaking them wants `t('tabs.untitled', …)` and **not** `nextUntitledTitle` — numbering disambiguates several *new* untitled buffers, and a tab reaching these sites has a path.

**Found on the way, not fixed here:** `send_markdown_path` returns raw `std::env::args()` filtered only on a leading `-` — no existence or directory check. `markpad ~/notes/` does reach `loadMarkdown` with a trailing separator. It cannot land on that branch (untitled tabs are never persisted, so there is none to repoint at startup), but the input is unvalidated.

### ② `tabHistory.ts` — kept, three dead parts removed

Inlining does not make the complexity vanish: four callers of identical shape come back as private methods on a 1100-line `TabManager`, which also absorbs the index arithmetic worth testing standalone.

- `createFileHistory(path, _content)` — second parameter unused, passed by all three callers
- `replaceCurrentHistoryEntry`'s `currentPath` — both callers passed `tab.path` *after* assigning the new path, so reading it would have read the target
- `goBackInHistory` / `goForwardInHistory` returned `history` unchanged, so both call sites assigned the tab's own array back over itself

### ③ `history: [content]` — the damage is one step later

`addNewTab` seeded the **path** history with the tab's *content*, a `const ''`.

Back on a fresh tab does nothing visible — `historyIndex` is 0 and the button is disabled. Navigate out of that tab and the history is `['', '/target.md']` at index 1: `canGoBack` is true, **the Back button lights up, and pressing it does nothing** — `goBack` rejects the `''` as falsy and never moves the index. Lit and dead, permanently.

Writing `[]` fixes nothing, because `navigateFileHistory` synthesises `[currentPath]` for an empty history — the same `''` by another route. So the rule went into the one function that grows a history, which also covers `claimPath` and a tab transferred in from an older build. The seeds were corrected too, so the invariant holds by construction.

---

`npm test` 969 · `npm run test:vitest` 72 · `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
