### PR TITLE
refactor(platform): give the app one answer for what platform it is running on

### DIFF
--- a/scripts/platformSource.spec.ts
+++ b/scripts/platformSource.spec.ts
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+
+import { test } from 'vitest';
+
+import { readSource } from './sourceTree.js';
+
+/*
+ * "What platform is this?" had two answers.
+ *
+ * `TitleBar.svelte` sniffed `navigator.userAgent` for "Macintosh"; every other
+ * consumer — the shortcut panel, the editor toolbar, the tab tooltips, the
+ * document context menu, Monaco's keybindings — read `settings.osType`, which
+ * the Rust `get_os_type` command fills in. Nothing compared the two, so nothing
+ * could notice them disagreeing.
+ *
+ * They disagree at exactly one moment, and it is the moment the title bar is
+ * first painted. `SettingsStore` sets `osType` from an `await invoke(…)` in its
+ * constructor, so the field holds its initial `'unknown'` for as long as that
+ * round trip takes — the first test below pins that window open. During it the
+ * user agent already says "Macintosh" while `settings.osType` still says
+ * `'unknown'`, which is why the title bar could draw Mac chrome above tab
+ * tooltips printing the Ctrl chords.
+ *
+ * That window is also why the obvious fix is wrong. Repointing the title bar at
+ * `settings.osType` alone would make a Mac render the `windows` class, the
+ * Windows minimise/maximise/close buttons and no `native-mac` chrome for those
+ * frames, and then rearrange itself — a visible regression, traded for an
+ * invisible one. `platformOf` consults `settings.osType` first and falls back to
+ * the synchronous browser hint only while it is unresolved, so there is one
+ * source and no flash. The rest of this file is that claim, in both directions.
+ */
+
+const { platformOf } = await import('../src/lib/utils/platform.js');
+
+function withNavigatorPlatform(value: string, body: () => void) {
+	const original = Object.getOwnPropertyDescriptor(navigator, 'platform');
+	Object.defineProperty(navigator, 'platform', { value, configurable: true });
+	try {
+		body();
+	} finally {
+		if (original) Object.defineProperty(navigator, 'platform', original);
+		else delete (navigator as { platform?: string }).platform;
+	}
+}
+
+// ------------------------------------------------- the window really is open
+
+test('settings.osType is still unknown when a component first renders', async () => {
+	// The premise of everything below, asserted rather than assumed. The store is
+	// constructed and read in the SAME synchronous turn a component's first
+	// render happens in, and `initOSType()` cannot have resolved by then however
+	// fast the backend is — an awaited `invoke` is at minimum a microtask later.
+	(window as any).__TAURI_INTERNALS__ = {
+		invoke: async (command: string) => (command === 'get_os_type' ? 'macos' : null),
+	};
+	const { SettingsStore } = await import('../src/lib/stores/settings.svelte.js');
+
+	const store = new SettingsStore();
+	try {
+		assert.equal(store.osType, 'unknown', 'the field a first render would read');
+
+		// And it does resolve, so the window is a window and not the whole life of
+		// the app: a title bar that read `settings.osType` alone would be correct
+		// from here on and wrong before it. That is the flash.
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		assert.equal(store.osType, 'macos');
+	} finally {
+		store.dispose();
+	}
+});
+
+// ------------------------------------------------------ platformOf, per case
+
+test('a resolved os type is the answer, whatever the browser would have said', () => {
+	// The direction that is red against the old title bar: a Mac whose os type is
+	// known reads as macOS even where the user agent does not say "Macintosh",
+	// and — the case that matters for a bug report — a Windows or Linux machine
+	// reads as `windows` even if something upstream lied to the browser.
+	withNavigatorPlatform('Win32', () => {
+		assert.equal(platformOf('macos'), 'macos');
+	});
+	withNavigatorPlatform('MacIntel', () => {
+		assert.equal(platformOf('windows'), 'windows');
+		assert.equal(platformOf('linux'), 'windows', 'Linux takes the Ctrl chords and the Windows controls');
+	});
+});
+
+test('during the startup window the browser hint answers, so the title bar cannot flash', () => {
+	// THE REGRESSION GUARD. Delete the fallback and this is the test that goes
+	// red: `platformOf('unknown')` would answer `'windows'` on a Mac, and the
+	// title bar would paint the Windows window controls before rearranging.
+	withNavigatorPlatform('MacIntel', () => {
+		assert.equal(platformOf('unknown'), 'macos');
+	});
+	withNavigatorPlatform('iPhone', () => {
+		assert.equal(platformOf('unknown'), 'macos');
+	});
+	withNavigatorPlatform('Win32', () => {
+		assert.equal(platformOf('unknown'), 'windows');
+	});
+	withNavigatorPlatform('', () => {
+		assert.equal(platformOf('unknown'), 'windows', 'no hint at all is not a Mac');
+	});
+});
+
+// ------------------------------------------- the title bar reads that source
+
+test('TitleBar decides the platform from settings.osType, not from the user agent', () => {
+	// Structural, and red against master: the component held
+	// `navigator.userAgent.includes('Macintosh')` and derived its chrome, its
+	// `native-mac` class and its menu modifier from it. What has to hold is that
+	// the platform enters this component through `platformOf(settings.osType)` and
+	// that every consumer inside it comes off that one value — spell the locals
+	// however you like.
+	const titleBar = readSource('src/lib/components/TitleBar.svelte');
+
+	const source = titleBar.match(/let (\w+) = \$derived\([^\n]*platformOf\(settings\.osType\)\)/);
+	assert.ok(source, 'the platform is derived from platformOf(settings.osType)');
+
+	assert.match(
+		titleBar,
+		new RegExp(`let (\\w+) = \\\$derived\\(${source![1]} === 'macos'\\)`),
+		'the mac test reads that value rather than asking the browser again',
+	);
+	assert.match(
+		titleBar,
+		new RegExp(`let (\\w+) = \\\$derived\\(modifierFor\\(${source![1]}\\)\\)`),
+		'the menu modifier comes from the same value, through modifierFor',
+	);
+
+	// `$derived` and not a plain const: `settings.osType` changes once, after
+	// mount. At a const the title bar would keep the fallback's verdict forever.
+	assert.doesNotMatch(titleBar, /const \w+ = platformOf\(/, 'the platform must stay reactive');
+});

--- a/scripts/singleImplementationConvention.test.ts
+++ b/scripts/singleImplementationConvention.test.ts
@@ -245,6 +245,42 @@ const RULES: Rule[] = [
 		allowed: ['src/lib/utils/imageEmbed.ts'],
 	},
 	{
+		name: 'the frontend asks the browser what platform this is in one place',
+		why: "The app had two independent answers to \"what platform is this?\". Everything read `settings.osType`, filled in by the Rust `get_os_type` command; TitleBar.svelte read `navigator.userAgent.includes('Macintosh')` and decided for itself. Two sources can disagree, and at startup they did — `settings.osType` is `'unknown'` until an `await invoke(…)` in the SettingsStore constructor returns, so on a Mac the title bar already drew Mac chrome while the tab tooltips beside it printed the Ctrl chords. `platformOf` in utils/platform.ts is the single answer: `settings.osType` when it is resolved, the synchronous browser hint only in the window before that, which is what keeps the title bar from flashing Windows chrome on a Mac.",
+		// Both spellings, because they are interchangeable for this question and a
+		// second source would reach for either. `navigator.language` (settings
+		// store) and `navigator.clipboard` (Editor.svelte) are deliberately not
+		// matched: neither is a platform test.
+		//
+		// Editor.svelte is allowed because editorOptionWiring.test.ts pins its
+		// `isMacPlatform()` helper by name, in that file, as the thing that picks
+		// the Monaco tab-cycle modifier — so the copy cannot move without that
+		// test moving with it. It is the same three lines platform.ts now holds
+		// and should be folded into it; the entry goes away when it is.
+		marker: /navigator\.(?:userAgent|platform)\b/g,
+		allowed: ['src/lib/utils/platform.ts', 'src/lib/components/Editor.svelte'],
+	},
+	{
+		name: 'the Cmd-or-Ctrl decision has one implementation',
+		why: "`modifierFor()` was exported by #629 so that `settings.osType === 'macos' ? 'Cmd' : 'Ctrl'` would be written once, and four sites never joined it: two in MarkdownViewer.svelte (the document context menu's chords and the editor toolbar's `modifier` prop), one in TitleBar.svelte, and Settings.svelte's `? 'macos' : 'windows'` feeding the shortcut panel. A hand-written copy is not merely redundant — it is a site that cannot pick up what the helper learns. TitleBar's copy branched on the user agent rather than on the os type at all, and Settings' copy answered `'windows'` for a Mac whose os type had not resolved yet, so the shortcut panel opened on the Ctrl chords.",
+		// The shape of the defect rather than the helpers' names: a site that
+		// copies this decision is by construction one that calls neither
+		// `modifierFor` nor `platformOf`, and what it contains instead is a
+		// `=== 'macos'` test used as a ternary condition — which covers the
+		// `'Cmd' : 'Ctrl'` spelling and the `'macos' : 'windows'` one together.
+		// A bare `=== 'macos'` guarding an `{#if}` or an `&&` is NOT matched and
+		// must not be: asking whether this is a Mac is fine, deciding again what
+		// follows from it is the duplicate.
+		//
+		// The second alternative catches the same decision made off a local that
+		// already holds the verdict — TitleBar's copy was `isMac ? 'Cmd' : 'Ctrl'`
+		// and reaches the `=== 'macos'` test through no literal at all. The
+		// declared union `'Ctrl' | 'Cmd'` in editorToolbar.ts is a type, has the
+		// two words in the other order and separated by a pipe, and is not matched.
+		marker: /===\s*(['"])macos\1\s*\?|(['"])Cmd\2\s*:\s*(['"])Ctrl\3/g,
+		allowed: ['src/lib/utils/shortcuts.ts', 'src/lib/utils/platform.ts'],
+	},
+	{
 		name: 'this suite reads a file through one function',
 		why: "A test that reads source with its own readFileSync gets the bytes Git checked out, and on Windows `core.autocrlf` makes those CRLF. Every `\\n` in a pattern then matches nothing and every anchor containing one is 'not found' — fifteen files were red on the maintainer's Windows checkout while cutting v2.7.0 and were hand-patched assertion by assertion (#452). `readSource` in sourceTree.ts decides the line ending once, on read, so the assertions stay written against `\\n` and a new test cannot re-open the hole by accident. Read the file with `readSource(path)` from './sourceTree.js' — it takes a cwd-relative string or a `new URL(…, import.meta.url)` — and write the assertion against `\\n`.",
 		// The call, not the import: `import { readFileSync }` on its own reads

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -112,7 +112,7 @@ import {
 } from './utils/scrollSync.js';
 import { resolveTheme, settings, TOC_WIDTH_RANGE } from './stores/settings.svelte.js';
 import { t } from './utils/i18n.js';
-import { formatChord } from './utils/shortcuts.js';
+import { formatChord, modifierFor } from './utils/shortcuts.js';
 import { createWindowSession } from './sessions/windowSession.svelte.js';
 import { createDocumentSession, type LoadMarkdownOptions } from './sessions/documentSession.svelte.js';
 
@@ -2372,7 +2372,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		// `formatChord` rather than two literals, so the Mac and Windows
 		// spellings cannot drift apart. F1 has no modifier and is the same
 		// everywhere.
-		const chord = (c: string) => formatChord(c, settings.osType === 'macos' ? 'Cmd' : 'Ctrl');
+		const chord = (c: string) => formatChord(c, modifierFor(settings.osType));
 
 		docContextMenu = {
 			show: true,
@@ -3600,7 +3600,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 							{#if settings.showEditorToolbar}
 								<div transition:slide={{ duration: 150 }}>
 									<EditorToolbar
-										modifier={settings.osType === 'macos' ? 'Cmd' : 'Ctrl'}
+										modifier={modifierFor(settings.osType)}
 										toolbarOrder={settings.editorToolbarOrder}
 										toolbarHidden={settings.editorToolbarHidden}
 										onaction={(actionId, payload) => editorPane?.runEditorAction(actionId, payload)}

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -22,6 +22,7 @@
 	import { fade, scale, fly } from 'svelte/transition';
 	import { t, getSupportedLanguages } from '../utils/i18n.js';
 	import { shortcutSections } from '../utils/shortcuts.js';
+	import { platformOf } from '../utils/platform.js';
 	import type { LanguageCode } from '../utils/i18n.js';
 	import { getEditorToolbarTools } from '../utils/editorToolbar.js';
 	import { getTitlebarToolbarActions, type TitlebarToolbarPlacement } from '../utils/titlebarToolbar.js';
@@ -1595,7 +1596,7 @@
 						`scripts/shortcutRegistry.test.ts` fires each one at the real
 						handlers — so this list cannot drift away from what the keys do.
 					-->
-					{#each shortcutSections(settings.osType === 'macos' ? 'macos' : 'windows') as section (section.group)}
+					{#each shortcutSections(platformOf(settings.osType)) as section (section.group)}
 						<div class="settings-group">
 							<div class="settings-group-header">
 								<h2>{t(section.labelKey, settings.language)}</h2>

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -10,7 +10,8 @@
 	import { settings } from '../stores/settings.svelte.js';
 	import { t } from '../utils/i18n.js';
 	import { getConfiguredTitlebarToolbarIds } from '../utils/titlebarToolbar.js';
-	import { shortcutLabel } from '../utils/shortcuts.js';
+	import { modifierFor, shortcutLabel } from '../utils/shortcuts.js';
+	import { platformOf } from '../utils/platform.js';
 	import { hasMarkdownLinkExtension } from '../utils/markdownLinks.js';
 	import { hasRealFilePath } from '../utils/tabFileActions.js';
 	import { getVersion } from '@tauri-apps/api/app';
@@ -118,9 +119,21 @@
 
 	const DEBUG_MACOS = false;
 
-	const isMac = typeof navigator !== 'undefined' && (navigator.userAgent.includes('Macintosh') || DEBUG_MACOS);
-	const useNativeMacChrome = isMac && !DEBUG_MACOS;
-	const modifier = isMac ? 'Cmd' : 'Ctrl';
+	// The platform comes from `settings.osType` — the Rust `get_os_type` answer
+	// the rest of the app already reads — rather than from this component's own
+	// user-agent sniff for "Macintosh", which was a second source that could
+	// disagree with it. `platformOf` covers the window before that
+	// command answers; see the comment on it for why the title bar cannot simply
+	// read `settings.osType` directly without flashing Windows chrome on a Mac.
+	//
+	// `$derived` rather than plain consts: the source is now reactive state, and
+	// `osType` can change once after mount (unknown → resolved). At plain consts
+	// the title bar would keep whatever the fallback said and never correct
+	// itself on a machine where the two do differ.
+	let platform = $derived(DEBUG_MACOS ? 'macos' : platformOf(settings.osType));
+	let isMac = $derived(platform === 'macos');
+	let useNativeMacChrome = $derived(isMac && !DEBUG_MACOS);
+	let modifier = $derived(modifierFor(platform));
 
 	let isWin11 = $state(false);
 	const tagColors = ['#5f6368', '#1a73e8', '#d93025', '#f9ab00', '#188038', '#d01884', '#a142f4', '#007b83'];

--- a/src/lib/utils/platform.ts
+++ b/src/lib/utils/platform.ts
@@ -1,0 +1,40 @@
+/**
+ * The one answer to "what platform is this?".
+ *
+ * There used to be two. Everything in the app read `settings.osType`, which the
+ * Rust `get_os_type` command fills in, while `TitleBar.svelte` decided for
+ * itself from `navigator.userAgent.includes('Macintosh')`. Two sources means
+ * they can disagree, and they did — not in the steady state, but at startup,
+ * which is the only moment the title bar is being painted for the first time.
+ * `settings.osType` is `'unknown'` until an `await invoke('get_os_type')` in the
+ * `SettingsStore` constructor comes back, so on a Mac the user agent already
+ * said "Macintosh" while the store still said "unknown". The title bar drew Mac
+ * chrome and the tab tooltips beside it printed `Ctrl+W`.
+ *
+ * Pointing the title bar straight at `settings.osType` would have swapped that
+ * disagreement for a worse one: for the frames before the command answers, a Mac
+ * would render the `windows` class, the Windows minimise/maximise/close buttons
+ * and no `native-mac` chrome, and then rearrange itself. So the resolution is
+ * not "pick one of the two" but "one function that consults both, in order".
+ *
+ * The `navigator.platform` fallback is the same one `isMacPlatform()` in
+ * Editor.svelte has used since #558, and the argument for it is written out in
+ * full there: the value is frozen at `"MacIntel"` on every Mac, Apple silicon
+ * included, so it is permanently wrong about the CPU and permanently right about
+ * the vendor — which is the only axis asked of it here. It therefore cannot
+ * reach a different verdict than `settings.osType` will, which is what makes
+ * consulting it *first* safe rather than merely fast. Editor.svelte keeps its
+ * own copy for now: `editorOptionWiring.test.ts` pins that helper by name, in
+ * that file, and folding the two together is a separate change.
+ *
+ * `'linux'` collapses to `'windows'` because that is the choice the app has
+ * always made — Linux uses the Ctrl chords and the Windows window controls — and
+ * the two callers that used to spell that collapse by hand (`Settings.svelte`'s
+ * `? 'macos' : 'windows'`, `TitleBar.svelte`'s `? 'Cmd' : 'Ctrl'`) were the
+ * second copies this replaces.
+ */
+export function platformOf(osType: string): 'macos' | 'windows' {
+	if (osType !== 'unknown') return osType === 'macos' ? 'macos' : 'windows';
+	const platform = typeof navigator === 'undefined' ? '' : navigator.platform || '';
+	return /^(Mac|iPhone|iPad|iPod)/i.test(platform) ? 'macos' : 'windows';
+}


### PR DESCRIPTION
Two defects of the same shape: the app answers "what platform is this?" in more than one place, and answers "Cmd or Ctrl?" by hand in places a helper already exists for.

### The platform question had two sources

`TitleBar.svelte` decided from `navigator.userAgent`; everything else reads `settings.osType`, which comes from Rust's `get_os_type`. Two sources that can disagree — and this one drives visible chrome: the `windows` class, the `native-mac` class, and the `{#if !isMac && !isWin11}` window-controls block.

**They genuinely can disagree.** `settings.osType` is `$state('unknown')` until an `await invoke(...)` in the `SettingsStore` constructor resolves. A new test pins that it is still `'unknown'` in the same synchronous turn the store is constructed — the turn a first render happens in — and resolves only after a macrotask. A Mac's user agent already says "Macintosh" during that window.

**So switching TitleBar to `settings.osType` alone would have shipped a regression**, not a fix: Windows minimise/maximise/close rendered on a Mac for those frames, then rearranged. That is worse than the inconsistency being removed.

**The repo already had the answer.** `Editor.svelte`'s `isMacPlatform()` (#558) solves exactly this: os type once resolved, `navigator.platform` while not. Its comment argues the fallback cannot reach a *different* macOS verdict, which is what makes that ordering safe rather than just lucky. Lifted into `src/lib/utils/platform.ts` as `platformOf(osType)`; TitleBar now derives platform, `isMac`, `useNativeMacChrome` and `modifier` from that one value — as `$derived`, since the source is reactive now.

### The ternaries: three, not four

Three in `MarkdownViewer.svelte` and `Settings.svelte`; the fourth was TitleBar's, which is the defect above.

Two go through the existing `modifierFor`. **The third does not fit it**, and that is worth naming rather than bending: `Settings.svelte:1598` needs a *platform* (`'macos' | 'windows' | 'linux'`) to hand to `shortcutSections`, not a `'Cmd' | 'Ctrl'`. It gets `platformOf` — the sibling that returns the platform — which is the same helper defect ② needed. That is why one module answers both.

**A follow-up this exposed but does not fix:** `modifierFor`'s doc says it handles `'unknown'`, and it does — by answering `Ctrl`. Correct as a default, wrong on a Mac during the startup window described above, which is why `Tab.svelte` and `TabList.svelte` can print Ctrl for those frames. The honest fix is `modifierFor = (osType) => platformOf(osType) === 'macos' ? 'Cmd' : 'Ctrl'`. `shortcuts.ts` is owned by another branch, so it is not touched here.

### Guardrail

Two rows in the RULES table:

- **the frontend asks the browser what platform this is in one place** — `navigator.userAgent|platform`, allowed in `utils/platform.ts` and, documented as temporary, `Editor.svelte`. `navigator.language` and `navigator.clipboard` are not matched.
- **the Cmd-or-Ctrl decision has one implementation** — `=== 'macos' ?` or `'Cmd' : 'Ctrl'`, allowed in `shortcuts.ts` and `platform.ts`. A bare `=== 'macos'` guarding an `{#if}` is deliberately not matched; that is a legitimate branch, not a second copy of the decision.

Both fire on master's files. Re-introducing each pattern by hand — `isMac ? 'Cmd' : 'Ctrl'` in `TabList.svelte`, a `navigator.userAgent` sniff in `Tab.svelte` — fires the matching rule. `platformOf`'s fallback has its own red case: delete it and `platformOf('unknown')` answers `'windows'` on a Mac, which is the flash.

### Left alone, with reasons

- **`Editor.svelte`'s own `isMacPlatform()`** — the same three lines `platform.ts` now holds, but `editorOptionWiring.test.ts:131` pins the helper *by name, in that file*. Folding them is a separate change; the guardrail lists it as an allowed site **with that reason written into the entry**, so the exception disappears when it is folded in.
- **`Tab.svelte` / `TabList.svelte`** — already route through `modifierFor`, the sanctioned helper. They inherit the `'unknown'` window above; that is a follow-up, not a second copy.
- **`DEBUG_MACOS` and the traffic-lights block** — unreachable while `DEBUG_MACOS === false`, pre-existing, unrelated scope.

`npm test` 854 → **856** · `vitest` 331 → **335** · `check` 0 errors.

**Not eyeballed in a running app.** This is Tauri window chrome; the browser preview cannot render it. On a Mac the visible outcome should be *no* change — the point is that the wrong controls no longer appear for the frames before `get_os_type` answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
