### PR TITLE
ci: pin node past the manifest lookup that keeps failing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,16 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: lts/*
+          # An exact major rather than `lts/*`. Resolving an LTS *alias*
+          # requires the version manifest, which is a network call made before
+          # the tool-cache lookup — and that call is what failed three times in
+          # one afternoon with `self-signed certificate`, on jobs whose own
+          # work needed no network at all. A semver range is matched against
+          # the runner's tool cache first, and the cache already holds what
+          # `lts/*` was resolving to (`Found in cache @ …/node/24.18.0`), so
+          # the manifest is never reached. If a future image drops 24 this
+          # falls back to fetching the manifest — today's behaviour, not worse.
+          node-version: 24
 
       - name: Get Version
         id: get_version
@@ -192,7 +201,16 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: lts/*
+          # An exact major rather than `lts/*`. Resolving an LTS *alias*
+          # requires the version manifest, which is a network call made before
+          # the tool-cache lookup — and that call is what failed three times in
+          # one afternoon with `self-signed certificate`, on jobs whose own
+          # work needed no network at all. A semver range is matched against
+          # the runner's tool cache first, and the cache already holds what
+          # `lts/*` was resolving to (`Found in cache @ …/node/24.18.0`), so
+          # the manifest is never reached. If a future image drops 24 this
+          # falls back to fetching the manifest — today's behaviour, not worse.
+          node-version: 24
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,16 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v7
         with:
-          node-version: lts/*
+          # An exact major rather than `lts/*`. Resolving an LTS *alias*
+          # requires the version manifest, which is a network call made before
+          # the tool-cache lookup — and that call is what failed three times in
+          # one afternoon with `self-signed certificate`, on jobs whose own
+          # work needed no network at all. A semver range is matched against
+          # the runner's tool cache first, and the cache already holds what
+          # `lts/*` was resolving to (`Found in cache @ …/node/24.18.0`), so
+          # the manifest is never reached. If a future image drops 24 this
+          # falls back to fetching the manifest — today's behaviour, not worse.
+          node-version: 24
 
       - name: install rust stable
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -108,7 +108,16 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v7
         with:
-          node-version: lts/*
+          # An exact major rather than `lts/*`. Resolving an LTS *alias*
+          # requires the version manifest, which is a network call made before
+          # the tool-cache lookup — and that call is what failed three times in
+          # one afternoon with `self-signed certificate`, on jobs whose own
+          # work needed no network at all. A semver range is matched against
+          # the runner's tool cache first, and the cache already holds what
+          # `lts/*` was resolving to (`Found in cache @ …/node/24.18.0`), so
+          # the manifest is never reached. If a future image drops 24 this
+          # falls back to fetching the manifest — today's behaviour, not worse.
+          node-version: 24
 
       - name: install rust stable
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
`node-version: lts/*` failed three times in one afternoon, always at the same step:

```
Attempt to resolve LTS alias from manifest...
##[error]self-signed certificate
```

### Why an alias is the fragile part

`lts/*` is an alias, and resolving one requires the version manifest — a network call `setup-node` makes **before** it looks in the tool cache.

The version behind that alias was already sitting there. A successful run on the same commit logs:

```
Found in cache @ /opt/hostedtoolcache/node/24.18.0/x64
```

So the download was never the problem, and the jobs that failed needed no network of their own.

### The change

A semver range skips the alias step and is matched against the tool cache first, so `24` resolves to the same `24.18.0` without reaching the manifest. Pinned as a major rather than a patch, so the runner image's own updates still apply.

If a future image drops 24 this falls back to fetching the manifest — today's behaviour, not worse — and the failure would name the version, which is a better signal than an alias failing to resolve.

Four call sites: `test.yml`, `test_build.yml`, and both in `build.yml`.

`npm test` 1035 · `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
