### PR TITLE
fix(shortcuts): stop the destructive chords answering to modifiers they never declared

### DIFF
--- a/scripts/jumpToSelectedFragment.test.ts
+++ b/scripts/jumpToSelectedFragment.test.ts
@@ -440,7 +440,7 @@ test('one function owns what ⌘E means, and every entry point uses it', () => {
 	// here, so the chord cannot mean one thing with the caret in the editor and
 	// another with it in the preview — which is what
 	// `formatShortcutKeymap.test.ts` pins from the other side.
-	assert.match(viewerSource, /if \(cmdOrCtrl && key === 'e'\) \{[\s\S]{0,600}?toggleEditView\(\)/);
+	assert.match(viewerSource, /if \(mod && key === 'e'\) \{[\s\S]{0,600}?toggleEditView\(\)/);
 	assert.equal(
 		(viewerSource.match(/ontoggleEdit=\{\(\) => toggleEditView\(\)\}/g) ?? []).length,
 		3,

--- a/scripts/previewWidth.test.ts
+++ b/scripts/previewWidth.test.ts
@@ -88,7 +88,9 @@ test('preview width keyboard shortcuts avoid editable controls and app modals', 
 	assert.match(viewerSource, /function canUsePreviewWidthShortcut\(target: EventTarget \| null, isSplit: boolean\)/);
 	assert.match(viewerSource, /showSettings \|\| modalState\.show \|\| promptModal\.show \|\| showHome/);
 	assert.match(viewerSource, /closest\('input, textarea, select, \[contenteditable="true"\], \[role="textbox"\]'\)/);
-	assert.match(viewerSource, /cmdOrCtrl && e\.altKey && !e\.shiftKey && \(code === 'BracketLeft' \|\| code === 'BracketRight'\)/);
+	// `modAlt` is the handler's name for "the platform modifier and Alt, and
+	// nothing else" — the chord these two keys are advertised under.
+	assert.match(viewerSource, /modAlt && \(code === 'BracketLeft' \|\| code === 'BracketRight'\)/);
 	assert.match(viewerSource, /settings\.previewFullWidth = false/);
 	assert.match(viewerSource, /settings\.previewMaxWidth = adjustPreviewMaxWidth\(settings\.previewMaxWidth, code === 'BracketLeft' \? -40 : 40\)/);
 });

--- a/scripts/saveFromReadingMode.test.ts
+++ b/scripts/saveFromReadingMode.test.ts
@@ -7,11 +7,13 @@ const viewer = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.met
 
 // The guard gained `!e.shiftKey` when Save As was finally bound to Mod+Shift+S:
 // the branch used to match on the modifier and the letter alone, so the chord
-// the app menu advertised for Save As fell through to a plain Save. The Save As
-// branch sits above this one, so slicing from here still captures exactly the
+// the app menu advertised for Save As fell through to a plain Save. It later
+// gained `!e.altKey` too, and both now come from `mod` — the handler's name for
+// "the platform modifier and nothing else". The Save As branch (`modShift`)
+// sits above this one, so slicing from here still captures exactly the
 // plain-save body every assertion below is about.
 function keydownSaveBranch(): string {
-	return sliceBetween(viewer, "if (cmdOrCtrl && !e.shiftKey && key === 's') {", "if (cmdOrCtrl && e.shiftKey && key === 't')");
+	return sliceBetween(viewer, "if (mod && key === 's') {", "if (modShift && key === 't')");
 }
 
 // Reported in #168 by @dayeggpi: with a document that was never saved,

--- a/scripts/shortcutRegistry.test.ts
+++ b/scripts/shortcutRegistry.test.ts
@@ -69,7 +69,12 @@ function toMonacoLabel(chord: string, mac: boolean): Chord {
 			const key = parts.pop()!;
 			const mods = new Set(parts);
 			const ctrl = mods.has('Ctrl') || (mods.has('Mod') && !mac);
-			const meta = mods.has('Mod') && mac;
+			// A literal `Meta` stays Meta on every platform, the same way a literal
+			// `Ctrl` does. The registry has no such row — the chords that need this
+			// spelling are the unadvertised ones named in
+			// DOCUMENT_CHORDS_NOT_ADVERTISED, which are written in registry syntax so
+			// the exemption list and the registry read alike.
+			const meta = mods.has('Meta') || (mods.has('Mod') && mac);
 			return [
 				ctrl && 'Ctrl',
 				mods.has('Shift') && 'Shift',
@@ -95,6 +100,7 @@ test('the chord translator agrees with the harness on chords both already know',
 	assert.equal(toMonacoLabel('Mod+Shift+E', false), 'Ctrl+Shift+E');
 	assert.equal(toMonacoLabel('Mod+K T', false), 'Ctrl+K T');
 	assert.equal(toMonacoLabel('Ctrl+Tab', true), 'Ctrl+Tab', 'a literal Ctrl stays Ctrl on macOS');
+	assert.equal(toMonacoLabel('Meta+Alt+Left', false), 'Alt+Meta+LeftArrow', 'a literal Meta stays Meta off macOS');
 	assert.equal(toMonacoLabel('Alt+Left', false), 'Alt+LeftArrow');
 
 	assert.deepEqual(mac.get('fmt-inline-code'), ['Shift+Meta+E']);
@@ -531,6 +537,42 @@ test('Save As runs Save As, and not a plain Save', () => {
 	}
 });
 
+test('a close chord wearing an extra modifier destroys nothing', () => {
+	// `Mod+W` and `Mod+Q` tested the platform modifier and the key and nothing
+	// else, so the whole Shift/Alt cross product reached them. `Shift+Cmd+W`,
+	// `Alt+Cmd+W` and `Shift+Cmd+Q` — the last of which is the macOS Log Out
+	// gesture — each threw the document away, while the neighbours in the same
+	// handler (`file-new`, `file-open`, `app-find`) had spelled every modifier
+	// out from the start.
+	//
+	// Not "these three chords do nothing" but "nothing destructive answers to a
+	// modifier it does not name": a fourth spelling nobody thought of fails here
+	// too, and so does a future destructive branch that forgets its guard.
+	const DESTRUCTIVE = ['closeFile', 'getCurrentWindow'];
+	let plainClosesFound = 0;
+
+	for (const platform of PLATFORMS) {
+		const keymap = documentKeymap(platform.osType);
+		for (const [chord, calls] of keymap) {
+			const damage = calls.filter((call) => DESTRUCTIVE.some((command) => call.startsWith(command)));
+			if (damage.length === 0) continue;
+			if (!/\b(Shift|Alt)\b/.test(chord)) {
+				plainClosesFound++;
+				continue;
+			}
+			assert.fail(
+				`${platform.name}: ${chord} runs ${damage.join(', ')} — a chord reached for a window-level or ` +
+					'"close all" gesture must not close the document',
+			);
+		}
+	}
+
+	// Without this the test passes just as happily when the handler answers no
+	// close chord at all, which is the empty-iteration failure the file guards
+	// against everywhere else.
+	assert.ok(plainClosesFound >= 3, `only ${plainClosesFound} unmodified close chords fire; the harness found nothing to guard`);
+});
+
 // -------------------------------------------------- editor bindings vs panel
 
 /**
@@ -735,6 +777,89 @@ test('every command the document handler can reach is advertised, or consciously
 
 	for (const command of Object.keys(DOCUMENT_NOT_ADVERTISED)) {
 		assert.ok(reachable.has(command), `${command} is no longer reachable — drop it from DOCUMENT_NOT_ADVERTISED`);
+	}
+});
+
+/**
+ * Every harness label one registry chord is answered by.
+ *
+ * `cmdOrCtrl` in the document handler is `e.ctrlKey || e.metaKey` on EVERY
+ * platform, so a `Mod` chord answers both spellings everywhere — a Windows
+ * user's Ctrl fingers keep working on a Mac and the reverse. That is one
+ * decision about the modifier, not one decision per chord, so it is applied
+ * here rather than repeated as thirty exemptions below.
+ */
+function documentSpellings(chord: string, mac: boolean): Chord[] {
+	if (!chord.includes('Mod')) return [toMonacoLabel(chord, mac)];
+	return [toMonacoLabel(chord, false), toMonacoLabel(chord, true)];
+}
+
+/**
+ * Chords the document handler answers that the panel deliberately never shows,
+ * written in registry syntax so this list and the registry read alike.
+ *
+ * The command-level test above cannot see any of this: it asks whether a
+ * command is mentioned somewhere, and `closeFile` is mentioned, so `Mod+W`
+ * accounted for `Shift+Mod+W`, `Alt+Mod+W` and the rest of the cross product
+ * as well. This is the same completeness question asked one level finer — per
+ * CHORD — which is the level the bug lived at.
+ *
+ * What that buys: a branch added tomorrow that forgets to say which modifiers
+ * must be up does not quietly grow four undocumented chords. It fails here,
+ * and the author either advertises what they bound or writes down why not.
+ */
+const DOCUMENT_CHORDS_NOT_ADVERTISED: Record<string, string> = {
+	'Mod+F4':
+		'The Windows document-close convention, kept as a second way to reach file-close. Not shown because ' +
+		'the panel already prints Mod+W for that command and a second row would read as a second command.',
+	'Mod+PageUp':
+		'Tab cycling as browsers and editors bind it. tab-prev advertises Ctrl+Shift+Tab; this is the same ' +
+		'command under the chord the muscle memory reaches for.',
+	'Mod+PageDown': 'The tab-next half of the same pair as Mod+PageUp.',
+	'Meta+Alt+Left':
+		'The macOS tab-cycling gesture (Cmd+Alt+arrow), kept for Mac users whose fingers expect it. Advertising ' +
+		'it would give tab-prev a platform-specific second row that is wrong on the other two platforms.',
+	'Meta+Alt+Right': 'The tab-next half of the same pair as Meta+Alt+Left.',
+	'Mod+OEM_102':
+		'The extra backslash key on ISO keyboards, the same physical gesture as view-toggle-split\'s Mod+\\. ' +
+		"The registry's own note on that row says why it is not shown as a second chord.",
+	'Meta+Tab':
+		'The Cmd twin of tab-next, which is spelled with a literal Ctrl precisely because Cmd+Tab is the macOS ' +
+		'application switcher and never reaches the app. Reachable in the handler, unreachable in practice.',
+	'Meta+Shift+Tab': 'The tab-prev half of the same pair as Meta+Tab.',
+};
+
+test('every chord the document handler answers is advertised, or consciously not', () => {
+	for (const platform of PLATFORMS) {
+		const advertised = new Set(
+			SHORTCUTS.filter((entry) => entry.documentCall)
+				.flatMap((entry) => entry.chords)
+				.flatMap((chord) => documentSpellings(chord, platform.mac)),
+		);
+		for (const chord of Object.keys(DOCUMENT_CHORDS_NOT_ADVERTISED)) {
+			for (const spelling of documentSpellings(chord, platform.mac)) advertised.add(spelling);
+		}
+
+		const answered = [...documentKeymap(platform.osType).keys()];
+		assert.ok(answered.length > 15, `${platform.name}: the handler answered ${answered.length} chords`);
+
+		assert.deepEqual(
+			answered.filter((chord) => !advertised.has(chord)).sort(),
+			[],
+			`${platform.name}: the keyboard reaches these chords and nothing accounts for them. ` +
+				'A branch must name every modifier that has to be UP, or the chord it really binds ' +
+				'belongs in SHORTCUTS or in DOCUMENT_CHORDS_NOT_ADVERTISED with a reason.',
+		);
+	}
+
+	// The exemption list must not rot: a chord that stopped firing has to leave it.
+	const live = new Set(PLATFORMS.flatMap((platform) => [...documentKeymap(platform.osType).keys()]));
+	for (const chord of Object.keys(DOCUMENT_CHORDS_NOT_ADVERTISED)) {
+		assert.ok(
+			documentSpellings(chord, false).some((spelling) => live.has(spelling)) ||
+				documentSpellings(chord, true).some((spelling) => live.has(spelling)),
+			`${chord} is no longer answered — drop it from DOCUMENT_CHORDS_NOT_ADVERTISED`,
+		);
 	}
 });
 

--- a/scripts/windowOrganization.test.ts
+++ b/scripts/windowOrganization.test.ts
@@ -59,6 +59,6 @@ test('window organization exposes move, merge, and carry actions', () => {
 	assert.match(tab, /menu-tab-move/);
 	assert.match(viewer, /async function mergeAllWindowsHere/);
 	assert.match(viewer, /async function carryActiveTabToNextWindow/);
-	assert.match(viewer, /cmdOrCtrl && e\.shiftKey && key === 'm'/);
+	assert.match(viewer, /modShift && key === 'm'/);
 	assert.match(titleBar, /onmergeAllWindows/);
 });

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -2767,15 +2767,39 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		const key = e.key.toLowerCase();
 		const code = e.code;
 
+		/*
+		 * The three modifier shapes almost every branch below wants, named once.
+		 *
+		 * A chord means the modifiers it names AND the absence of the ones it does
+		 * not. Half the branches here used to say only `cmdOrCtrl && key === …`,
+		 * which is not `Mod+X` — it is `Mod+X` plus its whole Shift/Alt cross
+		 * product. `Mod+W` was the expensive case: Shift+Cmd+W and Alt+Cmd+W are
+		 * what a user reaches for when they mean "close the window" or "close
+		 * everything", and both silently closed one document instead. `Mod+Q`,
+		 * `Mod+E`, `Mod+S`, `Mod+,` and the zoom chords all had the same hole, and
+		 * on macOS Shift+Cmd+Q — Log Out — reached the window-close branch.
+		 *
+		 * The guard is here rather than repeated in fourteen branches so that a
+		 * branch added later INHERITS it by reaching for `mod`, instead of having
+		 * to remember three negations. `shortcutRegistry.test.ts` closes the other
+		 * half: any chord this handler answers that the registry does not advertise
+		 * fails there, so a new branch cannot quietly grow a cross product again.
+		 *
+		 * Three branches are deliberately not written in these terms, each with its
+		 * reason at the branch: tab cycling (Shift picks the direction), zoom in
+		 * (`+` is the shifted `=`), and the Alt-only navigation chords.
+		 */
+		const mod = cmdOrCtrl && !e.shiftKey && !e.altKey;
+		const modShift = cmdOrCtrl && e.shiftKey && !e.altKey;
+		const modAlt = cmdOrCtrl && !e.shiftKey && e.altKey;
+
 		// The macOS application menu owns ⌘Q. Document shortcuts remain in the
 		// in-window controls, so they continue to act on the current webview.
-		if (settings.osType === 'macos' && cmdOrCtrl && !e.shiftKey) {
-			if (key === 'q') return; // → menu-app-quit
-		}
+		if (settings.osType === 'macos' && mod && key === 'q') return; // → menu-app-quit
 
 		const isSplit = tabManager.activeTab?.isSplit;
 
-		if (cmdOrCtrl && e.altKey && !e.shiftKey && (code === 'BracketLeft' || code === 'BracketRight')) {
+		if (modAlt && (code === 'BracketLeft' || code === 'BracketRight')) {
 			if (!canUsePreviewWidthShortcut(e.target, !!isSplit)) return;
 			e.preventDefault();
 			settings.previewFullWidth = false;
@@ -2788,16 +2812,21 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			reloadFromDisk();
 			return;
 		}
-		if (cmdOrCtrl && e.shiftKey && key === 'm') {
+		if (modShift && key === 'm') {
 			e.preventDefault();
 			carryActiveTabToNextWindow();
 			return;
 		}
-		if (cmdOrCtrl && key === 'w') {
+		// Nothing catches the Shift and Alt variants on the way past: they are not
+		// another command in disguise, they are a user asking the WINDOW manager
+		// for something. Leaving them unhandled — and unprevented — is what lets
+		// the OS answer them, which is strictly better than answering with the one
+		// irreversible thing the app can do.
+		if (mod && key === 'w') {
 			e.preventDefault();
 			closeFile();
 		}
-		if (cmdOrCtrl && e.code === 'F4') {
+		if (mod && code === 'F4') {
 			e.preventDefault();
 			closeFile();
 		}
@@ -2817,23 +2846,23 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		// about only one of the two, which left Ctrl+N doing nothing at all
 		// outside the editor. Both are listed here so the two paths cannot
 		// drift again; `formatShortcutKeymap.test.ts` holds them equal.
-		if (cmdOrCtrl && !e.shiftKey && !e.altKey && (key === 't' || key === 'n')) {
+		if (mod && (key === 't' || key === 'n')) {
 			e.preventDefault();
 			handleNewFile();
 		}
-		if (cmdOrCtrl && !e.shiftKey && !e.altKey && key === 'o') {
+		if (mod && key === 'o') {
 			e.preventDefault();
 			selectFile();
 		}
-			if (cmdOrCtrl && key === 'q') {
-				e.preventDefault();
-				getCurrentWindow().close();
-			}
-		if (cmdOrCtrl && !e.shiftKey && !e.altKey && (code === 'Backslash' || code === 'IntlBackslash')) {
+		if (mod && key === 'q') {
+			e.preventDefault();
+			getCurrentWindow().close();
+		}
+		if (mod && (code === 'Backslash' || code === 'IntlBackslash')) {
 			e.preventDefault();
 			if (tabManager.activeTabId) toggleSplitView(tabManager.activeTabId);
 		}
-		if (cmdOrCtrl && key === 'e') {
+		if (mod && key === 'e') {
 			e.preventDefault();
 			// The `silentSave` argument these two used to pass meant "suppress
 			// the unsaved-changes modal on the hotkey path". There is no modal
@@ -2844,7 +2873,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			//
 			toggleEditView();
 		}
-		if (cmdOrCtrl && e.shiftKey && !e.altKey && key === 's') {
+		if (modShift && key === 's') {
 			// Save As. The app menu advertised this chord for as long as the menu has
 			// existed, but nothing ever bound it: the branch below matched on
 			// `cmdOrCtrl && key === 's'` with no Shift guard, so the advertised
@@ -2855,7 +2884,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			saveContentAs();
 			return;
 		}
-		if (cmdOrCtrl && !e.shiftKey && key === 's') {
+		if (mod && key === 's') {
 			// Reading mode used to swallow the shortcut entirely. An untitled
 			// buffer reaches it with content still unsaved — `toggleEdit`
 			// only runs its save flow for tabs that already have a path — so
@@ -2869,51 +2898,61 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			if (saveTarget && (saveTarget.isDirty || saveTarget.path === '')) saveContent();
 		}
 
-		if (cmdOrCtrl && e.shiftKey && key === 't') {
+		if (modShift && key === 't') {
 			e.preventDefault();
 			handleUndoCloseTab();
 		}
-		if (cmdOrCtrl && code === 'Tab') {
+		// Not `mod`/`modShift`: Shift is the ARGUMENT here, not part of the chord's
+		// identity — it picks the direction. Alt still has to be up.
+		if (cmdOrCtrl && !e.altKey && code === 'Tab') {
 			e.preventDefault();
 			tabManager.cycleTab(e.shiftKey ? 'prev' : 'next');
 		}
-		if (cmdOrCtrl && code === 'PageUp') {
+		if (mod && code === 'PageUp') {
 			e.preventDefault();
 			tabManager.cycleTab('prev');
 		}
-		if (cmdOrCtrl && code === 'PageDown') {
+		if (mod && code === 'PageDown') {
 			e.preventDefault();
 			tabManager.cycleTab('next');
 		}
-		if (e.metaKey && e.altKey && code === 'ArrowLeft') {
+		// Alt-based chords, so they say what they need by hand: `mod` would demand
+		// Alt be up, which is the opposite of what these two bind.
+		if (e.metaKey && !e.ctrlKey && e.altKey && !e.shiftKey && code === 'ArrowLeft') {
 			e.preventDefault();
 			tabManager.cycleTab('prev');
 		}
-		if (e.metaKey && e.altKey && code === 'ArrowRight') {
+		if (e.metaKey && !e.ctrlKey && e.altKey && !e.shiftKey && code === 'ArrowRight') {
 			e.preventDefault();
 			tabManager.cycleTab('next');
 		}
-		if (e.altKey && !cmdOrCtrl && code === 'ArrowLeft') {
+		if (e.altKey && !e.shiftKey && !cmdOrCtrl && code === 'ArrowLeft') {
 			e.preventDefault();
 			navigateFileHistory('back');
 		}
-		if (e.altKey && !cmdOrCtrl && code === 'ArrowRight') {
+		if (e.altKey && !e.shiftKey && !cmdOrCtrl && code === 'ArrowRight') {
 			e.preventDefault();
 			navigateFileHistory('forward');
 		}
-		if (cmdOrCtrl && (key === '=' || key === '+')) {
+		// The one chord that cannot demand Shift be up. `+` IS the shifted `=` on
+		// the layouts that have both, so `mod` would delete the `+` spelling
+		// outright and leave Cmd+Shift+= — how a lot of people zoom in — dead. The
+		// guard is per-spelling instead: bare `=` wants no Shift, `+` brings its
+		// own. (The keymap harness only ever fires unshifted characters, so it sees
+		// the `=` half of this and never the `+` half.)
+		if (cmdOrCtrl && !e.altKey && (key === '+' || (key === '=' && !e.shiftKey))) {
 			e.preventDefault();
 			settings.zoomIn();
 		}
-		if (cmdOrCtrl && key === '-') {
+		if (mod && key === '-') {
 			e.preventDefault();
 			settings.zoomOut();
 		}
-		if (cmdOrCtrl && key === '0') {
+		if (mod && key === '0') {
 			e.preventDefault();
 			settings.resetZoom();
 		}
-		if (cmdOrCtrl && key === ',') {
+		if (mod && key === ',') {
 			e.preventDefault();
 			showSettings = true;
 		}
@@ -2921,7 +2960,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		// FindBar depending on focus and which panes are visible. We only
 		// preventDefault when we actually take the action ourselves —
 		// otherwise we let Monaco's own keybinding fire.
-		if (cmdOrCtrl && !e.shiftKey && !e.altKey && key === 'f') {
+		if (mod && key === 'f') {
 			const active = document.activeElement as Node | null;
 			const editorHasFocus = !!editorPaneEl && !!active && editorPaneEl.contains(active);
 			if (!editorHasFocus) {


### PR DESCRIPTION
`Mod+W` in the document-level `handleKeyDown` tested the platform modifier and the key, but not the other modifiers — so `Shift+Cmd+W` and `Alt+Cmd+W` also closed the file. Its neighbours guard theirs.

Auditing it found the same shape in **twelve** branches, not two.

### What the handler was actually answering

`scripts/keymapHarness.ts` already fuzzes the full Shift/Alt cross product against the real extracted handler, so this is measured rather than read:

**macOS: 123 chords answered. The registry advertises 20.** After the fix: **51**, every one advertised or explained.

Three of the strays are destructive, and one was not in the original report:

| branch | strays |
|---|---|
| `Mod+W` → `closeFile` | `Shift+Mod+W`, `Alt+Mod+W`, `Shift+Alt+Mod+W` |
| `Mod+Q` → window close | the same three — including `Shift+Cmd+Q`, which is macOS **Log Out** |
| `Mod+F4` → `closeFile` | the same three, a third path to the same irreversible action |

And one collision worth naming: `Mod+E` also answered `Shift+Mod+E`, which is `fmt-inline-code` *inside* the editor. One chord, two meanings, decided by which pane had focus.

### The three decisions

**Stray variants do nothing, and are not `preventDefault`'d.** The handler is a flat list of `if`s with no fallthrough chain to reach, and these chords have no second meaning in Markpad. Leaving them both unhandled and unprevented is the point: `Shift+Cmd+W` and `Alt+Cmd+W` are window-manager gestures, so the OS gets them back rather than the app answering with the one irreversible thing it can do.

**One shared guard, not fourteen.** Three named shapes — `mod`, `modShift`, `modAlt` — so a branch added tomorrow inherits the guard by reaching for `mod` instead of remembering three negations. It is the neighbours' guard spelled once; the correct branches mostly shrink.

**But a helper only helps branches that reach for it**, so the inheritance mechanism is a test rather than a convention. `shortcutRegistry.test.ts` already asked *"is every command the handler can reach advertised?"* — which `closeFile` passed while four undocumented chords ran it. The same question now runs **per chord**, which is the granularity the bug lived at. A future branch that forgets its guard fails there and has to either advertise what it bound or write down why not. Eight genuinely-unadvertised chords (`Mod+F4`, `Mod+PageUp/Down`, `Cmd+Alt+arrows`, ISO backslash, `Meta+Tab`) are now named with reasons instead of being invisible.

### One guard would have broken real behaviour

`key === '+'` **is** the shifted `=` on US/UK layouts, so applying the blanket `mod` shape to zoom-in would have deleted the `+` spelling and killed `Cmd+Shift+=` for everyone who zooms that way. That branch guards per spelling instead: `!altKey && (key === '+' || (key === '=' && !shiftKey))`.

Tab cycling is the other carve-out — there Shift is the **argument** (direction), not part of the chord's identity — so it guards Alt only. Both are commented in place.

### Falsification

- *a close chord wearing an extra modifier destroys nothing* — red on master with `macOS: Ctrl+Alt+W runs closeFile`. Asserts no chord matching `/\b(Shift|Alt)\b/` reaches `closeFile` or `getCurrentWindow`, plus a floor of ≥3 plain close chords so it cannot pass vacuously against an empty keymap.
- *every chord the document handler answers is advertised, or consciously not* — red on master with a 72-entry diff on macOS alone. Now empty.

Both drive the real extracted handler, not a description of it.

`npm test` 843 → **845** · `vitest` 351 · `check` 0 errors.

Five existing tests pinned the old branch text and were retargeted to the new spelling — they went red for that reason, not for a behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
