### PR TITLE
fix(session): turning off Restore State left the session file on disk

### DIFF
--- a/scripts/sessionRestoreResilience.spec.ts
+++ b/scripts/sessionRestoreResilience.spec.ts
@@ -97,6 +97,8 @@ const warnings: string[] = [];
 const errors: string[] = [];
 /** What the session asked the UI to tell the user, before any wording. */
 const notices: Array<{ deferredPath: string | null }> = [];
+/** The "Restore State on Reopen" setting, as the session sees it. */
+let restoreEnabled = true;
 
 function makeSession() {
 	return createWindowSession({
@@ -105,7 +107,7 @@ function makeSession() {
 		legacyStateKey: LEGACY_STATE_KEY,
 		restoreInProgressKey: RESTORE_IN_PROGRESS_KEY,
 		serializeState: () => tabManager.serializeState(),
-		shouldRestoreState: () => true,
+		shouldRestoreState: () => restoreEnabled,
 		isDisposed: () => false,
 		restoreState: (json) => tabManager.restoreState(json),
 		restoredTabs: () => tabManager.tabs.map((tab) => ({ id: tab.id, path: tab.path })),
@@ -146,6 +148,7 @@ function reset(paths: string[], contents: Record<string, string> = {}) {
 	unreadable = new Set();
 	onRead = () => {};
 	killsTheLaunch = () => false;
+	restoreEnabled = true;
 	died = false;
 	disk = new Map(paths.map((path) => [path, contents[path] ?? `# ${path}`]));
 	storedSnapshot = snapshotOf(paths);
@@ -550,4 +553,59 @@ test('a deferred document is released once Markpad has read it', async () => {
 	await session.persistState();
 
 	assert.equal(breadcrumb(), null, 'the deferral is not permanent');
+});
+
+// --- the localStorage era is over, and the switch that ended it still works ---
+//
+// The snapshot and the breadcrumb both moved to files on the Rust side; the
+// localStorage keys survive only as a read-once migration for a build that is
+// being upgraded over. Nothing writes them any more. That makes two things
+// worth locking down: the migration read still works, and every place that
+// used to erase the record by clearing localStorage still erases it.
+
+test('turning session restore off erases the record, as clearing localStorage used to', async () => {
+	reset(['/a.md', '/b.md']);
+	restoreEnabled = false;
+
+	await makeSession().restore();
+
+	assert.deepEqual(tabManager.tabs, [], 'nothing is restored');
+	// While the snapshot lived in localStorage this branch removed it, so
+	// switching the setting off ended the session for good. Once the snapshot
+	// moved to a file the same branch went on clearing keys nothing writes, and
+	// the list of every document the user had open stayed on disk indefinitely
+	// — including for the user who turned the setting off to stop that.
+	assert.equal(storedSnapshot, null, 'the file on the Rust side goes too');
+});
+
+test('a snapshot an older build left in localStorage is still restored, then migrated', async () => {
+	reset(['/a.md', '/b.md']);
+	// The world at first launch of a build that persists through Rust: the old
+	// key holds the session, the file does not exist yet. The entries carry the
+	// pre-v2 shape too — full tab records, an untitled entry, and the HOME
+	// sentinel — because that is what those users have.
+	storedSnapshot = null;
+	localStorage.setItem(
+		LEGACY_STATE_KEY,
+		JSON.stringify({
+			activeTabId: 'tab-0',
+			tabs: [
+				{ id: 'tab-0', path: '/a.md', title: 'a.md', content: '<h1>a</h1>', rawContent: '# a' },
+				{ id: 'tab-1', path: '', title: 'Untitled', content: '', rawContent: '' },
+				{ id: 'tab-2', path: 'HOME', title: 'Home' },
+				{ id: 'tab-3', path: '/b.md', title: 'b.md', content: '<h1>b</h1>', rawContent: '# b' },
+			],
+		}),
+	);
+
+	await makeSession().restore();
+
+	assert.deepEqual(
+		tabManager.tabs.map((tab) => tab.path),
+		['/a.md', '/b.md'],
+		'the documents come back; the untitled and HOME entries are not files',
+	);
+	assert.deepEqual(readsOf(), ['/a.md', '/b.md'], 'and their content is read from disk, not from the stale copy');
+	assert.deepEqual(persistedPaths(), ['/a.md', '/b.md'], 'the session is now on the Rust side');
+	assert.equal(localStorage.getItem(LEGACY_STATE_KEY), null, 'and the old key is not read a second time');
 });

--- a/src/lib/sessions/windowSession.svelte.ts
+++ b/src/lib/sessions/windowSession.svelte.ts
@@ -188,8 +188,14 @@ export function createWindowSession(options: WindowSessionOptions) {
 	async function restore() {
 		if (!options.isMainWindow || options.isDisposed()) return;
 		if (!options.shouldRestoreState()) {
-			localStorage.removeItem(options.windowStateKey);
-			localStorage.removeItem(options.legacyStateKey);
+			// Through `discardPersistedState`, because the snapshot is a file on
+			// the Rust side now. This branch is what makes turning the setting off
+			// end the session, and while the snapshot lived in localStorage the two
+			// `removeItem` calls did exactly that. Once it moved they went on
+			// clearing keys nothing writes any more, and the list of every document
+			// the user had open stayed on disk — for the user who switched the
+			// setting off to stop it being kept.
+			await discardPersistedState();
 			// Nothing will be restored, so there is nothing for a breadcrumb to
 			// say about the next launch.
 			await writeProgress({ running: false, pending: null, deferred: [], interruptions: 0 });


### PR DESCRIPTION
The todo asked to finish a migration `windowSession.svelte.ts:98-112` describes as unfinished. It isn't — that comment describes the *endpoint*, and the endpoint is reached. But auditing it turned up something the migration did leave behind.

### The bug

`restore()`'s `!shouldRestoreState()` branch is what makes the **"Restore State on Reopen"** setting take effect. While the snapshot lived in localStorage, its two `removeItem` calls ended the session and its record together.

The snapshot moved to a file on the Rust side in #214. The branch was not updated. It now clears two keys **nothing writes** and leaves `window-state-v2.json` on disk — so the list of every document the user had open persists in the config directory indefinitely, for exactly the user who turned the setting off to stop it being kept. Nothing rewrites the file while the setting is off, so a later launch can also resurrect a stale session.

Fix is the existing `discardPersistedState()`, which already clears both stores. Net +1 line of code. Test written first against master's behaviour, confirmed failing.

Two things had to hold before adding a destructive call to a startup path, and both do: `settings.restoreStateOnReopen` is loaded synchronously in the `SettingsStore` constructor, before `MarkdownViewer.init` runs, so there is no async window where it reads as its default; and `restore()` returns on `!isMainWindow` above this branch, so secondary windows cannot reach it.

### On the two localStorage keys

Every occurrence in production code is `getItem` or `removeItem` — zero `setItem`. Both are compat reads for a user upgrading over a pre-#214 (snapshot) or pre-#501 (breadcrumb) build.

**Kept, not deleted.** They cost four lines and buy that user a clean upgrade; deleting them silently drops their tabs. Added a test that drives the path end to end — pre-v2 records, an untitled entry, a `HOME` sentinel — so the compat path is asserted rather than assumed. Falsified by stubbing the legacy read to `null`.

### Why this data is on the Rust side at all

Worth recording, because #638's rule does not decide it. Rust does not *read* either file — `load_window_state` and `load_restore_progress` are `read_to_string` handing bytes to the frontend unparsed. By #638's ownership test ("Rust owns it because Rust reads it", as with `pinned_tags`) this is not Rust's data.

It is there for a different and correct reason: `setItem` is an async message to the WebKit storage process, and both records exist specifically to survive the event that loses that message — the last window closing, or the process being killed. That is **durability, not ownership** — a third category neither precedent covers.

`npm test` 872 · `vitest` 305 · `cargo test` 148 · `check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
