### PR TITLE
fix(tabs): take the tab menus' chords from the registry, not from a literal

### DIFF
--- a/scripts/shortcutRegistry.test.ts
+++ b/scripts/shortcutRegistry.test.ts
@@ -1,18 +1,23 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import ts from 'typescript';
+
 import { getEditorToolbarTools } from '../src/lib/utils/editorToolbar.js';
+import { isHomePath } from '../src/lib/utils/homeTab.js';
 import { getSupportedLanguages, t, translations, type LanguageCode, type Translation } from '../src/lib/utils/i18n.js';
 import {
 	SHORTCUTS,
 	SHORTCUT_GROUPS,
 	formatChord,
+	modifierFor,
 	shortcutLabel,
 	shortcutSections,
 	type ShortcutEntry,
 } from '../src/lib/utils/shortcuts.js';
+import { getTabFileActions, hasRealFilePath } from '../src/lib/utils/tabFileActions.js';
 import { OperatingSystem, PLATFORMS, documentKeymap, editorKeymap, type Chord } from './keymapHarness.js';
-import { readRustBackend, readSource } from './sourceTree.js';
+import { functionSource, readRustBackend, readSource, readSourceFiles } from './sourceTree.js';
 
 /*
  * THE CONTRACT: every chord the shortcuts panel shows is a chord that actually
@@ -301,6 +306,207 @@ test('the app menu prints no shortcut literal of its own', () => {
 	// than a chord.
 	const offRegistry = spans.filter((body) => !body.includes('shortcutLabel(') && !body.includes("t('tooltip.reset'"));
 	assert.deepEqual(offRegistry, [], 'every menu chord comes from shortcutLabel()');
+});
+
+/**
+ * A chord as a user reads it: a modifier word, a `+`, and something to press.
+ *
+ * `Mod+…` is deliberately absent — that is the registry's own spelling and is
+ * not a claim about any one platform.
+ */
+const CHORD_LITERAL = /\b(?:Ctrl|Cmd|Command|Meta|Super)\+(?:(?:Shift|Alt|Option|Ctrl|Cmd)\+)*[A-Za-z0-9\\[\]`,.\-=]/g;
+
+/**
+ * Whether the match at `index` is inside a comment.
+ *
+ * Judged from the text before it ON ITS OWN LINE, never by stripping comments
+ * out of the file first: a stripper that mistakes a block-comment opener inside
+ * a string literal for a real one swallows everything up to the next closer, and
+ * a chord hidden that way is a guard that quietly stopped guarding. This can
+ * only ever
+ * miss a literal that shares a line with an earlier `//`, which no display code
+ * in `src/` is written as.
+ */
+function inComment(text: string, index: number): boolean {
+	return /^\s*\*|\/\/|\/\*|<!--/.test(text.slice(text.lastIndexOf('\n', index) + 1, index));
+}
+
+/**
+ * Files allowed to spell a chord out.
+ *
+ * One, and it is the registry: `Ctrl+Tab` and `Ctrl+Shift+Tab` are a literal
+ * Ctrl on macOS too (Cmd+Tab is the system application switcher), so the table
+ * has to be able to say so. Everything else asks `shortcutLabel()`.
+ *
+ * NOT exempted, though the shapes are different: a `title=` tooltip is as
+ * user-visible as a menu row, and the two that read `(Ctrl+W)` and `(Ctrl+T)`
+ * were as wrong on macOS as the menu rows beside them. Comments are excluded by
+ * `inComment` rather than listed here — a comment discussing Cmd+S is prose, not
+ * a label.
+ */
+const CHORD_LITERAL_EXEMPT: Record<string, string> = {
+	'src/lib/utils/shortcuts.ts':
+		'the registry itself: the one file whose job is to spell chords, and the only place a literal Ctrl (Ctrl+Tab) is a deliberate cross-platform claim',
+};
+
+test('no chord is spelled by hand anywhere in src, in any shape', () => {
+	// The widening of the guard above, which only ever read
+	// `<span class="menu-shortcut">` bodies in `TitleBar.svelte`. Six live
+	// literals were invisible to it: three `shortcut:` properties in `Tab.svelte`,
+	// two in `TabList.svelte`, and two `title=` tooltips — a different shape in a
+	// different file, printed into the same span by `ContextMenu.svelte`. This
+	// sweep is shape-agnostic on purpose, so the next one does not need a seventh
+	// pattern written for it.
+	const files = readSourceFiles('src');
+	assert.ok(files.length > 50, `swept ${files.length} files`);
+
+	// Not vacuous: the pattern really does find chords in the file that has them.
+	const registry = readSource('src/lib/utils/shortcuts.ts');
+	assert.ok(
+		[...registry.matchAll(CHORD_LITERAL)].some((m) => !inComment(registry, m.index)),
+		'the chord pattern matches nothing even in the registry, so this sweep proves nothing',
+	);
+
+	const offenders: string[] = [];
+	for (const { path, text } of files) {
+		if (path in CHORD_LITERAL_EXEMPT) continue;
+		for (const match of text.matchAll(CHORD_LITERAL)) {
+			if (inComment(text, match.index)) continue;
+			offenders.push(`${path}:${text.slice(0, match.index).split('\n').length}: ${match[0]}…`);
+		}
+	}
+	assert.deepEqual(
+		offenders,
+		[],
+		'a keyboard chord is written out by hand here; it belongs in src/lib/utils/shortcuts.ts, ' +
+			'read back with shortcutLabel(id, modifierFor(settings.osType)) so macOS reads Cmd',
+	);
+
+	for (const path of Object.keys(CHORD_LITERAL_EXEMPT)) {
+		assert.ok(files.some((file) => file.path === path), `${path} is gone — drop it from CHORD_LITERAL_EXEMPT`);
+	}
+});
+
+// ------------------------------------------- the context menus, actually run
+
+/*
+ * `ContextMenu.svelte` prints `item.shortcut` into the SAME
+ * `<span class="menu-shortcut">` the app menu uses, so a chord handed to it sits
+ * in the same visual slot as a chord the app menu derived from the registry —
+ * and the tab menus handed it `'Ctrl+T'`, `'Ctrl+Shift+T'` and `'Ctrl+W'` as
+ * literals. On macOS that printed "New File · Ctrl+T" one keystroke away from
+ * the File menu's "Cmd+T", and Ctrl+T is not bound there at all: `Editor.svelte`
+ * binds `monaco.KeyMod.CtrlCmd`, which is ⌘ on a Mac.
+ *
+ * The guard above could not see it. It reads the `<span>` bodies of
+ * `TitleBar.svelte`, and these were `shortcut:` object properties in two other
+ * components — a different shape in a different file. Same for the two `title=`
+ * tooltips on the `+` button and the tab close button.
+ *
+ * So the menus are RUN here rather than read: the builder function is lifted out
+ * of its component (the same trick `keymapHarness.ts` uses on `handleKeyDown`)
+ * and evaluated with a `settings` store that says macOS, then one that says
+ * Windows. What comes back is the array `ContextMenu` would render, so the
+ * assertion is about the string the user sees rather than about the shape of the
+ * source that produced it.
+ */
+
+type MenuItem = { label?: string; shortcut?: string; separator?: true };
+
+/** The items `fn` in `file` builds, on `osType`. */
+async function contextMenuItems(file: string, fn: string, osType: string): Promise<MenuItem[]> {
+	const js = ts.transpileModule(functionSource(readSource(file), fn), {
+		compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ESNext },
+	}).outputText;
+
+	let menu: { items?: MenuItem[] } | undefined;
+	const known: Record<string, unknown> = {
+		// The real store field the component has to consult, and the real
+		// translator and registry functions — a stub for any of these would let a
+		// component that asked the wrong question still look right.
+		settings: { osType, language: 'en' },
+		t,
+		shortcutLabel,
+		modifierFor,
+		getTabFileActions,
+		hasRealFilePath,
+		isHomePath,
+		tab: { id: 'tab-1', path: '/notes/a.md', title: 'a.md' },
+		tabManager: { tabs: [{ id: 'tab-1' }, { id: 'tab-2' }] },
+		getCurrentWindow: () => ({ label: 'main' }),
+		emitTo: () => {},
+		// The only other window is this one, so the "move to window" section is
+		// empty and the shortcut-bearing rows are undisturbed.
+		invoke: async () => [],
+		console,
+	};
+
+	const scope = new Proxy(known, {
+		has: () => true,
+		get: (target, property) =>
+			typeof property === 'string' && property in target ? target[property] : () => undefined,
+		set: (target, property, value) => {
+			const items = (value as { items?: unknown })?.items;
+			if (Array.isArray(items)) menu = value as { items: MenuItem[] };
+			target[property as string] = value;
+			return true;
+		},
+	});
+
+	const build = new Function('scope', `with (scope) { ${js}\nreturn ${fn}; }`) as (
+		s: unknown,
+	) => (e: unknown) => unknown;
+
+	// `handleContainerContextMenu` returns early unless the event landed on the
+	// container itself, so target and currentTarget are the same object.
+	const el = { classList: { contains: () => false } };
+	await build(scope)({ preventDefault() {}, stopPropagation() {}, clientX: 10, clientY: 20, target: el, currentTarget: el });
+
+	assert.ok(menu?.items?.length, `${fn} in ${file} produced no menu at all; the harness is not running the real function`);
+	return menu!.items!;
+}
+
+/** file -> builder, and the labelled chords it must show on each platform. */
+const TAB_MENUS: Array<{ file: string; fn: string; macos: Array<[string, string]> }> = [
+	{
+		file: 'src/lib/components/Tab.svelte',
+		fn: 'handleContextMenu',
+		macos: [
+			['menu.newFile', 'Cmd+T'],
+			['menu.undoCloseTab', 'Cmd+Shift+T'],
+			['menu.closeFile', 'Cmd+W'],
+		],
+	},
+	{
+		file: 'src/lib/components/TabList.svelte',
+		fn: 'handleContainerContextMenu',
+		macos: [
+			['menu.newFile', 'Cmd+T'],
+			['menu.undoCloseTab', 'Cmd+Shift+T'],
+		],
+	},
+];
+
+test('the tab context menus print the modifier the user is on, not a hard-coded Ctrl', async () => {
+	for (const { file, fn, macos } of TAB_MENUS) {
+		for (const platform of ['macos', 'windows'] as const) {
+			const shown = (await contextMenuItems(file, fn, platform))
+				.filter((item) => item.shortcut)
+				.map((item) => [item.label, item.shortcut]);
+
+			const want = macos.map(([labelKey, chord]) => [
+				t(labelKey, 'en'),
+				platform === 'macos' ? chord : chord.replaceAll('Cmd', 'Ctrl'),
+			]);
+
+			assert.deepEqual(
+				shown,
+				want,
+				`${file}: the ${platform} tab context menu shows ${JSON.stringify(shown)}; ` +
+					'every chord in it must come from shortcutLabel() so it agrees with the app menu',
+			);
+		}
+	}
 });
 
 test('Save As runs Save As, and not a plain Save', () => {

--- a/src/lib/components/Tab.svelte
+++ b/src/lib/components/Tab.svelte
@@ -8,6 +8,7 @@
 	import { settings } from '../stores/settings.svelte.js';
 	import { getTabFileActions, hasRealFilePath } from '../utils/tabFileActions.js';
 	import { isHomePath } from '../utils/homeTab.js';
+	import { modifierFor, shortcutLabel } from '../utils/shortcuts.js';
 
 	let { tab, isActive, isLast, onclick, onclose } = $props<{
 		tab: Tab;
@@ -86,6 +87,10 @@
 		e.stopPropagation();
 
 		const currentLang = settings.language;
+		// ContextMenu prints `shortcut` into the same `<span class="menu-shortcut">`
+		// the app menu uses, so a literal here sits a keystroke away from the app
+		// menu's registry-derived chord and disagrees with it on macOS.
+		const modifier = modifierFor(settings.osType);
 		const fileActionItems: ContextMenuItem[] = getTabFileActions(tab.path).map((action) => ({
 			label: t(action.labelKey, currentLang),
 			disabled: action.disabled,
@@ -112,8 +117,8 @@
 			x: e.clientX,
 			y: e.clientY,
 			items: [
-				{ label: t('menu.newFile', currentLang), shortcut: 'Ctrl+T', onClick: () => emitTo(getCurrentWindow().label, 'menu-tab-new') },
-				{ label: t('menu.undoCloseTab', currentLang), shortcut: 'Ctrl+Shift+T', onClick: () => emitTo(getCurrentWindow().label, 'menu-tab-undo') },
+				{ label: t('menu.newFile', currentLang), shortcut: shortcutLabel('file-new', modifier), onClick: () => emitTo(getCurrentWindow().label, 'menu-tab-new') },
+				{ label: t('menu.undoCloseTab', currentLang), shortcut: shortcutLabel('tab-undo-close', modifier), onClick: () => emitTo(getCurrentWindow().label, 'menu-tab-undo') },
 				{
 					label: t('menu.rename', currentLang),
 					// Rename renames the file on disk; untitled and home tabs have
@@ -133,7 +138,7 @@
 				},
 				...moveToWindowItems,
 				{ separator: true },
-				{ label: t('menu.closeFile', currentLang), shortcut: 'Ctrl+W', onClick: () => emitTo(getCurrentWindow().label, 'menu-tab-close', tab.id) },
+				{ label: t('menu.closeFile', currentLang), shortcut: shortcutLabel('file-close', modifier), onClick: () => emitTo(getCurrentWindow().label, 'menu-tab-close', tab.id) },
 				{ label: t('menu.closeOtherTabs', currentLang), onClick: () => emitTo(getCurrentWindow().label, 'menu-tab-close-others', tab.id) },
 				{ label: t('menu.closeTabsToRight', currentLang), onClick: () => emitTo(getCurrentWindow().label, 'menu-tab-close-right', tab.id) },
 			],
@@ -186,7 +191,7 @@
 		<button class="tab-close" class:dirty={tab.isDirty} onclick={handleClose} onmousedown={(e) => {
 			e.stopPropagation();
 			e.preventDefault();
-		}} title={`${t('tooltip.close', settings.language)} (Ctrl+W)`}>
+		}} title={`${t('tooltip.close', settings.language)} (${shortcutLabel('file-close', modifierFor(settings.osType))})`}>
 			{#if tab.isDirty}
 				<span class="dirty-dot"></span>
 			{/if}

--- a/src/lib/components/TabList.svelte
+++ b/src/lib/components/TabList.svelte
@@ -6,6 +6,7 @@
 	import { settings } from '../stores/settings.svelte.js';
 	import { emitTo } from '@tauri-apps/api/event';
 	import { getCurrentWindow } from '@tauri-apps/api/window';
+	import { modifierFor, shortcutLabel } from '../utils/shortcuts.js';
 
 	import { flip } from 'svelte/animate';
 	import { tick } from 'svelte';
@@ -163,13 +164,14 @@
 		e.preventDefault();
 
 		const currentLang = settings.language;
+		const modifier = modifierFor(settings.osType);
 		tabListContextMenu = {
 			show: true,
 			x: e.clientX,
 			y: e.clientY,
 			items: [
-				{ label: t('menu.newFile', currentLang), shortcut: 'Ctrl+T', onClick: () => emitTo(getCurrentWindow().label, 'menu-tab-new') },
-				{ label: t('menu.undoCloseTab', currentLang), shortcut: 'Ctrl+Shift+T', onClick: () => emitTo(getCurrentWindow().label, 'menu-tab-undo') },
+				{ label: t('menu.newFile', currentLang), shortcut: shortcutLabel('file-new', modifier), onClick: () => emitTo(getCurrentWindow().label, 'menu-tab-new') },
+				{ label: t('menu.undoCloseTab', currentLang), shortcut: shortcutLabel('tab-undo-close', modifier), onClick: () => emitTo(getCurrentWindow().label, 'menu-tab-undo') },
 			]
 		};
 	}
@@ -223,7 +225,7 @@
 		<div class="scroll-shadow right" class:visible={showRightArrow}></div>
 	</div>
 
-	<button class="new-tab-btn" onclick={onnewTab} onmousedown={(e) => e.preventDefault()} title={`${t('tooltip.newTab', settings.language)} (Ctrl+T)`}>
+	<button class="new-tab-btn" onclick={onnewTab} onmousedown={(e) => e.preventDefault()} title={`${t('tooltip.newTab', settings.language)} (${shortcutLabel('file-new', modifierFor(settings.osType))})`}>
 		<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
 			><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
 	</button>

--- a/src/lib/utils/shortcuts.ts
+++ b/src/lib/utils/shortcuts.ts
@@ -313,8 +313,15 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 	},
 ];
 
-/** The modifier word each platform spells `Mod` with. */
-function modifierFor(platform: ShortcutPlatform): 'Cmd' | 'Ctrl' {
+/**
+ * The modifier word each platform spells `Mod` with.
+ *
+ * Takes the raw `settings.osType` rather than `ShortcutPlatform`, because that
+ * store field also carries `'unknown'` while the Tauri call that resolves it is
+ * still in flight. Every caller that has an os type and needs a modifier goes
+ * through here, so `=== 'macos' ? 'Cmd' : 'Ctrl'` is written once.
+ */
+export function modifierFor(platform: string): 'Cmd' | 'Ctrl' {
 	return platform === 'macos' ? 'Cmd' : 'Ctrl';
 }
 


### PR DESCRIPTION
On macOS, right-clicking a tab shows **"New File · Ctrl+T"** and **"Close · Ctrl+W"**, while the File menu one click away shows `Cmd+T` and `Cmd+W`. `Ctrl+T` is not bound on macOS at all — `Editor.svelte` binds `monaco.KeyMod.CtrlCmd`, which is ⌘ there.

Six chords were written by hand in `Tab.svelte` and `TabList.svelte` instead of coming from `SHORTCUTS` + `shortcutLabel()`, which renders `Mod` as `Cmd` or `Ctrl` per platform. `ContextMenu.svelte` puts `item.shortcut` in the same `<span class="menu-shortcut">` the app menu uses, so they sit in the same visual slot as the correct ones.

`TitleBar.svelte` records the same defect being fixed once before — a Reload tooltip reading `Ctrl+F5` for a binding that was plain F5.

### Platform source

`settings.osType`, which `MarkdownViewer.svelte` and `Settings.svelte` already read. Not `TitleBar.svelte`'s `navigator.userAgent.includes('Macintosh')` — that would be a third and fourth copy of a platform sniff. `modifierFor` is now exported from `shortcuts.ts` so the ternary is written once rather than seven times.

### Why the existing guard missed it

`shortcutRegistry.test.ts` asserted "the app menu prints no shortcut literal of its own", but only scanned `<span class="menu-shortcut">…</span>` in `TitleBar.svelte`. These six are `shortcut:` properties and `title=` attributes — invisible to it.

Two tests replace it:

- **Behavioural** — the two context-menu handlers are lifted out and run under `osType = 'macos'` and `'windows'`, asserting the exact label/shortcut pairs. Uses the same transpile-and-run harness `keymapHarness.ts` already applies to `handleKeyDown`.
- **Structural sweep** — one regex over all of `src`, shape-agnostic, so it sees properties, attributes and span bodies alike. Comments are excluded by checking the line prefix at the match rather than by stripping comments from the file: a stripper fooled by a block-comment opener inside a string swallows a chord and stops guarding silently.

The two `title=` tooltips can only be covered structurally — they are markup, so nothing can run them.

**One exemption**: `shortcuts.ts` itself, where `Ctrl+Tab` is a deliberate literal Ctrl on macOS too, since Cmd+Tab is the system app switcher. `title=` is deliberately not exempt.

### Noted, not changed

`MarkdownViewer.svelte` and `Settings.svelte` still hand-roll the same ternary in four places; `modifierFor` now exists for them. And `TitleBar.svelte` derives its modifier from `navigator.userAgent` while everything else reads `settings.osType` — two platform verdicts that can in principle disagree.

`npm test` 997 · `npm run test:vitest` 71 · `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
