### PR TITLE
perf(preview): replace the blocks that changed instead of the article

### DIFF
--- a/scripts/blockPatch.spec.ts
+++ b/scripts/blockPatch.spec.ts
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, test } from 'vitest';
 
 import { patchPreviewBlocks } from '../src/lib/utils/blockPatch.js';
+import { asRendererLine } from '../src/lib/utils/lineCoordinates.js';
+import {
+	findAnchorElement,
+	getPreviewOffsetForSourceLine,
+	type AnchorBox,
+	type AnchorNode,
+} from '../src/lib/utils/previewAnchor.js';
 
 /**
  * The shape `processMarkdownHtml` actually produces: a heading, then a
@@ -178,6 +185,83 @@ describe('blocks that renderRichContent rewrote', () => {
 
 		expect(host.querySelector('.mermaid-diagram')).toBe(diagram);
 		expect(diagram.getAttribute('data-sourcepos')).toBe('4:1-4:5');
+	});
+});
+
+/**
+ * The memos in `previewAnchor.ts` were written against a preview that was
+ * rebuilt wholesale, where a block whose source lines changed was necessarily a
+ * new node. This module keeps the node and rewrites the attribute on it, so the
+ * two halves only agree if the patch drops those memos — and the way to show
+ * that is to ask `previewAnchor` its own questions across a patch, not to watch
+ * for the invalidation call.
+ *
+ * There is no layout in jsdom, so the boxes are supplied. They are the ones the
+ * defect was first measured with: two blocks, 100px each, stacked from 0.
+ */
+describe('the source ranges previewAnchor has already read', () => {
+	test('follow a range rewritten in place on a node that was kept', () => {
+		const block = (line: number, text: string) =>
+			`<p data-sourcepos="${line}:1-${line}:${text.length}">${text}</p>`;
+
+		patchPreviewBlocks(host, block(1, 'alpha') + block(3, 'beta'));
+		const [alpha, beta] = Array.from(host.children) as HTMLElement[];
+
+		const boxes = new Map<AnchorNode, AnchorBox>([
+			[alpha, { top: 0, height: 100 }],
+			[beta, { top: 100, height: 100 }],
+		]);
+		const measure = (node: AnchorNode): AnchorBox => boxes.get(node) ?? { top: NaN, height: NaN };
+
+		// Ask first, so the answers for lines 1 and 3 are memoised against these
+		// two nodes. Scroll sync does this many times a second.
+		expect(getPreviewOffsetForSourceLine(host, asRendererLine(3), measure)).toBe(100);
+
+		// Two lines inserted above the document. Identical rendering, so both
+		// paragraphs are kept and only their `data-sourcepos` is rewritten.
+		patchPreviewBlocks(host, block(3, 'alpha') + block(5, 'beta'));
+		expect(Array.from(host.children)).toEqual([alpha, beta]);
+
+		// A memo keyed on a surviving node answers 100 and 300 here, and goes on
+		// answering that for the life of the node.
+		expect(getPreviewOffsetForSourceLine(host, asRendererLine(3), measure)).toBe(0);
+		expect(getPreviewOffsetForSourceLine(host, asRendererLine(5), measure)).toBe(100);
+	});
+
+	test('follow a replaced child up into the span of the container that kept it', () => {
+		patchPreviewBlocks(
+			host,
+			section([
+				{ line: 3, text: 'alpha' },
+				{ line: 5, text: 'beta' },
+			]),
+		);
+		const wrapper = host.querySelector('.foldable-content-wrapper');
+		const inner = host.querySelector('.content-inner');
+
+		// The wrapper and the `.content-inner` carry no range of their own; the
+		// answer for both is derived from the paragraphs inside them and memoised
+		// on the container. This is the call that memoises it.
+		expect(findAnchorElement(host, 5)?.element).toBe(paragraphs()[1]);
+
+		// Both paragraphs are rewritten and moved down five lines. The containers
+		// are kept and descended into — so nothing touches them, and their spans
+		// are stale even though every node holding a range is new.
+		patchPreviewBlocks(
+			host,
+			section([
+				{ line: 8, text: 'alphaX' },
+				{ line: 10, text: 'betaX' },
+			]),
+		);
+		expect(host.querySelector('.foldable-content-wrapper')).toBe(wrapper);
+		expect(host.querySelector('.content-inner')).toBe(inner);
+
+		// A stale span says the wrapper covers lines 3 to 5, so line 10 is inside
+		// nothing and the descent — which is strict here — gives up at the top
+		// level and hands the caller a null it has to guess its way out of.
+		expect(findAnchorElement(host, 10)?.element).toBe(paragraphs()[1]);
+		expect(findAnchorElement(host, 8)?.element).toBe(paragraphs()[0]);
 	});
 });
 

--- a/scripts/blockPatch.spec.ts
+++ b/scripts/blockPatch.spec.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { patchPreviewBlocks } from '../src/lib/utils/blockPatch.js';
+
+/**
+ * The shape `processMarkdownHtml` actually produces: a heading, then a
+ * `.foldable-content-wrapper > .content-inner` holding everything under it. It
+ * matters that the fixtures look like this rather than like a flat list of
+ * paragraphs — a flat document has no second level, and the second level is
+ * where every real edit lands.
+ */
+function section(paragraphs: { line: number; text: string }[]): string {
+	const blocks = paragraphs
+		.map(({ line, text }) => `<p data-sourcepos="${line}:1-${line}:${text.length}">${text}</p>`)
+		.join('');
+	return `<h1 data-sourcepos="1:1-1:5" id="t">Title</h1><div class="foldable-content-wrapper" id="wrap-0"><div class="content-inner">${blocks}</div></div>`;
+}
+
+let host: HTMLElement;
+
+beforeEach(() => {
+	document.body.innerHTML = '';
+	host = document.createElement('div');
+	document.body.appendChild(host);
+});
+
+function paragraphs(): HTMLElement[] {
+	return Array.from(host.querySelectorAll('.content-inner > p'));
+}
+
+describe('the first render', () => {
+	test('inserts every block and reports it as the work to enrich', () => {
+		const html = section([
+			{ line: 3, text: 'alpha' },
+			{ line: 5, text: 'beta' },
+		]);
+		const patch = patchPreviewBlocks(host, html);
+
+		expect(host.children.length).toBe(2);
+		expect(patch.inserted).toEqual([...host.children]);
+		expect(patch.kept).toBe(0);
+	});
+
+	test('drops the whitespace between blocks, so children and childNodes stay one list', () => {
+		patchPreviewBlocks(host, '<p>a</p>\n<p>b</p>\n');
+		expect(host.childNodes.length).toBe(host.children.length);
+	});
+});
+
+describe('typing one character in the middle of a document', () => {
+	const before = section([
+		{ line: 3, text: 'alpha' },
+		{ line: 5, text: 'beta' },
+		{ line: 7, text: 'gamma' },
+	]);
+	const after = section([
+		{ line: 3, text: 'alpha' },
+		{ line: 5, text: 'betaX' },
+		{ line: 7, text: 'gamma' },
+	]);
+
+	test('replaces exactly the block that changed and keeps the rest of the nodes', () => {
+		patchPreviewBlocks(host, before);
+		const [alpha, beta, gamma] = paragraphs();
+
+		const patch = patchPreviewBlocks(host, after);
+		const [alphaAfter, betaAfter, gammaAfter] = paragraphs();
+
+		expect(alphaAfter).toBe(alpha);
+		expect(gammaAfter).toBe(gamma);
+		expect(betaAfter).not.toBe(beta);
+		expect(betaAfter.textContent).toBe('betaX');
+	});
+
+	test('hands renderRichContent only the changed block', () => {
+		patchPreviewBlocks(host, before);
+		const patch = patchPreviewBlocks(host, after);
+
+		expect(patch.inserted.map((element) => element.textContent)).toEqual(['betaX']);
+		expect(patch.replaced).toBe(1);
+	});
+
+	test('descends through the fold wrapper instead of replacing the whole section', () => {
+		patchPreviewBlocks(host, before);
+		const wrapper = host.querySelector('.foldable-content-wrapper');
+		const inner = host.querySelector('.content-inner');
+
+		patchPreviewBlocks(host, after);
+
+		expect(host.querySelector('.foldable-content-wrapper')).toBe(wrapper);
+		expect(host.querySelector('.content-inner')).toBe(inner);
+	});
+});
+
+describe('inserting a line above everything', () => {
+	test('keeps the blocks that only moved, and refreshes their source ranges', () => {
+		patchPreviewBlocks(
+			host,
+			section([
+				{ line: 3, text: 'alpha' },
+				{ line: 5, text: 'beta' },
+			]),
+		);
+		const [alpha, beta] = paragraphs();
+
+		// Every line below the insertion is renumbered. This is the case a
+		// `data-sourcepos` key gets wrong: nothing about the rendering changed.
+		const patch = patchPreviewBlocks(
+			host,
+			section([
+				{ line: 4, text: 'alpha' },
+				{ line: 6, text: 'beta' },
+			]),
+		);
+
+		expect(paragraphs()).toEqual([alpha, beta]);
+		expect(patch.replaced).toBe(0);
+		expect(alpha.getAttribute('data-sourcepos')).toBe('4:1-4:5');
+		expect(beta.getAttribute('data-sourcepos')).toBe('6:1-6:4');
+	});
+});
+
+describe('typing in a heading', () => {
+	test('replaces the heading and looks inside the wrapper holding the rest of the file', () => {
+		patchPreviewBlocks(host, section([{ line: 3, text: 'alpha' }]));
+		const [alpha] = paragraphs();
+
+		const patch = patchPreviewBlocks(
+			host,
+			section([{ line: 3, text: 'alpha' }]).replace('>Title<', '>Titles<'),
+		);
+
+		expect(paragraphs()).toEqual([alpha]);
+		expect(patch.inserted.map((element) => element.tagName)).toEqual(['H1']);
+	});
+});
+
+describe('blocks that renderRichContent rewrote', () => {
+	test('survive a patch, because the diff keys off what was inserted, not what is there now', () => {
+		const before = section([
+			{ line: 3, text: 'alpha' },
+			{ line: 5, text: 'beta' },
+		]);
+		patchPreviewBlocks(host, before);
+
+		// What the code-block pass does to a `<pre>`: a new parent, a new sibling,
+		// and markup that no longer resembles what the renderer emitted.
+		const alpha = paragraphs()[0];
+		const shell = document.createElement('div');
+		shell.className = 'code-block-shell';
+		alpha.replaceWith(shell);
+		shell.appendChild(alpha);
+		shell.appendChild(document.createElement('button'));
+
+		const patch = patchPreviewBlocks(
+			host,
+			section([
+				{ line: 3, text: 'alpha' },
+				{ line: 5, text: 'betaX' },
+			]),
+		);
+
+		expect(host.querySelector('.code-block-shell')).toBe(shell);
+		expect(shell.contains(alpha)).toBe(true);
+		expect(patch.inserted.map((element) => element.textContent)).toEqual(['betaX']);
+	});
+
+	test('still get their source range refreshed, through the node that replaced them', () => {
+		patchPreviewBlocks(host, section([{ line: 3, text: 'alpha' }]));
+
+		const alpha = paragraphs()[0];
+		const diagram = document.createElement('div');
+		diagram.className = 'mermaid-diagram';
+		diagram.setAttribute('data-sourcepos', alpha.getAttribute('data-sourcepos')!);
+		alpha.replaceWith(diagram);
+
+		patchPreviewBlocks(host, section([{ line: 4, text: 'alpha' }]));
+
+		expect(host.querySelector('.mermaid-diagram')).toBe(diagram);
+		expect(diagram.getAttribute('data-sourcepos')).toBe('4:1-4:5');
+	});
+});
+
+describe('a container somebody else rewrote', () => {
+	test('is replaced wholesale rather than diffed against a stale record', () => {
+		patchPreviewBlocks(host, '<p>a</p><p>b</p>');
+		host.appendChild(document.createElement('p'));
+
+		const patch = patchPreviewBlocks(host, '<p>a</p><p>b</p>');
+
+		expect(patch.replaced).toBe(2);
+		expect(host.children.length).toBe(2);
+	});
+});

--- a/scripts/diagramCache.test.ts
+++ b/scripts/diagramCache.test.ts
@@ -111,7 +111,7 @@ async function render(
 	const root = (globalThis as any).document.createElement('div');
 	root.innerHTML = html;
 	await renderRichContent({
-		root,
+		roots: [root],
 		libraries: libraries(options.record, options.extraFor) as any,
 		mermaidTheme: options.theme ?? 'neutral',
 		idFactory: ids(),

--- a/scripts/exportRichContent.test.ts
+++ b/scripts/exportRichContent.test.ts
@@ -329,7 +329,7 @@ test('the renderer works on a detached element', async () => {
 	assert.equal(root.parentNode, null);
 
 	await renderRichContent({
-		root,
+		roots: [root],
 		libraries: fakeLibraries(record) as any,
 		mermaidTheme: 'neutral',
 		idFactory: (index: number) => `diagram-${index}`,

--- a/scripts/foldLayout.test.ts
+++ b/scripts/foldLayout.test.ts
@@ -48,11 +48,40 @@ test('preview lifecycle starts and cleans up fold observation', () => {
 	const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
 	assert.match(viewer, /observeFoldLayout\((?:markdownBody|body)\)/);
-	assert.match(viewer, /stopObservingFoldLayout\?\.\(\)/);
+	assert.match(viewer, /observation\.stop\(\)/);
 });
 
 test('fold measurement pauses while the preview pane is hidden by edit mode', () => {
 	const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
-	assert.match(viewer, /if \(!html \|\| !body \|\| \(isEditing && !isSplit\)\) return;/);
+	assert.match(viewer, /if \(!body \|\| \(isEditing && !isSplit\)\) return;/);
+});
+
+// The observation used to be torn down and rebuilt on every render, which is
+// how a document's every fold came to re-measure once per character:
+// `ResizeObserver.observe` re-registers a target it is already watching, and a
+// registration delivers an initial observation. What replaced it is a live
+// observation plus `observe` calls for the blocks the patch inserted, so the
+// two halves of that have to stay coupled — a viewer that re-observes the whole
+// host, or a `foldLayout.ts` that only observes from a root, puts the cost back
+// without changing a single assertion above.
+test('only newly patched blocks are handed to the fold observer', () => {
+	const viewer = readSource('src/lib/MarkdownViewer.svelte');
+	const foldLayout = readSource('src/lib/utils/foldLayout.ts');
+
+	assert.match(
+		viewer,
+		/for \(const \w+ of patch\.inserted\) foldLayout\?\.observe\(\w+\)/,
+		'the viewer must observe the patched blocks, not the whole preview',
+	);
+	assert.doesNotMatch(
+		viewer,
+		/foldLayout\?\.observe\(host\)/,
+		're-observing the host re-registers every fold in the document',
+	);
+	assert.match(
+		foldLayout,
+		/observe\(scope: Element\)/,
+		'observeFoldLayout must accept a scope smaller than the article',
+	);
 });

--- a/scripts/foldMeasurementBatching.test.ts
+++ b/scripts/foldMeasurementBatching.test.ts
@@ -50,6 +50,8 @@ function createFoldRoot(specs: { id: string; height: number | null }[]) {
 	});
 
 	const root = {
+		// The article, which is never itself a fold wrapper.
+		matches: () => false,
 		querySelectorAll: () => wrappers,
 		get offsetHeight() {
 			events.push({ type: 'commit' });
@@ -82,9 +84,9 @@ async function runFoldLayout(specs: { id: string; height: number | null }[]) {
 	globals.window = { addEventListener() {}, removeEventListener() {} };
 
 	try {
-		const stop = observeFoldLayout(root as unknown as HTMLElement);
+		const observation = observeFoldLayout(root as unknown as HTMLElement);
 		for (const frame of frames.splice(0)) frame();
-		stop();
+		observation.stop();
 		return events;
 	} finally {
 		Object.assign(globals, saved);

--- a/scripts/mermaidDiagramLabels.test.ts
+++ b/scripts/mermaidDiagramLabels.test.ts
@@ -162,7 +162,7 @@ async function renderDiagrams(): Promise<Map<string, ShimElement>> {
 		.join('');
 
 	await renderRichContent({
-		root: root as any,
+		roots: [root as any],
 		libraries: libraries() as any,
 		mermaidTheme: 'neutral',
 		idFactory: (index: number) => `diagram-${index}`,

--- a/scripts/previewSanitize.test.ts
+++ b/scripts/previewSanitize.test.ts
@@ -87,11 +87,49 @@ test('the preview sanitizes through the shared policy, not a local config', () =
 	// `markdownBody`, i.e. of the DOM the sanitized sink already injected. It is
 	// not a second policy, it is the same bytes read back out of the document —
 	// which is what the next two assertions pin.
-	const injected = [...new Set([...viewerSource.matchAll(/\{@html\s+([^}]+?)\s*\}/g)].map((m) => m[1]))].sort();
+	//
+	// The document's own sink is no longer one of them. `{@html sanitizedHtml}`
+	// rebuilt the whole article per keystroke, so the preview now patches in only
+	// the blocks that changed (see utils/blockPatch.ts) — which means the string
+	// becomes nodes inside that module instead of inside the compiler's `@html`.
+	// The security property is unchanged and the chain is the same length: the
+	// sanitizer's output, and nothing else, is what is parsed. The two
+	// assertions after this one are that chain.
+	//
+	// Matched at the start of a line so that a comment *about* `{@html}` — this
+	// file's subject, and the viewer is full of them now — cannot stand in for a
+	// sink and quietly satisfy the check.
+	const injected = [
+		...new Set([...viewerSource.matchAll(/^[^\S\n]*\{@html\s+([^}]+?)\s*\}/gm)].map((m) => m[1])),
+	].sort();
 	assert.deepEqual(
 		injected,
-		[sanitizedSinkName(), 'tooltip.html'].sort(),
+		['tooltip.html'],
 		'unexpected {@html} sink — what the preview injects is the shared sanitizer output',
+	);
+
+	// The document sink, in the form it takes now: one call, and what it is
+	// handed is the sanitized string. `patchPreviewBlocks` is the only way into
+	// the preview's article, so pinning its argument pins the whole path.
+	const patchArguments = [...viewerSource.matchAll(/patchPreviewBlocks\(\s*[\w.]+\s*,\s*([\w.]+)\s*\)/g)].map(
+		(match) => match[1],
+	);
+	assert.deepEqual(
+		patchArguments,
+		[sanitizedSinkName()],
+		'the preview must patch in the shared sanitizer output, once, and nothing else',
+	);
+
+	// And that the module it is handed to has no other way of making nodes out
+	// of a string: one `innerHTML`, assigned from the parameter above.
+	const blockPatchSource = readSource('src/lib/utils/blockPatch.ts');
+	const parses = [...blockPatchSource.matchAll(/\.(?:innerHTML|outerHTML|insertAdjacentHTML)\s*=\s*([^;]+);/g)].map(
+		(m) => m[1].trim(),
+	);
+	assert.deepEqual(
+		parses,
+		['sanitizedHtml'],
+		'blockPatch.ts must parse the sanitized string and never assemble markup of its own',
 	);
 
 	// Why the footnote sink is allowed, pinned as a direction rather than as a

--- a/scripts/renderProtocolDom.ts
+++ b/scripts/renderProtocolDom.ts
@@ -200,6 +200,18 @@ export class ShimNode {
 	querySelector(selector: string): ShimElement | null {
 		return this.querySelectorAll(selector)[0] ?? null;
 	}
+
+	/**
+	 * Does this element itself match?
+	 *
+	 * Needed since `renderRichContent` started taking a list of roots that are
+	 * blocks rather than the whole article: a root that IS a `[data-math]`
+	 * element has to be typeset, and `querySelectorAll` never returns the node
+	 * it was called on.
+	 */
+	matches(selector: string): boolean {
+		return parseSelectorList(selector).some((matcher) => matcher(this as unknown as ShimElement));
+	}
 }
 
 export class ShimText extends ShimNode {

--- a/scripts/richContentCache.test.ts
+++ b/scripts/richContentCache.test.ts
@@ -76,7 +76,7 @@ async function render(html: string, record: Recorder, mathOutput?: (source: stri
 	const root = (globalThis as any).document.createElement('div');
 	root.innerHTML = html;
 	await renderRichContent({
-		root,
+		roots: [root],
 		libraries: libraries(record, mathOutput) as any,
 		mermaidTheme: 'neutral',
 	});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -36,7 +36,8 @@ import {
 	sanitizeDiagramSvg,
 	type RichContentLibraries,
 } from './utils/richContent.js';
-import { observeFoldLayout } from './utils/foldLayout.js';
+import { observeFoldLayout, type FoldLayoutObservation } from './utils/foldLayout.js';
+import { patchPreviewBlocks } from './utils/blockPatch.js';
 import {
 	applyFold,
 	flipFold,
@@ -135,7 +136,21 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	let isFocused = $state(true);
 	
 	let markdownBody: HTMLElement | null = $state(null);
-	let stopObservingFoldLayout: (() => void) | null = null;
+	/**
+	 * The element holding the rendered document, and the only part of the
+	 * preview Svelte does not manage.
+	 *
+	 * `{@html sanitizedHtml}` used to sit here, which meant every keystroke threw
+	 * the article away and built a new one — the defect three rounds of fixes
+	 * could not reach, because a rebuilt tree is not obliged to lay out to the
+	 * same pixels. `blockPatch.ts` owns these children instead, so the ownership
+	 * has to be exclusive: Svelte's `{@html}` tracks the first and last node it
+	 * inserted and removes everything between them on the next update, which a
+	 * diff that removes either end quietly breaks. The front-matter panel stays
+	 * Svelte's, in the article, outside this element.
+	 */
+	let previewBlocks: HTMLElement | null = $state(null);
+	let foldLayout: FoldLayoutObservation | null = null;
 	
 	const highlightColorMap: Record<string, string> = {
 		default: 'color-mix(in srgb, var(--color-accent-fg) 40%, transparent)',
@@ -597,7 +612,6 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			const processed = await renderMarkdownPreview(raw, tab.path, tab.foldOverrides);
 			if (isDisposed) return;
 			tabManager.updateTabContent(tab.id, processed);
-			if (tabManager.activeTabId === tab.id) tick().then(renderRichContent);
 		},
 		dropRestoredTab: (tabId) => tabManager.closeTab(tabId),
 		// A partially loaded buffer must never be handed to another window.
@@ -833,12 +847,15 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	// tightening of the policy silently delete parts of the exported file; the
 	// exported document carries a CSP as the second line of defence.
 	//
-	// The preview has no second line: what it produces is injected straight into
-	// the live application document by `{@html sanitizedHtml}`. So the filter runs
-	// last, on exactly the string that gets injected — the processed HTML is
-	// cached in `tab.content` and re-sanitized at the sink (see `sanitizedHtml`),
-	// which means no parse/serialize round trip happens after the sanitizer has
-	// had its say. Moving the call here instead would inject a string the
+	// The preview has no second line: what it produces becomes nodes in the live
+	// application document, so the filter runs last, on exactly the string
+	// `patchPreviewBlocks` parses — the processed HTML is cached in `tab.content`
+	// and re-sanitized at the sink (see `sanitizedHtml`), which means no
+	// parse/serialize round trip happens after the sanitizer has had its say.
+	// The patch does not cut that string up or filter any part of it a second
+	// time: it parses the whole thing into a `<template>` and moves nodes out of
+	// it, so the bytes DOMPurify saw are the bytes that reach the document.
+	// Moving the call here instead would inject a string the
 	// sanitizer never saw.
 	//
 	// `folds` is a parameter rather than a read of the active tab because this
@@ -857,8 +874,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		const processed = await renderMarkdownPreview(tab.rawContent, tab.path, tab.foldOverrides);
 		tabManager.updateTabContent(tab.id, processed);
 		tab.previewedRawContent = tab.rawContent;
+		// The patch effect turns the new `tab.content` into DOM and enriches what
+		// it changed, so this only has to wait for the flush. It used to call
+		// `renderRichContent()` here as well, over the whole article — a second
+		// pass that now competes with the first one for the same nodes.
 		await tick();
-		renderRichContent();
 	}
 
 	function frontMatterFieldId(key: string) {
@@ -1080,12 +1100,19 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	 * The preview half of the shared renderer: same function the HTML export
 	 * calls, pointed at the live preview element and given the copy-to-clipboard
 	 * behaviour an exported file cannot have.
+	 *
+	 * `roots` is what the block patch just inserted. Omitting it means the whole
+	 * article, which is what a theme change (Mermaid bakes its colours into the
+	 * SVG) and the pre-export refresh need; passing it is what makes a keystroke
+	 * typeset one paragraph.
 	 */
-	async function renderRichContent() {
+	async function renderRichContent(roots?: HTMLElement[]) {
 		if (!markdownBody || !richLibraries) return;
+		const targets = roots ?? [markdownBody];
+		if (targets.length === 0) return;
 
 		await renderRichContentInto({
-			root: markdownBody,
+			roots: targets,
 			libraries: richLibraries,
 			mermaidTheme: currentMermaidTheme(),
 			onCopyCode: (code, label) => {
@@ -1106,33 +1133,60 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		});
 	}
 
+	/**
+	 * The one place a rendered document becomes preview DOM.
+	 *
+	 * It used to be three: `{@html sanitizedHtml}` put the markup in, this effect
+	 * enriched it — but only when `!isEditing`, so split view could not use it —
+	 * and the debounced render path called `tick().then(renderRichContent)` for
+	 * itself. The patch has to happen before the enrichment and the enrichment
+	 * has to be told what the patch changed, so the two stop being independent
+	 * effects racing on the same dependency and become one statement.
+	 */
 	$effect(() => {
-		if (sanitizedHtml && markdownBody && !isEditing && hljs && renderMathInElement && mermaid) renderRichContent();
+		const host = previewBlocks;
+		if (!host) {
+			// Still a read, so a document that lands before the element exists
+			// re-runs this rather than being missed.
+			void sanitizedHtml;
+			return;
+		}
+
+		const patch = patchPreviewBlocks(host, sanitizedHtml);
+		// Only the new blocks. `ResizeObserver.observe` on a target it is already
+		// watching re-registers it rather than doing nothing, and a fresh
+		// registration delivers an initial observation — so handing it the whole
+		// host would put back exactly the per-keystroke re-measure of every fold
+		// that keeping the observation alive removed.
+		for (const block of patch.inserted) foldLayout?.observe(block);
+		if (hljs && renderMathInElement && mermaid) renderRichContent(patch.inserted);
 	});
 
 	$effect(() => {
-		const html = sanitizedHtml;
 		const body = markdownBody;
-		if (!html || !body || (isEditing && !isSplit)) return;
+		if (!body || (isEditing && !isSplit)) return;
 
-		let cancelled = false;
-		tick().then(() => {
-			if (cancelled || body !== markdownBody) return;
-			stopObservingFoldLayout?.();
-			stopObservingFoldLayout = observeFoldLayout(body);
-		});
+		// Keyed on the article, not on the document it is showing. This used to
+		// depend on `sanitizedHtml` and so tore the observation down and rebuilt
+		// it on every keystroke — and a fresh `ResizeObserver.observe` delivers an
+		// initial observation, so every fold in the document re-measured per
+		// character whether or not anything about it had changed. A keystroke no
+		// longer reaches here at all: the blocks the patch left alone keep the
+		// registration they already had, and the ones it inserted are handed to
+		// `observe` by the patch effect above.
+		const observation = observeFoldLayout(body);
+		foldLayout = observation;
 
 		return () => {
-			cancelled = true;
-			stopObservingFoldLayout?.();
-			stopObservingFoldLayout = null;
+			observation.stop();
+			if (foldLayout === observation) foldLayout = null;
 		};
 	});
 
-	// Re-apply find highlights after the preview HTML is replaced. The
-	// `bind:innerHTML={sanitizedHtml}` on the article wipes the DOM on every
-	// edit/render pass; without this, highlights vanish until the user
-	// re-types in the find bar.
+	// Re-apply find highlights after a render. The patch only replaces the blocks
+	// that changed, so most highlights now survive on their own nodes — but the
+	// ones inside a replaced block do not, and without this they vanish until the
+	// user re-types in the find bar.
 	$effect(() => {
 		const _ = sanitizedHtml;
 		if (!findOpen || !findBar) return;
@@ -2635,8 +2689,8 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			// 120ms, and the reason is arithmetic rather than taste. This is a
 			// trailing debounce in front of the whole preview pipeline — one
 			// `render_markdown` round trip to Rust, `processMarkdownHtml`,
-			// DOMPurify, `{@html}` reparsing the article, then KaTeX, highlight.js
-			// and Mermaid over the result — and it arrived at 16ms with the split
+			// DOMPurify, the block patch, then KaTeX, highlight.js
+			// and Mermaid over what it changed — and it arrived at 16ms with the split
 			// view (ef219cf), unexplained. 16ms merges nothing a human types: even
 			// inside a fast burst keystrokes land 60–80ms apart, and at a normal
 			// pace roughly 125ms apart. Every character therefore started its own
@@ -2660,7 +2714,11 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 						) return;
 						tabManager.updateTabContent(tabId, processed);
 						currentTab.previewedRawContent = rawContent;
-						tick().then(renderRichContent);
+						// No `tick().then(renderRichContent)`: the new content is a
+						// dependency of the patch effect, which patches the blocks
+						// that changed and enriches exactly those. Calling it from
+						// here as well would re-run the whole document — the work
+						// this path exists to stop doing.
 					})
 					.catch(console.error);
 			}, 120);
@@ -3742,7 +3800,8 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 
 										</details>
 									{/if}
-									{@html sanitizedHtml}
+									<!-- Filled by the block patch, not by Svelte: see `previewBlocks`. -->
+									<div class="markdown-blocks" bind:this={previewBlocks}></div>
 								</article>
 								{#if tabManager.activeTabId && loadingTabs.includes(tabManager.activeTabId) && isAtBottom}
 								<div class="loading-chip" transition:fly={{ y: 20, duration: 300, easing: cubicOut }}>

--- a/src/lib/utils/blockPatch.ts
+++ b/src/lib/utils/blockPatch.ts
@@ -1,3 +1,4 @@
+import { invalidateAnchorMemos } from './previewAnchor.js';
 import { carrySourcepos } from './richContent.js';
 
 /**
@@ -58,6 +59,15 @@ import { carrySourcepos } from './richContent.js';
  * ranges are refreshed onto kept nodes from the new tree (`refreshSourcepos`).
  * That is an attribute write no CSS rule reads: no style invalidation, no
  * layout, no paint — the class of work this module exists to preserve.
+ *
+ * It is not, however, a write nothing reads. `previewAnchor.ts` memoises the
+ * range it parses off a node and the span it derives from a node's subtree, and
+ * both memos were built on the guarantee this module removes: that a node whose
+ * source lines changed is a *new* node, so a stale entry is unreachable. Keeping
+ * the node keeps the entry, and the memo goes on answering with the lines the
+ * block was on before the edit, for as long as the node lives. So the patch owes
+ * `invalidateAnchorMemos` a call — the whole of it, not per node, for the reason
+ * spelled out where those memos are declared.
  *
  * ## Keys are remembered, never read back off the live tree
  *
@@ -139,6 +149,11 @@ function childKeys(container: ParentNode): string[] {
 export function patchPreviewBlocks(host: HTMLElement, sanitizedHtml: string): BlockPatch {
 	const template = host.ownerDocument.createElement('template');
 	template.innerHTML = sanitizedHtml;
+
+	// Before the tree moves, not after: a patch that throws half-way through has
+	// still changed some of it, and an empty memo is only ever a slow answer
+	// where a stale one is a wrong one.
+	invalidateAnchorMemos();
 
 	const patch: BlockPatch = { inserted: [], replaced: 0, kept: 0 };
 	patchContainer(host, template.content, patch);

--- a/src/lib/utils/blockPatch.ts
+++ b/src/lib/utils/blockPatch.ts
@@ -1,0 +1,291 @@
+import { carrySourcepos } from './richContent.js';
+
+/**
+ * Putting the newly rendered document into the preview by replacing only the
+ * blocks that changed.
+ *
+ * The preview used to be `{@html sanitizedHtml}`: every keystroke destroyed the
+ * whole article and built a new one. Three rounds of fixes attacked the cost of
+ * rebuilding it — memoising KaTeX and highlight.js (#614), debouncing the
+ * pipeline against a pause rather than a frame (#614), measuring folds from
+ * layout height rather than scrollable extent (#617) — and the report never went
+ * away, because the remaining defect is not cost. `scrollTop` was measured
+ * unchanged at Δ0.0 while the text still moved: a rebuilt tree is not required
+ * to lay out to the same pixels as the one it replaced. Inline maths (KaTeX's
+ * auto-renderer, which has no memo), font metrics, a re-attached
+ * ResizeObserver, an image whose intrinsic size is not known again until it
+ * decodes — any one of them is a frame of difference, and there is no end to
+ * that list. The only stable tree is the one that is not rebuilt.
+ *
+ * So this module keeps the nodes whose rendering did not change and swaps the
+ * ones that did, which is what VS Code and Obsidian do for the same reason.
+ *
+ * Measured in Chromium over the real pipeline (comrak → `processMarkdownHtml` →
+ * `sanitizeMarkdownHtml` → here), typing one character in the middle of a
+ * paragraph, against the same edit applied by rebuilding the article:
+ *
+ *     samples/markdown-syntax.md   1000 -> 2 elements re-created (of 1733)
+ *     samples/katex-stress.md       230 -> 1                     (of 4641)
+ *     samples/stress-test.md       6985 -> 1                     (of 7819)
+ *
+ * and the whole apply — patch plus highlighting, typesetting and diagrams over
+ * what it changed — 23.8 -> 5.9ms, 27.7 -> 5.3ms and 51.1 -> 17.5ms
+ * respectively. What the reader is looking at is the node they were looking at
+ * before, not a copy of it: a fixed reference block sampled at frames 0, 1, 2, 5
+ * and 11 after the edit is at +0.000px in every case.
+ *
+ * Renaming a heading is the one edit that does not collapse to a block or two:
+ * comrak deduplicates heading ids (`objectives-24`, `objectives-25`, …), so
+ * renaming one renumbers every later duplicate and those blocks really are
+ * different markup. On stress-test.md that is 71 blocks instead of 1 — still a
+ * third of the document rather than all of it, and the id is in the markup, so
+ * no key can call them unchanged without lying.
+ *
+ * ## The key is the markup, not the source position
+ *
+ * comrak stamps every block with `data-sourcepos`, and it is tempting to diff
+ * on that. It is exactly wrong: inserting one line renumbers every block below
+ * the cursor, so a source-position key says "everything after the caret is
+ * new" — the whole document, on every keystroke, which is the thing being
+ * fixed. The key here is the block's own markup with every source range removed,
+ * so a paragraph that merely moved down two lines is recognised as the same
+ * paragraph. It is not hashed: the string *is* the key, which costs one map
+ * comparison per block and cannot collide.
+ *
+ * `data-sourcepos` still has to be *right* on a kept node — `lineCoordinates.ts`
+ * and `previewAnchor.ts` resolve every scroll-sync and anchor-restore question
+ * through it, and split-view scroll sync is running while the user types. So the
+ * ranges are refreshed onto kept nodes from the new tree (`refreshSourcepos`).
+ * That is an attribute write no CSS rule reads: no style invalidation, no
+ * layout, no paint — the class of work this module exists to preserve.
+ *
+ * ## Keys are remembered, never read back off the live tree
+ *
+ * `renderRichContent` rewrites what it touches: a `<pre>` gains a
+ * `.code-block-shell` parent and a copy button, a Mermaid `<pre>` becomes a
+ * `<div class="mermaid-diagram">`, a formula's `innerHTML` becomes KaTeX's. The
+ * live markup therefore has nothing to do with the markup that produced it, and
+ * a diff that re-serialised the live tree would find every enriched block
+ * "changed" forever. `renderedKeys` holds the keys of what this module last
+ * *inserted*, per container, positionally. Every one of those rewrites is
+ * one-node-for-one-node, so the positions still line up.
+ *
+ * A container whose live child count no longer matches its remembered keys is
+ * one somebody else rewrote; it gets replaced wholesale rather than guessed at.
+ *
+ * ## Why this descends
+ *
+ * "Top-level block" is not a useful unit in this pipeline. `processMarkdownHtml`
+ * re-parents everything under a heading into a `.foldable-content-wrapper`, so a
+ * document that opens with `# Title` has exactly two top-level children and the
+ * second one is the rest of the file. The diff therefore recurses into the
+ * containers Markpad builds itself (`DESCENDABLE`) — and only those. Their
+ * children are always whole blocks, which is what makes it safe to compare them
+ * as a list and to drop the inter-block whitespace. Descending into arbitrary
+ * elements is not: a `<p>` whose element children are unchanged can still have
+ * different text between them, and an element-wise diff would keep the old
+ * words.
+ */
+
+/**
+ * Source ranges, removed before a block is keyed. The values comrak writes are
+ * `line:col-line:col`, so there is no quote to escape and no need to parse.
+ */
+const SOURCEPOS_ATTRIBUTE = /\s+data-sourcepos="[^"]*"/g;
+
+/**
+ * The containers this diff may look inside instead of replacing.
+ *
+ * Every one is built by `processMarkdownHtml` out of `appendChild` calls on
+ * whole blocks, which is the property that makes a positional child diff sound.
+ */
+const DESCENDABLE =
+	'.foldable-content-wrapper, .content-inner, .markdown-alert, .markdown-alert-content';
+
+/** What this module last put into each container, in order. */
+const renderedKeys = new WeakMap<Element, string[]>();
+
+export interface BlockPatch {
+	/**
+	 * The elements that were newly inserted — everything, and only what,
+	 * `renderRichContent` has to visit. Never nested inside one another.
+	 */
+	inserted: HTMLElement[];
+	/** Elements inserted, at every depth the diff reached. Diagnostics. */
+	replaced: number;
+	/** Elements left in place, at every depth the diff reached. Diagnostics. */
+	kept: number;
+}
+
+function blockKey(element: Element): string {
+	return element.outerHTML.replace(SOURCEPOS_ATTRIBUTE, '');
+}
+
+function childKeys(container: ParentNode): string[] {
+	return Array.from(container.children).map(blockKey);
+}
+
+/**
+ * Bring the preview's blocks up to date with `sanitizedHtml`, replacing as few
+ * of them as possible.
+ *
+ * The string is parsed into a `<template>`, whose content lives in an inert
+ * document: the blocks that turn out to be unchanged are discarded without ever
+ * having loaded an image or run anything. Nothing is cut out of the string and
+ * nothing is filtered a second time — the caller sanitizes the whole document,
+ * exactly as it did when this was `{@html}`, and what is parsed here is that
+ * one string.
+ */
+export function patchPreviewBlocks(host: HTMLElement, sanitizedHtml: string): BlockPatch {
+	const template = host.ownerDocument.createElement('template');
+	template.innerHTML = sanitizedHtml;
+
+	const patch: BlockPatch = { inserted: [], replaced: 0, kept: 0 };
+	patchContainer(host, template.content, patch);
+	return patch;
+}
+
+function patchContainer(live: HTMLElement, next: ParentNode, patch: BlockPatch): void {
+	const nextElements = Array.from(next.children) as HTMLElement[];
+	const newKeys = childKeys(next);
+	const liveElements = Array.from(live.children) as HTMLElement[];
+	const oldKeys = renderedKeys.get(live);
+
+	renderedKeys.set(live, newKeys);
+
+	// First render into this container, or one whose children somebody else
+	// changed. Only elements are carried over: the whitespace between blocks is
+	// comrak's line breaks, invisible between block boxes, and keeping it out
+	// means `children` and `childNodes` stay the same list forever.
+	if (!oldKeys || oldKeys.length !== liveElements.length) {
+		live.replaceChildren(...nextElements);
+		for (const element of nextElements) rememberSubtree(element);
+		patch.inserted.push(...nextElements);
+		patch.replaced += nextElements.length;
+		return;
+	}
+
+	// Common prefix and suffix rather than a full edit-distance: the edit this
+	// exists for is a keystroke, which produces one changed block with an
+	// unchanged run on either side of it. A block that *moved* (cut here, pasted
+	// far away) falls outside the run and is replaced, which is correct and only
+	// costs the incrementality nobody is typing to get.
+	const shortest = Math.min(oldKeys.length, newKeys.length);
+	let head = 0;
+	while (head < shortest && oldKeys[head] === newKeys[head]) head += 1;
+	let tail = 0;
+	while (
+		tail < shortest - head &&
+		oldKeys[oldKeys.length - 1 - tail] === newKeys[newKeys.length - 1 - tail]
+	) {
+		tail += 1;
+	}
+	patch.kept += head + tail;
+
+	let oldFrom = head;
+	let oldTo = oldKeys.length - tail;
+	let newFrom = head;
+	let newTo = newKeys.length - tail;
+
+	// The changed run is usually a single container holding the edit. Descending
+	// from both ends rather than only the front is what keeps typing inside a
+	// heading from being a whole-document replacement: the `<h1>` really did
+	// change and gets swapped, and the wrapper carrying the rest of the file is
+	// reached from the other side and looked inside.
+	while (oldFrom < oldTo && newFrom < newTo && canDescend(liveElements[oldFrom], nextElements[newFrom])) {
+		descend(liveElements[oldFrom], nextElements[newFrom], patch);
+		oldFrom += 1;
+		newFrom += 1;
+	}
+	while (oldTo > oldFrom && newTo > newFrom && canDescend(liveElements[oldTo - 1], nextElements[newTo - 1])) {
+		descend(liveElements[oldTo - 1], nextElements[newTo - 1], patch);
+		oldTo -= 1;
+		newTo -= 1;
+	}
+
+	// Read before anything is removed: still a live node, and still in place
+	// afterwards, because everything removed sits before it.
+	const before = liveElements[oldTo] ?? null;
+	for (let index = oldFrom; index < oldTo; index += 1) liveElements[index].remove();
+
+	const incoming = nextElements.slice(newFrom, newTo);
+	if (incoming.length > 0) {
+		const fragment = live.ownerDocument.createDocumentFragment();
+		for (const element of incoming) fragment.appendChild(element);
+		live.insertBefore(fragment, before);
+		for (const element of incoming) rememberSubtree(element);
+		patch.inserted.push(...incoming);
+		patch.replaced += incoming.length;
+	}
+
+	// Kept blocks moved in the source even when they did not move on screen, and
+	// a nested container's whole child list shifts when a line is added above the
+	// heading that owns it — so the prefix needs this as much as the suffix does.
+	for (let index = 0; index < head; index += 1) {
+		refreshSourcepos(liveElements[index], nextElements[index]);
+	}
+	for (let index = 1; index <= tail; index += 1) {
+		refreshSourcepos(liveElements[liveElements.length - index], nextElements[nextElements.length - index]);
+	}
+}
+
+function descend(live: HTMLElement, next: HTMLElement, patch: BlockPatch): void {
+	// The container is kept, so it keeps its own source range too — a callout is
+	// annotated, and scroll sync reads the outermost annotation it can find.
+	carrySourcepos(next, live);
+	patchContainer(live, next, patch);
+}
+
+function canDescend(live: Element, next: Element): boolean {
+	return (
+		live.tagName === next.tagName &&
+		// A fold that was toggled has `is-collapsed` on one side and not the
+		// other; that is a replacement, not a container to look inside.
+		live.className === next.className &&
+		next.childElementCount > 0 &&
+		next.matches(DESCENDABLE)
+	);
+}
+
+/**
+ * Record the keys of every descendable container inside a freshly inserted
+ * block, so the *next* diff can look inside it instead of replacing it.
+ *
+ * Must run before `renderRichContent` touches these nodes, which is why the
+ * patch and the enrichment are ordered rather than independent.
+ */
+function rememberSubtree(element: Element): void {
+	if (element.matches(DESCENDABLE)) renderedKeys.set(element, childKeys(element));
+	for (const container of element.querySelectorAll(DESCENDABLE)) {
+		renderedKeys.set(container, childKeys(container));
+	}
+}
+
+function annotatedNodes(element: Element): Element[] {
+	const nodes = element.hasAttribute('data-sourcepos') ? [element] : [];
+	nodes.push(...element.querySelectorAll('[data-sourcepos]'));
+	return nodes;
+}
+
+/**
+ * Copy the new source ranges onto a block that is being kept.
+ *
+ * The two subtrees are the same markup apart from the ranges the key strips, so
+ * their annotated elements line up one for one — including after enrichment,
+ * because every node `renderRichContent` replaces it replaces singly and
+ * `carrySourcepos` moves the range across. A length mismatch means that
+ * assumption does not hold for this block; leaving it untouched is the safe
+ * answer, and it costs a stale range rather than a wrong one somewhere else.
+ */
+function refreshSourcepos(live: Element, next: Element): void {
+	const liveNodes = annotatedNodes(live);
+	const nextNodes = annotatedNodes(next);
+	if (liveNodes.length !== nextNodes.length) return;
+
+	for (let index = 0; index < liveNodes.length; index += 1) {
+		const range = nextNodes[index].getAttribute('data-sourcepos');
+		if (range !== null && liveNodes[index].getAttribute('data-sourcepos') !== range) {
+			liveNodes[index].setAttribute('data-sourcepos', range);
+		}
+	}
+}

--- a/src/lib/utils/export.ts
+++ b/src/lib/utils/export.ts
@@ -306,7 +306,13 @@ async function renderExportRichContent(root: HTMLElement, ctx: ExportContext): P
 	try {
 		const libraries = ctx.libraries ?? (await loadRichContentLibraries());
 		await renderRichContent({
-			root,
+			// One root, and always the whole thing: an exported file is a string,
+			// so there is no previous DOM to keep any of. The preview's split from
+			// this — same render, same filter, same detached parse, then either
+			// serialize it or diff it into the article — is the whole reason
+			// `blockPatch.ts` takes an already-sanitized string and produces nodes
+			// rather than owning a render of its own.
+			roots: [root],
 			libraries,
 			mermaidTheme: ctx.mermaidTheme,
 			onError: (error) => console.error('Rich content failed to render for HTML export', error),

--- a/src/lib/utils/foldLayout.ts
+++ b/src/lib/utils/foldLayout.ts
@@ -82,7 +82,24 @@ function updateFoldHeights(root: HTMLElement) {
 	}
 }
 
-export function observeFoldLayout(root: HTMLElement): () => void {
+export interface FoldLayoutObservation {
+	/**
+	 * Start watching the fold contents inside newly rendered markup.
+	 *
+	 * Called with the blocks `blockPatch.ts` just inserted, rather than with the
+	 * whole article. The observation used to be torn down and rebuilt on every
+	 * keystroke, which meant a document's every fold got a fresh
+	 * ResizeObserver registration per character — and a fresh registration
+	 * delivers an initial observation, so every fold re-measured whether or not
+	 * anything about it had changed. A block nobody replaced now keeps the
+	 * observer it already had. `observe` is idempotent, so re-registering a
+	 * survivor costs nothing either.
+	 */
+	observe(scope: Element): void;
+	stop(): void;
+}
+
+export function observeFoldLayout(root: HTMLElement): FoldLayoutObservation {
 	let frame: number | null = null;
 
 	const scheduleUpdate = () => {
@@ -94,18 +111,47 @@ export function observeFoldLayout(root: HTMLElement): () => void {
 	};
 
 	const observer = new ResizeObserver(scheduleUpdate);
-	for (const content of root.querySelectorAll<HTMLElement>(
-		`${FOLD_WRAPPER_SELECTOR} > .content-inner`,
-	)) {
-		observer.observe(content);
-	}
+	const observe = (scope: Element) => {
+		// A block that just replaced another is not obliged to be the same height,
+		// and every fold wrapper above it is still pinned to the height the old one
+		// measured. For the frame it takes ResizeObserver to fire, `.content-inner`
+		// — `overflow: visible` while expanded — spills past the box meant to hold
+		// it, and the next section is overlapped. Rebuilding the article never
+		// showed this: a fresh wrapper carries no inline property and lays out at
+		// `auto`. Releasing puts the patch on that same footing, and the measured
+		// height is republished below either way. A collapsed wrapper is unaffected
+		// — its `height: 0` comes from the more specific `.is-collapsed` rule.
+		for (let element = scope.parentElement; element; element = element.parentElement) {
+			if (element.matches(FOLD_WRAPPER_SELECTOR)) {
+				element.style.removeProperty('--fold-content-height');
+			}
+		}
 
+		// `querySelectorAll` never returns the node it was called on, and a block
+		// the patch inserted can itself be the wrapper.
+		if (scope.matches(FOLD_WRAPPER_SELECTOR)) {
+			const own = scope.querySelector<HTMLElement>(FOLD_CONTENT_SELECTOR);
+			if (own) observer.observe(own);
+		}
+		for (const content of scope.querySelectorAll<HTMLElement>(
+			`${FOLD_WRAPPER_SELECTOR} > .content-inner`,
+		)) {
+			observer.observe(content);
+		}
+
+		scheduleUpdate();
+	};
+
+	observe(root);
 	window.addEventListener('resize', scheduleUpdate);
 	scheduleUpdate();
 
-	return () => {
-		observer.disconnect();
-		window.removeEventListener('resize', scheduleUpdate);
-		if (frame !== null) cancelAnimationFrame(frame);
+	return {
+		observe,
+		stop: () => {
+			observer.disconnect();
+			window.removeEventListener('resize', scheduleUpdate);
+			if (frame !== null) cancelAnimationFrame(frame);
+		},
 	};
 }

--- a/src/lib/utils/previewAnchor.ts
+++ b/src/lib/utils/previewAnchor.ts
@@ -280,16 +280,48 @@ function elementChildren(node: AnchorNode): AnchorNode[] {
  * every candidate sibling on every call, and on a 13,000-line document that is
  * ~6ms per mapping — measured, in Chrome, over this pipeline's own output.
  *
- * WHAT INVALIDATES THEM: nothing, explicitly. The answer for a node is a
- * function of that node's own attribute and of its subtree's annotated blocks,
- * neither of which is edited in place — the preview is rebuilt wholesale by
- * `bind:innerHTML` on every render pass, so a changed document is a new set of
- * nodes, and the entries describing the old ones are collected with them.
- * Folding, task checkboxes and rich-content rendering all leave the annotated
+ * WHAT INVALIDATES THEM: `invalidateAnchorMemos`, which `patchPreviewBlocks`
+ * calls before it touches the tree. It has to, because these answers are no
+ * longer a function of a node's identity.
+ *
+ * They used to be, and this comment used to say so: the preview was rebuilt
+ * wholesale by `bind:innerHTML` on every render pass, so a changed document was
+ * a new set of nodes and the entries describing the old ones were collected
+ * with them. Nothing invalidated these memos because nothing could.
+ * `blockPatch.ts` breaks that premise on purpose — it keeps the nodes whose
+ * rendering did not change, and rewrites `data-sourcepos` ON THOSE KEPT NODES
+ * from the new tree (`refreshSourcepos`, `carrySourcepos`). A kept node is the
+ * same key, so its entry survives the edit that changed its range, and the memo
+ * keeps answering with the lines the block used to be on — permanently, because
+ * nothing is ever going to replace that node either. Every edit that shifts a
+ * line number widens the error, and scroll sync, the tab reading position and
+ * the outline's current heading all resolve through here.
+ *
+ * Both maps are dropped whole rather than entry by entry, because `spanCache`
+ * cannot be invalidated per node. A span is a property of the subtree, not of
+ * the element: the patch keeps a `.foldable-content-wrapper` and replaces a
+ * paragraph inside it, and the wrapper's cached span is stale without the
+ * wrapper itself having been touched. Per-node invalidation would have to walk
+ * to the root from every change and would silently under-invalidate the first
+ * time somebody added a case that skipped the walk; two assignments cannot miss
+ * an ancestor. The cost is one cold lookup per render pass — renders are
+ * debounced against a pause in typing, scroll events are not — and that lookup
+ * refills the memo for every event after it.
+ *
+ * Folding, task checkboxes and rich-content rendering still leave the annotated
  * blocks and their ranges exactly where they were.
  */
-const ownRangeCache = new WeakMap<object, LineRange | null>();
-const spanCache = new WeakMap<object, LineRange | null>();
+let ownRangeCache = new WeakMap<object, LineRange | null>();
+let spanCache = new WeakMap<object, LineRange | null>();
+
+/**
+ * Forget every memoised range. Whoever rewrites a `data-sourcepos` in place, or
+ * changes what is inside a node that is being kept, owes this call.
+ */
+export function invalidateAnchorMemos(): void {
+	ownRangeCache = new WeakMap<object, LineRange | null>();
+	spanCache = new WeakMap<object, LineRange | null>();
+}
 
 function ownRange(node: AnchorNode): LineRange | null {
 	const cached = ownRangeCache.get(node as object);

--- a/src/lib/utils/richContent.ts
+++ b/src/lib/utils/richContent.ts
@@ -142,8 +142,17 @@ export function sanitizeDiagramSvg(svg: string): string {
 }
 
 export interface RenderRichContentOptions {
-	/** The element holding processed Markdown. Live or detached, both work. */
-	root: HTMLElement;
+	/**
+	 * The elements holding processed Markdown. Live or detached, both work.
+	 *
+	 * A list, not one element, because the preview no longer rebuilds its
+	 * article: `blockPatch.ts` replaces the blocks that changed and hands their
+	 * new nodes here, so a keystroke typesets one paragraph instead of the
+	 * document. The export passes the single detached element it is building.
+	 * The roots must not contain one another — each is visited on its own, so a
+	 * nested pair would be highlighted, typeset and wrapped twice.
+	 */
+	roots: HTMLElement[];
 	libraries: RichContentLibraries;
 	/** Mermaid's own theme name, from `resolveMermaidTheme`. */
 	mermaidTheme: string;
@@ -185,17 +194,32 @@ export function carrySourcepos(from: Element, to: Element) {
 const COPY_ICON_SVG =
 	'<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>';
 
+/**
+ * Everything in `root`'s subtree matching `selector`, and `root` itself if it
+ * matches.
+ *
+ * `querySelectorAll` alone was right while the root was the whole article,
+ * because a block is never the article. It is wrong for a root that IS a block:
+ * a patched-in `<p data-math="display">` would be skipped by its own typesetting
+ * pass.
+ */
+function selfAndDescendants(root: HTMLElement, selector: string): Element[] {
+	const matches: Element[] = root.matches(selector) ? [root] : [];
+	matches.push(...root.querySelectorAll(selector));
+	return matches;
+}
+
 export async function renderRichContent(options: RenderRichContentOptions): Promise<void> {
-	const { root, libraries } = options;
-	if (!root) return;
+	const { roots, libraries } = options;
+	if (roots.length === 0) return;
 
 	const { hljs, katex, renderMathInElement, mermaid } = libraries;
 	if (!hljs || !renderMathInElement || !mermaid) return;
 
-	const doc = root.ownerDocument ?? document;
+	const doc = roots[0].ownerDocument ?? document;
 	const idFactory = options.idFactory ?? defaultIdFactory;
 
-	const codeBlocks = Array.from(root.querySelectorAll('pre code'));
+	const codeBlocks = roots.flatMap((root) => selfAndDescendants(root, 'pre code'));
 
 	// `htmlLabels: false` is what keeps a diagram's text in the picture. With
 	// Mermaid's default (`true`) every label is an HTML `<div>`/`<span>` inside a
@@ -336,8 +360,8 @@ export async function renderRichContent(options: RenderRichContentOptions): Prom
 
 	// KaTeX math rendering
 	if (katex) {
-		const mathElements = root.querySelectorAll('[data-math]');
-		for (const el of Array.from(mathElements)) {
+		const mathElements = roots.flatMap((root) => selfAndDescendants(root, '[data-math]'));
+		for (const el of mathElements) {
 			const isDisplay = el.getAttribute('data-math') === 'display';
 			const mathSource = el.getAttribute('data-math-source') || el.textContent || '';
 			try {
@@ -357,10 +381,16 @@ export async function renderRichContent(options: RenderRichContentOptions): Prom
 		}
 	}
 
+	// The one pass with no memo behind it (see #614: there is no seam to
+	// memoise without re-implementing KaTeX's delimiter scanner), so it is also
+	// the one that gains most from being handed a paragraph instead of a
+	// document. Per root, because the scanner walks a subtree.
 	if (renderMathInElement) {
-		renderMathInElement(root, {
-			delimiters: MATH_DELIMITERS,
-			throwOnError: false,
-		});
+		for (const root of roots) {
+			renderMathInElement(root, {
+				delimiters: MATH_DELIMITERS,
+				throwOnError: false,
+			});
+		}
 	}
 }


### PR DESCRIPTION
Every keystroke rebuilt the whole article: `{@html}` destroyed and re-created every element, then `renderRichContent` walked the new tree. A rebuilt tree is not obliged to settle identically, so #614 (memoise the renderers), #617 (fix the fold measurement) and #622 (lengthen the debounce) each removed one source of movement without removing the source.

This replaces only the blocks whose rendered markup changed.

### Measured — Chromium, real pipeline, one character typed mid-paragraph

| | elements re-created | apply | reference block drift |
|---|---|---|---|
| `markdown-syntax.md` | 1000 → **2** (of 1733) | 23.8 → **5.9ms** | +0.000px |
| `katex-stress.md` | 230 → **1** (of 4641) | 27.7 → **5.3ms** | +0.000px |
| `stress-test.md` | 6985 → **1** (of 7819) | 51.1 → **17.5ms** | +0.000px |

In the running app: one keystroke keeps 10 nodes and replaces 1. Inserting a line keeps 10, inserts 1, and the block below correctly moves `4:1-4:16` → `5:1-5:16`.

### What this does not claim

**The bench could not make the old rebuild path drift.** It measured +0.000px there too — on this corpus, in this browser. #614's memos make KaTeX and highlight.js output byte-identical and the samples carry no images.

So this removes the *class* of defect — 1–5 nodes touched instead of 1000–6985 — rather than a reproduced instance of it. It is not "measured the jump, fixed the jump."

### The four decisions

**Diff key: rendered markup with `data-sourcepos` stripped.** Not hashed — the string *is* the key, so one map comparison and no collision risk. `data-sourcepos` is excluded because inserting a line shifts it on every block below, which would make the whole document "changed".

**Sanitize is untouched.** `$derived(sanitizeMarkdownHtml(htmlContent))` still runs over the whole document. The patcher parses that one string into a `<template>` — an inert document, so discarded blocks never load an image — and moves nodes out of it. No string cutting, no second filter pass, so the sanitize-last argument and the `singleImplementationConvention` rule both hold as written.

**`renderRichContent` takes `roots: HTMLElement[]`** instead of one root, and runs only over changed blocks. `renderMathInElement` — the one pass #614 could not memoise, because KaTeX's auto-renderer walks the tree with its own bundled copy — is now per-block rather than per-document.

**Export forks after the detached tree.** Export passes `roots: [wrapper]`; the shared part is render → filter → detached tree, and the fork is serialise versus diff-in. Nothing renders twice.

**`data-sourcepos` is refreshed on kept nodes.** They can be stale even in an unchanged prefix — a nested container's whole child list shifts when a line is added above the heading that owns it — and split-view scroll sync reads it while the user is typing. It is an attribute no CSS rule matches: no invalidation, no layout, no paint.

### Known bad case

**Renaming a heading touches 71 blocks instead of 1** on `stress-test.md`. comrak dedupes heading ids (`objectives-24`, `-25`, …), so renaming one renumbers every later duplicate. Those blocks genuinely *are* different markup — no key can call them unchanged without lying. Still a third of the document rather than all of it.

### Two things the work turned up

**A regression the bench caught.** A patched block is not obliged to be the same height, and the fold wrapper stayed pinned to its old `--fold-content-height` for a frame while `.content-inner` spilled over the next section. `observe()` now releases the pinned height above an inserted block. A rebuilt wrapper never showed this, because it carries no inline property.

**`{@html sanitizedHtml}` had to go.** Svelte tracks its first and last node and removes everything between them on update, so a diff that removes either end breaks it silently. The document now lives in its own `<div class="markdown-blocks">`; the front-matter panel stays Svelte's.

Rewriting `previewSanitize.test.ts` to follow the chain to its new home turned up that **its old regex was matching on comments** — a false green, closed by anchoring to line start.

### Net subtraction elsewhere

Three enrichment call sites collapsed to one, and the fold observation no longer tears itself down on every keystroke.

`npm test` 996 · `npm run test:vitest` 81 · `cargo test` 145 · `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
