### PR TITLE
test: run the runes-module suites under the compiler that owns runes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,22 @@ unchanged. Two things bite:
   resolves to its SSR build and `$effect` never flushes — the runes go quietly back to
   behaving like the shims.
 - `readSource(new URL('…', import.meta.url))` throws under vitest, which serves test files
-  over `http://`. Use the cwd-relative string form.
+  over `http://`. Use the cwd-relative string form. (`sourceTree.ts`'s own helpers already
+  do; `rustSourceFiles` had the same bug in `readdirSync` and was fixed the same way.)
+- Stub `get_os_type`. Importing `tabs.svelte.ts` pulls in the `settings` singleton, which
+  boots for real under the compiler; `initOSType` catches a rejection but not a `null`
+  answer, so a bare `invoke: () => Promise.resolve(null)` leaves `osType` null and the
+  font defaults it indexes undefined.
+
+Three of the shimmed files were left where they are, because a rename does not reach what
+is wrong with them:
+
+- `foldStatePerDocument.test.ts` cuts functions out of `.svelte` files with its own
+  brace-pairing scanner. The logic has to move into a `.svelte.ts` module first.
+- `tabReadingPosition.test.ts` calls `installShimDom()`, which assigns `globalThis.document`
+  — under vitest that replaces jsdom's. Its harness has to move to the real DOM first.
+- `checkedReadMigration.test.ts` is mostly the two never-migrate categories: that an
+  unchecked command exists nowhere in `src` *or* in the Rust crate.
 
 ### Anything a test constructs inside an effect root must be torn down
 

--- a/scripts/documentEncodingRoundTrip.spec.ts
+++ b/scripts/documentEncodingRoundTrip.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 import { functionSource, readRustBackend, readSource, sliceBetween } from './sourceTree.js';
 
@@ -24,23 +25,9 @@ import { functionSource, readRustBackend, readSource, sliceBetween } from './sou
  * than read for.
  */
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
-Object.defineProperty(g, 'navigator', { value: { language: 'en-US' }, configurable: true });
-Object.defineProperty(g, 'localStorage', {
-	value: { getItem: () => null, setItem: () => {}, removeItem: () => {}, clear: () => {} },
-	configurable: true,
-});
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity, and jsdom
+// supplies `window` and `localStorage`. Only the Tauri backend is stubbed.
 
 /** What the backend reports for the next read. Set per test. */
 let fileEncoding = 'UTF-8';
@@ -50,7 +37,8 @@ const BODY = '# 中文标题';
 /** Every `save_file_content` the session issued, in order. */
 let writes: Array<{ path: string; content: string; encoding: string }> = [];
 
-g.window.__TAURI_INTERNALS__ = {
+(window as any).__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (command: string, args: Record<string, unknown>) => {
 		const cmd = command.replace(/^plugin:[^|]*\|/, '');
 		if (cmd === 'get_os_type') return Promise.resolve('macos');

--- a/scripts/documentLoadFailure.spec.ts
+++ b/scripts/documentLoadFailure.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 // A read can fail on a file that is perfectly fine a moment later: a watcher
 // fires while another process is replacing the file, a network volume blinks,
@@ -15,22 +16,14 @@ import test from 'node:test';
 // collaborators as plain callbacks, and eleven other files in this suite
 // already build one, so the failure can be run instead of described.
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity. Only
+// the Tauri backend, which jsdom cannot provide, is stubbed.
 let handleInvoke: (cmd: string, args: any) => unknown = (cmd) => {
 	throw new Error(`unexpected invoke: ${cmd}`);
 };
-g.window.__TAURI_INTERNALS__ = {
+(window as any).__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (cmd: string, args: any) => Promise.resolve(handleInvoke(cmd, args)),
 };
 

--- a/scripts/editorWritesThroughTheStore.spec.ts
+++ b/scripts/editorWritesThroughTheStore.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 import ts from 'typescript';
 
@@ -37,27 +38,10 @@ import { callbackBodies, readSource } from './sourceTree.js';
 // Svelte runes and the Tauri bridge, faked as the other lifting tests do, so
 // `tabs.svelte.ts` imports under plain node.
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
-
-const localStore = new Map<string, string>();
-g.localStorage = {
-	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
-	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
-	removeItem: (key: string) => void localStore.delete(key),
-	clear: () => localStore.clear(),
-};
-g.window.__TAURI_INTERNALS__ = {
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity, and jsdom
+// supplies `window` and `localStorage`. Only the Tauri backend is stubbed.
+(window as any).__TAURI_INTERNALS__ = {
 	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
 };

--- a/scripts/explicitSaveCancelsAutoSave.spec.ts
+++ b/scripts/explicitSaveCancelsAutoSave.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 import { readSource } from './sourceTree.js';
 
@@ -29,26 +30,9 @@ import { readSource } from './sourceTree.js';
 // to know. These assert the duty is discharged there, and that no call site
 // has quietly taken it back.
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
-
-const localStore = new Map<string, string>();
-g.localStorage = {
-	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
-	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
-	removeItem: (key: string) => void localStore.delete(key),
-	clear: () => localStore.clear(),
-};
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity, and jsdom
+// supplies `window` and `localStorage`. Only the Tauri backend is stubbed.
 
 const disk = new Map<string, string>();
 /**
@@ -60,7 +44,7 @@ const events: string[] = [];
 /** What the Save As dialog returns next. `null` is the user pressing Cancel. */
 let nextSaveTarget: string | null = null;
 
-g.window.__TAURI_INTERNALS__ = {
+(window as any).__TAURI_INTERNALS__ = {
 	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (cmd: string, args: any) => {
 		if (cmd === 'canonicalize_path') return Promise.resolve(args.path);
@@ -106,7 +90,7 @@ function makeSession() {
 function reset() {
 	tabManager.closeAll();
 	tabManager.recentlyClosed.length = 0;
-	localStore.clear();
+	localStorage.clear();
 	disk.clear();
 	events.length = 0;
 	nextSaveTarget = null;

--- a/scripts/externalChangeReload.spec.ts
+++ b/scripts/externalChangeReload.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 import { readSource, sliceBetween } from './sourceTree.js';
 
@@ -10,29 +11,21 @@ import { readSource, sliceBetween } from './sourceTree.js';
 // even tell what they lost. Turning Live Mode ON must likewise never pull
 // disk content over the buffer; it only installs the watcher.
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity, and jsdom
+// supplies `window` and `localStorage`. Only the Tauri backend is stubbed.
 let handleInvoke: (cmd: string, args: any) => unknown = (cmd) => {
 	throw new Error(`unexpected invoke: ${cmd}`);
 };
-g.window.__TAURI_INTERNALS__ = {
+(window as any).__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (cmd: string, args: any) => Promise.resolve(handleInvoke(cmd, args)),
 };
 
 const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
 
-const viewer = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
 function makeSession(overrides: Record<string, unknown> = {}) {
 	return createDocumentSession({

--- a/scripts/homeSentinelSnapshot.spec.ts
+++ b/scripts/homeSentinelSnapshot.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 // The home screen sits in a tab, and that tab's path is the sentinel string
 // `'HOME'` rather than a file. `serializeState` filtered on `path !== ''`, so
@@ -15,27 +16,10 @@ import test from 'node:test';
 // the wording. The restore-loop half lives in sessionRestoreResilience.test.ts,
 // which already has the window-session harness.
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
-
-const localStore = new Map<string, string>();
-g.localStorage = {
-	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
-	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
-	removeItem: (key: string) => void localStore.delete(key),
-	clear: () => localStore.clear(),
-};
-g.window.__TAURI_INTERNALS__ = {
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store runs under real reactivity, and jsdom supplies
+// `window` and `localStorage`. Only the Tauri backend is stubbed.
+(window as any).__TAURI_INTERNALS__ = {
 	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
 };
@@ -44,7 +28,7 @@ const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 
 function reset() {
 	tabManager.closeAll();
-	localStore.clear();
+	localStorage.clear();
 }
 
 test('a session snapshot never carries the home tab', () => {

--- a/scripts/homeTabRender.spec.ts
+++ b/scripts/homeTabRender.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 import { parse } from 'svelte/compiler';
 
@@ -44,27 +45,10 @@ import { readSource } from './sourceTree.js';
 // Svelte runes and the Tauri bridge, faked exactly as homeSentinelSnapshot.ts
 // does, so `tabs.svelte.ts` and `settings.svelte.ts` import under plain node.
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
-
-const localStore = new Map<string, string>();
-g.localStorage = {
-	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
-	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
-	removeItem: (key: string) => void localStore.delete(key),
-	clear: () => localStore.clear(),
-};
-g.window.__TAURI_INTERNALS__ = {
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity, and jsdom
+// supplies `window` and `localStorage`. Only the Tauri backend is stubbed.
+(window as any).__TAURI_INTERNALS__ = {
 	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
 };
@@ -180,7 +164,7 @@ const showsDocumentContainer = (showHome = false) => evaluateGate(showHome);
 
 function reset() {
 	tabManager.closeAll();
-	localStore.clear();
+	localStorage.clear();
 }
 
 // --------------------------------------------------------------- the regression

--- a/scripts/imageUndoKeepsFile.spec.ts
+++ b/scripts/imageUndoKeepsFile.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 import ts from 'typescript';
 
@@ -50,27 +51,10 @@ import { callbackBodies, functionSource, readSource } from './sourceTree.js';
 // Svelte runes and the Tauri bridge, faked as homeSentinelSnapshot.ts does, so
 // `tabs.svelte.ts` imports under plain node.
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
-
-const localStore = new Map<string, string>();
-g.localStorage = {
-	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
-	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
-	removeItem: (key: string) => void localStore.delete(key),
-	clear: () => localStore.clear(),
-};
-g.window.__TAURI_INTERNALS__ = {
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity, and jsdom
+// supplies `window` and `localStorage`. Only the Tauri backend is stubbed.
+(window as any).__TAURI_INTERNALS__ = {
 	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
 };

--- a/scripts/largeFileLoadRevision.spec.ts
+++ b/scripts/largeFileLoadRevision.spec.ts
@@ -1,10 +1,11 @@
 import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 import { readSource } from './sourceTree.js';
 
-const sessionPath = new URL('../src/lib/sessions/documentSession.svelte.ts', import.meta.url);
+const sessionPath = 'src/lib/sessions/documentSession.svelte.ts';
 const session = existsSync(sessionPath) ? readSource(sessionPath) : '';
 
 test('large-file completion requires the current clean load revision and unchanged view mode', () => {
@@ -32,18 +33,9 @@ test('large-file completion requires the current clean load revision and unchang
 // These drive the real TabManager and the real document session, so they lock
 // the outcome rather than the shape of the guard.
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity, and jsdom
+// supplies `window` and `localStorage`. Only the Tauri backend is stubbed.
 
 // The preview always returns isFull=false to exercise the two-stage path
 // regardless of the actual threshold — no need for a multi-MB test string.
@@ -59,7 +51,8 @@ let handleInvoke: (cmd: string, args: any) => unknown = () => {
 	throw new Error('unexpected invoke');
 };
 
-g.window.__TAURI_INTERNALS__ = {
+(window as any).__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (cmd: string, args: any) => Promise.resolve(handleInvoke(cmd, args)),
 };
 

--- a/scripts/lossySaveRefusalScope.spec.ts
+++ b/scripts/lossySaveRefusalScope.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 /*
  * `isLossySaveRefused` is read by the auto-save timer's FAILURE handler:
@@ -27,29 +28,16 @@ import test from 'node:test';
  * tab, not a memory of what was once said about it.
  */
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
-Object.defineProperty(g, 'navigator', { value: { language: 'en-US' }, configurable: true });
-Object.defineProperty(g, 'localStorage', {
-	value: { getItem: () => null, setItem: () => {}, removeItem: () => {}, clear: () => {} },
-	configurable: true,
-});
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity. Only
+// the Tauri backend, which jsdom cannot provide, is stubbed.
 
 /** Whether `save_file_content` succeeds. Set per test. */
 let writeFails = false;
 const LOSSY = 'text with � in it';
 
-g.window.__TAURI_INTERNALS__ = {
+(window as any).__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (command: string, args: Record<string, unknown>) => {
 		const cmd = command.replace(/^plugin:[^|]*\|/, '');
 		if (cmd === 'get_os_type') return Promise.resolve('macos');

--- a/scripts/oneWritePerTabInFlight.spec.ts
+++ b/scripts/oneWritePerTabInFlight.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 // #436 closed one direction of the save race: `saveContent` now disarms the
 // auto-save debounce itself, so an *armed* timer can no longer fire during an
@@ -26,26 +27,9 @@ import test from 'node:test';
 // writes *after*, from a snapshot taken *after*, so the last rename is the
 // newest text.
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
-
-const localStore = new Map<string, string>();
-g.localStorage = {
-	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
-	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
-	removeItem: (key: string) => void localStore.delete(key),
-	clear: () => localStore.clear(),
-};
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity, and
+// jsdom supplies `window` and `localStorage`. Only the Tauri backend is stubbed.
 
 const disk = new Map<string, string>();
 /** Writes that have started but not yet reached their rename. */
@@ -66,7 +50,7 @@ let writeCount = 0;
 /** What the Save/Save As dialog returns next. `null` is the user cancelling. */
 let nextSaveTarget: string | null = null;
 
-g.window.__TAURI_INTERNALS__ = {
+(window as any).__TAURI_INTERNALS__ = {
 	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (cmd: string, args: any) => {
 		if (cmd === 'canonicalize_path') return Promise.resolve(args.path);
@@ -123,7 +107,7 @@ function makeSession() {
 function reset() {
 	tabManager.closeAll();
 	tabManager.recentlyClosed.length = 0;
-	localStore.clear();
+	localStorage.clear();
 	disk.clear();
 	unsettledWrites = 0;
 	sawOverlap = false;

--- a/scripts/pathIdentityCaseFolding.spec.ts
+++ b/scripts/pathIdentityCaseFolding.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 // On macOS and Windows the filesystem folds case: `/notes/A.md` and
 // `/notes/a.md` are ONE file. (APFS folds Unicode normalization too, so the
@@ -23,26 +24,9 @@ import test from 'node:test';
 // backend stubbed to behave like a case-insensitive volume. They assert
 // behaviour — buffers kept, files not written, tab counts — never wording.
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
-
-const localStore = new Map<string, string>();
-g.localStorage = {
-	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
-	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
-	removeItem: (key: string) => void localStore.delete(key),
-	clear: () => localStore.clear(),
-};
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity, and
+// jsdom supplies `window` and `localStorage`. Only the Tauri backend is stubbed.
 
 /** Files by their on-disk name, and whether each decoded lossily. */
 const disk = new Map<string, { body: string; lossy: boolean }>();
@@ -66,7 +50,7 @@ function lookup(path: string): string | null {
 /** What the dialog will return next. */
 let nextSaveTarget: string | null = null;
 
-g.window.__TAURI_INTERNALS__ = {
+(window as any).__TAURI_INTERNALS__ = {
 	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (cmd: string, args: any) => {
 		if (cmd === 'canonicalize_path') {
@@ -128,7 +112,7 @@ function makeSession() {
 function reset() {
 	tabManager.closeAll();
 	tabManager.recentlyClosed.length = 0;
-	localStore.clear();
+	localStorage.clear();
 	disk.clear();
 	writes.length = 0;
 	errors.length = 0;

--- a/scripts/renderedHtmlField.spec.ts
+++ b/scripts/renderedHtmlField.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 import { parse } from 'svelte/compiler';
 import ts from 'typescript';
@@ -55,27 +56,10 @@ import { readSource } from './sourceTree.js';
 // Svelte runes and the Tauri bridge, faked as homeTabRender.test.ts does, so
 // `tabs.svelte.ts` and `settings.svelte.ts` import under plain node.
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
-
-const localStore = new Map<string, string>();
-g.localStorage = {
-	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
-	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
-	removeItem: (key: string) => void localStore.delete(key),
-	clear: () => localStore.clear(),
-};
-g.window.__TAURI_INTERNALS__ = {
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity, and jsdom
+// supplies `window` and `localStorage`. Only the Tauri backend is stubbed.
+(window as any).__TAURI_INTERNALS__ = {
 	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
 };
@@ -241,7 +225,7 @@ const exportWouldRun = (() => {
 
 function reset() {
 	tabManager.closeAll();
-	localStore.clear();
+	localStorage.clear();
 	settings.showToc = false;
 	settings.newFileDefaultMode = true;
 }

--- a/scripts/sessionRestoreResilience.spec.ts
+++ b/scripts/sessionRestoreResilience.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 // Startup restore is a data-safety path: the snapshot is the only record of
 // which documents the user had open. Two ways it used to destroy that record:
@@ -19,26 +20,9 @@ import test from 'node:test';
 // `launch()` harness at the bottom goes further and models the kill itself,
 // including what a kill takes with it.
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
-
-const localStore = new Map<string, string>();
-g.localStorage = {
-	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
-	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
-	removeItem: (key: string) => void localStore.delete(key),
-	clear: () => localStore.clear(),
-};
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity, and
+// jsdom supplies `window` and `localStorage`. Only the Tauri backend is stubbed.
 
 const WINDOW_STATE_KEY = 'savedTabsDataV2';
 const LEGACY_STATE_KEY = 'savedTabsData';
@@ -63,7 +47,7 @@ let onRead: (path: string) => void = () => {};
 let killsTheLaunch: (call: { cmd: string; args: any }) => boolean = () => false;
 let died = false;
 
-g.window.__TAURI_INTERNALS__ = {
+(window as any).__TAURI_INTERNALS__ = {
 	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (cmd: string, args: any) => {
 		invokeCalls.push({ cmd, args });
@@ -154,7 +138,7 @@ function snapshotOf(paths: string[]): string {
 function reset(paths: string[], contents: Record<string, string> = {}) {
 	tabManager.closeAll();
 	tabManager.recentlyClosed.length = 0;
-	localStore.clear();
+	localStorage.clear();
 	invokeCalls = [];
 	warnings.length = 0;
 	errors.length = 0;
@@ -255,7 +239,7 @@ test('an interrupted restore names the document it was on', async () => {
 
 test('the launch after an interruption restores everything except the suspect', async () => {
 	reset(['/a.md', '/big.md', '/c.md']);
-	localStore.set(
+	localStorage.setItem(
 		RESTORE_IN_PROGRESS_KEY,
 		JSON.stringify({ running: true, pending: '/big.md', deferred: [], interruptions: 0 }),
 	);
@@ -280,7 +264,7 @@ test('a breadcrumb from an older build no longer wipes the session', async () =>
 	reset(['/a.md', '/b.md']);
 	// Pre-fix builds wrote the string 'true' and the next launch deleted the
 	// entire snapshot on sight.
-	localStore.set(RESTORE_IN_PROGRESS_KEY, 'true');
+	localStorage.setItem(RESTORE_IN_PROGRESS_KEY, 'true');
 
 	await makeSession().restore();
 
@@ -306,7 +290,7 @@ test('a finished restore leaves no breadcrumb behind', async () => {
 
 test('deferrals accumulate one document per interruption instead of retrying forever', async () => {
 	reset(['/a.md', '/one.md', '/two.md']);
-	localStore.set(
+	localStorage.setItem(
 		RESTORE_IN_PROGRESS_KEY,
 		JSON.stringify({ running: true, pending: '/one.md', deferred: [], interruptions: 0 }),
 	);
@@ -315,7 +299,7 @@ test('deferrals accumulate one document per interruption instead of retrying for
 
 	// The next launch dies on a different document.
 	reset(['/a.md', '/one.md', '/two.md']);
-	localStore.set(
+	localStorage.setItem(
 		RESTORE_IN_PROGRESS_KEY,
 		JSON.stringify({ running: true, pending: '/two.md', deferred: ['/one.md'], interruptions: 1 }),
 	);
@@ -332,7 +316,7 @@ test('deferrals accumulate one document per interruption instead of retrying for
 
 test('after repeated interruptions startup stops reading but still hands back every tab', async () => {
 	reset(['/a.md', '/b.md', '/c.md']);
-	localStore.set(
+	localStorage.setItem(
 		RESTORE_IN_PROGRESS_KEY,
 		JSON.stringify({ running: true, pending: null, deferred: [], interruptions: 2 }),
 	);
@@ -417,7 +401,7 @@ async function launch(dies: (call: { cmd: string; args: any }) => boolean = () =
 	// A new process: no tabs on screen, and nothing left of the store the last
 	// kill took down with it.
 	tabManager.closeAll();
-	localStore.clear();
+	localStorage.clear();
 	died = false;
 	killsTheLaunch = dies;
 
@@ -551,7 +535,7 @@ test('a launch that was not interrupted tells the user nothing', async () => {
 
 test('a deferred document is released once Markpad has read it', async () => {
 	reset(['/a.md', '/big.md']);
-	localStore.set(
+	localStorage.setItem(
 		RESTORE_IN_PROGRESS_KEY,
 		JSON.stringify({ running: true, pending: '/big.md', deferred: [], interruptions: 0 }),
 	);

--- a/scripts/sourceTree.ts
+++ b/scripts/sourceTree.ts
@@ -141,8 +141,9 @@ export function readSourceFiles(dir: string): SourceFile[] {
  * the crate, not about which file the author last put X in.
  */
 export function rustSourceFiles(): string[] {
-	const dir = new URL('../src-tauri/src/', import.meta.url);
-	return readdirSync(dir)
+	// Cwd-relative, not `import.meta.url`: see the note on `readSource`. Under
+	// vitest that URL is `http://`, which `readdirSync` refuses outright.
+	return readdirSync('src-tauri/src')
 		.filter((name) => name.endsWith('.rs'))
 		.sort()
 		.map((name) => `src-tauri/src/${name}`);
@@ -157,7 +158,7 @@ export function rustSourceFiles(): string[] {
  */
 export function readRustBackend(): string {
 	return rustSourceFiles()
-		.map((path) => readSource(new URL(`../${path}`, import.meta.url)))
+		.map((path) => readSource(path))
 		.join('\n');
 }
 

--- a/scripts/taskToggleLineEndings.spec.ts
+++ b/scripts/taskToggleLineEndings.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 import { readRustBackend, readSource, sliceBetween, sliceFrom } from './sourceTree.js';
 
@@ -25,25 +26,17 @@ import { LIST_MARKER, TASK_BOX } from '../src/lib/utils/listSyntax.js';
 // passes `sourceLine: 1` — the one line number the bug cannot reach, since at
 // offset 0 there is no preceding terminator for `\s*` to eat.
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity, and jsdom
+// supplies `window` and `localStorage`. Only the Tauri backend is stubbed.
 
 let invokeCalls: Array<{ cmd: string; args: any }> = [];
 let handleInvoke: (cmd: string, args: any) => unknown = () => {
 	throw new Error('unexpected invoke');
 };
 
-g.window.__TAURI_INTERNALS__ = {
+(window as any).__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (cmd: string, args: any) => {
 		invokeCalls.push({ cmd, args });
 		return Promise.resolve(handleInvoke(cmd, args)).then((value) => value);
@@ -248,7 +241,7 @@ test('LF: two blank lines above the list', async () => {
 // and rebuilding drops the reader's scroll position, which in a long document
 // throws the view somewhere else entirely.
 
-const sessionSource = readSource(new URL('../src/lib/sessions/documentSession.svelte.ts', import.meta.url));
+const sessionSource = readSource('src/lib/sessions/documentSession.svelte.ts');
 
 test('a toggle tells the preview it is already up to date', async () => {
 	const doc = ['intro', '', '- [ ] one', '- [ ] two'].join('\n') + '\n';

--- a/scripts/truncatedBufferGuard.spec.ts
+++ b/scripts/truncatedBufferGuard.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 import { functionSource, readSource, sliceBetween, sliceFrom } from './sourceTree.js';
 
@@ -13,18 +14,9 @@ import { functionSource, readSource, sliceBetween, sliceFrom } from './sourceTre
 // These tests drive the real TabManager and the real document session with a
 // stubbed Tauri bridge, so they lock the behaviour, not the wording.
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity, and jsdom
+// supplies `window` and `localStorage`. Only the Tauri backend is stubbed.
 
 const PREVIEW_BYTES = 50000;
 const FULL = `# big\n\n${'x'.repeat(PREVIEW_BYTES)}\n\ntail that must never be lost\n`;
@@ -36,7 +28,8 @@ let handleInvoke: (cmd: string, args: any) => unknown = () => {
 	throw new Error('unexpected invoke');
 };
 
-g.window.__TAURI_INTERNALS__ = {
+(window as any).__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (cmd: string, args: any) => {
 		invokeCalls.push({ cmd, args });
 		return Promise.resolve(handleInvoke(cmd, args)).then((value) => value);
@@ -46,7 +39,7 @@ g.window.__TAURI_INTERNALS__ = {
 const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
 
-const viewer = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
 const errors: string[] = [];
 /** Non-failure notices the session raised, in order. */

--- a/scripts/undoHistoryPerTab.spec.ts
+++ b/scripts/undoHistoryPerTab.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 import ts from 'typescript';
 
@@ -42,27 +43,10 @@ import { callbackBodies, functionSource, readSource } from './sourceTree.js';
 // Svelte runes and the Tauri bridge, faked as windowTagEditor.ts does, so
 // `tabs.svelte.ts` imports under plain node.
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
-
-const localStore = new Map<string, string>();
-g.localStorage = {
-	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
-	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
-	removeItem: (key: string) => void localStore.delete(key),
-	clear: () => localStore.clear(),
-};
-g.window.__TAURI_INTERNALS__ = {
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity, and jsdom
+// supplies `window` and `localStorage`. Only the Tauri backend is stubbed.
+(window as any).__TAURI_INTERNALS__ = {
 	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
 };

--- a/scripts/viewModeWithoutSaving.spec.ts
+++ b/scripts/viewModeWithoutSaving.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 import { offsetOf, readSource, sliceBetween, sliceFrom } from './sourceTree.js';
 import ts from 'typescript';
@@ -27,19 +28,11 @@ import ts from 'typescript';
 
 // ---------------------------------------------------------------- environment
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
-g.window.__TAURI_INTERNALS__ = g.window.__TAURI_INTERNALS__ ?? {
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity, and jsdom
+// supplies `window` and `localStorage`. Only the Tauri backend is stubbed.
+(window as any).__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: () => Promise.reject(new Error('no invoke expected in these tests')),
 };
 
@@ -47,7 +40,7 @@ const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 const { settings } = await import('../src/lib/stores/settings.svelte.js');
 const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
 
-const viewer = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
 
 // ------------------------------------------------------------ source plucking
 

--- a/scripts/windowStateRestore.spec.ts
+++ b/scripts/windowStateRestore.spec.ts
@@ -1,22 +1,18 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 import { offsetOf, readSource, sliceBetween } from './sourceTree.js';
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
-g.window.__TAURI_INTERNALS__ = g.window.__TAURI_INTERNALS__ ?? {
-	invoke: () => Promise.resolve(null),
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity, and jsdom
+// supplies `window` and `localStorage`. Only the Tauri backend is stubbed.
+(window as any).__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	// `get_os_type` is the settings store booting on import: `initOSType` only
+	// catches a rejection, so answering `null` leaves `osType` null and the
+	// font defaults it then indexes are undefined.
+	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
 };
 
 const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');

--- a/scripts/windowTagPerWindow.spec.ts
+++ b/scripts/windowTagPerWindow.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 /*
  * A new window starts with no tag.
@@ -24,26 +25,9 @@ import test from 'node:test';
  * check read it, and nothing writes a registry `tag_name` back into a window.
  */
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
-
-const localStore = new Map<string, string>();
-g.localStorage = {
-	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
-	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
-	removeItem: (key: string) => void localStore.delete(key),
-	clear: () => localStore.clear(),
-};
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity, and
+// jsdom supplies `window` and `localStorage`. Only the Tauri backend is stubbed.
 
 const WINDOW_STATE_KEY = 'savedTabsDataV2';
 const LEGACY_STATE_KEY = 'savedTabsData';
@@ -80,7 +64,7 @@ const TRANSFER_PAYLOAD = JSON.stringify({
 
 let invokeCalls: Array<{ cmd: string; args: any }> = [];
 
-g.window.__TAURI_INTERNALS__ = {
+(window as any).__TAURI_INTERNALS__ = {
 	// A detached window, which is what `create_transfer_window` builds.
 	metadata: {
 		currentWindow: { label: 'window-abc' },
@@ -146,7 +130,7 @@ function makeSession(isMainWindow: boolean) {
 function reset() {
 	tabManager.closeAll();
 	tabManager.setWindowTag(null);
-	localStore.clear();
+	localStorage.clear();
 	invokeCalls = [];
 }
 

--- a/scripts/windowTags.spec.ts
+++ b/scripts/windowTags.spec.ts
@@ -1,21 +1,19 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+
+import { test } from 'vitest';
 
 import { offsetOf, readSource } from './sourceTree.js';
 
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin, so the store and the session run under real reactivity, and jsdom
+// supplies `window` and `localStorage`. Only the Tauri backend is stubbed.
+// `get_os_type` is the settings store booting on import: `initOSType` only
+// catches a rejection, so answering `null` leaves `osType` null and the font
+// defaults it then indexes are undefined.
+(window as any).__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
 };
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
-g.window.__TAURI_INTERNALS__ = g.window.__TAURI_INTERNALS__ ?? { invoke: () => Promise.resolve(null) };
 
 const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 const runtime = readSource('src-tauri/src/window_runtime.rs');


### PR DESCRIPTION
`#615` set up the two-runner split and migrated three files as a pilot; `#624` closed the effect leak that made rolling further out unsafe. This is the rollout.

**21 of 24 files** move to vitest, in four commits of 7 / 5 / 4 / 5, each green on both runners before the next started. **No assertion changed anywhere** — the hand-rolled `localStorage` and `navigator` stubs went with the shims, because jsdom has real ones.

**330 lines of shim deleted** (252 of rune shim, 78 of storage/navigator stubs). Net `scripts/` diff −247.

| | before | after |
|---|---|---|
| `npm test` | 1043 pass / 6.9s | 853 pass / 4.9s |
| `npm run test:vitest` | 89 pass / 3.2s | 279 pass / 5.1s |
| total | **1132** | **1132** |

### The point of the exercise, in one bug

`windowStateRestore` and `windowTags` stubbed the bridge as `invoke: () => Promise.resolve(null)`. That is fine under a shim, where nothing the settings store does on import is observable. Under the real compiler the singleton boots for real, and it crashed:

```
Cannot read properties of undefined (reading 'editorFont')
```

`initOSType` catches a *rejection* but not a `null` **success** — `osType` becomes `null`, and `DEFAULT_FONTS[null]` is `undefined`.

Fixed in the two stubs, **not in the store**. Every other file in the suite already answers `get_os_type`, and Rust's command always returns a string, so this is latent robustness rather than a live defect. Flagged rather than folded in: this branch changes the runner, and a behaviour fix mixed in would leave nothing separable to review.

### The three that stay on `node --test`

- **`foldStatePerDocument`** — its subject is a function sliced out of a `.svelte` file with a hand-written brace matcher. A runner swap does not reach that; the logic needs extracting into a `.svelte.ts` first.
- **`tabReadingPosition`** — calls `installShimDom()`, which assigns `globalThis.document` and would *replace* jsdom's. Migrating means rewriting its anchor harness onto the real DOM — a behaviour change, not a rename.
- **`checkedReadMigration`** — 6 of its 9 tests are both never-migrate categories at once: "the unchecked command exists nowhere in `src`" (an absence claim) and the same over the Rust crate (cross-language). Its 3 behaviour tests would gain; the file's subject would not.

`.svelte` component tests and `singleImplementationConvention` never carried rune shims, so nothing there needed triaging.

### Two infra fixes inside `scripts/`

`sourceTree.ts`'s `rustSourceFiles()` resolved `src-tauri/src/` through `import.meta.url`, and `readdirSync` threw `The URL must be of scheme file` — the exact trap `readSource` already documents, one layer down. Now cwd-relative.

`AGENTS.md` records that trap, the `get_os_type` requirement for any file that constructs the settings store, and the three exclusions with what each would need first.

`npm run check` 777 files / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
