### PR TITLE
fix(settings): guard the OS type instead of casting whatever arrives

### DIFF
--- a/scripts/osTypeFallback.spec.ts
+++ b/scripts/osTypeFallback.spec.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+
+import { flushSync } from 'svelte';
+import { onTestFinished, test } from 'vitest';
+
+/*
+ * `initOSType` caught a *rejection* and answered `'unknown'`, but a successful
+ * `null` went through `as OSType` into the field. `DEFAULT_FONTS[null]` is
+ * `undefined`, and the constructor reads `.editorFont` off it on the next line
+ * — so the store threw while starting, before any setting had been applied.
+ *
+ * The shipped app cannot reach it: the Rust command always answers a string.
+ * It surfaced in #635, where the vitest move began booting the real singleton
+ * against a bridge stub that answered `null` to everything, and the fix there
+ * was to correct the two stubs. This closes the store's half.
+ */
+
+let osTypeAnswer: unknown = 'macos';
+(window as any).__TAURI_INTERNALS__ = {
+	invoke: async (command: string) => (command === 'get_os_type' ? osTypeAnswer : null),
+};
+
+const { DEFAULT_FONTS, SettingsStore, isOSType } = await import('../src/lib/stores/settings.svelte.js');
+
+function bootWith(answer: unknown) {
+	osTypeAnswer = answer;
+	localStorage.clear();
+	const store = new SettingsStore();
+	onTestFinished(() => store.dispose());
+	return store;
+}
+
+test('the guard admits the four the backend can answer with, and nothing else', () => {
+	for (const ok of ['macos', 'windows', 'linux', 'unknown']) assert.equal(isOSType(ok), true);
+	for (const bad of [null, undefined, '', 'Darwin', 'macOS', 0, {}]) assert.equal(isOSType(bad), false);
+});
+
+test('a backend that answers null leaves the store on a usable OS type', async () => {
+	// THE BUG: `as OSType` put `null` in the field, and the font defaults are
+	// indexed by it. Awaiting a macrotask lets the constructor's own
+	// `initOSType().then(…)` settle — that continuation is where it threw.
+	const store = bootWith(null);
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	flushSync();
+
+	assert.equal(store.osType, 'unknown');
+	assert.equal(store.editorFont, DEFAULT_FONTS.unknown.editorFont);
+	assert.equal(store.previewFont, DEFAULT_FONTS.unknown.previewFont);
+	assert.equal(store.codeFont, DEFAULT_FONTS.unknown.codeFont);
+});
+
+test('a string the union does not contain is treated the same way', async () => {
+	// A future backend answering `'Darwin'` is the same defect wearing a string:
+	// it typechecks through a cast and indexes to `undefined` just as well.
+	const store = bootWith('Darwin');
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	flushSync();
+
+	assert.equal(store.osType, 'unknown');
+	assert.equal(store.editorFont, DEFAULT_FONTS.unknown.editorFont);
+});
+
+test('a real answer is still honoured', async () => {
+	const store = bootWith('macos');
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	flushSync();
+
+	assert.equal(store.osType, 'macos');
+	assert.equal(store.editorFont, DEFAULT_FONTS.macos.editorFont);
+});

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -52,6 +52,24 @@ export type ThemeSetting = 'system' | 'light' | 'dark' | `vscode:${string}`;
 
 export const DEFAULT_THEME: ThemeSetting = 'system';
 
+/**
+ * The four the backend can answer `get_os_type` with.
+ *
+ * Guarded rather than cast, because the failure that reaches here is not a
+ * rejection. `initOSType` catches those; what it did not catch was a
+ * *successful* `null` or `undefined`, which `as OSType` laundered into the
+ * union. `DEFAULT_FONTS[null]` is `undefined`, and the line after it reads
+ * `.editorFont` off that — so the store's constructor threw before any
+ * setting was applied.
+ *
+ * Not reachable from the shipped app: the Rust command always answers with a
+ * string. It surfaced in #635, when the vitest move started booting the real
+ * singleton against a bridge stub that answered `null` to everything.
+ */
+export function isOSType(value: unknown): value is OSType {
+	return value === 'macos' || value === 'windows' || value === 'linux' || value === 'unknown';
+}
+
 export function isThemeSetting(value: unknown): value is ThemeSetting {
 	if (value === 'system' || value === 'light' || value === 'dark') return true;
 	return typeof value === 'string' && value.startsWith('vscode:') && value.length > 'vscode:'.length;
@@ -758,8 +776,8 @@ export class SettingsStore {
 
 	async initOSType() {
 		try {
-			const osType = await invoke<string>('get_os_type');
-			this.osType = osType as OSType;
+			const osType = await invoke<unknown>('get_os_type');
+			this.osType = isOSType(osType) ? osType : 'unknown';
 		} catch (e) {
 			console.error('Failed to get OS type:', e);
 			this.osType = 'unknown';


### PR DESCRIPTION
`initOSType` caught a rejection and answered `'unknown'`. A **successful** `null` went through `as OSType` straight into the field — and `DEFAULT_FONTS[null]` is `undefined`, with the constructor reading `.editorFont` off it on the next line. The store threw while starting, before a single setting had been applied.

The shipped app cannot reach it: the Rust `get_os_type` always answers with a string.

It surfaced in #635, where migrating the suites to vitest started booting the real singleton against a bridge stub that answered `null` to everything. That PR fixed the two stubs and deliberately left the store alone — a runner migration carrying a behaviour change leaves nothing separable to review. This is the other half.

### The change

`isOSType` is a guard beside `isThemeSetting` and `isSupportedLanguage`, and the `invoke` is typed `unknown` rather than `string` so the cast has nowhere left to hide.

A future backend answering `'Darwin'` is the same defect wearing a string, and now takes the same fallback — the test asserts that case explicitly, because it is the one a cast would still let through if the guard were written as a null check.

Reverting to `as OSType` turns 2 of the 4 red.

`npm test` 872 · `npm run test:vitest` 307 · `npm run check` 786 files / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
