### PR TITLE
feat(editor): continue a Markdown list when Enter is pressed inside one

### DIFF
--- a/scripts/listContinuation.test.ts
+++ b/scripts/listContinuation.test.ts
@@ -1,0 +1,451 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { KeyCode } from 'monaco-editor/esm/vs/editor/common/standalone/standaloneEnums.js';
+import { KeyMod } from 'monaco-editor/esm/vs/editor/common/services/editorBaseApi.js';
+import ts from 'typescript';
+
+import { listEnter, parseListItem } from '../src/lib/utils/listEditing.js';
+import { functionSource, readSource } from './sourceTree.js';
+
+/*
+ * Issue #604's second item: Enter on a list item continues the list, Tab
+ * changes its level, and Enter on an empty item ends the list.
+ *
+ * WHAT IS RUN AND WHAT IS ONLY READ
+ *
+ * The decision — "given this line and this caret, what should the next line
+ * say" — is a pure function in `src/lib/utils/listEditing.ts` and is CALLED
+ * here, once per shape of list item the app claims to understand.
+ *
+ * The two handlers in `Editor.svelte` are lifted out of the component and run
+ * against a stub editor, the same trick `keymapHarness.ts` uses, so what is
+ * asserted is the edit they really produce rather than the shape of the source
+ * that produces it.
+ *
+ * What NO test here can establish is that Monaco delivers these two keys at
+ * runtime: keybinding resolution, the `when` clauses and the vim adapter all
+ * live in a browser. What is pinned instead is the condition the app DECLARES —
+ * the `when` expression is evaluated out of the source and read back — because
+ * an Enter binding that forgets `!suggestWidgetVisible` breaks the completion
+ * popup silently, and that is the one mistake this feature invites.
+ */
+
+// ------------------------------------------------------------- the pure part
+
+/** `listEnter` at the end of `line`, which is where Enter is normally pressed. */
+function enterAtEnd(line: string) {
+	return listEnter(line, line.length + 1);
+}
+
+test('a bullet item continues with the same bullet character', () => {
+	// Not normalised to `-`: CommonMark starts a NEW list when the bullet
+	// character changes, so answering `* a` with `- ` would split the list.
+	assert.deepEqual(enterAtEnd('- item'), { kind: 'continue', text: '- ' });
+	assert.deepEqual(enterAtEnd('* item'), { kind: 'continue', text: '* ' });
+	assert.deepEqual(enterAtEnd('+ item'), { kind: 'continue', text: '+ ' });
+});
+
+test('an ordered item counts up and keeps its delimiter', () => {
+	assert.deepEqual(enterAtEnd('1. item'), { kind: 'continue', text: '2. ' });
+	assert.deepEqual(enterAtEnd('3) item'), { kind: 'continue', text: '4) ' });
+	assert.deepEqual(enterAtEnd('9. item'), { kind: 'continue', text: '10. ' });
+	// `1.` and `1)` are two different lists, which is #451's defect one
+	// delimiter over; the delimiter travels with the number.
+	assert.deepEqual(enterAtEnd('1) item'), { kind: 'continue', text: '2) ' });
+});
+
+test('a task item continues with an UNCHECKED box, whatever the old one was', () => {
+	assert.deepEqual(enterAtEnd('- [ ] item'), { kind: 'continue', text: '- [ ] ' });
+	assert.deepEqual(enterAtEnd('- [x] item'), { kind: 'continue', text: '- [ ] ' });
+	assert.deepEqual(enterAtEnd('- [X] item'), { kind: 'continue', text: '- [ ] ' });
+	// The box belongs to the marker, not to the text: an ordered task list
+	// keeps both halves.
+	assert.deepEqual(enterAtEnd('1. [x] item'), { kind: 'continue', text: '2. [ ] ' });
+});
+
+test('indentation and block-quote prefixes are carried to the new item', () => {
+	assert.deepEqual(enterAtEnd('  - nested'), { kind: 'continue', text: '  - ' });
+	assert.deepEqual(enterAtEnd('\t\t1. deep'), { kind: 'continue', text: '\t\t2. ' });
+	// A quoted list item is a list item — the rule #631 established for the
+	// toolbar, applied to the key that writes the next one.
+	assert.deepEqual(enterAtEnd('> - quoted'), { kind: 'continue', text: '> - ' });
+	assert.deepEqual(enterAtEnd('  > > 2. deep quote'), { kind: 'continue', text: '  > > 3. ' });
+});
+
+test('a hand-aligned list stays aligned', () => {
+	// The separator is copied rather than normalised to one space, so a list
+	// someone lined up by hand is not silently un-aligned by pressing Enter.
+	assert.deepEqual(enterAtEnd('-   item'), { kind: 'continue', text: '-   ' });
+	assert.deepEqual(enterAtEnd('1.  item'), { kind: 'continue', text: '2.  ' });
+});
+
+test('Enter on an empty item ends the list', () => {
+	// The behaviour the issue does not ask for and the feature is unusable
+	// without: this is the only keystroke that gets a user OUT of a list.
+	assert.deepEqual(enterAtEnd('- '), { kind: 'clear', line: '' });
+	assert.deepEqual(enterAtEnd('1. '), { kind: 'clear', line: '' });
+	assert.deepEqual(enterAtEnd('  * '), { kind: 'clear', line: '' });
+	assert.deepEqual(enterAtEnd('- [ ] '), { kind: 'clear', line: '' });
+	assert.deepEqual(enterAtEnd('- [x] '), { kind: 'clear', line: '' });
+	// A box with nothing after it at all, which is what a user who has just
+	// typed the checkbox is looking at.
+	assert.deepEqual(enterAtEnd('- [ ]'), { kind: 'clear', line: '' });
+	// An item that is only whitespace is empty too.
+	assert.deepEqual(enterAtEnd('-    '), { kind: 'clear', line: '' });
+});
+
+test('ending a quoted list stays inside the quote', () => {
+	assert.deepEqual(enterAtEnd('> - '), { kind: 'clear', line: '> ' });
+	assert.deepEqual(enterAtEnd('> > 1. '), { kind: 'clear', line: '> > ' });
+});
+
+test('lines that are not list items are left to the ordinary Enter', () => {
+	for (const line of [
+		'',
+		'plain text',
+		'# heading',
+		'> quoted prose',
+		'    indented code',
+		// A thematic break is a bullet character followed by more of them, never
+		// by a space — which is what keeps `---` out.
+		'---',
+		'***',
+		'___',
+		// A bare marker with nothing after it, not even a space.
+		'-',
+		'1.',
+	]) {
+		assert.equal(enterAtEnd(line), null, JSON.stringify(line));
+	}
+});
+
+test('a caret still inside the marker gets the ordinary Enter', () => {
+	// Enter at the very start of `- item` means "make room above me". A
+	// continuation there would write a second marker in front of the first.
+	assert.equal(listEnter('- item', 1), null);
+	assert.equal(listEnter('- item', 2), null);
+	assert.deepEqual(listEnter('- item', 3), { kind: 'continue', text: '- ' });
+	assert.equal(listEnter('  - [ ] item', 8), null);
+	assert.deepEqual(listEnter('  - [ ] item', 9), { kind: 'continue', text: '  - [ ] ' });
+});
+
+test('a caret in the middle of an item still continues the list', () => {
+	// Splitting an item is continuing it: the tail moves down behind the new
+	// marker, which is what every editor does and what the caller relies on.
+	assert.deepEqual(listEnter('- hello world', 9), { kind: 'continue', text: '- ' });
+});
+
+test('parseListItem reports where the marker ends', () => {
+	const item = parseListItem('  > - [x]  do it');
+	assert.ok(item);
+	assert.deepEqual(
+		{
+			prefix: item.prefix,
+			marker: item.marker,
+			box: item.box,
+			content: item.content,
+			contentColumn: item.contentColumn,
+		},
+		{ prefix: '  > ', marker: '-', box: '[x]', content: 'do it', contentColumn: 12 },
+	);
+	assert.equal('  > - [x]  do it'.slice(item.contentColumn - 1), 'do it');
+});
+
+// ------------------------------------------------- the handlers, actually run
+
+const EDITOR = 'src/lib/components/Editor.svelte';
+
+type Recorded = {
+	triggers: string[];
+	edits: Array<{ range: number[]; text: string; cursor: number[] }>;
+	undoStops: number;
+};
+
+class FakeRange {
+	constructor(
+		readonly startLineNumber: number,
+		readonly startColumn: number,
+		readonly endLineNumber: number,
+		readonly endColumn: number,
+	) {}
+	isEmpty() {
+		return this.startLineNumber === this.endLineNumber && this.startColumn === this.endColumn;
+	}
+	numbers() {
+		return [this.startLineNumber, this.startColumn, this.endLineNumber, this.endColumn];
+	}
+}
+
+/**
+ * One of the two component handlers, extracted and evaluated with a stub editor.
+ *
+ * The list logic in scope is the REAL module, so a handler that stopped calling
+ * it — or called it with the wrong column — fails here rather than passing
+ * against a second, more agreeable copy.
+ */
+function runHandler(
+	name: string,
+	options: { lines: string[]; selections: number[][]; eol?: string },
+): Recorded {
+	const recorded: Recorded = { triggers: [], edits: [], undoStops: 0 };
+	const eol = options.eol ?? '\n';
+	const selections = options.selections.map((s) => new FakeRange(s[0], s[1], s[2], s[3]));
+
+	const model = {
+		getLineContent: (line: number) => options.lines[line - 1],
+		getLineMaxColumn: (line: number) => options.lines[line - 1].length + 1,
+		getEOL: () => eol,
+	};
+
+	const scope: Record<string, unknown> = {
+		listEnter,
+		parseListItem,
+		monaco: { Range: FakeRange, Selection: FakeRange },
+		editor: {
+			getModel: () => model,
+			getSelections: () => selections,
+			pushUndoStop: () => {
+				recorded.undoStops += 1;
+			},
+			trigger: (_source: string, handlerId: string, payload: { text?: string } | null) => {
+				recorded.triggers.push(payload?.text ? `${handlerId}:${JSON.stringify(payload.text)}` : handlerId);
+			},
+			executeEdits: (
+				_source: string,
+				edits: Array<{ range: FakeRange; text: string }>,
+				cursor: FakeRange[],
+			) => {
+				for (const [index, edit] of edits.entries()) {
+					recorded.edits.push({
+						range: edit.range.numbers(),
+						text: edit.text,
+						cursor: cursor[index].numbers(),
+					});
+				}
+			},
+		},
+	};
+
+	const js = ts.transpileModule(`const handler = ${functionSource(readSource(EDITOR), name)};`, {
+		compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ESNext },
+	}).outputText;
+	const build = new Function('scope', `with (scope) { ${js}\nreturn handler; }`) as (
+		s: unknown,
+	) => () => void;
+	build(new Proxy(scope, { has: () => true }))();
+
+	return recorded;
+}
+
+test('Enter on a list item inserts the line break and the next marker in one edit', () => {
+	const run = runHandler('continueListOnEnter', { lines: ['- item'], selections: [[1, 7, 1, 7]] });
+
+	assert.deepEqual(run.triggers, [], 'the plain Enter must not fire as well');
+	assert.deepEqual(run.edits, [
+		{ range: [1, 7, 1, 7], text: '\n- ', cursor: [2, 3, 2, 3] },
+	]);
+	assert.equal(run.undoStops, 1, 'the continuation is its own undo step');
+});
+
+test('the line break is the document\'s, not a hard-coded \\n', () => {
+	// The CRLF class of defect this repo has been bitten by before (#148): a
+	// handler that writes '\n' into a CRLF document leaves one mixed line
+	// behind, and nothing downstream reports it.
+	const run = runHandler('continueListOnEnter', {
+		lines: ['1. item'],
+		selections: [[1, 8, 1, 8]],
+		eol: '\r\n',
+	});
+	assert.deepEqual(run.edits.map((edit) => edit.text), ['\r\n2. ']);
+});
+
+test('Enter on an empty item replaces the line instead of breaking it', () => {
+	const run = runHandler('continueListOnEnter', { lines: ['- ', 'x'], selections: [[1, 3, 1, 3]] });
+
+	assert.deepEqual(run.triggers, []);
+	assert.deepEqual(run.edits, [
+		// The whole line, marker and all, becomes nothing — and the caret stays
+		// on it. No line is added: this keystroke leaves the list, it does not
+		// extend it.
+		{ range: [1, 1, 1, 3], text: '', cursor: [1, 1, 1, 1] },
+	]);
+});
+
+test('Enter anywhere else is a plain Enter', () => {
+	for (const lines of [['plain text'], ['---'], ['']]) {
+		const run = runHandler('continueListOnEnter', {
+			lines,
+			selections: [[1, lines[0].length + 1, 1, lines[0].length + 1]],
+		});
+		assert.deepEqual(run.edits, [], JSON.stringify(lines[0]));
+		assert.deepEqual(run.triggers, ['type:"\\n"'], JSON.stringify(lines[0]));
+	}
+});
+
+test('a selection, or a second caret, gets the plain Enter', () => {
+	// One edit at the primary selection would silently discard what the other
+	// carets were about to do.
+	const spanning = runHandler('continueListOnEnter', {
+		lines: ['- item'],
+		selections: [[1, 3, 1, 7]],
+	});
+	assert.deepEqual(spanning.edits, []);
+	assert.deepEqual(spanning.triggers, ['type:"\\n"']);
+
+	const multi = runHandler('continueListOnEnter', {
+		lines: ['- one', '- two'],
+		selections: [
+			[1, 6, 1, 6],
+			[2, 6, 2, 6],
+		],
+	});
+	assert.deepEqual(multi.edits, []);
+	assert.deepEqual(multi.triggers, ['type:"\\n"']);
+});
+
+test('Tab on a list item indents the line; Tab anywhere else is a Tab', () => {
+	// `editor.action.indentLines` moves the whole line by one level wherever the
+	// caret is on it; the core `tab` command inserts indentation AT the caret,
+	// which inside an item's text would be a tab character in the sentence.
+	for (const line of ['- item', '  1. item', '> - [x] item', '- ']) {
+		const run = runHandler('indentListItemOnTab', { lines: [line], selections: [[1, 3, 1, 3]] });
+		assert.deepEqual(run.triggers, ['editor.action.indentLines'], line);
+		assert.deepEqual(run.edits, [], line);
+	}
+
+	for (const line of ['plain text', '# heading', '']) {
+		const run = runHandler('indentListItemOnTab', { lines: [line], selections: [[1, 1, 1, 1]] });
+		assert.deepEqual(run.triggers, ['tab'], JSON.stringify(line));
+	}
+
+	// A selection spans lines on purpose or by accident; Monaco's own Tab
+	// already indents every line of it.
+	const selected = runHandler('indentListItemOnTab', {
+		lines: ['- one', '- two'],
+		selections: [[1, 1, 2, 6]],
+	});
+	assert.deepEqual(selected.triggers, ['tab']);
+});
+
+// ------------------------------------------------------------- the when clauses
+
+/**
+ * Every `editor.addCommand(binding, handler, when)` the component registers, as
+ * the values Monaco is handed.
+ *
+ * The arguments are EVALUATED, not matched as text: the keybinding numbers come
+ * from Monaco's real `KeyMod`/`KeyCode` and the `when` expression is the string
+ * the component computes, template literal and shared constant included. So
+ * renaming the constant or reflowing the call changes nothing here; changing a
+ * key or dropping a guard changes everything.
+ */
+function addCommandCalls(): Array<{ binding: number; handler: string; when: string }> {
+	const text = readSource(EDITOR);
+	const script = text.slice(text.indexOf('>', text.indexOf('<script')) + 1, text.indexOf('</script>'));
+	const file = ts.createSourceFile('editor.ts', script, ts.ScriptTarget.ES2022, true);
+
+	const constants: Record<string, string> = {};
+	const calls: Array<{ binding: number; handler: string; when: string }> = [];
+
+	const evaluate = (expression: string): unknown =>
+		new Function('monaco', 'constants', `with (constants) { return (${expression}); }`)(
+			{ KeyMod, KeyCode },
+			constants,
+		);
+
+	const visit = (node: ts.Node) => {
+		if (
+			ts.isVariableDeclaration(node) &&
+			ts.isIdentifier(node.name) &&
+			node.initializer &&
+			(ts.isStringLiteral(node.initializer) || ts.isTemplateExpression(node.initializer))
+		) {
+			// Best effort: the component is full of template literals built from
+			// component state (`${label}px`), and none of them is a `when` clause.
+			// One that fails to evaluate here is simply not a constant the calls
+			// below can be reading, and an argument that turns out to need it
+			// fails loudly at its own `evaluate`.
+			try {
+				constants[node.name.text] = String(evaluate(node.initializer.getText()));
+			} catch {
+				/* not a constant */
+			}
+		}
+
+		if (
+			ts.isCallExpression(node) &&
+			node.expression.getText() === 'editor.addCommand' &&
+			node.arguments.length === 3
+		) {
+			calls.push({
+				binding: evaluate(node.arguments[0].getText()) as number,
+				handler: node.arguments[1].getText(),
+				when: String(evaluate(node.arguments[2].getText())),
+			});
+		}
+
+		ts.forEachChild(node, visit);
+	};
+	visit(file);
+
+	assert.ok(calls.length >= 4, `found ${calls.length} addCommand calls; the extraction is not running`);
+	return calls;
+}
+
+/** Guards that must stand in front of BOTH keys, and what owns the key without them. */
+const SHARED_GUARDS: Record<string, string> = {
+	editorTextFocus: 'the find box and the rename input both take Enter, and neither is the text',
+	'!editorReadonly': 'reading mode types nothing',
+	'!suggestWidgetVisible':
+		'Enter accepts a completion and Tab accepts a completion; this app has two completion providers, so the popup is a live case',
+	'!inSnippetMode': 'Tab jumps to the next snippet placeholder',
+};
+
+test('the list keys are registered, and behind every guard that owns them first', () => {
+	const calls = addCommandCalls();
+
+	const enter = calls.filter((call) => call.binding === KeyCode.Enter);
+	assert.equal(enter.length, 1, 'exactly one Enter binding');
+	assert.equal(enter[0].handler, 'continueListOnEnter');
+
+	const tab = calls.filter((call) => call.binding === KeyCode.Tab);
+	assert.equal(tab.length, 1, 'exactly one plain-Tab binding');
+	assert.equal(tab[0].handler, 'indentListItemOnTab');
+
+	for (const call of [enter[0], tab[0]]) {
+		for (const [guard, why] of Object.entries(SHARED_GUARDS)) {
+			assert.ok(
+				call.when.split('&&').some((clause) => clause.trim() === guard),
+				`${call.handler} is bound without ${guard}: ${why}. when = ${call.when}`,
+			);
+		}
+	}
+
+	// Tab's own extra guard: the accessibility toggle exists so that Tab leaves
+	// the editor, and a binding at weight 1000 would take that away.
+	assert.ok(
+		tab[0].when.includes('!editorTabMovesFocus'),
+		`Tab is bound without !editorTabMovesFocus: ${tab[0].when}`,
+	);
+});
+
+test('Shift+Tab is left to Monaco, which already outdents the line', () => {
+	// The deliberate omission, stated rather than left implicit. A wrapper in
+	// front of `outdent` would be a second name for a key that is already right.
+	const shiftTab = KeyMod.Shift | KeyCode.Tab;
+	assert.ok(
+		!addCommandCalls().some((call) => call.binding === shiftTab),
+		'a Shift+Tab command has appeared; either it does more than outdent, or it should go',
+	);
+
+	// …and the claim it rests on, pinned against the installed Monaco rather
+	// than assumed: `outdent` is bound to Shift+Tab, in the editor, when Tab is
+	// not moving focus.
+	const core = readSource(
+		new URL('../node_modules/monaco-editor/esm/vs/editor/browser/coreCommands.js', import.meta.url),
+	);
+	const outdent = core.slice(core.indexOf("id: 'outdent'"), core.indexOf("id: 'tab'"));
+	assert.match(outdent, /KeyMod\.Shift \*\/ \| 2 \/\* KeyCode\.Tab/);
+	assert.match(outdent, /EditorContextKeys\.editorTextFocus, EditorContextKeys\.tabDoesNotMoveFocus/);
+});

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -10,6 +10,7 @@
 		type InlineWrapToolId,
 		type LineMarkerToolId,
 	} from '../utils/editorToolbar.js';
+	import { listEnter, parseListItem } from '../utils/listEditing.js';
 	import { editorOptionsFromSettings } from '../utils/editorOptions.js';
 	import { getTabModel, lineEndingLabel, tabModelUri } from '../utils/tabModels.js';
 	import { installVimScrollCommands } from '../utils/vimScrollCommands.js';
@@ -714,6 +715,49 @@
 		// re-register on a language change.
 		editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyV, pasteFromClipboard, "editorTextFocus");
 
+		// Enter and Tab on a list item (#604). Bare commands rather than actions
+		// for the same reason Ctrl+V is one: they carry no label, appear in no
+		// menu and are not chords a user is told about — they are what those two
+		// keys already mean, one Markdown rule further on.
+		//
+		// THE `when` CLAUSES ARE THE WHOLE RISK HERE.
+		//
+		// `addCommand` registers at weight 1000, above every Monaco default
+		// including the suggest widget's — so a binding with no condition does not
+		// merely add a meaning to Enter, it TAKES Enter away from whatever else
+		// wanted it. Each clause below names something that owns the key first:
+		//
+		//   editorTextFocus      the caret is in the text, not in the find box or
+		//                        the rename input (both of which take Enter);
+		//   !editorReadonly      reading mode types nothing;
+		//   !suggestWidgetVisible  the completion popup is open, where Enter
+		//                        accepts and Tab accepts — this app has a heading
+		//                        and a file-path completion provider, so it is a
+		//                        live case, not a hypothetical one;
+		//   !inSnippetMode       Tab jumps to the next placeholder;
+		//   !editorTabMovesFocus the accessibility toggle, whose entire purpose is
+		//                        that Tab leaves the editor.
+		//
+		// Neither handler is a dead end: when the caret is not on a list item they
+		// re-trigger the ordinary command, so a non-list Enter is a plain Enter and
+		// a non-list Tab is a plain Tab, auto-indent and all.
+		//
+		// VIM MODE NEEDS NO CLAUSE OF ITS OWN. monaco-vim listens on
+		// `editor.onKeyDown`, which fires on the textarea — inside the container
+		// the keybinding service listens on — and it calls `stopPropagation()` on
+		// every key its keymap claims. So in normal mode vim's Enter (move down a
+		// line) runs and this command never sees the key; in insert mode vim
+		// passes the key through and continuation happens, which is what a vim
+		// user writing a list wants. The order is DOM nesting, not luck.
+		const LIST_KEY_CONTEXT =
+			"editorTextFocus && !editorReadonly && !suggestWidgetVisible && !inSnippetMode";
+		editor.addCommand(monaco.KeyCode.Enter, continueListOnEnter, LIST_KEY_CONTEXT);
+		editor.addCommand(
+			monaco.KeyCode.Tab,
+			indentListItemOnTab,
+			`${LIST_KEY_CONTEXT} && !editorTabMovesFocus`,
+		);
+
 		editorReady = true;
 
 		// After the view-state / anchor-line restore above, deliberately: an
@@ -836,6 +880,76 @@
 	// renders, so a list toggle cannot forget to displace a competing marker.
 	const toggleLineMarkerTool = (id: LineMarkerToolId) => {
 		transformSelectedLines(id, (lines) => toggleLineMarker(id, lines));
+	};
+
+	/**
+	 * Enter on a list item writes the next item's marker; Enter on an item that
+	 * has a marker and no text takes the marker away instead, which is how a
+	 * list ends. What the next line should say is decided by `listEnter` in
+	 * utils/listEditing.ts, where it can be tested without a browser.
+	 *
+	 * Only a single collapsed caret is claimed. A selection, or several carets,
+	 * gets the ordinary Enter: replacing a multi-cursor edit with one edit at
+	 * the primary selection would silently drop the others' work.
+	 */
+	const continueListOnEnter = () => {
+		const model = editor.getModel();
+		const selections = editor.getSelections();
+		// The key's ordinary meaning, re-sent. `type` with a newline is what the
+		// keyboard itself delivers, so auto-indent and the model's own EOL still
+		// apply — this handler is a detour, never a replacement.
+		const plainEnter = () => editor.trigger("keyboard", "type", { text: "\n" });
+		if (!model || selections?.length !== 1 || !selections[0].isEmpty()) return plainEnter();
+
+		const selection = selections[0];
+		const line = selection.startLineNumber;
+		const next = listEnter(model.getLineContent(line), selection.startColumn);
+		if (!next) return plainEnter();
+
+		// Its own undo step, so one Ctrl+Z gives back the marker this took away
+		// rather than unwinding the sentence typed before it.
+		editor.pushUndoStop();
+
+		if (next.kind === "clear") {
+			editor.executeEdits(
+				"list-continuation",
+				[{ range: new monaco.Range(line, 1, line, model.getLineMaxColumn(line)), text: next.line }],
+				[new monaco.Selection(line, next.line.length + 1, line, next.line.length + 1)],
+			);
+			return;
+		}
+
+		const column = next.text.length + 1;
+		editor.executeEdits(
+			"list-continuation",
+			[{ range: selection, text: `${model.getEOL()}${next.text}` }],
+			[new monaco.Selection(line + 1, column, line + 1, column)],
+		);
+	};
+
+	/**
+	 * Tab on a list item raises its nesting level; anywhere else it is a Tab.
+	 *
+	 * SHIFT+TAB IS DELIBERATELY NOT BOUND. Monaco's own `outdent` command already
+	 * has that chord and already takes one indent level off the current line
+	 * wherever the caret sits on it — which is precisely "lower the level". A
+	 * command of ours in front of it would be a second name for a key that is
+	 * already right, and one more `when` clause to get wrong.
+	 *
+	 * `editor.action.indentLines` rather than a hand-written edit for the same
+	 * reason, and it is also what makes Tab mean the level and not the caret: the
+	 * core `tab` command inserts indentation AT the caret, so a Tab in the middle
+	 * of an item's text would drop a tab character into the sentence.
+	 */
+	const indentListItemOnTab = () => {
+		const model = editor.getModel();
+		const selections = editor.getSelections();
+		const onListItem =
+			!!model &&
+			selections?.length === 1 &&
+			selections[0].isEmpty() &&
+			parseListItem(model.getLineContent(selections[0].startLineNumber)) !== null;
+		editor.trigger("keyboard", onListItem ? "editor.action.indentLines" : "tab", null);
 	};
 
 	const wrapAsCodeBlock = () => {

--- a/src/lib/utils/listEditing.ts
+++ b/src/lib/utils/listEditing.ts
@@ -1,0 +1,140 @@
+import { LIST_MARKER, LIST_MARKER_PREFIX, ORDERED_MARKER, TASK_BOX } from './listSyntax.js';
+
+/**
+ * "Given a list line and where the caret is, what should the next line be" —
+ * the whole of issue #604's second item, with no editor in it.
+ *
+ * WHY THIS IS A SEPARATE MODULE
+ *
+ * The interesting part of list continuation is arithmetic on a string: which
+ * marker the next item wears, how much indentation it keeps, whether the item
+ * was empty and the marker should therefore go away. The uninteresting part is
+ * asking Monaco for the line and handing it back an edit. Keeping the first
+ * part here means it can be RUN by `node --test` — every case in
+ * `scripts/listEditing.test.ts` is the real function, not a description of it —
+ * and leaves `Editor.svelte` with a keybinding, a `when` clause and four lines
+ * of plumbing, which is all that genuinely needs a browser.
+ *
+ * The marker vocabulary comes from ./listSyntax.ts, which is the same grammar
+ * the toolbar's toggles and the preview's checkbox rewrite read. A fourth
+ * spelling of "what a list marker looks like" is exactly what #631 collapsed,
+ * and `scripts/singleImplementationConvention.test.ts` holds it collapsed.
+ */
+
+/**
+ * One list item, split into the pieces continuation has to decide about
+ * separately.
+ *
+ * The separator between the marker and the content is CAPTURED rather than
+ * normalised: `-   item` is a hand-aligned list, and answering it with `- ` on
+ * the next line silently un-aligns a document the user lined up by hand.
+ */
+export type ListItem = {
+	/** Indentation and any block-quote markers — what makes a nested item nested. */
+	readonly prefix: string;
+	/** `-`, `+`, `*`, `1.` or `1)`, without the space after it. */
+	readonly marker: string;
+	/** The whitespace between the marker and what follows it. */
+	readonly spacing: string;
+	/** `[ ]` / `[x]` when this is a task item, else null. */
+	readonly box: string | null;
+	/** The whitespace after the box, empty when the box ends the line. */
+	readonly boxSpacing: string;
+	/** Everything after the marker (and the box): the text of the item. */
+	readonly content: string;
+	/** 1-based column where `content` starts, which is where the marker ends. */
+	readonly contentColumn: number;
+};
+
+/**
+ * A list item, anchored at both ends.
+ *
+ * The separator after the marker is REQUIRED (`[ \t]+`) and that is what keeps
+ * `---` and `***` out: a thematic break is a bullet character followed by more
+ * bullet characters, not by a space, so it never matches and Enter on it stays
+ * Enter. The separator after a task box is optional, so that the `- [ ]` a user
+ * has just typed — no trailing space yet — is recognised as the empty task item
+ * it is rather than as a bullet whose text happens to be `[ ]`.
+ */
+const LIST_ITEM = new RegExp(
+	String.raw`^(${LIST_MARKER_PREFIX})(${LIST_MARKER})([ \t]+)(?:(${TASK_BOX})([ \t]*))?(.*)$`,
+);
+
+/** Is this whole marker an ordered one? The one question `nextMarker` asks. */
+const ORDERED_ONLY = new RegExp(String.raw`^${ORDERED_MARKER}$`);
+
+/** The item `line` is, or null when it is not a list item at all. */
+export function parseListItem(line: string): ListItem | null {
+	const match = LIST_ITEM.exec(line);
+	if (!match) return null;
+
+	const [, prefix, marker, spacing, box, boxSpacing, content] = match;
+	const markerLength =
+		prefix.length + marker.length + spacing.length + (box ? box.length + boxSpacing.length : 0);
+
+	return {
+		prefix,
+		marker,
+		spacing,
+		box: box ?? null,
+		boxSpacing: box ? boxSpacing : '',
+		content,
+		contentColumn: markerLength + 1,
+	};
+}
+
+/**
+ * The marker the item after this one wears.
+ *
+ * Bullets are returned unchanged, deliberately: `-`, `*` and `+` are three
+ * spellings of the same list and CommonMark treats a change of character as the
+ * start of a NEW list, so answering `* item` with `- ` would split the list the
+ * user is in the middle of writing. Ordered markers count up and keep their
+ * delimiter, for the same reason one delimiter over — `3)` and `4.` are two
+ * lists, not one.
+ */
+function nextMarker(marker: string): string {
+	if (!ORDERED_ONLY.test(marker)) return marker;
+	return `${Number(marker.slice(0, -1)) + 1}${marker.slice(-1)}`;
+}
+
+/**
+ * What Enter should do on this line.
+ *
+ * `continue` is the ordinary case: the text to put at the head of the new line,
+ * after the line break. `clear` is the escape hatch every Markdown editor has
+ * and this one needs most — an item with a marker and no text is how a list
+ * ENDS, so Enter there takes the marker away instead of writing another one,
+ * and the caller replaces the whole line with `line` rather than breaking it.
+ * Without that there is no keystroke that gets a user out of a list.
+ */
+export type ListEnter =
+	| { readonly kind: 'continue'; readonly text: string }
+	| { readonly kind: 'clear'; readonly line: string };
+
+/**
+ * Enter at `column` (1-based, as Monaco counts) of `line`, or null for "this is
+ * not a list item; do whatever Enter normally does".
+ *
+ * A caret still inside the marker answers null too. Enter with the caret at the
+ * very start of `- item` means "make room above me", and a continuation there
+ * would write its marker in front of the one already on the line.
+ */
+export function listEnter(line: string, column: number): ListEnter | null {
+	const item = parseListItem(line);
+	if (!item || column < item.contentColumn) return null;
+
+	if (item.content.trim() === '') {
+		// The prefix is kept when it carries a block quote (`> - ` empties to
+		// `> `, staying in the quote the user is writing) and dropped when it is
+		// only indentation, which would otherwise leave a line of trailing
+		// spaces behind on every list a user finishes.
+		return { kind: 'clear', line: item.prefix.trim() === '' ? '' : item.prefix };
+	}
+
+	// A checked box never propagates: the new item is something still to do.
+	// `boxSpacing` can be empty when the box ended the line, and a `- [ ]` with
+	// no space after it is not a task item to any renderer.
+	const box = item.box ? `[ ]${item.boxSpacing || ' '}` : '';
+	return { kind: 'continue', text: `${item.prefix}${nextMarker(item.marker)}${item.spacing}${box}` };
+}


### PR DESCRIPTION
Implements the second half of #604.

Press Enter inside a list item and the next line carries the same marker: bullets keep the character they were written with, ordered items increment, task items arrive unticked. Tab changes the level. Enter on an item with no content clears the marker and leaves the list — without that last one there is no way out of a list, so it is not optional.

### Where the logic lives

`src/lib/utils/listEditing.ts` — `parseListItem(line)` and `listEnter(line, column)`, the second returning a union of `{kind:'continue', text}` or `{kind:'clear', line}`. Every marker pattern is assembled from `listSyntax.ts`'s fragments, so there is no fourth spelling of the grammar. `Editor.svelte` is left with two handlers and two `addCommand` lines.

### The `when` conditions, and why they are not optional

```js
const LIST_KEY_CONTEXT =
  "editorTextFocus && !editorReadonly && !suggestWidgetVisible && !inSnippetMode";
editor.addCommand(monaco.KeyCode.Enter, continueListOnEnter, LIST_KEY_CONTEXT);
editor.addCommand(monaco.KeyCode.Tab,   indentListItemOnTab,
                  `${LIST_KEY_CONTEXT} && !editorTabMovesFocus`);
```

`addCommand` registers at weight **1000**, above suggest's `EditorContrib+90` and core's 0. An unconditional binding does not *add* a meaning to Enter — it *takes Enter away*. And `suggestWidgetVisible` is live here: this editor has two completion providers, headings and file paths.

Neither handler is a dead end. Off a list line they re-issue the original meaning through `editor.trigger("keyboard", "type", {text: "\n"})` / `trigger(…, "tab")`, so a normal Enter is still a normal Enter with auto-indent. Both also require a **single collapsed cursor** — a selection or multiple cursors fall through, rather than having the other cursors' edits swallowed.

**Shift+Tab is deliberately not bound.** Monaco's core `outdent` already owns that chord and already removes one level of indentation from the current line. Wrapping it would give a correct key a second name plus a `when` clause that could be wrong. A test pins that dependency by reading `outdent`'s registration out of monaco's own `coreCommands.js`, so a monaco upgrade that drops it goes red rather than quiet.

### vim mode needs no context key

monaco-vim hooks `editor.onKeyDown` on the textarea; the keybinding service listens on the container, in the bubble phase. The textarea is deeper, so it runs first, and vim calls `stopPropagation()` for keys its keymap claims.

So in normal mode vim's `<CR>` wins and these commands never see the key; in insert mode vim lets it through and continuation happens — which is what a vim user writing a list wants. **The order comes from DOM nesting, not from luck.**

One side effect: Tab in normal mode, which vim does not implement, now adjusts the list level instead of inserting a tab character. Left as an improvement rather than branched around.

### Known gaps

- **Indenting does not renumber.** `2. foo` indented one level stays `2.`, rendering as a sub-list starting at 2.
- **Not yet run in the real app.** Whether the keybindings actually deliver, and the vim ordering above, can only be confirmed by running it — the reasoning is traced to monaco's registration points, but that is not the same thing. A debug build is on the Desktop for exactly that.

`npm test` 1062 (+19) · `npm run test:vitest` 89 · `npm run check` 779 files / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
