### PR TITLE
fix(settings): collect the last two writers outside the persistence mechanism

### DIFF
--- a/scripts/recentFilesWriteRace.spec.ts
+++ b/scripts/recentFilesWriteRace.spec.ts
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict';
+
+import { test } from 'vitest';
+
+/*
+ * The race `updateStoredRecentFiles` documented but did not close.
+ *
+ * Re-reading before writing fixed the reported defect — a window publishing a
+ * snapshot of its own stale in-memory array — but the read and the write are
+ * still two calls. localStorage has no compare-and-swap and the spec's storage
+ * mutex is implemented nowhere, so a sibling window's `setItem` can land
+ * between them, and the entry that sibling had just added is overwritten by a
+ * list computed before it existed.
+ *
+ * The answer here is to read back what landed and re-apply the mutation over
+ * whatever list won. It works because every mutation is "apply my one change to
+ * the list you hand me": promote, drop and rename are each idempotent and each
+ * merge, so re-applying folds this window's change into the sibling's. Both
+ * windows run it, so whoever loses an interleaving is the one that retries.
+ *
+ * The alternative was Rust owning the list under a `Mutex`, the way
+ * `update_pinned_tags` owns the pin list. See the commit message and the note
+ * on `updateStoredRecentFiles` for why that lock is available there and not
+ * here.
+ *
+ * This file runs under vitest for jsdom's REAL localStorage: the interleaving
+ * is staged by wrapping `Storage.prototype.setItem`, which a hand-written shim
+ * would let the test define into existence.
+ */
+(window as any).__TAURI_INTERNALS__ = { invoke: async () => 'macos' };
+
+const { promoteRecentFile, updateStoredRecentFiles } = await import('../src/lib/utils/recentFiles.js');
+
+const KEY = 'recent-files';
+
+const stored = () => JSON.parse(localStorage.getItem(KEY) ?? '[]') as string[];
+
+function seed(files: string[]) {
+	localStorage.clear();
+	localStorage.setItem(KEY, JSON.stringify(files));
+}
+
+/**
+ * Stages window B's `setItem` landing immediately after each of window A's,
+ * `times` times over — the interleaving in which A's write is the one that
+ * loses. Returns a disposer; the caller restores in a `finally`.
+ */
+function clobberAfterWrite(value: string[], times: number) {
+	const original = Storage.prototype.setItem;
+	let remaining = times;
+	Storage.prototype.setItem = function patched(key: string, item: string) {
+		original.call(this, key, item);
+		if (key === KEY && remaining > 0) {
+			remaining--;
+			original.call(this, key, JSON.stringify(value));
+		}
+	};
+	return () => {
+		Storage.prototype.setItem = original;
+	};
+}
+
+test('an entry is not lost to a sibling window that writes a moment later', () => {
+	// THE RACE. Both windows read `['/old.md']`; B's write lands after A's, so
+	// the stored list is B's and `/from-a.md` was never in it. Unrepaired, the
+	// file the user just opened in window A is simply not in their recent list.
+	seed(['/old.md']);
+	const restore = clobberAfterWrite(['/from-b.md', '/old.md'], 1);
+	try {
+		const result = updateStoredRecentFiles((current) => promoteRecentFile(current, '/from-a.md'));
+
+		assert.deepEqual(stored(), ['/from-a.md', '/from-b.md', '/old.md'], 'the losing window did not fold its change back in');
+		// ...and the window that retried knows the merged list without a reload,
+		// so its own home screen is not the stale one.
+		assert.deepEqual(result, stored());
+	} finally {
+		restore();
+	}
+});
+
+test('a removal survives the same interleaving', () => {
+	// The other direction: A's mutation is a deletion, and B's write resurrects
+	// the entry A removed. Re-applying `dropRecentFile` over B's list is what
+	// makes the deletion stick.
+	seed(['/a.md', '/b.md']);
+	const restore = clobberAfterWrite(['/c.md', '/a.md', '/b.md'], 1);
+	try {
+		updateStoredRecentFiles((current) => current.filter((file) => file !== '/a.md'));
+
+		assert.deepEqual(stored(), ['/c.md', '/b.md']);
+		assert.ok(!stored().includes('/a.md'), 'the deletion was undone by the other window');
+	} finally {
+		restore();
+	}
+});
+
+test('a window that keeps losing gives up rather than spinning', () => {
+	// The cap. A sibling that overwrites every single attempt must not turn a
+	// click into an unbounded loop — N windows retrying each other is a
+	// live-lock, and this runs synchronously on the main thread. Giving up costs
+	// the one entry that every interleaving used to cost.
+	seed(['/old.md']);
+	const restore = clobberAfterWrite(['/relentless.md'], Number.MAX_SAFE_INTEGER);
+	try {
+		const result = updateStoredRecentFiles((current) => promoteRecentFile(current, '/from-a.md'));
+
+		assert.deepEqual(stored(), ['/relentless.md'], 'the last writer still wins');
+		assert.ok(result.includes('/from-a.md'), 'and the caller is handed the list it computed');
+	} finally {
+		restore();
+	}
+});
+
+test('an uncontended write still costs exactly one setItem', () => {
+	// The read-back must not become a second write: `writeStoredSetting` is
+	// compare-and-set precisely so that a list which did not change fires no
+	// `storage` event in the other windows, and an echoed write-back would undo
+	// that. Counted through the real `Storage.prototype`.
+	seed(['/a.md']);
+	const original = Storage.prototype.setItem;
+	const writes: string[] = [];
+	Storage.prototype.setItem = function patched(key: string, item: string) {
+		writes.push(key);
+		original.call(this, key, item);
+	};
+	try {
+		updateStoredRecentFiles((current) => promoteRecentFile(current, '/b.md'));
+		assert.deepEqual(writes, [KEY]);
+
+		writes.length = 0;
+		updateStoredRecentFiles((current) => promoteRecentFile(current, '/b.md'));
+		assert.deepEqual(writes, [], 'a list that did not change must not be written back');
+	} finally {
+		Storage.prototype.setItem = original;
+	}
+});

--- a/scripts/singleImplementationConvention.test.ts
+++ b/scripts/singleImplementationConvention.test.ts
@@ -234,17 +234,7 @@ const RULES: Rule[] = [
 		// appends to rather than a scalar preference — but its write already goes
 		// through `writeStoredSetting`, so it does not match this marker at all.
 		marker: /localStorage\.setItem\s*\(/g,
-		allowed: [
-			'src/lib/stores/settings.svelte.ts',
-			// KNOWN GAP, not an exemption. `editor.splitScrollSync` is a scalar
-			// preference like any other and belongs in `createSettingsPersistence`;
-			// it is listed only because collecting it means editing the tab store,
-			// which was out of the blast radius of the change that added this rule.
-			// It has the milder half of the same defect: one key, one write, so it
-			// cannot clobber its neighbours, but no listener, so a second window
-			// keeps its own answer until it restarts. Delete this line when it moves.
-			'src/lib/stores/tabs.svelte.ts',
-		],
+		allowed: ['src/lib/stores/settings.svelte.ts'],
 	},
 	{
 		name: 'the app writes an image embed in one place',

--- a/scripts/splitScrollSyncSetting.spec.ts
+++ b/scripts/splitScrollSyncSetting.spec.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+
+import { flushSync } from 'svelte';
+import { test } from 'vitest';
+
+import { readSource } from './sourceTree.js';
+
+/*
+ * `editor.splitScrollSync` — the sticky "does a new split start scroll-locked"
+ * answer — was the last localStorage write outside `writeStoredSetting`. The
+ * tab store read it in its constructor and wrote it with a bare
+ * `localStorage.setItem`.
+ *
+ * That is the milder half of the defect #618 collected the other three writers
+ * for: one key and one write, so it could not clobber its neighbours the way a
+ * whole-snapshot write did. What it still had was the other half — no `storage`
+ * listener. Markpad opens several windows, each a separate webview over one
+ * shared localStorage, so flipping scroll sync in window A left window B
+ * seeding its next split from its own construction-time answer until it was
+ * restarted, while every preference beside it synced live.
+ *
+ * It is a preference, not tab state: `Tab.isScrollSynced` is the per-tab value
+ * (it lives in the window-state snapshot and is what the title bar toggles),
+ * and this is the one scalar every tab and every window seeds from. So it now
+ * lives in `SettingsStore` with the rest of them, and `TabManager` exposes it
+ * under its tab-side name.
+ *
+ * This runs under vitest so the runes are the compiler's: `$effect` really
+ * tracks, `flushSync()` really runs the write effects, and jsdom's
+ * `localStorage` and `window` are real. Only the Tauri backend is stubbed.
+ */
+(window as any).__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
+};
+
+const { createSettingsPersistence, settings, writeStoredSetting } = await import('../src/lib/stores/settings.svelte.js');
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+
+const KEY = 'editor.splitScrollSync';
+
+/** jsdom does not fire `storage` for writes made by this same document. */
+function dispatchStorage(key: string | null, newValue: string | null) {
+	window.dispatchEvent(new StorageEvent('storage', { key, newValue, storageArea: localStorage }));
+}
+
+function reset() {
+	tabManager.closeAll();
+	settings.splitScrollSync = false;
+	// The write effects and the `storage` listener are only live once flushed.
+	flushSync();
+}
+
+/** A split tab, the way the app reaches one. */
+function splitTab(path: string) {
+	tabManager.addTab(path, `# ${path}`);
+	const id = tabManager.activeTabId!;
+	tabManager.setSplitEnabled(id, true);
+	return { id, tab: () => tabManager.tabs.find((candidate) => candidate.id === id)! };
+}
+
+test('the split scroll-sync preference is a persisted setting like every other one', () => {
+	const entry = createSettingsPersistence().find((candidate) => candidate.key === KEY);
+	assert.ok(entry, `${KEY} is not in createSettingsPersistence, so nothing syncs or validates it`);
+});
+
+test('a stored preference survives a restart and seeds the next split', () => {
+	reset();
+	localStorage.setItem(KEY, 'true');
+	dispatchStorage(KEY, 'true');
+
+	const { tab } = splitTab('/notes/restored.md');
+	assert.equal(tab().isScrollSynced, true);
+});
+
+test('a sibling window flipping scroll sync arrives without a restart', () => {
+	// THE BUG. Window B holds its own answer; window A flips the toggle and
+	// publishes it. With no listener, B kept seeding splits from `false` until it
+	// was restarted — the one behaviour the settings mechanism exists to give.
+	reset();
+	assert.equal(tabManager.splitScrollSyncPreference, false);
+
+	localStorage.setItem(KEY, 'true');
+	dispatchStorage(KEY, 'true');
+
+	assert.equal(tabManager.splitScrollSyncPreference, true, 'the sibling window change never arrived');
+
+	const { tab } = splitTab('/notes/sibling.md');
+	assert.equal(tab().isScrollSynced, true, 'and the next split still started from the stale answer');
+});
+
+test('the arriving value is not echoed back at the window that sent it', () => {
+	// Compare-and-set, not a flag: the write-back is dropped because the value is
+	// already what is stored, so storage -> state -> effect -> write stops here.
+	reset();
+	localStorage.setItem(KEY, 'true');
+	dispatchStorage(KEY, 'true');
+
+	const entry = createSettingsPersistence().find((candidate) => candidate.key === KEY)!;
+	assert.equal(writeStoredSetting(entry.key, entry.read(settings)), false);
+});
+
+test('toggling scroll sync on a tab publishes the preference for the other windows', () => {
+	reset();
+	const { id } = splitTab('/notes/toggled.md');
+
+	tabManager.toggleScrollSync(id);
+	assert.equal(tabManager.splitScrollSyncPreference, true);
+	flushSync();
+	assert.equal(localStorage.getItem(KEY), 'true');
+
+	// Un-splitting keeps whatever the tab ended up with, as it always did.
+	tabManager.setSplitEnabled(id, false);
+	assert.equal(tabManager.splitScrollSyncPreference, true);
+});
+
+test('the tab store keeps no localStorage of its own', () => {
+	// Both halves: the bare `setItem` the convention rule now forbids outright,
+	// and the constructor's `getItem`, which is the load path that has to move
+	// with it or the two would drift.
+	const tabsSource = readSource('src/lib/stores/tabs.svelte.ts');
+	assert.doesNotMatch(tabsSource, /localStorage\.(?:get|set)Item\s*\(/);
+});

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -436,6 +436,17 @@ export class SettingsStore {
 	occurrencesHighlight = $state(false);
 	showWhitespace = $state(false);
 	stickyScroll = $state(true);
+	/**
+	 * Whether a newly split tab starts with its panes scroll-locked.
+	 *
+	 * A preference, not a tab's state: `Tab.isScrollSynced` is the per-tab
+	 * answer, lives in the window-state snapshot, and is what the title bar
+	 * toggles. This is the sticky default the last toggle left behind, which
+	 * `TabManager.splitScrollSyncPreference` seeds the next split from — one
+	 * scalar shared by every tab and every window, so it belongs here with the
+	 * rest of them rather than in the tab store that reads it.
+	 */
+	splitScrollSync = $state(false);
 	openFileMode = $state<OpenFileMode>(DEFAULT_OPEN_FILE_MODE);
 	newFileDefaultMode = $state(true);
 	showRecentFiles = $state(true);
@@ -834,6 +845,7 @@ export function createSettingsPersistence(): PersistedSetting<SettingsStore>[] {
 		booleanSetting('editor.occurrencesHighlight', (s) => s.occurrencesHighlight, (s, v) => { s.occurrencesHighlight = v; }),
 		booleanSetting('editor.showWhitespace', (s) => s.showWhitespace, (s, v) => { s.showWhitespace = v; }),
 		booleanSetting('editor.stickyScroll', (s) => s.stickyScroll, (s, v) => { s.stickyScroll = v; }),
+		booleanSetting('editor.splitScrollSync', (s) => s.splitScrollSync, (s, v) => { s.splitScrollSync = v; }),
 		booleanSetting('editor.showToc', (s) => s.showToc, (s, v) => { s.showToc = v; }),
 		stringSetting('editor.highlightColor', (s) => s.highlightColor, (s, v) => { s.highlightColor = v; }),
 		{

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -276,22 +276,28 @@ export interface Tab {
 class TabManager {
 	tabs = $state<Tab[]>([]);
 	activeTabId = $state<string | null>(null);
-	splitScrollSyncPreference = $state(false);
 	windowTag = $state<{ name: string; color: string; pinned: boolean } | null>(null);
 
-	constructor() {
-		if (typeof localStorage !== 'undefined' && typeof localStorage.getItem === 'function') {
-			const saved = localStorage.getItem('editor.splitScrollSync');
-			if (saved !== null) {
-				this.splitScrollSyncPreference = saved === 'true';
-			}
-		}
+	/**
+	 * The sticky "does a new split start scroll-locked" answer, stored as
+	 * `settings.splitScrollSync` and named here for the tab code that seeds a
+	 * split from it — `Tab.isScrollSynced` is the per-tab value, and the two
+	 * names being different is the point.
+	 *
+	 * It used to be a `$state` here with a bare `localStorage.setItem` beside
+	 * it. One key and one write, so it could not clobber its neighbours the way
+	 * the three writers #618 collected did — but nothing listened for `storage`,
+	 * so a second window kept its own answer until it was restarted, while every
+	 * other preference synced live. Reaching through the settings store is what
+	 * makes it a persisted entry like the rest: compare-and-set on write, and
+	 * the store's own `storage` listener folding in what the siblings did.
+	 */
+	get splitScrollSyncPreference(): boolean {
+		return settings.splitScrollSync;
 	}
 
-	private saveSplitScrollSyncPreference() {
-		if (typeof localStorage !== 'undefined' && typeof localStorage.setItem === 'function') {
-			localStorage.setItem('editor.splitScrollSync', String(this.splitScrollSyncPreference));
-		}
+	set splitScrollSyncPreference(value: boolean) {
+		settings.splitScrollSync = value;
 	}
 
 	get activeTab() {
@@ -873,7 +879,6 @@ class TabManager {
 			tab.isScrollSynced = this.splitScrollSyncPreference;
 		} else {
 			this.splitScrollSyncPreference = tab.isScrollSynced;
-			this.saveSplitScrollSyncPreference();
 		}
 	}
 
@@ -889,7 +894,6 @@ class TabManager {
 		if (tab) {
 			tab.isScrollSynced = !tab.isScrollSynced;
 			this.splitScrollSyncPreference = tab.isScrollSynced;
-			this.saveSplitScrollSyncPreference();
 		}
 	}
 

--- a/src/lib/utils/recentFiles.ts
+++ b/src/lib/utils/recentFiles.ts
@@ -7,6 +7,14 @@ import { writeStoredSetting } from '../stores/settings.svelte.js';
 // itself is not a contract with anyone.
 const RECENT_FILES_KEY = 'recent-files';
 const RECENT_FILES_LIMIT = 9;
+/**
+ * How many times {@link updateStoredRecentFiles} will re-apply its mutation
+ * over a sibling window's write before giving up. A cap rather than a loop
+ * until success: N windows all retrying each other is a live-lock, and this
+ * runs synchronously on a click. Exhausting it loses one recent-file entry,
+ * which is exactly what happened on every interleaving before.
+ */
+const RECENT_FILES_WRITE_ATTEMPTS = 3;
 
 /**
  * The recent-file list, as stored. Anything that is not an array of strings is
@@ -63,14 +71,39 @@ export function readStoredRecentFiles(): string[] {
  * makes each change a change to the *stored* list rather than to a stale copy
  * of it.
  *
- * It narrows the race rather than closing it. Two windows are two documents
- * over one storage area and the spec's storage mutex is not implemented
- * anywhere, so the `getItem`/`setItem` pair below can still interleave with
- * another window's. It is accepted here because the cycle is one synchronous
- * turn of the event loop, it runs only on discrete user actions, and the worst
- * loss is one recent-file entry the next open restores — three things that are
- * NOT true of every shared key. `update_pinned_tags` in `window_runtime.rs`
- * documents the contrast and takes a real lock.
+ * Re-reading alone narrows the race without closing it. Two windows are two
+ * documents over one storage area, the spec's storage mutex is not implemented
+ * anywhere, and localStorage has no compare-and-swap — so a sibling's write can
+ * still land between this window's `getItem` and its `setItem`, and the entry
+ * that sibling had just added is gone.
+ *
+ * So the cycle reads back what actually landed. If the stored list is not the
+ * one this window just wrote, a sibling overwrote it, and `mutate` is applied
+ * again over the list that won. That works because every mutation here is
+ * "apply my one change to whatever list you hand me" — promote, drop, rename
+ * are each idempotent and each merge — so re-applying folds this change into
+ * the sibling's instead of one of the two being dropped. Both windows run this
+ * code, so the loser of any interleaving is the one that retries, and the pair
+ * converges without either of them holding anything.
+ *
+ * What is left: a sibling write that lands after the read-back. That window is
+ * itself reading back, finds the list this one published, and merges into it —
+ * so the surviving loss needs a sibling to clobber us *and* to see its own
+ * write intact, which is a second interleaving inside a few microseconds of
+ * synchronous code that runs only on discrete user actions. The attempt cap is
+ * what keeps two busy windows from live-locking; hitting it loses one entry
+ * that the next open restores, which is the pre-existing worst case.
+ *
+ * Rust owning the list instead — the way `update_pinned_tags` in
+ * `window_runtime.rs` owns the pin list under a real `Mutex` — was the other
+ * answer, and it is not available for the same reason it was available there.
+ * That lock works because every window is a thread of one Rust process; these
+ * writers are separate webview processes with no shared primitive between them,
+ * so a backend list would have to be pushed back out to each window anyway,
+ * which is what the `storage` event already does. And Rust is the authority on
+ * pins because Rust reads them (it owns the window list); nothing in the
+ * backend reads recent files. Moving them there would make a list the home
+ * screen renders synchronously into an async IPC round trip at every reader.
  *
  * The write goes through {@link writeStoredSetting} (#370) so that a write
  * which changes nothing does not fire a `storage` event in the other windows.
@@ -79,8 +112,13 @@ export function readStoredRecentFiles(): string[] {
  * "I am applying a remote change" flag is documented there.
  */
 export function updateStoredRecentFiles(mutate: (current: string[]) => string[]): string[] {
-	const next = dedupe(mutate(readStoredRecentFiles())).slice(0, RECENT_FILES_LIMIT);
-	writeStoredSetting(RECENT_FILES_KEY, JSON.stringify(next));
+	let next: string[] = [];
+	for (let attempt = 0; attempt < RECENT_FILES_WRITE_ATTEMPTS; attempt++) {
+		next = dedupe(mutate(readStoredRecentFiles())).slice(0, RECENT_FILES_LIMIT);
+		const written = JSON.stringify(next);
+		writeStoredSetting(RECENT_FILES_KEY, written);
+		if (JSON.stringify(readStoredRecentFiles()) === written) break;
+	}
 	return next;
 }
 


### PR DESCRIPTION
The last two writers outside the `PersistedSetting` mechanism. After this, `allowed` on the `localStorage is written through one function` rule is `settings.svelte.ts` alone, and the KNOWN-GAP note that #618 left in it is gone.

---

### ① `splitScrollSync` is a preference, not per-tab state

Worth establishing first, because it decides whether the move is even correct. The per-tab value is `Tab.isScrollSynced` — the title-bar toggle, kept in the window-state snapshot, untouched here. `splitScrollSyncPreference` was a single sticky scalar that `setSplitEnabled` seeds a *new* split from and the toggle writes back: one value for every tab in every window.

So it becomes `SettingsStore.splitScrollSync` and one `booleanSetting('editor.splitScrollSync', …)` row. `TabManager` keeps the old name as a get/set pair onto `settings` — partly because `openFileMode.test.ts` pins the literal `tab.isScrollSynced = this.splitScrollSyncPreference` in source, and partly because the two names being distinct is worth keeping.

Symptom fixed: one key, one write, so nothing was clobbering — but with no listener a sibling window stayed stale until restart.

---

### ② `recentFiles`: frontend re-apply, not Rust ownership

`updateStoredRecentFiles` now **reads back and re-applies** its change, capped at 3 attempts.

It converges because all three mutations are "apply my one change to whatever list you hand me" — promote, drop and rename are idempotent and merging — so the loser of an interleaving folds its change into the winner's list. Both windows run it, so a pair converges with nobody holding a lock.

**What remains:** a sibling write landing *after* our read-back. That sibling is reading back too, so it merges into what we published; a real loss needs a second interleaving inside a few microseconds of synchronous code that only runs on discrete user actions. Exhausting the cap loses one entry — the pre-existing worst case — and the cap is there because N windows retrying each other on a synchronous click is a live-lock.

**Why not the `pinned_tags` answer.** That `Mutex` works because all windows are threads of *one* Rust process. The localStorage writers are separate webview processes with no shared primitive, so a backend list would still have to be pushed out to each window — which `storage` already does. And Rust owns pins because Rust *reads* them: it owns the window list. Nothing in the backend reads recent files, so moving them would turn a list the home screen renders synchronously into an async IPC round trip at every reader.

Not folded into `PersistedSetting` either: it is an append-target collection, and that would discard the re-read the whole fix depends on.

---

Both were checked against removal of the `src` change alone: 5 of 6 fail for the setting, 2 of 4 for the race — the other two there are guards (attempt cap, one `setItem` per update) and pass either way by design.

`npm test` 1043 · `npm run test:vitest` 99 · `npm run check` 779 files / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
