### PR TITLE
fix(editor): escape what a markdown link destination cannot carry

### DIFF
--- a/scripts/imageEmbed.test.ts
+++ b/scripts/imageEmbed.test.ts
@@ -1,0 +1,192 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { resolveExportImagePath } from '../src/lib/utils/exportHtml.js';
+import {
+	DEFAULT_IMAGE_DIRECTORY,
+	documentParentDir,
+	encodeImageDestination,
+	imageEmbed,
+} from '../src/lib/utils/imageEmbed.js';
+import { resolveDocumentRelativePath } from '../src/lib/utils/markdown.js';
+import { readSource } from './sourceTree.js';
+
+/*
+	The link the app writes for a pasted or dropped image has to name the file
+	Rust just created — after a CommonMark parse, and after each of Markpad's
+	two readers has had its way with the result.
+
+	So every case below is checked end to end, through the real readers:
+
+	  parse    the destination CommonMark hands the renderer, per its grammar
+	  preview  `processMarkdownHtml`: decodeURIComponent, then resolve
+	  export   `resolveExportImagePath`, imported here, not modelled
+
+	The one thing modelled rather than run is comrak, which is Rust. Its
+	`escape_href` (comrak 0.54, src/html.rs) is the identity on everything
+	`encodeImageDestination` emits: its safe set covers the unreserved ASCII we
+	pass through, it copies a `%` verbatim when two hex digits follow, and the
+	two characters it does rewrite — `&` to `&amp;`, `'` to `&#x27;` — are
+	undone by the HTML parser before either reader sees them. Passing the
+	destination straight to the readers is therefore faithful, and
+	`the escapes comrak passes through unchanged` below pins the assumption
+	that matters.
+*/
+
+/**
+ * The destination CommonMark reads out of `![alt](…)`: it ends at the first
+ * ASCII space or control character, and parentheses count only while balanced.
+ * This is where `photo).png` loses its tail, so the fix has to be visible here
+ * before anything downstream is worth checking.
+ */
+function parseDestination(embed: string): string {
+	const open = embed.indexOf('](');
+	assert.notEqual(open, -1, `not an inline image: ${embed}`);
+
+	let depth = 1;
+	let i = open + 2;
+	for (; i < embed.length; i++) {
+		const char = embed[i];
+		if (char.charCodeAt(0) <= 0x20) break;
+		if (char === '\\') {
+			i++;
+			continue;
+		}
+		if (char === '(') depth++;
+		if (char === ')' && --depth === 0) break;
+	}
+	return embed.slice(open + 2, i);
+}
+
+/** What the preview does with a `src` in `processMarkdownHtml`. */
+function previewResolves(destination: string, tabPath: string): string {
+	return resolveDocumentRelativePath(tabPath, decodeURIComponent(destination));
+}
+
+const TAB_PATH = '/home/u/notes/note.md';
+
+/**
+ * `relPath` is what `save_image` / `copy_file_to_img` return: the image
+ * directory and the file name joined with `/`, relative to the document.
+ */
+function roundTrips(relPath: string, expectedFile: string) {
+	const destination = parseDestination(imageEmbed(relPath));
+
+	assert.equal(
+		destination,
+		encodeImageDestination(relPath),
+		'CommonMark truncated the destination',
+	);
+	assert.equal(previewResolves(destination, TAB_PATH), expectedFile, 'preview');
+	assert.equal(resolveExportImagePath(destination, TAB_PATH), expectedFile, 'export');
+}
+
+test('a file name whose # would otherwise become an anchor', () => {
+	// The report: `![alt](img/note#1.png)` exports as `img/note`.
+	roundTrips('img/note#1.png', '/home/u/notes/img/note#1.png');
+	assert.equal(imageEmbed('img/note#1.png'), '![alt](img/note%231.png)');
+});
+
+test('spaces, which were the only thing the old code escaped', () => {
+	roundTrips('img/my photo.png', '/home/u/notes/img/my photo.png');
+	assert.equal(imageEmbed('img/my photo.png'), '![alt](img/my%20photo.png)');
+});
+
+test('an unbalanced parenthesis, which ends the link early', () => {
+	roundTrips('img/photo).png', '/home/u/notes/img/photo).png');
+	roundTrips('img/photo(1.png', '/home/u/notes/img/photo(1.png');
+});
+
+test('balanced parentheses, which CommonMark allows and we encode anyway', () => {
+	// Legal unescaped, so this is a deliberate cost: one rule beats a paren
+	// counter, and both spellings name the same file at every reader.
+	roundTrips('img/photo (1).png', '/home/u/notes/img/photo (1).png');
+});
+
+test('a ? , which the export resolver reads as a query string', () => {
+	roundTrips('img/really?.png', '/home/u/notes/img/really?.png');
+});
+
+test('a literal % , which decodes back into a different name unencoded', () => {
+	// comrak copies `%20` through untouched, so an unencoded `50%20off.png`
+	// reaches decodeURIComponent and comes out as `50 off.png`.
+	roundTrips('img/50%20off.png', '/home/u/notes/img/50%20off.png');
+	assert.equal(imageEmbed('img/50%20off.png'), '![alt](img/50%2520off.png)');
+});
+
+test('a backslash, which CommonMark reads as an escape', () => {
+	// Encoded for the parse — unencoded, `\(` is an escape and the destination
+	// comes out as `img/a(b.png`, a different file.
+	assert.equal(imageEmbed('img/a\\(b.png'), '![alt](img/a%5C%28b.png)');
+	assert.equal(parseDestination(imageEmbed('img/a\\(b.png')), 'img/a%5C%28b.png');
+
+	// Not round-tripped, and this is the one case that cannot be: both readers
+	// resolve through a path splitter that counts `\` as a directory separator
+	// on purpose, because a Windows author writes `![](img\a.png)` and means
+	// one. See resolveDocumentRelativePath in src/lib/utils/markdown.ts. A
+	// POSIX file whose *name* contains a backslash is unreachable through a
+	// Markpad link however it is spelled, so nothing here can fix it.
+	assert.equal(
+		previewResolves('img/a%5C%28b.png', TAB_PATH),
+		'/home/u/notes/img/a/(b.png',
+	);
+});
+
+test('an imageDirectory carrying the same characters', () => {
+	roundTrips('my imgs #1/photo.png', '/home/u/notes/my imgs #1/photo.png');
+	roundTrips('assets (old)/a?.png', '/home/u/notes/assets (old)/a?.png');
+});
+
+test('an empty imageDirectory, whose leading slash is not an absolute path', () => {
+	// Rust joins with `/`, so an empty setting yields `/photo.png`; left alone
+	// it resolves to the filesystem root at both readers.
+	roundTrips('/photo #1.png', '/home/u/notes/photo #1.png');
+	assert.equal(imageEmbed('/photo #1.png'), '![alt](photo%20%231.png)');
+});
+
+test('non-ASCII names stay readable in the document', () => {
+	// The reason encodeURI/encodeURIComponent were not used: both would write
+	// `%E5%9B%BE%E7%89%87/…` into a file a person reads.
+	assert.equal(imageEmbed('图片/截图.png'), '![alt](图片/截图.png)');
+	roundTrips('图片/截图 1.png', '/home/u/notes/图片/截图 1.png');
+});
+
+test('the escapes comrak passes through unchanged', () => {
+	// Every byte we emit is either in comrak's HREF_SAFE set or a `%` followed
+	// by two hex digits, which its escape_href copies verbatim. If this ever
+	// fails, the destination is being double-escaped on the way to the HTML.
+	const safe = /^(?:[-_.+!*(),#@?=;:/$~a-zA-Z0-9]|%[0-9A-F]{2}|[^\x00-\x7f])*$/;
+	for (const relPath of ['img/note#1.png', 'img/my photo.png', 'img/50%20off.png']) {
+		assert.match(encodeImageDestination(relPath), safe);
+	}
+});
+
+test('angle brackets would need the export resolver changed to work', () => {
+	// The other candidate, and the form headingReference.ts uses for spaces and
+	// parentheses. It answers the CommonMark grammar and nothing else: the `#`
+	// reaches the readers raw, and the export resolver — correctly, for a URL —
+	// treats it as a fragment. Recorded so the choice is not re-litigated from
+	// memory; if this ever starts returning the whole path, angle brackets are
+	// back on the table.
+	assert.equal(parseDestination('![alt](<img/note#1.png>)'), '<img/note#1.png>');
+	assert.equal(resolveExportImagePath('img/note#1.png', TAB_PATH), '/home/u/notes/img/note');
+	assert.equal(resolveExportImagePath('img/a?.png', TAB_PATH), '/home/u/notes/img/a');
+});
+
+test('documentParentDir refuses a path with no directory in it', () => {
+	assert.equal(documentParentDir('/home/u/notes/note.md'), '/home/u/notes');
+	assert.equal(documentParentDir('C:\\notes\\note.md'), 'C:\\notes');
+	assert.equal(documentParentDir('note.md'), null);
+});
+
+test('Editor.svelte writes an image link through this module only', () => {
+	// The two call sites — paste (`save_image`) and drop (`copy_file_to_img`) —
+	// carried verbatim copies of this logic 300 lines apart, and the space-only
+	// escape had to be fixed in both. singleImplementationConvention.test.ts
+	// keeps the embed string itself single; this keeps the pre-fix escape from
+	// coming back next to it.
+	const source = readSource('src/lib/components/Editor.svelte');
+	assert.equal(source.includes('%20'), false, 'a hand-rolled space escape is back');
+	assert.match(source, /imageEmbed\(relPath\)/);
+	assert.equal(source.includes(`|| "${DEFAULT_IMAGE_DIRECTORY}"`), false);
+});

--- a/scripts/imageUndoKeepsFile.test.ts
+++ b/scripts/imageUndoKeepsFile.test.ts
@@ -77,6 +77,11 @@ g.window.__TAURI_INTERNALS__ = {
 
 const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 const { lineEndingLabel } = await import('../src/lib/utils/tabModels.js');
+// The real module, not a stub: the embed these tests match against is the one
+// it writes, and its escaping is pinned separately in imageEmbed.test.ts.
+const { DEFAULT_IMAGE_DIRECTORY, documentParentDir, imageEmbed } = await import(
+	'../src/lib/utils/imageEmbed.js'
+);
 
 // ------------------------------------------------- the component, as written
 
@@ -248,7 +253,7 @@ type Component = {
  * the statements that run are the component's own.
  */
 const factorySource = ts.transpileModule(
-	`const __component = (invoke, settings, tabManager, monaco, editor, lineEndingLabel) => {
+	`const __component = (invoke, settings, tabManager, monaco, editor, lineEndingLabel, DEFAULT_IMAGE_DIRECTORY, documentParentDir, imageEmbed) => {
 		let wordCount = 0;
 		let currentLanguage = 'markdown';
 		let lineEnding = 'LF';
@@ -318,6 +323,9 @@ function createComponent(backend: Backend, editor: unknown): Component {
 		monaco: unknown,
 		editor: unknown,
 		lineEndingLabel: unknown,
+		defaultImageDirectory: unknown,
+		parentDir: unknown,
+		embed: unknown,
 	) => Component;
 
 	return factory(
@@ -327,6 +335,9 @@ function createComponent(backend: Backend, editor: unknown): Component {
 		monacoStub,
 		editor,
 		lineEndingLabel,
+		DEFAULT_IMAGE_DIRECTORY,
+		documentParentDir,
+		imageEmbed,
 	);
 }
 

--- a/scripts/singleImplementationConvention.test.ts
+++ b/scripts/singleImplementationConvention.test.ts
@@ -238,6 +238,14 @@ const RULES: Rule[] = [
 		],
 	},
 	{
+		name: 'the app writes an image embed in one place',
+		why: "Pasting a screenshot and dropping a file are two commands (`save_image`, `copy_file_to_img`) returning the same kind of relative path, and Editor.svelte built the link for each with its own inline copy of the same four expressions, 300 lines apart. Both copies escaped the space and nothing else, so a file named `note#1.png` was written as `![alt](img/note#1.png)` and read back — by the preview and by the export resolver — as `img/note`. A third caller copying either one reintroduces it. `imageEmbed` in src/lib/utils/imageEmbed.ts is the single writer; scripts/imageEmbed.test.ts runs the round trip through the real readers.",
+		// The emitted Markdown itself: a magic string handed to another parser,
+		// which is what makes it a legal marker.
+		marker: /!\[alt\]\(/g,
+		allowed: ['src/lib/utils/imageEmbed.ts'],
+	},
+	{
 		name: 'this suite reads a file through one function',
 		why: "A test that reads source with its own readFileSync gets the bytes Git checked out, and on Windows `core.autocrlf` makes those CRLF. Every `\\n` in a pattern then matches nothing and every anchor containing one is 'not found' — fifteen files were red on the maintainer's Windows checkout while cutting v2.7.0 and were hand-patched assertion by assertion (#452). `readSource` in sourceTree.ts decides the line ending once, on read, so the assertions stay written against `\\n` and a new test cannot re-open the hole by accident. Read the file with `readSource(path)` from './sourceTree.js' — it takes a cwd-relative string or a `new URL(…, import.meta.url)` — and write the assertion against `\\n`.",
 		// The call, not the import: `import { readFileSync }` on its own reads

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -26,6 +26,11 @@
 		type ScrollSyncPosition,
 	} from '../utils/scrollSync.js';
 	import { asBufferLine, type BufferLine } from '../utils/lineCoordinates.js';
+	import {
+		DEFAULT_IMAGE_DIRECTORY,
+		documentParentDir,
+		imageEmbed,
+	} from '../utils/imageEmbed.js';
 
 	// Monaco is ~86% of the startup JavaScript (a 4.4 MB chunk, ~360ms of
 	// parse+eval, paid once per window because every window is its own webview)
@@ -649,7 +654,8 @@
 						tab.path.lastIndexOf("/"),
 					);
 					const parentDir = tab.path.substring(0, lastSlash);
-					const imgDirName = settings.imageDirectory || "img";
+					const imgDirName =
+						settings.imageDirectory || DEFAULT_IMAGE_DIRECTORY;
 
 					try {
 						const [currentEntries, imgEntries] = await Promise.all([
@@ -1421,19 +1427,17 @@
 					const filename = `paste_${Date.now()}.${ext}`;
 
 					const tabPath = tabManager.activeTab.path;
-					const dirMatch = tabPath.match(/^(.*)[/\\][^/\\]+$/);
-					if (dirMatch) {
-						const parentDir = dirMatch[1];
-						const imgDirName = settings.imageDirectory || "img";
+					const parentDir = documentParentDir(tabPath);
+					if (parentDir !== null) {
+						const imgDirName =
+							settings.imageDirectory || DEFAULT_IMAGE_DIRECTORY;
 						const relPath = (await invoke("save_image", {
 							parentDir,
 							filename,
 							base64Data: base64Image,
 							imageDirectory: imgDirName,
 						})) as string;
-						// Remove leading slash if imageDirectory was empty, to ensure relative path
-						const escapedPath = relPath.replace(/ /g, "%20").replace(/^\//, "");
-						const embed = `![alt](${escapedPath})`;
+						const embed = imageEmbed(relPath);
 
 						const position = editor.getPosition();
 						if (position) {
@@ -1744,20 +1748,17 @@
 		if (!position) return;
 
 		const tabPath = tabManager.activeTab.path;
-		const match = tabPath.match(/^(.*)[/\\][^/\\]+$/);
-		if (!match) return;
-		const parentDir = match[1];
+		const parentDir = documentParentDir(tabPath);
+		if (parentDir === null) return;
 
 		try {
-			const imgDirName = settings.imageDirectory || "img";
+			const imgDirName = settings.imageDirectory || DEFAULT_IMAGE_DIRECTORY;
 			const relPath = (await invoke("copy_file_to_img", {
 				srcPath: path,
 				parentDir,
 				imageDirectory: imgDirName,
 			})) as string;
-			// Remove leading slash if imageDirectory was empty
-			const escapedPath = relPath.replace(/ /g, "%20").replace(/^\//, "");
-			const embed = `![alt](${escapedPath})`;
+			const embed = imageEmbed(relPath);
 
 			editor.executeEdits(
 				"drop-image",

--- a/src/lib/utils/imageEmbed.ts
+++ b/src/lib/utils/imageEmbed.ts
@@ -1,0 +1,95 @@
+/**
+ * The Markdown an image lands in when the *app* writes the link — a pasted
+ * screenshot (`save_image`) or a dropped file (`copy_file_to_img`). Both used
+ * to build the same four expressions inline, 300 lines apart, and both
+ * escaped spaces and nothing else.
+ *
+ * A file the app just copied is a file the app must be able to read back on
+ * the next render. So the escaping question here is narrower than "escape a
+ * URL": which characters, left raw, make Markpad's own two readers resolve
+ * this link to a *different* path than the one Rust just wrote?
+ *
+ * Three of them, and the shape of the answer follows from where each reader
+ * looks:
+ *
+ *   1. CommonMark's own destination grammar, which comrak parses with. A
+ *      destination that is not wrapped in `<…>` ends at the first ASCII space
+ *      or control character, may contain parentheses only balanced, and
+ *      treats `\` as an escape. `note (1).png` survives by luck; `photo).png`
+ *      ends the link at the `)` and the rest becomes literal text.
+ *   2. `processMarkdownHtml` in ./markdown.ts, which the preview runs: it
+ *      takes the `src` comrak emitted and calls `decodeURIComponent` on it
+ *      before handing it to `convertFileSrc`.
+ *   3. `resolveExportImagePath` in ./exportHtml.ts, which HTML/PDF export
+ *      runs: it splits the `src` at the first `#` or `?` — those are a
+ *      fragment and a query in every URL — and `decodeURIComponent`s the rest.
+ *
+ * Both readers decode, so the wire format between this function and them is
+ * percent-encoding; that is not a choice, it is what is already there. What is
+ * a choice is *how much* to encode, and the answer is: exactly the characters
+ * the three readers misread, and nothing else.
+ *
+ *   - `encodeURI` was never a candidate: it leaves `#`, `?`, `(` and `)`
+ *     alone, which is the whole bug.
+ *   - `encodeURIComponent` encodes `/` to `%2F`, so it cannot see a path at
+ *     all; per-segment it would work, but it also percent-encodes every
+ *     non-ASCII byte, and `图片/截图.png` — a perfectly good name that the
+ *     preview and the export both already resolve — would be written into the
+ *     user's document as forty characters of `%E5%9B%BE…`. The document is
+ *     text a person reads and edits; over-encoding it is a regression that no
+ *     test would have caught.
+ *   - Angle brackets (`![alt](<path>)`), the form ./headingReference.ts uses
+ *     for the same class of problem, answer reader 1 and only reader 1. They
+ *     put a raw `#` into the destination, comrak's `escape_href` keeps `#`
+ *     verbatim (it is in its safe set), and `resolveExportImagePath` then
+ *     splits `img/note#1.png` into `img/note` + `#1.png` and exports a dead
+ *     link. Making them work would mean changing what a `#` means to the
+ *     export resolver — for every hand-written link too, not just ours. See
+ *     the `<…>` cases in scripts/imageEmbed.test.ts, which pin that.
+ *
+ * `%` is on the list for a reason that is easy to miss: comrak passes a `%`
+ * through untouched when two hex digits follow it, so a file genuinely named
+ * `50%20off.png` reaches `decodeURIComponent` as `50%20off.png` and comes back
+ * out as `50 off.png` — a file that does not exist. Encoding it to `%2550…`
+ * first is what makes the round trip total.
+ */
+
+/** Where images go when the setting is empty. */
+export const DEFAULT_IMAGE_DIRECTORY = 'img';
+
+/**
+ * ASCII control characters and space end a destination; `(`, `)` and `\` are
+ * the grammar's own metacharacters; `<` and `>` are its other destination
+ * form; `#` and `?` are read as fragment and query by the export resolver; `%`
+ * is the encoding's own escape and has to be encoded to survive it. Everything
+ * else — letters in any script, `&`, `'`, `+`, `,`, `=`, `@`, `~` — is left as
+ * the user named it, and comrak escapes for HTML whatever HTML needs.
+ */
+const NEEDS_PERCENT_ENCODING = /[\x00-\x20\x7f%()<>?#\\]/g;
+
+/** The document's directory, or `null` for a path with no separator in it. */
+export function documentParentDir(tabPath: string): string | null {
+	const match = tabPath.match(/^(.*)[/\\][^/\\]+$/);
+	return match ? match[1] : null;
+}
+
+/**
+ * The relative path Rust returned, spelled so that it names the same file
+ * after a Markdown parse and a `decodeURIComponent`.
+ *
+ * The leading slash goes first: `save_image` and `copy_file_to_img` both join
+ * with `/`, so an empty `imageDirectory` returns `/photo.png`, and a
+ * destination starting with `/` is an absolute path to every reader.
+ */
+export function encodeImageDestination(relPath: string): string {
+	return relPath
+		.replace(/^\//, '')
+		.replace(NEEDS_PERCENT_ENCODING, (char) =>
+			'%' + char.charCodeAt(0).toString(16).toUpperCase().padStart(2, '0'),
+		);
+}
+
+/** The whole embed, as it is inserted into the editor. */
+export function imageEmbed(relPath: string): string {
+	return `![alt](${encodeImageDestination(relPath)})`;
+}


### PR DESCRIPTION
Drop a file called `note#1.png` into the editor and Markpad writes `![alt](img/note#1.png)`. The renderer reads `#1.png` as a fragment, resolves the src to `img/note`, and the image is broken in the document that was just written. An unbalanced paren in the name does the same. Only spaces were being escaped.

The logic existed twice — once for paste, once for drop — identical in four consecutive expressions. Both were wrong the same way.

### The escaping choice

Driven by tracing the three readers, not by picking an encoder:

1. CommonMark's destination grammar (comrak) — spaces and control characters end it, parens must balance, `\` escapes
2. Preview `processMarkdownHtml` — `decodeURIComponent(src)`, then resolve
3. Export `resolveExportImagePath` — splits at the first `#` or `?`, then `decodeURIComponent`

Readers 2 and 3 already decode, so percent-encoding is not a choice — it is the wire format that was there all along. The only question is how much of it.

**Chosen: minimal percent-encoding** of `[\x00-\x20\x7f%()<>?#\\]`.

- **`encodeURI` — no.** Leaves `#`, `?`, `(`, `)` alone, which is the entire bug.
- **`encodeURIComponent` — no.** Kills `/`. Per-segment it would be correct, but it also encodes every non-ASCII byte, so `图片/截图.png` — which both readers resolve fine today — lands in the user's own document as forty characters of `%E5%9B%BE…`. A readability regression bought for nothing.
- **Angle brackets, `![alt](<path>)` — no, and this is the one worth stating.** `headingReference.ts` uses them for exactly this problem, so it looked like the house answer. But they satisfy reader 1 only: comrak keeps `#` verbatim inside them (it is in `HREF_SAFE`), so the `#` reaches reader 3 raw and `resolveExportImagePath` still splits `img/note#1.png` into `img/note` plus a fragment and exports a dead link. Two assertions pin that so it is not re-argued from memory.

One non-obvious character on the list: **`%` itself**. comrak copies a `%` through when two hex digits follow, so a file genuinely named `50%20off.png` decoded back to `50 off.png`. Pre-existing, same class, fixed here.

Existing documents are unaffected — `%20` still decodes to a space.

### Placement

`src/lib/utils/imageEmbed.ts`, next to `headingReference.ts`, which answers the neighbouring question for heading links. A `singleImplementationConvention` row marks `![alt](` so a third caller cannot copy either original.

### Known limit, recorded rather than fixed

A POSIX file whose *name* contains a backslash is escaped correctly for the parse, but both readers resolve through a splitter that treats `\` as a directory separator on purpose — a Windows author writing `![](img\a.png)` means one. Such a file is unreachable through a Markpad link however the link is spelled. The test asserts the actual behaviour and says why.

`npm test` 1010 · `npm run test:vitest` 71 · `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
