### PR TITLE
fix(editor): teach the list buttons the marker grammar the renderer already knows

### DIFF
--- a/scripts/editorToolbar.test.ts
+++ b/scripts/editorToolbar.test.ts
@@ -151,7 +151,6 @@ const LINE_MARKER_MATRIX: Array<[LineMarkerToolId, string, string]> = [
 	['fmt-bullet-list', '1. foo', '- foo'],
 	['fmt-bullet-list', '- [ ] foo', '- foo'],
 	['fmt-bullet-list', '- [x] foo', '- foo'],
-	['fmt-bullet-list', '> foo', '- > foo'],
 
 	// Numbered list.
 	['fmt-numbered-list', 'foo', '1. foo'],
@@ -159,7 +158,6 @@ const LINE_MARKER_MATRIX: Array<[LineMarkerToolId, string, string]> = [
 	['fmt-numbered-list', '1. foo', 'foo'],
 	['fmt-numbered-list', '- [ ] foo', '1. foo'],
 	['fmt-numbered-list', '1. [ ] foo', '1. foo'],
-	['fmt-numbered-list', '> foo', '1. > foo'],
 
 	// Checklist.
 	['fmt-checklist', 'foo', '- [ ] foo'],
@@ -167,7 +165,49 @@ const LINE_MARKER_MATRIX: Array<[LineMarkerToolId, string, string]> = [
 	['fmt-checklist', '1. foo', '- [ ] foo'],
 	['fmt-checklist', '- [ ] foo', 'foo'],
 	['fmt-checklist', '- [x] foo', 'foo'],
-	['fmt-checklist', '> foo', '- [ ] > foo'],
+
+	// `1)` is the other ordered delimiter CommonMark defines, and the renderer
+	// has always read it (`TASK_SOURCE_RE`, and the preview's own checkbox
+	// rewrite). The toolbar knew only `1.`, so bullet on `1) item` produced
+	// `- 1) item` — issue #451 exactly, one delimiter over — and the numbered
+	// button added a second marker to a line that already was an ordered item
+	// instead of taking it off.
+	['fmt-bullet-list', '1) item', '- item'],
+	['fmt-numbered-list', '1) item', 'item'],
+	['fmt-numbered-list', '2) item', 'item'],
+	['fmt-checklist', '1) item', '- [ ] item'],
+	['fmt-checklist', '1) [ ] item', '- [ ] item'],
+
+	// Indentation belongs to the line, not to the marker: it is what makes the
+	// item a *nested* one, and a toggle that dropped it flattened the item to top
+	// level. The button did not even see the marker — `- sub` behind four spaces
+	// matched neither `own` nor `competing` — so a click on any nested bullet
+	// answered with `-     - sub`.
+	['fmt-bullet-list', '    - sub', '    sub'],
+	['fmt-bullet-list', '    sub', '    - sub'],
+	['fmt-bullet-list', '  1. sub', '  - sub'],
+	['fmt-numbered-list', '\t1. sub', '\tsub'],
+	['fmt-numbered-list', '\t- sub', '\t1. sub'],
+	['fmt-bullet-list', '  - [ ] sub', '  - sub'],
+	['fmt-checklist', '    - [x] sub', '    sub'],
+	['fmt-quote', '  - sub', '  > - sub'],
+
+	// A list item inside a block quote is a list item — the same grammar the
+	// renderer reads to find a task line. The quote markers travel with the
+	// indentation for the same reason: they say where the item sits, and a list
+	// button that consumed them would lift the item out of the quote.
+	['fmt-bullet-list', '> - item', '> item'],
+	['fmt-numbered-list', '> - item', '> 1. item'],
+	['fmt-checklist', '> - [ ] item', '> item'],
+	['fmt-bullet-list', '> > - deep', '> > deep'],
+
+	// Which is also why a list button on a quoted *paragraph* now writes the
+	// marker inside the quote. `- > foo` — the old answer — is a list item
+	// containing a quote, a different document from the quoted list item the
+	// click asked for, and one that no second click could undo.
+	['fmt-bullet-list', '> foo', '> - foo'],
+	['fmt-numbered-list', '> foo', '> 1. foo'],
+	['fmt-checklist', '> foo', '> - [ ] foo'],
 
 	// Quote wraps, it does not displace: a quoted list item is the point.
 	['fmt-quote', 'foo', '> foo'],
@@ -205,6 +245,21 @@ test('a selection that mixes marker types converges on the toggled one', () => {
 	);
 
 	assert.deepEqual(toggleLineMarker('fmt-bullet-list', ['- alpha', '- beta']), ['alpha', 'beta']);
+});
+
+test('a nested selection keeps every line at the depth the author put it', () => {
+	// The whole selection is already bulleted, so this is the removal branch —
+	// the one that used to hand back `- top` / `- sub` with the indentation
+	// eaten, collapsing two levels into one.
+	assert.deepEqual(
+		toggleLineMarker('fmt-bullet-list', ['- top', '    - sub', '\t\t- deeper']),
+		['top', '    sub', '\t\tdeeper'],
+	);
+
+	assert.deepEqual(
+		toggleLineMarker('fmt-numbered-list', ['    alpha', '    beta']),
+		['    1. alpha', '    2. beta'],
+	);
 });
 
 test('numbering counts content lines and leaves blank lines alone', () => {

--- a/scripts/singleImplementationConvention.test.ts
+++ b/scripts/singleImplementationConvention.test.ts
@@ -96,6 +96,15 @@ const RULES: Rule[] = [
 		allowed: ['src/lib/utils/markdownLinks.ts', 'src/lib/MarkdownViewer.svelte'],
 	},
 	{
+		name: 'the list-marker grammar has one implementation in src',
+		why:
+			"\"What a list item's marker looks like\" had three spellings: the Rust renderer's TASK_SOURCE_RE, the preview's checkbox rewrite in documentSession.svelte.ts, and the toolbar's line-marker toggles. The first two agreed; the toolbar's copy accepted neither an indented item nor the `1)` delimiter, so a click on a nested bullet answered `-     - sub` and a click on `1) item` answered `- 1) item` — issue #451 verbatim, one delimiter over. utils/listSyntax.ts holds the vocabulary now. What each site wraps around it — the anchors, the separator, and whether the leading indentation is consumed or preserved — stays at the call site on purpose: the renderer throws that prefix away, the toolbar has to put it back, and sharing *that* would flatten every nested list item on the first click. The Rust copy is pinned against this one by taskToggleLineEndings.test.ts, because no import crosses that boundary.",
+		// The two fragments distinctive enough that prose cannot match them: the
+		// task box's character class and the ordered delimiter pair.
+		marker: /\[ xX\]|\\d\+\[\.\)\]/g,
+		allowed: ['src/lib/utils/listSyntax.ts'],
+	},
+	{
 		name: 'YouTube links never become embedded frames',
 		why: 'The app dropped frame-src from its CSP and renders YouTube as a thumbnail anchor that opens the browser; an iframe path is the pre-fix version and cannot load.',
 		marker: /createElement\((['"])iframe\1\)/g,

--- a/scripts/taskToggleLineEndings.test.ts
+++ b/scripts/taskToggleLineEndings.test.ts
@@ -1,7 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { readSource, sliceBetween } from './sourceTree.js';
+import { readRustBackend, readSource, sliceBetween, sliceFrom } from './sourceTree.js';
+
+import { LIST_MARKER, TASK_BOX } from '../src/lib/utils/listSyntax.js';
 
 // Toggling a task checkbox in the preview finds the line to rewrite by counting
 // `\n` up to the regex match. Three rounds of fixes for #148 were verified on
@@ -171,6 +173,33 @@ for (const [name, eol] of [
 		}
 	});
 }
+
+test('the marker grammar the renderer reads still matches listSyntax.ts', () => {
+	// The last cross-language copy of this vocabulary. The rewrite above only
+	// gets a chance to run on lines the *renderer* turned into a task item, and
+	// `TASK_SOURCE_RE` is what decides that — so a marker one side accepts and
+	// the other does not is a checkbox that draws and then refuses to toggle.
+	// Every TypeScript reader imports the fragments from utils/listSyntax.ts
+	// (pinned by singleImplementationConvention.test.ts); Rust cannot, so the
+	// drift is caught here instead, by reading the pattern back out of the
+	// source and looking for the fragments inside it.
+	//
+	// Fragments rather than the whole pattern, deliberately: what surrounds them
+	// is allowed to differ. Rust asks a yes/no question about one line and may
+	// spell its whitespace `\s`; the rewrite above works over the whole body
+	// with `/m` and may not (see the comment at the call site). The marker
+	// itself is the only part that has to be the same on both sides.
+	const declared = sliceFrom(readRustBackend(), 'static TASK_SOURCE_RE');
+	const pattern = /Regex::new\(r"([^"]*)"\)/.exec(declared);
+	assert.notEqual(pattern, null, 'TASK_SOURCE_RE no longer holds a raw regex literal');
+
+	for (const fragment of [LIST_MARKER, TASK_BOX]) {
+		assert.ok(
+			pattern![1].includes(fragment),
+			`the Rust renderer reads ${JSON.stringify(pattern![1])}, which does not contain ${fragment} — the two sides disagree about what a list item is`,
+		);
+	}
+});
 
 test('a tab-indented task keeps its indentation', async () => {
 	// `[ \t]*` has to admit a tab, or a tab-indented task stops being found at

--- a/src/lib/sessions/documentSession.svelte.ts
+++ b/src/lib/sessions/documentSession.svelte.ts
@@ -4,6 +4,7 @@ import { settings } from '../stores/settings.svelte.js';
 import { tabManager, type Tab } from '../stores/tabs.svelte.js';
 import { getMarkdownBodyWithoutFrontMatter } from '../utils/frontMatter.js';
 import { t } from '../utils/i18n.js';
+import { LIST_MARKER, LIST_MARKER_PREFIX, TASK_BOX } from '../utils/listSyntax.js';
 import { hasMarkdownLinkExtension } from '../utils/markdownLinks.js';
 import { canonicalizePath, isSameFilePath } from '../utils/pathIdentity.js';
 
@@ -724,6 +725,11 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		if (!(await ensureFullContent(tab.id))) return false;
 		const raw = tab.rawContent;
 		const body = getMarkdownBodyWithoutFrontMatter(raw);
+		// The marker grammar comes from `listSyntax.ts`, shared with the editor
+		// toolbar's line-marker toggles; what surrounds it does not. Here the
+		// prefix is *captured* and written back out, because this rewrite replaces
+		// the box in the middle of the line rather than the head of it.
+		//
 		// Horizontal whitespace only, and it has to stay that way. `\s` matches
 		// `\r` as well as `\n`, and JavaScript's `/m` `^` also matches at the
 		// position *between* a `\r` and its `\n`. With `\s*` greedy, every match
@@ -733,11 +739,14 @@ export function createDocumentSession(options: DocumentSessionOptions) {
 		// as "the checkbox does not work" (#148); anywhere else the off-by-one
 		// lands on a *real* task line and silently toggles the wrong one. Every
 		// CRLF document was affected, which is to say every Windows author.
-		const updatedBody = body.replace(/^([ \t]*(?:>[ \t]*)*(?:[-+*]|\d+[.)])[ \t]+)\[( |x|X)\]/gm, (match, prefix, _state, offset) => {
-			const line = body.slice(0, offset).split('\n').length;
-			if (line === sourceLine) return `${prefix}[${nowChecked ? 'x' : ' '}]`;
-			return match;
-		});
+		const updatedBody = body.replace(
+			new RegExp(String.raw`^(${LIST_MARKER_PREFIX}${LIST_MARKER}[ \t]+)${TASK_BOX}`, 'gm'),
+			(match, prefix, offset) => {
+				const line = body.slice(0, offset).split('\n').length;
+				if (line === sourceLine) return `${prefix}[${nowChecked ? 'x' : ' '}]`;
+				return match;
+			},
+		);
 		const updated = `${raw.slice(0, raw.length - body.length)}${updatedBody}`;
 		if (updated === raw) return false;
 		tabManager.updateTabRawContent(tab.id, updated);

--- a/src/lib/utils/editorToolbar.ts
+++ b/src/lib/utils/editorToolbar.ts
@@ -1,3 +1,10 @@
+import {
+	BULLET_MARKER,
+	LIST_MARKER,
+	LIST_MARKER_PREFIX,
+	ORDERED_MARKER,
+	TASK_BOX,
+} from './listSyntax.js';
 import { shortcutLabel } from './shortcuts.js';
 
 type EditorToolbarGroup = 'inline' | 'block' | 'list' | 'insert';
@@ -53,7 +60,8 @@ const EDITOR_TOOLBAR_TOOLS: EditorToolbarTool[] = BASE_TOOLBAR_TOOLS.map((tool) 
 
 export const DEFAULT_EDITOR_TOOLBAR_ORDER = EDITOR_TOOLBAR_TOOLS.map((tool) => tool.id);
 
-const TASK_BOX = String.raw`\[[ xX]\]\s+`;
+/** The box and the space after it, which travel together. */
+const TASK_BOX_MARKER = String.raw`${TASK_BOX}\s+`;
 
 /**
  * A bullet, an ordered number and a task box all claim the same slot at the
@@ -65,12 +73,37 @@ const TASK_BOX = String.raw`\[[ xX]\]\s+`;
  * more. The ordered-plus-box form is matched too, so the `1. [ ] foo` that the
  * old numbered-list toggle used to produce normalises on the next toggle
  * instead of round-tripping to an orphan box.
+ *
+ * The marker vocabulary itself comes from ./listSyntax.ts, shared with the
+ * renderer's side of the same grammar. It used to be spelled here as
+ * `(?:[-*+]|\d+\.)`, which is the same defect one delimiter over: `1) foo`
+ * became `- 1) foo`.
  */
-const ANY_LIST_MARKER = new RegExp(String.raw`^(?:[-*+]|\d+\.)\s+(?:${TASK_BOX})?`);
+const ANY_LIST_MARKER = new RegExp(String.raw`^${LIST_MARKER}\s+(?:${TASK_BOX_MARKER})?`);
 
 const ANY_HEADING = /^#{1,6}\s+/;
 
+/** Leading indentation, which every tool preserves. */
+const INDENT = /^[ \t]*/;
+
+/**
+ * Indentation plus block-quote nesting: the prefix the *list* tools preserve.
+ *
+ * A quoted list item (`> - item`) is a list item — it is what the renderer reads
+ * as one — so the list buttons have to find the marker behind the quote markers
+ * rather than write a second marker in front of them. The quote and heading
+ * tools keep `INDENT` instead: Quote's whole job is to add a `>` in front of
+ * whatever is there, including another `>`.
+ */
+const QUOTED_INDENT = new RegExp(String.raw`^${LIST_MARKER_PREFIX}`);
+
 type LineMarker = {
+	/**
+	 * What this tool leaves untouched at the head of the line. Matched first, and
+	 * put back afterwards: it is the difference between un-bulleting a nested item
+	 * and flattening it to the top level.
+	 */
+	readonly prefix: RegExp;
 	/** Matches the marker this tool owns; deciding when a toggle un-toggles. */
 	readonly own: RegExp;
 	/** The marker text. The argument counts content lines, for `1.`, `2.`, … */
@@ -84,28 +117,31 @@ type LineMarker = {
 };
 
 const LINE_MARKERS = {
-	'fmt-quote': { own: /^>\s+/, render: () => '> ', competing: null },
+	'fmt-quote': { prefix: INDENT, own: /^>\s+/, render: () => '> ', competing: null },
 	// The list toggles exclude a following task box from `own` so that they add
 	// their marker to a checklist item instead of un-toggling it and leaving the
 	// box behind.
 	'fmt-bullet-list': {
-		own: new RegExp(String.raw`^[-*+]\s+(?!${TASK_BOX})`),
+		prefix: QUOTED_INDENT,
+		own: new RegExp(String.raw`^${BULLET_MARKER}\s+(?!${TASK_BOX_MARKER})`),
 		render: () => '- ',
 		competing: ANY_LIST_MARKER,
 	},
 	'fmt-numbered-list': {
-		own: new RegExp(String.raw`^\d+\.\s+(?!${TASK_BOX})`),
+		prefix: QUOTED_INDENT,
+		own: new RegExp(String.raw`^${ORDERED_MARKER}\s+(?!${TASK_BOX_MARKER})`),
 		render: (itemIndex: number) => `${itemIndex}. `,
 		competing: ANY_LIST_MARKER,
 	},
 	'fmt-checklist': {
-		own: new RegExp(String.raw`^[-*+]\s+${TASK_BOX}`),
+		prefix: QUOTED_INDENT,
+		own: new RegExp(String.raw`^${BULLET_MARKER}\s+${TASK_BOX_MARKER}`),
 		render: () => '- [ ] ',
 		competing: ANY_LIST_MARKER,
 	},
-	'fmt-heading-1': { own: /^#\s+/, render: () => '# ', competing: ANY_HEADING },
-	'fmt-heading-2': { own: /^##\s+/, render: () => '## ', competing: ANY_HEADING },
-	'fmt-heading-3': { own: /^###\s+/, render: () => '### ', competing: ANY_HEADING },
+	'fmt-heading-1': { prefix: INDENT, own: /^#\s+/, render: () => '# ', competing: ANY_HEADING },
+	'fmt-heading-2': { prefix: INDENT, own: /^##\s+/, render: () => '## ', competing: ANY_HEADING },
+	'fmt-heading-3': { prefix: INDENT, own: /^###\s+/, render: () => '### ', competing: ANY_HEADING },
 } satisfies Record<string, LineMarker>;
 
 export type LineMarkerToolId = keyof typeof LINE_MARKERS;
@@ -119,18 +155,35 @@ export const LINE_MARKER_TOOL_IDS = Object.keys(LINE_MARKERS) as LineMarkerToolI
  * marker; otherwise the marker is applied to all of them, which is what makes a
  * mixed selection converge on one list type instead of stacking markers.
  * Blank lines are left exactly as they are and are not numbered.
+ *
+ * The caller hands over whole lines, untrimmed (`Editor.svelte` reads the
+ * selection from column 1), so every line arrives with whatever puts it where it
+ * is: the indentation of a nested item, the `>` of a quoted one. That prefix is
+ * split off, held, and put back — the markers below are matched against the rest
+ * of the line and never see it. Matching them against the whole line instead is
+ * what made a nested bullet unrecognisable, and stripping the prefix along with
+ * the marker is what would have flattened the item to the top level.
  */
 export function toggleLineMarker(id: LineMarkerToolId, lines: readonly string[]): string[] {
 	const marker = LINE_MARKERS[id];
+	// Both patterns can match the empty string, so `exec` never returns null —
+	// the fallback is there for the type, not for a case.
+	const split = (line: string) => {
+		const prefix = (marker.prefix.exec(line) ?? [''])[0];
+		return { prefix, rest: line.slice(prefix.length) };
+	};
+
 	const contentLines = lines.filter((line) => line.trim().length > 0);
-	const shouldRemove = contentLines.length > 0 && contentLines.every((line) => marker.own.test(line));
+	const shouldRemove =
+		contentLines.length > 0 && contentLines.every((line) => marker.own.test(split(line).rest));
 
 	let itemIndex = 1;
 	return lines.map((line) => {
 		if (!line.trim()) return line;
-		if (shouldRemove) return line.replace(marker.own, '');
-		const body = marker.competing ? line.replace(marker.competing, '') : line;
-		return `${marker.render(itemIndex++)}${body}`;
+		const { prefix, rest } = split(line);
+		if (shouldRemove) return `${prefix}${rest.replace(marker.own, '')}`;
+		const body = marker.competing ? rest.replace(marker.competing, '') : rest;
+		return `${prefix}${marker.render(itemIndex++)}${body}`;
 	});
 }
 

--- a/src/lib/utils/listSyntax.ts
+++ b/src/lib/utils/listSyntax.ts
@@ -1,0 +1,63 @@
+/**
+ * "What a Markdown list item's marker looks like", written once.
+ *
+ * Three places have to agree on this and had drifted into three spellings: the
+ * Rust renderer's `TASK_SOURCE_RE`, the preview's checkbox rewrite in
+ * `sessions/documentSession.svelte.ts`, and the editor toolbar's line-marker
+ * toggles in `./editorToolbar.ts`. The first two matched each other by luck; the
+ * toolbar's copy accepted neither an indented item nor the `1)` delimiter, so a
+ * click on a nested bullet answered `-     - sub` and a click on `1) item`
+ * answered `- 1) item` — which is issue #451 verbatim, one delimiter over.
+ *
+ * WHAT IS SHARED AND WHAT IS DELIBERATELY NOT
+ *
+ * These are pattern *fragments*, not patterns. What each consumer wraps around
+ * them — the anchors, the separator between marker and text, and above all what
+ * it does with the prefix — stays where it is, because that part is genuinely
+ * different:
+ *
+ *   - the renderer only asks "is this a task line?", so it consumes the prefix
+ *     and throws it away;
+ *   - the preview's rewrite captures the prefix and writes it back out, because
+ *     it is replacing the box in the middle of the line;
+ *   - the toolbar splits the prefix off, transforms the rest, and re-attaches
+ *     it, because the prefix is what makes a nested item nested. A toolbar that
+ *     consumed it like the renderer does would flatten every nested list item to
+ *     the top level on the first click — a worse defect than the one this module
+ *     exists to fix.
+ *
+ * So: same grammar, opposite disposal. Anything about whitespace *handling*
+ * belongs to the call site, and only the marker vocabulary lives here.
+ */
+
+/** `-`, `+`, `*` — the three bullet characters, which are interchangeable. */
+export const BULLET_MARKER = String.raw`[-+*]`;
+
+/**
+ * `1.` and `1)`. CommonMark defines both delimiters and the renderer reads both;
+ * a document written with `1)` is an ordered list everywhere except in a toolbar
+ * that forgot the second half.
+ */
+export const ORDERED_MARKER = String.raw`\d+[.)]`;
+
+/** Either kind of list marker, without its trailing space. */
+export const LIST_MARKER = String.raw`(?:${BULLET_MARKER}|${ORDERED_MARKER})`;
+
+/**
+ * The checkbox of a task list item, unchecked or checked in either case.
+ *
+ * Part of the marker rather than part of the text: a toggle that took `- ` off
+ * `- [ ] foo` would leave the orphan `[ ] foo`, which nothing recognises.
+ */
+export const TASK_BOX = String.raw`\[[ xX]\]`;
+
+/**
+ * What may stand between the start of a line and the marker: indentation, then
+ * any depth of block-quote nesting.
+ *
+ * Horizontal whitespace only, and it has to stay that way — `\s` also matches
+ * `\r` and `\n`, which is how the preview's checkbox rewrite used to resolve
+ * every task in a CRLF document to the previous line (#148). See the call site
+ * in documentSession.svelte.ts for the full account.
+ */
+export const LIST_MARKER_PREFIX = String.raw`[ \t]*(?:>[ \t]*)*`;


### PR DESCRIPTION
Put the cursor on a nested list item and press the bullet button:

```
    - sub item      →      -     - sub item
```

Press it on an ordered item written with the other CommonMark delimiter:

```
1) item             →      - 1) item
```

That second one is the exact defect `editorToolbar.ts`'s own comment says it exists to prevent (`1. foo` → `- 1. foo`), just with `)` instead of `.`.

`toggleLineMarker` is handed whole, untrimmed lines, but its patterns recognised neither leading whitespace nor `1)`. The same grammar is spelled correctly in two other places — `TASK_SOURCE_RE` in `markdown.rs` and the checkbox rewrite in `documentSession.svelte.ts`.

### What is shared, and what deliberately is not

`src/lib/utils/listSyntax.ts` exports pattern **fragments**, not patterns: `BULLET_MARKER`, `ORDERED_MARKER`, `LIST_MARKER`, `TASK_BOX`, `LIST_MARKER_PREFIX`. Each site composes its own regex from them.

Anchors, the marker→text separator and the handling of the leading prefix all stay at the call site, because **the three sites want the same grammar and opposite disposal**:

- the renderer consumes the prefix and discards it
- the rewrite captures and re-emits it
- the toolbar splits it off and re-attaches it

Sharing the disposal is what would flatten every nested item to top level on the first click. So `toggleLineMarker` grew a per-tool `prefix` regex, matched first and re-attached last. List tools preserve indentation **and** quote markers — a quoted list item is a list item, which is what makes `> - item` toggle off instead of stacking. Quote and heading tools preserve indentation only.

The separator also stays local: `[ \t]+` in the rewrite because of the #148 CRLF bug, `\s+` in the toolbar, which gets one line at a time.

### One behaviour change worth reviewing

A list button on a quoted **paragraph** now writes inside the quote:

```
> foo       →   > - foo        (was:  - > foo)
```

The old output was a list item containing a quote. Nothing recognised that shape afterwards, so a second click could not undo it. Required for the quote-nesting case to work at all.

### Cross-language guard

`taskToggleLineEndings.test.ts` reads `TASK_SOURCE_RE`'s raw literal out of the Rust source and asserts it contains `LIST_MARKER` and `TASK_BOX` as substrings — fragments rather than whole-pattern equality, because Rust legitimately spells its surrounding whitespace `\s`. The marker vocabulary is the only part that must agree, and the check fails in both directions if either side adds or drops one.

A `singleImplementationConvention` rule pins the TS copies to `listSyntax.ts` alone.

### Not touched

`scripts/renderProtocol.test.ts` keeps a fourth restatement of `TASK_SOURCE_RE`, deliberately documented as a restatement over its own fixture.

`npm test` 1015 · `npm run test:vitest` 71 · `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
