### PR TITLE
test: close the last three harness gaps left by the vitest migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,8 +227,13 @@ Of the other two:
   `globalThis.document` — under vitest that replaces jsdom's. Its anchor harness was
   rewritten onto the real DOM (`tabReadingPosition.spec.ts`), which it could be because
   `findAnchorElement` reads structure and attributes and measures nothing.
-- `checkedReadMigration.test.ts` is mostly the two never-migrate categories: that an
-  unchecked command exists nowhere in `src` *or* in the Rust crate.
+- `checkedReadMigration.test.ts` was two files in one, which is why neither answer fit
+  it. Six of its tests are the never-migrate categories — an unchecked command existing
+  nowhere in `src` *or* in the Rust crate, and four statement-order claims about a
+  `.svelte` component — and stayed. The three that drive `ensureFullContent` are a runes
+  module run for real, and are `checkedReadMigration.spec.ts` now. A file that shims
+  runes is worth opening before it is worth renaming: the split may be per test rather
+  than per file.
 
 ### A real DOM is not a layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,15 +215,31 @@ unchanged. Two things bite:
   answer, so a bare `invoke: () => Promise.resolve(null)` leaves `osType` null and the
   font defaults it indexes undefined.
 
-Three of the shimmed files were left where they are, because a rename does not reach what
-is wrong with them:
+One shimmed file is still where it is, because a rename does not reach what is wrong
+with it:
 
 - `foldStatePerDocument.test.ts` cuts functions out of `.svelte` files with its own
   brace-pairing scanner. The logic has to move into a `.svelte.ts` module first.
-- `tabReadingPosition.test.ts` calls `installShimDom()`, which assigns `globalThis.document`
-  — under vitest that replaces jsdom's. Its harness has to move to the real DOM first.
+
+Of the other two:
+
+- `tabReadingPosition.test.ts` called `installShimDom()`, which assigns
+  `globalThis.document` — under vitest that replaces jsdom's. Its anchor harness was
+  rewritten onto the real DOM (`tabReadingPosition.spec.ts`), which it could be because
+  `findAnchorElement` reads structure and attributes and measures nothing.
 - `checkedReadMigration.test.ts` is mostly the two never-migrate categories: that an
   unchecked command exists nowhere in `src` *or* in the Rust crate.
+
+### A real DOM is not a layout
+
+jsdom implements the DOM, not CSS layout: `offsetTop`, `offsetHeight` and every
+`getBoundingClientRect()` are 0. So migrating a file buys real answers about structure,
+attributes, traversal and parsing, and buys nothing at all about geometry. A test whose
+subject is a position on screen has to construct the boxes either way —
+`scrollSyncAcrossFolds.test.ts` lays a document out with collapsed folds in it, and
+`anchorJumpUnderZoom.spec.ts` builds elements whose rects carry a zoom factor while their
+`offsetWidth` does not. Neither is worse for being under `node --test` or better for being
+under vitest; the geometry is the fixture.
 
 ### Anything a test constructs inside an effect root must be torn down
 

--- a/scripts/checkedReadMigration.spec.ts
+++ b/scripts/checkedReadMigration.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * The behavioural half of `checkedReadMigration.test.ts`: `ensureFullContent`,
+ * driven for real.
+ *
+ * #379 made every read that fills a WRITABLE buffer report whether the decode
+ * was lossy, so the tab can refuse to write U+FFFD back over a file that was
+ * merely in another encoding. Three reads kept the bare command:
+ * `ensureFullContent`, and the two in MarkdownViewer that fill the editor and
+ * the split pane. They were safe — but only because each re-read a file whose
+ * tab `loadMarkdown` had already flagged. That is an invariant held by call
+ * sites agreeing with each other, and the failure mode when one stops agreeing
+ * is a destroyed document. It is now held by the code: every one of them reads
+ * the fidelity itself.
+ *
+ * These three tests are here rather than in the `.test.ts` because they run the
+ * store and the session, and both are runes modules. Under `node --test` they
+ * only ran at all because the file installed `$state`/`$derived`/`$effect` onto
+ * `globalThis` itself, and a hand-written rune is not the compiler's: no deep
+ * proxying, no `$derived` laziness, and `$effect` never re-runs. `tab.isTruncated`
+ * and `tab.hasReplacementChars` are read straight back out of the store here,
+ * so the shim was standing exactly where the assertions look.
+ *
+ * The six that stayed behind are the two never-migrate categories: that the
+ * unchecked command exists nowhere in `src` and is gone from the Rust crate,
+ * and the four `.svelte` source-shape assertions about the component call
+ * sites. Nothing this file could run would observe any of them.
+ */
+
+import assert from 'node:assert/strict';
+
+import { test } from 'vitest';
+
+const PARTIAL = 'first half';
+const FULL = 'first half and the rest';
+
+/** Set per test. `get_os_type` is the settings store booting on import. */
+let handleInvoke: (cmd: string, args: Record<string, unknown>) => unknown = (cmd) => {
+	if (cmd === 'get_os_type') return 'macos';
+	throw new Error(`unexpected invoke: ${cmd}`);
+};
+const errors: string[] = [];
+
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin. Only the Tauri backend, which jsdom cannot provide, is stubbed.
+(window as any).__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (command: string, args: Record<string, unknown>) =>
+		Promise.resolve(handleInvoke(command.replace(/^plugin:[^|]*\|/, ''), args ?? {})),
+	transformCallback: (fn: unknown) => fn,
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
+
+function makeSession() {
+	return createDocumentSession({
+		setShowHome: () => {},
+		currentFile: () => tabManager.activeTab?.path ?? '',
+		resetScrollHistory: () => {},
+		renderMarkdown: async () => '<p>x</p>',
+		afterLoad: async () => {},
+		saveRecentFile: () => {},
+		deleteRecentFile: () => {},
+		setLoadingTabs: () => {},
+		measureInitialViewport: () => {},
+		isScrolling: () => false,
+		renderRichContent: () => {},
+		onError: (message) => errors.push(message),
+		selfWriteGraceMs: 400,
+		cancelPendingAutoSave: () => {},
+		askClose: async () => 'discard' as const,
+		onCloseSaveNewerEdits: () => {},
+		onCloseAutoSaveFailed: () => {},
+		onPartialCopySaved: () => {},
+	});
+}
+
+/** Open a >50KB file and leave the background full read pending forever. */
+async function openPartial() {
+	tabManager.closeAll();
+	errors.length = 0;
+	handleInvoke = (cmd) => {
+		if (cmd === 'open_markdown_preview') return ['<p>preview</p>', PARTIAL, false, false];
+		if (cmd === 'read_file_content_checked') return new Promise(() => {});
+		throw new Error(`unexpected invoke: ${cmd}`);
+	};
+	const session = makeSession();
+	await session.loadMarkdown('/docs/big.md');
+	const tab = tabManager.activeTab!;
+	assert.equal(tab.isTruncated, true, 'precondition: the buffer is partial');
+	assert.equal(tab.hasReplacementChars, false, 'precondition: the preview decoded cleanly');
+	return { session, tab };
+}
+
+test("completing a partial buffer carries the tail's own verdict", async () => {
+	// The case the old comment called safe: the preview covered the first 50KB
+	// and decoded cleanly, but a file can be valid UTF-8 up to there and not
+	// after. With the bare command the tab kept the preview's verdict and the
+	// next auto-save wrote U+FFFD over the file.
+	const { session, tab } = await openPartial();
+
+	handleInvoke = (cmd) => {
+		if (cmd === 'read_file_content_checked') return [FULL, true];
+		throw new Error(`unexpected invoke: ${cmd}`);
+	};
+
+	assert.equal(await session.ensureFullContent(tab.id), true);
+	assert.equal(tab.rawContent, FULL);
+	assert.equal(tab.hasReplacementChars, true, 'the completed buffer must carry its own fidelity');
+});
+
+test('completing a clean tail also clears a stale flag', async () => {
+	// The same mechanism in the other direction: a verdict that is decided on
+	// every read cannot go stale.
+	const { session, tab } = await openPartial();
+	tabManager.setTabDecodedLossy(tab.id, true);
+
+	handleInvoke = (cmd) => {
+		if (cmd === 'read_file_content_checked') return [FULL, false];
+		throw new Error(`unexpected invoke: ${cmd}`);
+	};
+
+	assert.equal(await session.ensureFullContent(tab.id), true);
+	assert.equal(tab.hasReplacementChars, false);
+});
+
+test('the completed buffer is refused or accepted according to that verdict', async () => {
+	// End to end: the flag is not decoration, it decides the write.
+	const { session, tab } = await openPartial();
+	handleInvoke = (cmd) => {
+		if (cmd === 'read_file_content_checked') return [FULL, true];
+		if (cmd === 'save_file_content') return null;
+		throw new Error(`unexpected invoke: ${cmd}`);
+	};
+	await session.ensureFullContent(tab.id);
+
+	assert.equal(await session.saveContent(tab.id), false, 'a lossy buffer must not overwrite its file');
+	assert.equal(session.isLossySaveRefused(tab.id), true);
+	assert.ok(errors.length > 0, 'and the user is told once');
+});

--- a/scripts/checkedReadMigration.test.ts
+++ b/scripts/checkedReadMigration.test.ts
@@ -3,27 +3,6 @@ import test from 'node:test';
 
 import { offsetOf, readRustBackend, readSource, readSourceFiles, sliceBetween } from './sourceTree.js';
 
-// Runes and the Tauri bridge, shimmed the way truncatedBufferGuard.test.ts
-// shims them: the stores are runes modules, and Node's test runner gives every
-// file its own process, so this cannot leak into another suite.
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
-Object.defineProperty(g, 'navigator', { value: { language: 'en-US' }, configurable: true });
-Object.defineProperty(g, 'localStorage', {
-	value: { getItem: () => null, setItem: () => {}, removeItem: () => {}, clear: () => {} },
-	configurable: true,
-});
-
 /*
  * #379 made every read that fills a WRITABLE buffer report whether the decode
  * was lossy, so the tab can refuse to write U+FFFD back over a file that was
@@ -35,120 +14,31 @@ Object.defineProperty(g, 'localStorage', {
  * is a destroyed document. It is now held by the code: every one of them reads
  * the fidelity itself.
  *
- * `ensureFullContent` is exercised for real below. The two MarkdownViewer sites
- * are in a Svelte component and are asserted against its source: those tests
- * establish that the checked command is called and its verdict stored, not that
- * the store then behaves — `lossyDecodeSaveGuard.test.ts` covers that.
+ * WHAT IS LEFT IN THIS FILE, AND WHY IT IS HERE RATHER THAN UNDER VITEST
+ *
+ * Every assertion below reads source text, and each one is of a kind no run can
+ * reach:
+ *
+ *   - that the unchecked command exists NOWHERE. An absence is not observable
+ *     at run time: executing the checked read cannot prove there is no other
+ *     caller of the unchecked one. The same claim then crosses into the Rust
+ *     crate, where nothing but the spelling connects the two sides.
+ *   - the two MarkdownViewer call sites, and the two auto-save ones. They are
+ *     in a `.svelte` component, and mounting one here would put jsdom in for
+ *     Monaco, mermaid and KaTeX to earn a weaker claim than the text does —
+ *     what these pin is the ORDER of statements inside a handler (flag the tab
+ *     before the buffer is published; recognise the refusal before raising the
+ *     generic toast), which is a property of the code as written.
+ *
+ * `ensureFullContent` is not here: it is a runes module driven for real, and
+ * running it under a hand-written `$state` was standing exactly where the
+ * assertions look. It is `checkedReadMigration.spec.ts` now. `lossyDecodeSaveGuard.test.ts`
+ * and `lossySaveRefusalScope.spec.ts` cover the store behaviour these source
+ * assertions deliberately stop short of.
  *
  * The second half of this file is the toast the guard's refusal used to
  * trigger every 1.5 seconds.
  */
-
-const PARTIAL = 'first half';
-const FULL = 'first half and the rest';
-
-/** Set per test. `get_os_type` is the settings store booting on import. */
-let handleInvoke: (cmd: string, args: Record<string, unknown>) => unknown = (cmd) => {
-	if (cmd === 'get_os_type') return 'macos';
-	throw new Error(`unexpected invoke: ${cmd}`);
-};
-const errors: string[] = [];
-
-g.window.__TAURI_INTERNALS__ = {
-	invoke: (command: string, args: Record<string, unknown>) =>
-		Promise.resolve(handleInvoke(command.replace(/^plugin:[^|]*\|/, ''), args ?? {})),
-	transformCallback: (fn: unknown) => fn,
-};
-
-const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
-const { createDocumentSession } = await import('../src/lib/sessions/documentSession.svelte.js');
-
-function makeSession() {
-	return createDocumentSession({
-		setShowHome: () => {},
-		currentFile: () => tabManager.activeTab?.path ?? '',
-		resetScrollHistory: () => {},
-		renderMarkdown: async () => '<p>x</p>',
-		afterLoad: async () => {},
-		saveRecentFile: () => {},
-		deleteRecentFile: () => {},
-		setLoadingTabs: () => {},
-		measureInitialViewport: () => {},
-		isScrolling: () => false,
-		renderRichContent: () => {},
-		onError: (message) => errors.push(message),
-		selfWriteGraceMs: 400,
-		cancelPendingAutoSave: () => {},
-		askClose: async () => 'discard' as const,
-		onCloseSaveNewerEdits: () => {},
-		onCloseAutoSaveFailed: () => {},
-		onPartialCopySaved: () => {},
-	});
-}
-
-/** Open a >50KB file and leave the background full read pending forever. */
-async function openPartial() {
-	tabManager.closeAll();
-	errors.length = 0;
-	handleInvoke = (cmd) => {
-		if (cmd === 'open_markdown_preview') return ['<p>preview</p>', PARTIAL, false, false];
-		if (cmd === 'read_file_content_checked') return new Promise(() => {});
-		throw new Error(`unexpected invoke: ${cmd}`);
-	};
-	const session = makeSession();
-	await session.loadMarkdown('/docs/big.md');
-	const tab = tabManager.activeTab!;
-	assert.equal(tab.isTruncated, true, 'precondition: the buffer is partial');
-	assert.equal(tab.hasReplacementChars, false, 'precondition: the preview decoded cleanly');
-	return { session, tab };
-}
-
-test('completing a partial buffer carries the tail\'s own verdict', async () => {
-	// The case the old comment called safe: the preview covered the first 50KB
-	// and decoded cleanly, but a file can be valid UTF-8 up to there and not
-	// after. With the bare command the tab kept the preview's verdict and the
-	// next auto-save wrote U+FFFD over the file.
-	const { session, tab } = await openPartial();
-
-	handleInvoke = (cmd) => {
-		if (cmd === 'read_file_content_checked') return [FULL, true];
-		throw new Error(`unexpected invoke: ${cmd}`);
-	};
-
-	assert.equal(await session.ensureFullContent(tab.id), true);
-	assert.equal(tab.rawContent, FULL);
-	assert.equal(tab.hasReplacementChars, true, 'the completed buffer must carry its own fidelity');
-});
-
-test('completing a clean tail also clears a stale flag', async () => {
-	// The same mechanism in the other direction: a verdict that is decided on
-	// every read cannot go stale.
-	const { session, tab } = await openPartial();
-	tabManager.setTabDecodedLossy(tab.id, true);
-
-	handleInvoke = (cmd) => {
-		if (cmd === 'read_file_content_checked') return [FULL, false];
-		throw new Error(`unexpected invoke: ${cmd}`);
-	};
-
-	assert.equal(await session.ensureFullContent(tab.id), true);
-	assert.equal(tab.hasReplacementChars, false);
-});
-
-test('the completed buffer is refused or accepted according to that verdict', async () => {
-	// End to end: the flag is not decoration, it decides the write.
-	const { session, tab } = await openPartial();
-	handleInvoke = (cmd) => {
-		if (cmd === 'read_file_content_checked') return [FULL, true];
-		if (cmd === 'save_file_content') return null;
-		throw new Error(`unexpected invoke: ${cmd}`);
-	};
-	await session.ensureFullContent(tab.id);
-
-	assert.equal(await session.saveContent(tab.id), false, 'a lossy buffer must not overwrite its file');
-	assert.equal(session.isLossySaveRefused(tab.id), true);
-	assert.ok(errors.length > 0, 'and the user is told once');
-});
 
 // --- the two component call sites -------------------------------------------
 

--- a/scripts/previewSanitize.spec.ts
+++ b/scripts/previewSanitize.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * What the shared sanitizer actually does to an author stylesheet — run, not
+ * described.
+ *
+ * `previewSanitize.test.ts` pins the WIRING: that the preview reaches the
+ * shared policy, that the policy forbids `<style>`, that no second DOMPurify
+ * call site assembles a config of its own. None of that runs DOMPurify, because
+ * DOMPurify needs a real DOM and `node --test` has none. The behavioural half
+ * therefore used to be a table of numbers measured by hand in a browser and
+ * pasted into a comment — true when it was written and unfalsifiable ever
+ * after.
+ *
+ * jsdom has a real DOM and a real cascade, so it is a test now. The payload is
+ * the one that comment recorded, verbatim:
+ *
+ *     <style>.titlebar{display:none} body{background-image:url("…/beacon")}</style>
+ *
+ * and the observable is the same one: the preview injects `tab.content` into
+ * the APPLICATION'S OWN document, so a stylesheet that survives the filter is
+ * not scoped to the article — it restyles Markpad. `.titlebar` is a real
+ * element of the app's chrome, and `getComputedStyle` is what answers whether
+ * the document author moved it.
+ *
+ * The `background-image` half is the beacon: in a browser the computed value
+ * being a URL is followed by a request for it (the comment recorded the entry
+ * in `performance.getEntriesByType('resource')`, and the shipped CSP allows it
+ * — `img-src … https:`). jsdom does not fetch it. The computed value is the
+ * part that is a property of the sanitizer rather than of the network stack,
+ * and it is the part asserted here.
+ *
+ * WHY THE "BEFORE" ROW IS ASSERTED TOO: without it "the `<style>` is gone"
+ * proves nothing about the policy — an unrelated change that dropped every
+ * `<style>` on any config would keep it green. The old config is DOMPurify's
+ * default plus the URI pattern the viewer had hand-copied, which is exactly the
+ * shape the regression had, and under it the payload still works. That is the
+ * difference the policy makes.
+ */
+
+import assert from 'node:assert/strict';
+
+import DOMPurify from 'dompurify';
+import { afterEach, test } from 'vitest';
+
+import { sanitizeMarkdownHtml, ALLOWED_MARKDOWN_URI_REGEXP } from '../src/lib/utils/sanitize.js';
+
+/** The document author's payload, as it arrives from comrak (`render.unsafe_ = true`). */
+const POC_STYLE = '<style>.titlebar{display:none} body{background-image:url("https://attacker.example/beacon")}</style>';
+
+/**
+ * A rendered document carrying it.
+ *
+ * The leading paragraph is not decoration. DOMPurify serializes its parse
+ * tree's `<body>`, and the HTML parser puts a `<style>` that opens a fragment
+ * into `<head>` instead — so a payload-only string comes back empty on ANY
+ * config, and the two rows below would agree for a reason that has nothing to
+ * do with the policy. Every real rendered document has prose before the raw
+ * HTML in it.
+ */
+const RENDERED = `<p>An ordinary paragraph of prose.</p>\n${POC_STYLE}`;
+
+/** The config the viewer used to build at its own call site: the URI pattern, and nothing else. */
+const VIEWER_LOCAL_CONFIG = { ALLOWED_URI_REGEXP: ALLOWED_MARKDOWN_URI_REGEXP };
+
+/**
+ * The app's own document, with the chrome the payload aims at.
+ *
+ * No inline `style` on the titlebar: an inline declaration outranks a class
+ * selector, which would make the "before" row look safe for the wrong reason.
+ * The app's own rule is a stylesheet rule, so the test's is too.
+ */
+function mountApp(): { titlebar: Element; preview: HTMLElement } {
+	document.head.innerHTML = '<style>.titlebar{display:flex} body{background-image:none}</style>';
+	document.body.innerHTML = '<div class="titlebar"></div><div class="markdown-body"></div>';
+	return {
+		titlebar: document.querySelector('.titlebar')!,
+		preview: document.querySelector<HTMLElement>('.markdown-body')!,
+	};
+}
+
+afterEach(() => {
+	document.head.innerHTML = '';
+	document.body.innerHTML = '';
+});
+
+test('the config the preview used to build lets a document restyle the application', () => {
+	const { titlebar, preview } = mountApp();
+	assert.equal(getComputedStyle(titlebar).display, 'flex', 'precondition: the app decides where its chrome is');
+
+	const sanitized = DOMPurify.sanitize(RENDERED, VIEWER_LOCAL_CONFIG);
+	assert.match(sanitized, /<style>/, 'the old config keeps the author stylesheet — that is the regression');
+
+	preview.innerHTML = sanitized;
+
+	assert.equal(getComputedStyle(titlebar).display, 'none', "the document hid the app's title bar");
+	assert.equal(
+		getComputedStyle(document.body).backgroundImage,
+		'url("https://attacker.example/beacon")',
+		'and pointed the app at an outbound URL',
+	);
+});
+
+test('the shared policy drops the stylesheet and leaves the application alone', () => {
+	const { titlebar, preview } = mountApp();
+
+	const sanitized = sanitizeMarkdownHtml(RENDERED);
+	assert.doesNotMatch(sanitized, /<style/i, 'the shared policy forbids the tag');
+	assert.match(sanitized, /<p>An ordinary paragraph of prose\.<\/p>/, 'and keeps the document itself');
+
+	preview.innerHTML = sanitized;
+
+	assert.equal(getComputedStyle(titlebar).display, 'flex');
+	assert.equal(getComputedStyle(document.body).backgroundImage, 'none');
+});
+
+test('the inline style attribute is still allowed, because documents use it', () => {
+	// The other half of the policy decision, and the reason it is `FORBID_TAGS`
+	// rather than "strip everything that styles": an inline declaration is scoped
+	// to the one element the author wrote it on, so `<img style="width:50%">`
+	// keeps working. Run rather than read: `FORBID_ATTR: ['style']` would pass
+	// every assertion in the test above and silently break existing files.
+	const { preview } = mountApp();
+
+	preview.innerHTML = sanitizeMarkdownHtml('<p style="text-align:center">centred</p>');
+
+	const paragraph = preview.querySelector('p')!;
+	assert.equal(getComputedStyle(paragraph).textAlign, 'center');
+});

--- a/scripts/previewSanitize.test.ts
+++ b/scripts/previewSanitize.test.ts
@@ -13,32 +13,25 @@ import { SANITIZER_FILES, callSiteOffsets, enclosingFunctionName, filesMatching,
 // allowlist with its CSS unfiltered.
 //
 // DOMPurify needs a real DOM, which the Node test runner does not have, so the
-// behavioural half was measured against the pinned build (dompurify 3.4.12,
-// `dist/purify.js`) in a real browser, with the payload below injected exactly
-// the way `{@html}` injects it, into a document that also contained a
-// `.titlebar` element:
+// behavioural half of this file was for a while a table of numbers measured by
+// hand in a browser and pasted into this comment — the payload injected the way
+// `{@html}` injects it, the `<style>` surviving the old config and hiding the
+// app's `.titlebar`, the beacon showing up in
+// `performance.getEntriesByType('resource')`. All true when it was written, and
+// unfalsifiable ever after: no change to `src/` could disagree with a comment.
 //
-//   config                                     output          .titlebar        body background-image
-//   {ALLOWED_URI_REGEXP}        (before)        <style> kept    display: none    url("https://attacker.example/beacon")
-//   MARKDOWN_SANITIZE_CONFIG    (after)         <style> gone    display: flex    none
+// It runs now. `previewSanitize.spec.ts` is the same payload against the same
+// two configs under jsdom, which has a real DOM and a real cascade, asserting
+// what `getComputedStyle` says about the application's own chrome afterwards.
+// (The one thing it cannot observe is the request for the beacon URL, which
+// jsdom does not issue; the computed value that names it is asserted instead.
+// In the app both halves are permitted by the shipped CSP — `style-src 'self'
+// 'unsafe-inline' …` and `img-src 'self' asset: https: …`, in
+// src-tauri/tauri.conf.json.)
 //
-// The beacon was not hypothetical: `performance.getEntriesByType('resource')`
-// listed `https://attacker.example/beacon` after the injection. In the app both
-// halves are permitted by the shipped CSP — `style-src 'self' 'unsafe-inline' …`
-// and `img-src 'self' asset: https: …` (src-tauri/tauri.conf.json).
-//
-// The payload was, verbatim:
-//
-//   <style>.titlebar{display:none} body{background-image:url("https://attacker.example/beacon")}</style>
-//
-// It used to be a `POC_STYLE` constant with an `assert.match(POC_STYLE,
-// /^<style>/)` under it. That assertion read as part of the chain below but had
-// no end in `src/`: both sides were this file, one line apart, so no change to
-// the application could ever fail it. The payload is documentation, so it is
-// documentation now.
-//
-// What is checkable here is the wiring that decides which config the preview
-// gets, and that is what these tests pin.
+// What is checkable HERE is the wiring that decides which config the preview
+// gets, and that is what these tests pin. It is the half a runtime test cannot
+// reach: which call sites exist, and which of them build a policy of their own.
 
 const SOURCES = readSourceFiles('src');
 const viewerSource = readSource('src/lib/MarkdownViewer.svelte');

--- a/scripts/tabReadingPosition.spec.ts
+++ b/scripts/tabReadingPosition.spec.ts
@@ -23,54 +23,59 @@
  *     rate: how often a line number carried over from document A resolves to
  *     some unrelated block of document B, so the cascade stops there and the
  *     later entries are never consulted.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THIS IS A `.spec.ts`
+ *
+ * It used to call `installShimDom()` from `renderProtocolDom.ts` and hand-write
+ * the runes onto `globalThis`. Both are stand-ins, and under vitest both are
+ * worse than what the environment already has: the shim ASSIGNS
+ * `globalThis.document`, so it would replace jsdom's, and a hand-written
+ * `$state` is not the compiler's — no deep proxying, and `$effect` never
+ * re-runs. Every one of them is gone. `TabManager` is built by the Svelte
+ * compiler and the document is jsdom's, so `DOMParser`, the HTML parser it
+ * feeds, and `processMarkdownHtml`'s own DOM surgery are all the real ones.
+ *
+ * WHAT THE REAL DOM DOES AND DOES NOT SETTLE
+ *
+ * `findAnchorElement` is a walk over `data-sourcepos` ranges, `classList` and
+ * `childNodes` — structure and attributes, every one of which jsdom answers
+ * for real. It never measures anything, so nothing below needs a layout.
+ *
+ * jsdom has no layout: `offsetTop`, `offsetHeight` and every rect are 0. So the
+ * question of WHERE a resolved anchor lands — `getAnchorScrollTop`, the
+ * offset->line mapping, a collapsed fold's zero height — cannot be asked here
+ * and is not asked here. Those tests supply their own geometry on purpose
+ * (`scrollSyncAcrossFolds.test.ts` lays the document out with folds in it,
+ * `anchorJumpUnderZoom.spec.ts` builds elements whose rects carry a zoom
+ * factor). "It resolves" is a real answer; "it lands at 1420px" would not be.
  */
 
 import assert from 'node:assert/strict';
-import test from 'node:test';
 
-import { installShimDom, parseHtml, type ShimElement } from './renderProtocolDom.ts';
+import { test } from 'vitest';
 
-// ---------------------------------------------------------------- environment
-
-const g = globalThis as any;
-const runeEffect = (fn: () => void) => {
-	void fn;
-};
-runeEffect.root = (fn: () => unknown) => fn();
-g.$state = (value: unknown) => value;
-g.$state.raw = (value: unknown) => value;
-g.$state.snapshot = (value: unknown) => value;
-g.$derived = (value: unknown) => value;
-g.$derived.by = (fn: () => unknown) => fn();
-g.$effect = runeEffect;
-g.window = g.window ?? {};
-g.window.__TAURI_INTERNALS__ = g.window.__TAURI_INTERNALS__ ?? {
+// The runes are the compiler's, not ours: vitest builds `.svelte.ts` through the
+// Svelte plugin. Only the Tauri backend, which jsdom cannot provide, is stubbed
+// — `get_os_type` because importing the store boots the settings singleton, and
+// a `null` answer to that one leaves the font defaults it indexes undefined.
+(window as any).__TAURI_INTERNALS__ = {
 	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
 	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
 };
 
-const localStore = new Map<string, string>();
-g.localStorage = g.localStorage ?? {
-	getItem: (key: string) => (localStore.has(key) ? localStore.get(key)! : null),
-	setItem: (key: string, value: string) => void localStore.set(key, String(value)),
-	removeItem: (key: string) => void localStore.delete(key),
-	clear: () => localStore.clear(),
-};
-
-installShimDom();
-
 const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
-const { processMarkdownHtml } = await import('../src/lib/utils/markdown.ts');
-const { findAnchorElement } = await import('../src/lib/utils/previewAnchor.ts');
-const { asRendererLine, lineCoordinates } = await import('../src/lib/utils/lineCoordinates.ts');
-const { snapshotTab, validateTransferPayload } = await import('../src/lib/utils/tabTransfer.ts');
+const { processMarkdownHtml } = await import('../src/lib/utils/markdown.js');
+const { findAnchorElement } = await import('../src/lib/utils/previewAnchor.js');
+const { asRendererLine, lineCoordinates } = await import('../src/lib/utils/lineCoordinates.js');
+const { snapshotTab, validateTransferPayload } = await import('../src/lib/utils/tabTransfer.js');
 
 type Tab = (typeof tabManager.tabs)[number];
 
 function reset() {
 	tabManager.closeAll();
 	tabManager.recentlyClosed.length = 0;
-	localStore.clear();
+	localStorage.clear();
 }
 
 /** A tab whose reader is a long way down a document, all four fields written. */
@@ -233,17 +238,34 @@ function buildDocument(name: string, sections: number, paragraphsPerSection: num
 const DOC_A = buildDocument('alpha', 60, 6);
 const DOC_B = buildDocument('beta', 40, 11);
 
-function render(doc: DocumentBuilder, path: string): ShimElement {
-	return parseHtml(processMarkdownHtml(doc.html(), path, new Set<string>())).body;
+/**
+ * The rendered article, in the element the restore actually walks: the preview
+ * hands `findAnchorElement` its `.markdown-body` container
+ * (`MarkdownViewer.svelte:1223`), which is the element the sanitized string was
+ * parsed into.
+ */
+function render(doc: DocumentBuilder, path: string): HTMLElement {
+	const body = document.createElement('div');
+	body.className = 'markdown-body';
+	body.innerHTML = processMarkdownHtml(doc.html(), path, new Set<string>());
+	return body;
 }
 
 const BODY_B = render(DOC_B, '/notes/b.md');
 
-function textOf(element: unknown): string {
-	return String((element as { textContent?: string }).textContent ?? '');
-}
+test('a line number carried over from the previous document resolves into this one', () => {
+	// The fixture is the real pipeline's output, so say what it produced: a
+	// document of nothing but headings and paragraphs is one where every block
+	// after the first heading is inside a `.foldable-content-wrapper` that
+	// carries no source range of its own, which is the shape the descent exists
+	// for.
+	const blocks = BODY_B.querySelectorAll('[data-sourcepos]').length;
+	assert.equal(blocks, 40 + 40 * 11, 'every block of document B is annotated');
+	assert.ok(
+		BODY_B.querySelectorAll('.foldable-content-wrapper:not([data-sourcepos])').length > 0,
+		'and the sections are wrapped in containers that are not',
+	);
 
-test('a line number carried over from the previous document resolves into this one', (t) => {
 	// Every source line the reader could have been parked on in document A.
 	const carried = DOC_A.lines;
 
@@ -253,26 +275,26 @@ test('a line number carried over from the previous document resolves into this o
 	}
 	const percent = Math.round((resolved / carried.length) * 1000) / 10;
 
-	t.diagnostic(`document A: ${carried.length} anchorable source lines`);
-	t.diagnostic(`document B: ${BODY_B.querySelectorAll('[data-sourcepos]').length} blocks with data-sourcepos`);
-	t.diagnostic(`carried anchors resolving inside document B: ${resolved}/${carried.length} (${percent}%)`);
-
 	// This is the mechanism, not a property of these two fixtures: while the
 	// carried line is inside the other document's range it resolves, the first
 	// cascade entry reports success, and `scrollPercentage` and `scrollTop` —
 	// the field the old `navigate()` reset — are never consulted.
 	assert.ok(
 		percent > 50,
-		`a stale anchor line is expected to resolve in a document of similar length, got ${percent}%`,
+		`a stale anchor line is expected to resolve in a document of similar length, ` +
+			`got ${resolved}/${carried.length} (${percent}%) over ${blocks} annotated blocks`,
 	);
 
 	// And it resolves to the wrong text: the block at that line in B, which
 	// says `beta`, has nothing to do with the block the reader left in A.
 	const sample = DOC_A.lines[Math.floor(DOC_A.lines.length / 2)];
-	const match = findAnchorElement(BODY_B, sample)!;
-	t.diagnostic(`line ${sample} of A resolves to B's ${textOf(match.element).trim().slice(0, 48)}`);
+	const match = findAnchorElement(BODY_B, sample);
 	assert.ok(match, `expected line ${sample} to resolve inside document B`);
-	assert.match(textOf(match.element), /beta/);
+	assert.match(
+		(match.element as Element).textContent ?? '',
+		/beta/,
+		`line ${sample} of document A resolves to a block of document B`,
+	);
 });
 
 test('a cleared reading position resolves to nothing, so the cascade falls through to the top', () => {


### PR DESCRIPTION
Three test files were left behind by the vitest migration, each for its own reason. All three are closed here. **No `src/` or `src-tauri/` change** — the diff is `scripts/` plus one section of `AGENTS.md`.

`npm test` 854 → **841** · `vitest` 331 → **347** · total 1185 → **1188**. The +3 is new behaviour coverage; the rest is tests moving files, none lost.

---

### `previewSanitize` — a table of results a human measured in a browser and pasted into a comment

Now a test. Same payload verbatim, injected into a document that holds the app's own `.titlebar`, because the defect is that the preview injects into the **application's** document. The observable is `getComputedStyle`: the old viewer-local config keeps the `<style>`, hides the titlebar and puts the beacon URL on `body`; `sanitizeMarkdownHtml` drops it and leaves both alone. A third test pins that the inline `style` *attribute* is still allowed.

**Effect:** the two rows that were a claim are now a gate. `FORBID_TAGS: []` turns test 2 red; `FORBID_ATTR: ['style']` turns test 3 red.

Two things the browser measurement hid, both now fixed in the fixture: DOMPurify serializes its parse tree's `<body>`, and the HTML parser hoists a `<style>` that *opens* a fragment into `<head>` — so a payload-only string comes back empty under **every** config and both rows would agree for a reason that has nothing to do with the policy. The fixture puts prose in front, as real rendered documents do. Second, jsdom never fetches the beacon, so the assertion is the computed value naming the URL rather than a network entry.

### `tabReadingPosition` — called `installShimDom()`, which replaces jsdom's DOM

Rewritten onto the real DOM and renamed to `.spec.ts`; the shim and the hand-written runes are both gone.

This is worth doing here specifically because `findAnchorElement` walks `data-sourcepos`, `classList` and `childNodes` — structure and attributes only, and **it measures nothing**. So the whole anchor half gets true answers with no constructed geometry: real `DOMParser`, real `processMarkdownHtml` re-parenting, and the lookup running on the `div.markdown-body` the viewer actually hands it.

**What deliberately stayed out:** anything about *where* a resolved anchor lands. jsdom returns 0 for `offsetTop`, `offsetHeight` and every rect, so `getAnchorScrollTop`, the offset↔line mapping and a collapsed fold's zero height cannot be asked here — they stay in the files whose fixtures supply boxes. No layout assertions were added. `AGENTS.md` gains a short **"a real DOM is not a layout"** note so the next reader doesn't make that jump on seeing this file move.

**Effect:** cutting `clearReadingPosition` back to its historical `tab.scrollTop = 0` turns 4 tests red. Making the descent refuse to derive a range for an unannotated container drops the stale-anchor hit rate 100% → 8.3%, with the numbers in the failure message.

### `checkedReadMigration` — split per test, not per file

The file's *subject* does not migrate, but 3 of its 9 tests do. `.test.ts` keeps 6, a new `.spec.ts` takes 3, and both carry a comment saying why they are on that side.

Staying: the absence claim ("this command does not exist in `src`") and the Rust-crate test, which are cross-language; plus four statement-**order** claims inside `.svelte` handlers, where mounting the component would substitute jsdom for Monaco/mermaid/KaTeX to earn a *weaker* claim. Moving: the three `ensureFullContent` tests, which read `tab.isTruncated` / `tab.hasReplacementChars` straight back out of a runes store — exactly where the shim was standing.

**Effect, both directions:** dropping `setTabDecodedLossy` from `ensureFullContent` turns the 3 migrated tests red; re-adding an `invoke('read_file_content')` to `documentSession.svelte.ts` turns the retained absence test red.

---

Splitting a file rather than moving it whole is the choice worth flagging. The alternative — keep all 9 where they are — costs a rune shim standing for 3 tests; move all 9 — costs mounting real components to make claims that get weaker in the process. The split pays neither, at the price of one extra file and a comment on each side explaining the line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
