### PR TITLE
refactor(tabs): give the anchor line the renderer-line type it always was

### DIFF
--- a/scripts/lossyDecodeSaveGuard.test.ts
+++ b/scripts/lossyDecodeSaveGuard.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import type { Tab } from '../src/lib/stores/tabs.svelte.js';
+import { asRendererLine } from '../src/lib/utils/lineCoordinates.js';
 import { buildTransferredTab, snapshotTab, validateTransferPayload } from '../src/lib/utils/tabTransfer.js';
 import { offsetOf, readRustBackend, readSource, sliceBetween } from './sourceTree.js';
 
@@ -209,7 +210,7 @@ function makeTab(overrides: Partial<Tab> = {}): Tab {
 		historyIndex: 0,
 		editorViewState: null,
 		scrollPercentage: 0,
-		anchorLine: 0,
+		anchorLine: asRendererLine(0),
 		isSplit: false,
 		splitRatio: 0.5,
 		isScrollSynced: false,

--- a/scripts/renderedHtmlField.spec.ts
+++ b/scripts/renderedHtmlField.spec.ts
@@ -5,6 +5,7 @@ import { test } from 'vitest';
 import { parse } from 'svelte/compiler';
 import ts from 'typescript';
 
+import { asRendererLine } from '../src/lib/utils/lineCoordinates.js';
 import { readSource } from './sourceTree.js';
 
 /*
@@ -429,7 +430,7 @@ test('every Tab construction site starts the rendered-HTML field empty', () => {
 		history: ['/notes/c.md'],
 		historyIndex: 0,
 		scrollPercentage: 0,
-		anchorLine: 0,
+		anchorLine: asRendererLine(0),
 		isSplit: false,
 		splitRatio: 0.5,
 		isScrollSynced: false,

--- a/scripts/tabPathIdentity.spec.ts
+++ b/scripts/tabPathIdentity.spec.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
 
+import { asRendererLine } from '../src/lib/utils/lineCoordinates.js';
+
 // A file path identifies a tab. Two tabs on one file are two buffers with two
 // dirty flags and two auto-save timers writing the same file in turn, so
 // whichever lands last silently overwrites the other's work. Every way to
@@ -150,7 +152,7 @@ test('a tab arriving from another window does not duplicate a file open here', (
 		isEditing: true,
 		scrollTop: 0,
 		scrollPercentage: 0,
-		anchorLine: 0,
+		anchorLine: asRendererLine(0),
 		isSplit: false,
 		splitRatio: 0.5,
 		isScrollSynced: false,

--- a/scripts/tabReadingPosition.test.ts
+++ b/scripts/tabReadingPosition.test.ts
@@ -62,6 +62,8 @@ installShimDom();
 const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
 const { processMarkdownHtml } = await import('../src/lib/utils/markdown.ts');
 const { findAnchorElement } = await import('../src/lib/utils/previewAnchor.ts');
+const { asRendererLine, lineCoordinates } = await import('../src/lib/utils/lineCoordinates.ts');
+const { snapshotTab, validateTransferPayload } = await import('../src/lib/utils/tabTransfer.ts');
 
 type Tab = (typeof tabManager.tabs)[number];
 
@@ -77,7 +79,7 @@ function openScrolledTab(path: string): Tab {
 	const tab = tabManager.tabs.find((item) => item.path === path)!;
 	tab.scrollTop = 4820;
 	tab.scrollPercentage = 0.73;
-	tab.anchorLine = 812;
+	tab.anchorLine = asRendererLine(812);
 	tab.editorViewState = { cursorState: 'monaco-live-object' };
 	return tab;
 }
@@ -110,7 +112,7 @@ test('going back to the previous file leaves the tab at the top of it', () => {
 	reset();
 	const tab = openScrolledTab('/notes/a.md');
 	tabManager.navigate(tab.id, '/notes/b.md');
-	tab.anchorLine = 44;
+	tab.anchorLine = asRendererLine(44);
 	tab.scrollPercentage = 0.2;
 	tab.scrollTop = 900;
 	tab.editorViewState = { cursorState: 'monaco-live-object' };
@@ -127,7 +129,7 @@ test('going forward again leaves the tab at the top of that file', () => {
 	const tab = openScrolledTab('/notes/a.md');
 	tabManager.navigate(tab.id, '/notes/b.md');
 	tabManager.goBack(tab.id);
-	tab.anchorLine = 300;
+	tab.anchorLine = asRendererLine(300);
 	tab.scrollPercentage = 0.5;
 	tab.scrollTop = 2000;
 	tab.editorViewState = { cursorState: 'monaco-live-object' };
@@ -290,4 +292,68 @@ test('a cleared reading position resolves to nothing, so the cascade falls throu
 	// stage 3 — and stage 3 is the top of the document.
 	assert.equal(tab.scrollPercentage, 0);
 	assert.equal(tab.scrollTop, 0);
+});
+
+/* ------------------------------------------------------------------ */
+/* which numbering the anchor is in                                    */
+/* ------------------------------------------------------------------ */
+//
+// `anchorLine` is a RENDERER line. `getPreviewScrollAnchor` writes it off
+// `data-sourcepos` and the restore above reads it back with
+// `findAnchorElement` against the same attributes, and both of those count
+// from the first line of the BODY — while the editor's own line numbers count
+// from the first line of the FILE. In a document with front matter the two
+// differ by its height, and #607 made that difference a TYPE so that a
+// crossing which forgets to convert cannot compile.
+//
+// The brand has no run-time representation, so the assertion cannot be an
+// `assert`. It is the `@ts-expect-error` comments below, which invert into
+// exactly the failure wanted: if the brand is ever dropped, those lines start
+// compiling, and `npm run check` fails them as unused directives.
+
+/** Six buffer lines of YAML above the body, so the two numberings differ by 6. */
+const WITH_FRONT_MATTER = ['---', 'title: "T"', 'tags:', '  - a', '---', '', '# Title'].join('\n') + '\n';
+
+test('the tab anchor is a renderer line, and only converts one way round', () => {
+	reset();
+	const tab = openScrolledTab('/notes/a.md');
+	const coords = lineCoordinates(WITH_FRONT_MATTER);
+
+	// What the brand permits, and the conversion any caller aiming the EDITOR
+	// with this field owes: line 812 of the body is line 818 of the buffer.
+	assert.equal(coords.toBufferLine(tab.anchorLine), 818);
+	assert.equal(coords.toRendererLine(coords.toBufferLine(tab.anchorLine)), 812);
+
+	// What it forbids. First the crossing read backwards — treating the anchor
+	// as if it were already on the editor's numbering, which is the shape a
+	// caller reaches for when it does not know which side of the shift it is
+	// on.
+	// @ts-expect-error `Tab.anchorLine` is a RendererLine; `toRendererLine` wants a BufferLine
+	coords.toRendererLine(tab.anchorLine);
+
+	// Then the write. This one is last because it does go through at run time:
+	// a Monaco line stored as the reading position, which is what sends the
+	// preview restore the height of the front matter too far down the
+	// document. Before the brand it compiled.
+	// @ts-expect-error a BufferLine is not assignable to `Tab.anchorLine`
+	tab.anchorLine = coords.toBufferLine(tab.anchorLine);
+});
+
+test('branding both sides of a snapshot changes none of its bytes', () => {
+	reset();
+	const tab = openScrolledTab('/notes/a.md');
+
+	// The brand is phantom, so it cannot survive JSON and nothing on the wire
+	// should have moved. Both persisted forms are checked, because both were
+	// re-declared on the way back in: the cross-window transfer payload, and
+	// the window-state snapshot in localStorage.
+	const wire = JSON.stringify(snapshotTab(tab));
+	assert.equal(JSON.parse(wire).anchorLine, 812);
+
+	const arrived = validateTransferPayload(wire);
+	assert.ok(arrived, 'a snapshot of a real tab must validate');
+	assert.equal(arrived.anchorLine, 812);
+
+	tabManager.restoreState(tabManager.serializeState());
+	assert.equal(tabManager.tabs.find((item) => item.path === '/notes/a.md')?.anchorLine, 812);
 });

--- a/scripts/tabTransfer.test.ts
+++ b/scripts/tabTransfer.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import { readSource, sliceBetween } from './sourceTree.js';
 
 import type { Tab } from '../src/lib/stores/tabs.svelte.js';
+import { asRendererLine } from '../src/lib/utils/lineCoordinates.js';
 import {
 	buildTransferredTab,
 	snapshotTab,
@@ -34,7 +35,7 @@ function makeTab(overrides: Partial<Tab> = {}): Tab {
 		historyIndex: 1,
 		editorViewState: { cursorState: 'monaco-live-object' },
 		scrollPercentage: 0.42,
-		anchorLine: 7,
+		anchorLine: asRendererLine(7),
 		isSplit: true,
 		splitRatio: 0.3,
 		isScrollSynced: true,

--- a/scripts/undoHistoryPerTab.spec.ts
+++ b/scripts/undoHistoryPerTab.spec.ts
@@ -4,6 +4,7 @@ import { test } from 'vitest';
 
 import ts from 'typescript';
 
+import { asRendererLine } from '../src/lib/utils/lineCoordinates.js';
 import { callbackBodies, functionSource, readSource } from './sourceTree.js';
 
 /*
@@ -734,7 +735,7 @@ test('a tab moved to another window has its model disposed on the way out', () =
 			isScrollSynced: false,
 			scrollTop: 0,
 			scrollPercentage: 0,
-			anchorLine: 0,
+			anchorLine: asRendererLine(0),
 			hasReplacementChars: false,
 			encoding: 'UTF-8',
 			history: ['/docs/a.md'],

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -5,6 +5,7 @@ import { hasRealFilePath } from '../utils/tabFileActions.js';
 import { HOME_TAB_PATH, isHomePath } from '../utils/homeTab.js';
 import { buildTransferredTab, type TransferableTab } from '../utils/tabTransfer.js';
 import { canonicalizePath, isSameFilePath } from '../utils/pathIdentity.js';
+import { asRendererLine, type RendererLine } from '../utils/lineCoordinates.js';
 import { retainTabModels } from '../utils/tabModels.js';
 import {
 	canGoBackInHistory,
@@ -131,6 +132,15 @@ export interface Tab {
 	 * anything once the layout changes — a re-render, a fold, a resize, a swap
 	 * between the two panes. Reach for it first.
 	 *
+	 * A RENDERER line specifically, which is why it carries the brand. It is
+	 * written by `getPreviewScrollAnchor`, whose numbers come straight off
+	 * `data-sourcepos`, and read back by `findAnchorElement` against the same
+	 * attributes — both sides count from the first line of the BODY, not of the
+	 * file. Anything that wants to aim the EDITOR with it owes a
+	 * `lineCoordinates(raw).toBufferLine(...)` first, and the brand is what
+	 * makes forgetting that a type error instead of a document that opens the
+	 * height of its own front matter off (#607).
+	 *
 	 * `scrollPercentage` is a 0-1 fraction of the scrollable range. It survives
 	 * a container of some other height, but it drifts with the content: the
 	 * "rough percentage of the document instead of where you left off" that
@@ -152,7 +162,7 @@ export interface Tab {
 	 * them, and `editorViewState`, through `clearReadingPosition`.
 	 */
 	scrollPercentage: number;
-	anchorLine: number;
+	anchorLine: RendererLine;
 	isSplit: boolean;
 	splitRatio: number;
 	isScrollSynced: boolean;
@@ -404,7 +414,10 @@ class TabManager {
 					historyIndex: fileHistory.historyIndex,
 					editorViewState: null,
 					scrollPercentage: typeof saved.scrollPercentage === 'number' ? saved.scrollPercentage : 0,
-					anchorLine: typeof saved.anchorLine === 'number' ? saved.anchorLine : 0,
+					// The brand is phantom, so nothing of it survives JSON — which is
+					// exactly why the read side has to re-declare what came back.
+					// `serializeState` wrote a renderer line; this says so again.
+					anchorLine: asRendererLine(typeof saved.anchorLine === 'number' ? saved.anchorLine : 0),
 					isSplit: saved.isSplit === true,
 					splitRatio: typeof saved.splitRatio === 'number' ? saved.splitRatio : 0.5,
 					isScrollSynced: saved.isScrollSynced === true,
@@ -545,7 +558,7 @@ class TabManager {
 			historyIndex: fileHistory.historyIndex,
 			editorViewState: null,
 			scrollPercentage: 0,
-			anchorLine: 0,
+			anchorLine: asRendererLine(0),
 			isSplit: false,
 			splitRatio: 0.5,
 			isScrollSynced: false,
@@ -586,7 +599,7 @@ class TabManager {
 			historyIndex: 0,
 			editorViewState: null,
 			scrollPercentage: 0,
-			anchorLine: 0,
+			anchorLine: asRendererLine(0),
 			isSplit: false,
 			splitRatio: 0.5,
 			isScrollSynced: false,
@@ -623,7 +636,7 @@ class TabManager {
 			historyIndex: 0,
 			editorViewState: null,
 			scrollPercentage: 0,
-			anchorLine: 0,
+			anchorLine: asRendererLine(0),
 			isSplit: false,
 			splitRatio: 0.5,
 			isScrollSynced: false,
@@ -856,10 +869,28 @@ class TabManager {
 		}
 	}
 
+	/**
+	 * The one place a bare number becomes this tab's anchor.
+	 *
+	 * `line` is a plain `number` and not a `RendererLine`, which is the ONE
+	 * unbranded claim left on this field, and it is deliberate rather than an
+	 * oversight. Two components write here and they do not agree on what they
+	 * are writing: `MarkdownViewer.svelte` hands over `getPreviewScrollAnchor`,
+	 * a renderer line off `data-sourcepos`; `components/Editor.svelte` hands
+	 * over `ranges[0].startLineNumber + 2`, a MONACO line, which is a buffer
+	 * line. Branding this parameter turns that second call into the type error
+	 * it deserves to be — and there is no conversion to write there without
+	 * settling which of the two numberings the field is (it is the renderer's:
+	 * `findAnchorElement` reads it back against `data-sourcepos`).
+	 *
+	 * So the assertion sits here, where it is visible, instead of at four call
+	 * sites where it would not be. Whoever fixes the editor's half takes this
+	 * parameter to `RendererLine` and deletes this comment.
+	 */
 	updateTabAnchorLine(id: string, line: number) {
 		const tab = this.tabs.find((t) => t.id === id);
 		if (tab) {
-			tab.anchorLine = line;
+			tab.anchorLine = asRendererLine(line);
 		}
 	}
 
@@ -1036,7 +1067,7 @@ class TabManager {
 	 */
 	private clearReadingPosition(tab: Tab) {
 		tab.editorViewState = null;
-		tab.anchorLine = 0;
+		tab.anchorLine = asRendererLine(0);
 		tab.scrollPercentage = 0;
 		tab.scrollTop = 0;
 	}

--- a/src/lib/utils/tabTransfer.ts
+++ b/src/lib/utils/tabTransfer.ts
@@ -1,4 +1,5 @@
 import type { Tab } from '../stores/tabs.svelte.js';
+import { asRendererLine, type RendererLine } from './lineCoordinates.js';
 import { nextUntitledTitle } from './untitledTitle.js';
 
 /**
@@ -55,7 +56,15 @@ export interface TransferableTab {
 	splitRatio: number;
 	scrollTop: number;
 	scrollPercentage: number;
-	anchorLine: number;
+	/**
+	 * A renderer line, as on the tab it was snapshotted from — see
+	 * `Tab.anchorLine`. The brand is phantom, so the wire format is a plain
+	 * JSON number and unchanged; what it buys is that the destination window
+	 * cannot quietly rebuild the tab with the arriving number read as a buffer
+	 * line. `NUMBER_FIELDS` below still validates it as a number, which is all
+	 * the wire can be checked for.
+	 */
+	anchorLine: RendererLine;
 	historyIndex: number;
 	history: string[];
 }
@@ -146,7 +155,10 @@ export function validateTransferPayload(json: string): TransferableTab | null {
 		splitRatio: obj.splitRatio as number,
 		scrollTop: obj.scrollTop as number,
 		scrollPercentage: obj.scrollPercentage as number,
-		anchorLine: obj.anchorLine as number,
+		// The number survived JSON; the brand did not. Re-declared here rather
+		// than left to `as number`, so the deserialising side states which
+		// numbering it believes arrived instead of inheriting it by accident.
+		anchorLine: asRendererLine(obj.anchorLine as number),
 		historyIndex: obj.historyIndex as number,
 		history: [...history] as string[],
 	};


### PR DESCRIPTION
`#607` gave the two line spaces different types — `BufferLine` for the editor's numbering, `RendererLine` for `data-sourcepos` — and branded destinations rather than sources, so every crossing that skips a conversion is a compile error.

`tab.anchorLine` was left a plain `number`. It is a renderer line, and the restore path reads it through an unbranded `findAnchorElement`, so the distinction stopped at that hop.

### What changed

`Tab.anchorLine` and `TransferableTab.anchorLine` are `RendererLine`. `lineCoordinates.ts`, `previewAnchor.ts`, `MarkdownViewer.svelte` and `windowSession.svelte.ts` needed nothing — `getPreviewScrollAnchor` already returns a `RendererLine`, and `windowSession` only handles `TransferableTab` whole.

Both sides of the snapshot are typed, not just the write: `restoreState`'s `typeof saved.anchorLine === 'number'` and `validateTransferPayload`'s cast both go through `asRendererLine` now. A runtime test asserts the wire bytes are unchanged on both forms.

**`LineRange`, `findAnchorElement` and `getAnchorScrollTop` are untouched.** A `RendererLine` *is* a `number`, so it passes to all three unchanged — #607's decision to leave them alone and this change do not conflict. Eight existing fixtures needed `asRendererLine`, not the ~30 wrappers that decision was weighed against.

### What it surfaced, and did not fix

`updateTabAnchorLine`'s parameter had to stay a plain `number`, because **two panes write through it in different numberings**:

- `MarkdownViewer.svelte:1435` passes `getPreviewScrollAnchor(...)` — a renderer line. Correct.
- `Editor.svelte:793` passes `ranges[0].startLineNumber + 2` — a Monaco line, i.e. a **buffer line** — and `Editor.svelte:486` reads the field back through `revealLineNearTop`, which also wants a buffer line.

Each pane round-trips the field in its own numbering, so the cross-pane path is off by the front matter's height in both directions. That is exactly the defect class #607 exists to prevent, still live.

Branding the setter's parameter turns it into a compile error in `Editor.svelte` — which is being changed on another branch, so this leaves an assertion and a comment naming the site instead of a red diff. **The editor's write is a genuine bug and wants an owner for that file.**

### On the falsification

The brand is a compile-time property, so the test is two `@ts-expect-error` directives — one storing a buffer line in `anchorLine`, one passing it to `toRendererLine`. An *unused* directive is itself an error, so a green `npm run check` is the assertion. Deleting one gives 1 error; reverting the field to `number` gives 4.

`npm test` 874 (+2) · `npm run test:vitest` 303 · `npm run check` 785 files / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
