### PR TITLE
perf(preview): scan the article once, and keep the sections between renumbered headings

### DIFF
--- a/scripts/blockPatchRenumber.spec.ts
+++ b/scripts/blockPatchRenumber.spec.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { patchPreviewBlocks } from '../src/lib/utils/blockPatch.js';
+
+/**
+ * Renaming a heading, which is the edit #632 could not collapse.
+ *
+ * comrak deduplicates heading ids by numbering them, so a document with
+ * repeated headings — `## Objectives` under every section, which is what a
+ * template-driven document looks like — renumbers every later duplicate when
+ * one of them is renamed. Those headings really did change: the id is in the
+ * markup, it is what `#anchor` links, the outline and `data-fold-key` name the
+ * heading by, and no key can call them unchanged without lying about it.
+ *
+ * What was NOT forced is everything BETWEEN them. The changed run at that
+ * level of the document is `h2, wrapper, h2, wrapper, …`, and the wrappers
+ * hold the whole body of the document; the diff descended into containers from
+ * each end of the run and replaced the rest of it wholesale, so one renamed
+ * heading took a third of `samples/stress-test.md` with it. A renumbering adds
+ * and removes no blocks, so the two runs are the same length and line up pair
+ * for pair — which is all it takes to ask each pair the question the ends were
+ * already being asked.
+ */
+
+let host: HTMLElement;
+
+beforeEach(() => {
+	document.body.innerHTML = '';
+	host = document.createElement('div');
+	document.body.appendChild(host);
+});
+
+/**
+ * Sections in the shape `processMarkdownHtml` builds them, with comrak's own
+ * id numbering applied to the headings.
+ */
+function sections(headings: string[]): string {
+	const taken = new Map<string, number>();
+	return headings
+		.map((heading, index) => {
+			const slug = heading.toLowerCase();
+			const seen = taken.get(slug) ?? 0;
+			taken.set(slug, seen + 1);
+			const id = seen === 0 ? slug : `${slug}-${seen}`;
+			const line = index * 4 + 1;
+			return (
+				`<h2 id="${id}" data-fold-key="${id}" data-sourcepos="${line}:1-${line}:${heading.length + 3}">${heading}</h2>` +
+				'<div class="foldable-content-wrapper"><div class="content-inner">' +
+				`<p data-sourcepos="${line + 2}:1-${line + 2}:6">body ${index}</p>` +
+				'</div></div>'
+			);
+		})
+		.join('');
+}
+
+const bodies = () => Array.from(host.querySelectorAll('.content-inner > p'));
+
+describe('renaming one of many identical headings', () => {
+	const before = sections(['Objectives', 'Objectives', 'Objectives', 'Objectives', 'Objectives']);
+	const after = sections(['Goals', 'Objectives', 'Objectives', 'Objectives', 'Objectives']);
+
+	test('renumbers every later heading, which is why they cannot be kept', () => {
+		expect(before).toContain('id="objectives-4"');
+		// Every heading's id moved up one, so all five blocks really are different
+		// markup. This is the premise, not the defect.
+		expect(after).toContain('id="goals"');
+		expect(after).toContain('id="objectives-3"');
+		expect(after).not.toContain('id="objectives-4"');
+	});
+
+	test('replaces the headings and nothing else', () => {
+		patchPreviewBlocks(host, before);
+		const kept = bodies();
+
+		const patch = patchPreviewBlocks(host, after);
+
+		expect(patch.inserted.map((element) => element.tagName)).toEqual(['H2', 'H2', 'H2', 'H2', 'H2']);
+		expect(patch.replaced).toBe(5);
+		// Identity, not equality: every paragraph in this document renders to the
+		// same markup, so "the same node" is the only question worth asking.
+		expect(bodies().every((body, index) => body === kept[index])).toBe(true);
+	});
+
+	test('leaves the wrappers holding the document in place', () => {
+		patchPreviewBlocks(host, before);
+		const wrappers = Array.from(host.querySelectorAll('.foldable-content-wrapper'));
+
+		patchPreviewBlocks(host, after);
+
+		expect(
+			Array.from(host.querySelectorAll('.foldable-content-wrapper')).every(
+				(wrapper, index) => wrapper === wrappers[index],
+			),
+		).toBe(true);
+	});
+
+	test('gives the kept blocks the new heading ids to be anchors for', () => {
+		patchPreviewBlocks(host, before);
+		patchPreviewBlocks(host, after);
+
+		expect(Array.from(host.querySelectorAll('h2')).map((h) => h.id)).toEqual([
+			'goals',
+			'objectives',
+			'objectives-1',
+			'objectives-2',
+			'objectives-3',
+		]);
+	});
+});
+
+describe('an edit that adds a block to the changed run', () => {
+	test('still replaces the run, rather than pairing blocks that do not correspond', () => {
+		patchPreviewBlocks(host, sections(['Alpha', 'Beta']));
+
+		// One section became two: the runs are different lengths, so there is no
+		// pairing to be had and the diff falls back to swapping the run.
+		const patch = patchPreviewBlocks(host, sections(['Alpha', 'Beta', 'Gamma']));
+
+		expect(host.querySelectorAll('h2').length).toBe(3);
+		expect(Array.from(host.querySelectorAll('h2')).map((h) => h.id)).toEqual(['alpha', 'beta', 'gamma']);
+		expect(patch.inserted.length).toBeGreaterThan(0);
+	});
+});
+
+describe('the one-character edit #632 exists for', () => {
+	test('is still one block, with the run walk in the way', () => {
+		patchPreviewBlocks(host, sections(['Alpha', 'Beta', 'Gamma']));
+		const kept = bodies();
+
+		const after = sections(['Alpha', 'Beta', 'Gamma']).replace('>body 1<', '>body 1X<');
+		const patch = patchPreviewBlocks(host, after);
+
+		expect(patch.inserted.map((element) => element.textContent)).toEqual(['body 1X']);
+		expect(bodies()[0]).toBe(kept[0]);
+		expect(bodies()[2]).toBe(kept[2]);
+	});
+});

--- a/scripts/richContentIdempotence.spec.ts
+++ b/scripts/richContentIdempotence.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'vitest';
+
+import { renderRichContent, type RichContentLibraries } from '../src/lib/utils/richContent.js';
+
+/**
+ * `renderRichContent` is run twice over the same nodes, and has to survive it.
+ *
+ * The reuse branches in the code-block pass — the `.code-block-shell` it adopts
+ * instead of nesting, the `.lang-label`s it removes before adding one — look
+ * like export-only defensiveness, on the theory that the preview always hands
+ * this function freshly parsed markup. It does not. Three preview paths call it
+ * with no `roots` at all, which means the whole live article, every node of it
+ * already enriched by the render before:
+ *
+ *   - a theme change (`MarkdownViewer.svelte`), because Mermaid bakes its
+ *     colours into the SVG and the diagrams have to be drawn again;
+ *   - `syncPreviewForPrint`, before a PDF export;
+ *   - re-activating a tab (`documentSession.svelte.ts`).
+ *
+ * #632 made this sharper rather than moot. The preview used to throw its
+ * article away on every keystroke, so an enriched node's life was one render
+ * long; now the patch keeps nodes across renders and the passes above meet
+ * markup that has been through here an unbounded number of times. Without the
+ * reuse, each pass wraps the last pass's shell in another shell and adds
+ * another copy button — a `.code-block-shell` per theme toggle, for the life of
+ * the document.
+ *
+ * The libraries are stood in for at the same boundary `exportRichContent`
+ * uses: what is under test is Markpad's own bookkeeping around them.
+ */
+function libraries(): RichContentLibraries {
+	return {
+		hljs: {
+			getLanguage: (name: string) => (name === 'js' ? {} : undefined),
+			highlight: (code: string) => ({ value: `<span class="hl">${code}</span>` }),
+		},
+		katex: { renderToString: (source: string) => `<span class="katex">${source}</span>` },
+		renderMathInElement: () => {},
+		mermaid: { initialize: () => {}, render: async () => ({ svg: '<svg></svg>' }) },
+	};
+}
+
+function root(html: string): HTMLElement {
+	const element = document.createElement('div');
+	element.innerHTML = html;
+	document.body.replaceChildren(element);
+	return element;
+}
+
+async function render(target: HTMLElement) {
+	await renderRichContent({ roots: [target], libraries: libraries(), mermaidTheme: 'default' });
+}
+
+describe('a second pass over already enriched nodes', () => {
+	test('adopts the shell it built last time instead of nesting another one', async () => {
+		const article = root('<pre><code class="language-js">const answer = 42;</code></pre>');
+
+		await render(article);
+		const shell = article.querySelector('.code-block-shell');
+		const pre = article.querySelector('pre');
+		expect(shell).not.toBeNull();
+
+		await render(article);
+		await render(article);
+
+		expect(article.querySelectorAll('.code-block-shell').length).toBe(1);
+		expect(article.querySelector('.code-block-shell')).toBe(shell);
+		expect(shell!.parentElement).toBe(article);
+		expect(pre!.parentElement).toBe(shell);
+	});
+
+	test('leaves one copy button, not one per pass', async () => {
+		const article = root('<pre><code class="language-js">const answer = 42;</code></pre>');
+
+		await render(article);
+		await render(article);
+		await render(article);
+
+		expect(article.querySelectorAll('.lang-label').length).toBe(1);
+		expect(article.querySelector('.lang-label')!.textContent).toBe('js');
+	});
+
+	test('holds for a fenced block with no language, which gets the icon instead', async () => {
+		const article = root('<pre><code>plain text</code></pre>');
+
+		await render(article);
+		await render(article);
+
+		expect(article.querySelectorAll('.code-block-shell').length).toBe(1);
+		expect(article.querySelectorAll('.lang-label').length).toBe(1);
+	});
+});

--- a/scripts/runeProps.svelte.ts
+++ b/scripts/runeProps.svelte.ts
@@ -1,0 +1,12 @@
+/**
+ * A props object a test can mutate and a mounted component will react to.
+ *
+ * `mount()` takes plain props and never looks at them again; only a `$state`
+ * proxy makes an update reach the component, and `$state` is a compiler rune
+ * that exists solely inside `.svelte` / `.svelte.ts` modules. So the one line
+ * that has to live in such a module lives here, and the tests stay `.spec.ts`.
+ */
+export function runeProps<T extends object>(initial: T): T {
+	let props = $state(initial);
+	return props;
+}

--- a/scripts/tocDocumentPasses.spec.ts
+++ b/scripts/tocDocumentPasses.spec.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeAll, describe, expect, test } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+
+import Toc from '../src/lib/components/Toc.svelte';
+import { runeProps } from './runeProps.svelte.js';
+
+/**
+ * What the outline costs per render, and that the cheaper scan still reads the
+ * document the same way.
+ *
+ * `<Toc>` is handed the whole `sanitizedHtml` string, which changes on every
+ * keystroke, and it does not parse it — it uses it as the signal that the
+ * preview has been rendered and then reads the live DOM. So the cost is not a
+ * second parse of the document. It is `querySelectorAll` over the whole
+ * article, and it used to be three of those per render (headings, block
+ * anchors, and `[id]` — every element in the document that has one) plus a
+ * sort, and SIX whenever the outline actually changed, because the effect read
+ * the `items` it writes and so scheduled itself again.
+ *
+ * A render is a keystroke, and #632 brought the rest of the render down to
+ * one changed block. Counting the walks is the only way to keep this from
+ * quietly growing back, so the count is the assertion.
+ */
+
+/**
+ * Svelte's `slide` transition drives the Web Animations API, which jsdom does
+ * not implement. Nothing here is about the animation, so it is given something
+ * that finishes immediately.
+ */
+beforeAll(() => {
+	(Element.prototype as any).animate = () => ({
+		cancel() {},
+		pause() {},
+		play() {},
+		finish() {},
+		onfinish: null,
+		oncancel: null,
+		currentTime: 0,
+		startTime: 0,
+		playbackRate: 1,
+		playState: 'finished',
+		finished: Promise.resolve(),
+		effect: { getComputedTiming: () => ({ delay: 0, duration: 0, endTime: 0 }) },
+	});
+});
+
+interface Harness {
+	body: HTMLElement;
+	props: { markdownBody: HTMLElement; htmlContent: string };
+	/** Selectors the outline ran over the whole article since the last reset. */
+	passes: string[];
+	render(html: string): void;
+	entries(): string[];
+	stop(): void;
+}
+
+let running: Harness | null = null;
+
+afterEach(() => {
+	running?.stop();
+	running = null;
+});
+
+function harness(html: string): Harness {
+	const body = document.createElement('div');
+	body.innerHTML = html;
+	const target = document.createElement('div');
+	document.body.replaceChildren(body, target);
+
+	const passes: string[] = [];
+	const queryAll = body.querySelectorAll.bind(body);
+	(body as any).querySelectorAll = (selector: string) => {
+		passes.push(selector);
+		return queryAll(selector);
+	};
+
+	const props = runeProps({ markdownBody: body, htmlContent: html });
+	const component = mount(Toc, { target, props });
+	flushSync();
+
+	const instance: Harness = {
+		body,
+		props,
+		passes,
+		render(next: string) {
+			body.innerHTML = next;
+			// The same dependency the preview changes: a new sanitized document.
+			props.htmlContent = next;
+			passes.length = 0;
+			flushSync();
+		},
+		entries: () => Array.from(target.querySelectorAll('.toc-link')).map((el) => el.textContent!.trim()),
+		stop: () => unmount(component),
+	};
+	running = instance;
+	return instance;
+}
+
+const heading = (level: number, id: string, text: string, line: number) =>
+	`<h${level} id="${id}" data-fold-key="${id}" data-sourcepos="${line}:1-${line}:9">${text}</h${level}>`;
+
+const anchor = (id: string, line: number) =>
+	`<a id="${id}" class="block-id-anchor" data-label="${id}" data-sourcepos="${line}:1-${line}:9"></a>`;
+
+/** A paragraph carrying an id, which is what made the `[id]` walk expensive. */
+const para = (id: string, text: string) => `<p id="${id}">${text}</p>`;
+
+describe('what one render costs the outline', () => {
+	test('walks the article once when nothing about the outline changed', () => {
+		const toc = harness(heading(1, 'a', 'Alpha', 1) + para('p1', 'x'));
+
+		toc.render(heading(1, 'a', 'Alpha', 1) + para('p1', 'xy'));
+
+		expect(toc.passes).toEqual(['h1, h2, h3, h4, h5, h6, a[id].block-id-anchor, span[id].block-id-anchor']);
+	});
+
+	test('walks it once when the outline DID change, not twice', () => {
+		const toc = harness(heading(1, 'a', 'Alpha', 1) + para('p1', 'x'));
+
+		// Renaming a heading is the edit that changes the outline, and it is also
+		// the edit that changes the most blocks — the one render that could least
+		// afford to scan the document a second time is the one that did.
+		toc.render(heading(1, 'a', 'Alphas', 1) + para('p1', 'x'));
+
+		expect(toc.passes.length).toBe(1);
+		expect(toc.entries()).toEqual(['Alphas']);
+	});
+});
+
+describe('the entries that one walk produces', () => {
+	test('interleaves headings and block anchors in document order', () => {
+		const toc = harness(
+			heading(1, 'title', 'Title', 1) +
+				para('p1', 'intro') +
+				anchor('note', 3) +
+				heading(2, 'first', 'First', 5) +
+				anchor('mark', 7) +
+				heading(2, 'second', 'Second', 9),
+		);
+
+		expect(toc.entries()).toEqual(['Title', 'note', 'First', 'mark', 'Second']);
+	});
+
+	test('keeps an anchor that sits inside a heading after the heading', () => {
+		const toc = harness(
+			`<h2 id="section" data-fold-key="section" data-sourcepos="1:1-1:9">Section${anchor('inline', 1)}</h2>`,
+		);
+
+		expect(toc.entries()).toEqual(['Section', 'inline']);
+	});
+
+	test('drops a heading the renderer gave no id, and empties out with the document', () => {
+		const toc = harness('<h2 data-sourcepos="1:1-1:9">Nameless</h2>' + heading(2, 'named', 'Named', 3));
+		expect(toc.entries()).toEqual(['Named']);
+
+		toc.render('<p>no headings at all</p>');
+		expect(toc.entries()).toEqual([]);
+	});
+});

--- a/src/lib/components/Toc.svelte
+++ b/src/lib/components/Toc.svelte
@@ -46,7 +46,35 @@
 		line: RendererLine | null;
 	}
 
+	/**
+	 * Everything the outline can show, in the order the document holds it.
+	 *
+	 * One query rather than three. `querySelectorAll` returns document order,
+	 * so asking for the headings and the block anchors together IS the
+	 * interleaving — this used to ask for each separately and then sort the two
+	 * lists back together against a third walk (`[id]`, which matches every
+	 * element in the document carrying one) built into a position map.
+	 *
+	 * That cost is per render, and a render is a keystroke. #632 stopped the
+	 * preview rebuilding its article for one character; an outline that walks
+	 * the whole of it three times regardless spends a good part of that back,
+	 * and on the documents where the patch matters most — 7819 elements in
+	 * `samples/stress-test.md` — it is the largest remaining full-document pass
+	 * in the render.
+	 */
+	const ENTRY_SELECTOR = 'h1, h2, h3, h4, h5, h6, a[id].block-id-anchor, span[id].block-id-anchor';
+
 	let items = $state<TocItem[]>([]);
+	/**
+	 * What `items` currently holds, for deciding whether the scan changed
+	 * anything.
+	 *
+	 * Kept here rather than recomputed from `items` inside the effect, because
+	 * reading a `$state` there makes the effect depend on itself: assigning
+	 * `items` scheduled the effect again, and every render that changed the
+	 * outline scanned the whole document twice.
+	 */
+	let itemsFingerprint = '';
 	let activeId = $state<string | null>(null);
 	let tocContainer: HTMLElement | null = $state(null);
 	let activeTargetEl: HTMLElement | null = null;
@@ -61,8 +89,16 @@
 		if (htmlContent && markdownBody) {
 			const result: TocItem[] = [];
 
-			const hs = markdownBody.querySelectorAll('h1, h2, h3, h4, h5, h6') as NodeListOf<HTMLElement>;
-			for (const h of Array.from(hs)) {
+			const entries = markdownBody.querySelectorAll(ENTRY_SELECTOR) as NodeListOf<HTMLElement>;
+			for (const el of Array.from(entries)) {
+				if (el.classList.contains('block-id-anchor')) {
+					result.push({ id: el.id, text: el.getAttribute('data-label') || el.id, foldKey: '', level: 0, isBlock: true, line: sourceLineOf(el.dataset.sourcepos) });
+					continue;
+				}
+
+				// Everything the selector matches that is not a block anchor is a
+				// heading, which is the only other thing it asks for.
+				const h = el;
 				let text = h.textContent || '';
 				text = text.replace(/\s*\^[a-zA-Z0-9_-]+$/, '');
 				const anchor = h.querySelector('a.anchor') as HTMLElement | null;
@@ -71,21 +107,6 @@
 					result.push({ id, text: text.trim(), foldKey: foldKeyOf(h), level: parseInt(h.tagName[1], 10), isBlock: false, line: sourceLineOf(h.dataset.sourcepos) });
 				}
 			}
-
-			const blockAnchors = markdownBody.querySelectorAll('a[id].block-id-anchor, span[id].block-id-anchor') as NodeListOf<HTMLElement>;
-			for (const el of Array.from(blockAnchors)) {
-				const id = el.id;
-				const label = el.getAttribute('data-label') || id;
-				result.push({ id, text: label, foldKey: '', level: 0, isBlock: true, line: sourceLineOf(el.dataset.sourcepos) });
-			}
-
-			const allIds = new Map<string, number>();
-			const allEls = markdownBody.querySelectorAll('[id]') as NodeListOf<HTMLElement>;
-			let order = 0;
-			for (const el of Array.from(allEls)) {
-				allIds.set(el.id, order++);
-			}
-			result.sort((a, b) => (allIds.get(a.id) ?? 999) - (allIds.get(b.id) ?? 999));
 
 			for (let i = 0; i < result.length; i++) {
 				const item = result[i];
@@ -100,14 +121,14 @@
 				}
 			}
 
-			const currentFingerprint = items.map(i => `${i.id}-${i.text}-${i.level}-${i.line}`).join('|');
 			const newFingerprint = result.map(i => `${i.id}-${i.text}-${i.level}-${i.line}`).join('|');
-			
-			if (currentFingerprint !== newFingerprint) {
+			if (newFingerprint !== itemsFingerprint) {
+				itemsFingerprint = newFingerprint;
 				items = result;
 			}
-		} else {
-			if (items.length > 0) items = [];
+		} else if (itemsFingerprint !== '') {
+			itemsFingerprint = '';
+			items = [];
 		}
 	});
 

--- a/src/lib/utils/blockPatch.ts
+++ b/src/lib/utils/blockPatch.ts
@@ -35,12 +35,30 @@ import { carrySourcepos } from './richContent.js';
  * before, not a copy of it: a fixed reference block sampled at frames 0, 1, 2, 5
  * and 11 after the edit is at +0.000px in every case.
  *
- * Renaming a heading is the one edit that does not collapse to a block or two:
+ * Renaming a heading is the one edit that does not collapse to a block or two.
  * comrak deduplicates heading ids (`objectives-24`, `objectives-25`, …), so
- * renaming one renumbers every later duplicate and those blocks really are
- * different markup. On stress-test.md that is 71 blocks instead of 1 — still a
- * third of the document rather than all of it, and the id is in the markup, so
- * no key can call them unchanged without lying.
+ * renaming one renumbers every later duplicate, and those headings really are
+ * different markup: the id is what an `#anchor` link, the outline and
+ * `data-fold-key` name the heading by, so no key can call them unchanged
+ * without lying. What is not forced is the content BETWEEN them, and that was
+ * where the cost sat — the changed run at that level of the document is
+ * `h2, wrapper, h2, wrapper, …`, the wrappers hold the body of the file, and
+ * the run was swapped whole. On stress-test.md that was 71 blocks, a third of
+ * the document, for one renamed heading. The run is now walked pairwise when
+ * both sides have the same length, so the headings are replaced and the
+ * wrappers are descended into.
+ *
+ * Keeping the heading nodes as well and rewriting their ids — the trick
+ * `refreshSourcepos` plays with source ranges — is the tempting next step, and
+ * it does not work. That trick is sound only because every node
+ * `renderRichContent` replaces it replaces singly, so the annotated nodes line
+ * up one for one on both sides after enrichment. Ids have no such property:
+ * enrichment INVENTS them, a Mermaid SVG carrying dozens where the `<pre>` it
+ * replaced had none, so the two `[id]` lists do not correspond and the
+ * length-mismatch bail leaves a kept block wearing an id nothing links to any
+ * more. A stale anchor target is a wrong answer; replacing a heading is only
+ * work. Dropping ids from the key without rewriting them at all is the same
+ * defect with none of the machinery.
  *
  * ## The key is the markup, not the source position
  *
@@ -218,19 +236,46 @@ function patchContainer(live: HTMLElement, next: ParentNode, patch: BlockPatch):
 		newTo -= 1;
 	}
 
-	// Read before anything is removed: still a live node, and still in place
-	// afterwards, because everything removed sits before it.
-	const before = liveElements[oldTo] ?? null;
-	for (let index = oldFrom; index < oldTo; index += 1) liveElements[index].remove();
+	// What is left is the run that really changed. When both sides have the same
+	// number of blocks in it, the two line up pair for pair, and each pair can
+	// be asked the question the ends were asked instead of the run being swapped
+	// wholesale. That is the difference between "a heading changed" and "a third
+	// of the document changed": renumbering `objectives-24` renames every later
+	// duplicate, and the run that spans them is `h2, wrapper, h2, wrapper, …`
+	// where only the headings differ. The wrappers hold the body of the file.
+	//
+	// Same length is the whole condition, and it is not a heuristic: it is what
+	// says the blocks correspond. An edit that adds or removes one shifts
+	// everything after it, there is no pairing to be had, and the run is swapped
+	// as before — which is also the case the prefix/suffix diff was chosen for.
+	if (oldTo - oldFrom === newTo - newFrom) {
+		for (let index = 0; index < oldTo - oldFrom; index += 1) {
+			const liveElement = liveElements[oldFrom + index];
+			const nextElement = nextElements[newFrom + index];
+			if (canDescend(liveElement, nextElement)) {
+				descend(liveElement, nextElement, patch);
+				continue;
+			}
+			liveElement.replaceWith(nextElement);
+			rememberSubtree(nextElement);
+			patch.inserted.push(nextElement);
+			patch.replaced += 1;
+		}
+	} else {
+		// Read before anything is removed: still a live node, and still in place
+		// afterwards, because everything removed sits before it.
+		const before = liveElements[oldTo] ?? null;
+		for (let index = oldFrom; index < oldTo; index += 1) liveElements[index].remove();
 
-	const incoming = nextElements.slice(newFrom, newTo);
-	if (incoming.length > 0) {
-		const fragment = live.ownerDocument.createDocumentFragment();
-		for (const element of incoming) fragment.appendChild(element);
-		live.insertBefore(fragment, before);
-		for (const element of incoming) rememberSubtree(element);
-		patch.inserted.push(...incoming);
-		patch.replaced += incoming.length;
+		const incoming = nextElements.slice(newFrom, newTo);
+		if (incoming.length > 0) {
+			const fragment = live.ownerDocument.createDocumentFragment();
+			for (const element of incoming) fragment.appendChild(element);
+			live.insertBefore(fragment, before);
+			for (const element of incoming) rememberSubtree(element);
+			patch.inserted.push(...incoming);
+			patch.replaced += incoming.length;
+		}
 	}
 
 	// Kept blocks moved in the source even when they did not move on screen, and


### PR DESCRIPTION
Three items from the backlog. **One of them was wrong**, and that is the first commit.

---

### ① The re-entrancy branches in `renderRichContent` are not dead — test only, no source change

They were filed as "only meaningful for export; the preview always gets fresh nodes". That is false, and was false before #632. Three preview paths call `renderRichContent()` with **no `roots`** — the whole live, already-enriched article:

- `MarkdownViewer.svelte:442` — theme change, because Mermaid bakes its colours into the SVG
- `MarkdownViewer.svelte:2184` — `syncPreviewForPrint`, ahead of PDF export
- `documentSession.svelte.ts:521` — re-activating a tab

#632 made them **more** load-bearing rather than less. The preview used to discard the article on every keystroke, so an enriched node lived for one render; nodes now persist, so those three passes meet markup that has been through the function an unbounded number of times.

Deleting the `existingWrapper` branch: three passes over one code block produce **3 nested `.code-block-shell`s and 3 `.lang-label`s** instead of one each — one more of both per theme toggle, for the life of the tab.

`richContent.ts` is unchanged. The commit is the test that would have caught the deletion.

---

### ② The outline scanned the article three times per render, six when it mattered

Half of the filing was wrong: `Toc.svelte` does **not** parse `sanitizedHtml`. No DOMParser, no regex — the string is a change signal and the entries are read off the live DOM.

But it ran three full-article `querySelectorAll`s, the third over `[id]` — every id-bearing element, 7819 of them on `stress-test.md` — purely to sort the first two lists back into document order. One combined selector returns them in that order already.

And it ran **six** whenever the outline actually changed, because the effect computed its fingerprint from `items`, the `$state` it writes. It depended on itself and scheduled a second full scan. The render that could least afford it — renaming a heading — was the one that paid twice.

One selector; the map and sort are gone; the fingerprint is a plain variable. The three ordering tests pass before and after, which is the point.

---

### ③ Renumbered headings: 9 blocks replaced, not 71

The known bad case from #632 was "renaming a heading touches a third of the document, and no key can call those blocks unchanged without lying". The premise held; the conclusion did not.

Those blocks were never all headings. The run is `h2, wrapper, h2, wrapper, …`, and the diff descended from each end of the changed run and swapped the whole middle — so the wrappers holding the document's actual content went with the headings whose ids had changed.

A renumbering adds and removes no blocks, so **the two runs are the same length**. That is not a heuristic; it is the statement that the blocks correspond. Walking the run pairwise replaces the headings — they fail `canDescend`, and their ids genuinely did change — and descends into the wrappers. Unequal-length runs fall back to the wholesale swap.

Five identical headings with one renamed: **9 replaced → 5**, and the 5 are exactly the `<h2>`s. Every paragraph and wrapper is the same node.

**The alternative is recorded as a dead end**, in the header comment: excluding `id` from the key and rewriting it on kept nodes. `refreshSourcepos` is sound only because `renderRichContent` replaces each annotated node singly; ids have no such property, because enrichment *invents* them — a Mermaid SVG carries dozens where the `<pre>` had none. The `[id]` lists would not correspond, and the length-mismatch bail would leave a kept block wearing an id nothing links to. A stale anchor target is a wrong answer; replacing a heading is only work.

---

Each of the three was checked against its own removal. No existing test file was modified — worth knowing that `tocFollowsEditor.test.ts` asserts on Toc's *source text*, so the new code was shaped to keep those strings rather than edit the test.

`npm test` 1043 · `npm run test:vitest` 103 · `npm run check` 781 files / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
