### PR TITLE
fix(shortcuts): scope Ctrl+F4 to Windows, as its requirement always said

### DIFF
--- a/scripts/shortcutRegistry.test.ts
+++ b/scripts/shortcutRegistry.test.ts
@@ -573,6 +573,50 @@ test('a close chord wearing an extra modifier destroys nothing', () => {
 	assert.ok(plainClosesFound >= 3, `only ${plainClosesFound} unmodified close chords fire; the harness found nothing to guard`);
 });
 
+test('Mod+F4 closes a document on Windows, the one platform it was scoped to', () => {
+	// The scope is not a judgement call made here — it is the requirement the
+	// binding shipped with and then exceeded. `docs/requirements/157-ctrl-f4-
+	// close-tab.md`, added by the same commit that added the branch (4670743,
+	// "add Ctrl+F4 shortcut to close active tab on Windows"), lists under "Out of
+	// scope": "macOS / Linux (dort ist Ctrl+F4 kein Standard)". The handler bound
+	// it on all three anyway. The doc was later swept away with the rest of
+	// docs/ (d69c181), which is how the intent stopped being checkable — so it is
+	// restated here, where it now fails if it is exceeded again.
+	//
+	// The convention argument agrees and is why the doc says what it says:
+	// Ctrl+F4 closes a document window on Windows, an MDI-era convention still
+	// live in Office and the IDEs. macOS has none — Cmd+F4 means nothing, and
+	// with "Use F1, F2, etc. as standard function keys" off, which is the
+	// default, F4 runs a system function and the app never receives the event.
+	//
+	// What this is NOT is a rule about odd-looking chords. `Cmd+Shift+=` stays on
+	// every platform though it looks similarly strange: it is not a platform
+	// convention at all, it is how "Cmd plus" is typed — `+` is the shifted `=`
+	// on every layout — so Mac users press it as much as anyone. The question is
+	// "does anyone on this platform actually press this?", not "does it carry a
+	// Shift?".
+	for (const platform of PLATFORMS) {
+		const keymap = documentKeymap(platform.osType);
+		// Both spellings on every platform: `cmdOrCtrl` is `ctrlKey || metaKey`
+		// everywhere, so a Mac or a Linux box answering EITHER one is the defect.
+		for (const spelling of documentSpellings('Mod+F4', platform.mac)) {
+			const fired = keymap.get(spelling) ?? [];
+			if (platform.osType === 'windows') {
+				assert.ok(
+					fired.includes('closeFile'),
+					`${platform.name}: ${spelling} runs ${fired.join(', ') || 'nothing'} instead of closeFile`,
+				);
+			} else {
+				assert.deepEqual(
+					fired,
+					[],
+					`${platform.name}: ${spelling} still runs ${fired.join(', ')} — requirement 157 puts this platform out of scope`,
+				);
+			}
+		}
+	}
+});
+
 // -------------------------------------------------- editor bindings vs panel
 
 /**
@@ -810,8 +854,10 @@ function documentSpellings(chord: string, mac: boolean): Chord[] {
  */
 const DOCUMENT_CHORDS_NOT_ADVERTISED: Record<string, string> = {
 	'Mod+F4':
-		'The Windows document-close convention, kept as a second way to reach file-close. Not shown because ' +
-		'the panel already prints Mod+W for that command and a second row would read as a second command.',
+		'The Windows document-close convention, kept there as a second way to reach file-close and gated off ' +
+		'macOS and Linux, which requirement 157 put out of scope from the start (see the per-platform test ' +
+		'above). Not shown because the panel already prints Mod+W for that command and a second row would read ' +
+		'as a second command — and a row true on one platform of three would have to say so.',
 	'Mod+PageUp':
 		'Tab cycling as browsers and editors bind it. tab-prev advertises Ctrl+Shift+Tab; this is the same ' +
 		'command under the chord the muscle memory reaches for.',

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -2826,7 +2826,41 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 			e.preventDefault();
 			closeFile();
 		}
-		if (mod && code === 'F4') {
+		// Windows only, which is the scope this binding was written to and then
+		// exceeded. `docs/requirements/157-ctrl-f4-close-tab.md`, added by the
+		// same commit as the branch itself (4670743, "add Ctrl+F4 shortcut to
+		// close active tab on Windows"), puts "macOS / Linux (dort ist Ctrl+F4
+		// kein Standard)" under "Out of scope"; the handler bound all three
+		// anyway. So this is not a new product decision, it is the documented one
+		// finally being implemented. The doc went away with the rest of docs/ in
+		// d69c181, which is how the intent stopped being checkable —
+		// `shortcutRegistry.test.ts` now holds it instead.
+		//
+		// The convention argument is why the requirement says that: Ctrl+F4
+		// closes a document window on Windows, still live in Office and the IDEs.
+		// macOS has no equivalent — Cmd+F4 means nothing, and with "Use F1, F2,
+		// etc. as standard function keys" off, which is the default, F4 runs a
+		// system function and the app never receives the event at all
+		// (hand-tested on a Mac: it did nothing). A Mac was therefore offered a
+		// THIRD route to an irreversible action that was at once non-conventional
+		// and nearly unpressable.
+		//
+		// Not a rule about odd-looking chords: `Cmd+Shift+=` stays on every
+		// platform. That one is not a platform convention, it is how "Cmd plus"
+		// is typed — `+` is the shifted `=` on every layout — so Mac users press
+		// it as much as anyone. The question is "does anyone on this platform
+		// actually press this?", not "does it carry a Shift?".
+		//
+		// A bare `settings.osType` comparison next to #646's `platformOf` is
+		// deliberate, not an oversight. `platformOf` answers `'macos' | 'windows'`
+		// and folds Linux INTO `'windows'` — correct for the two questions it was
+		// built for (which modifier to print, which window chrome to draw) and
+		// unable to express this one, which needs all three apart. And the reason
+		// to avoid a bare comparison does not apply to this spelling: `osType` is
+		// `'unknown'` until the Rust command answers, and `=== 'windows'` resolves
+		// that window to DO NOT FIRE. It fails closed, which is the only
+		// acceptable direction for a branch that throws a document away.
+		if (settings.osType === 'windows' && mod && code === 'F4') {
 			e.preventDefault();
 			closeFile();
 		}


### PR DESCRIPTION
`Ctrl/Cmd+F4` closed a document on every platform. It was never meant to.

The commit that introduced it, `4670743`, is titled *"add Ctrl+F4 shortcut to close active tab **on Windows**"*, and the requirement it shipped with says so outright:

```
## Out of scope
- macOS / Linux (dort ist Ctrl+F4 kein Standard)
```

The code shipped cross-platform anyway. So this is not a new product decision — it restores the documented intent, and the convention argument is only *why* the requirement says what it says: `Ctrl+F4` closes a document window on Windows, an MDI-era convention still live in IDEs, Office and browsers. macOS and Linux have no equivalent, and on macOS the default "Use F1, F2, etc. as standard function keys" setting *off* means the key usually never reaches the app at all. Hand-testing confirmed nothing happened.

That left a third route to an irreversible action alive on two platforms where nobody has reason to press it.

### Why a bare `osType === 'windows'` and not `platformOf`

`platformOf` (#646) answers `'macos' | 'windows'` and folds Linux into `'windows'`, so it **structurally cannot express a three-way scope** — using it would have kept the binding alive on Linux, against the requirement.

The other spelling, `!== 'macos'`, is worse than wrong here. `osType` is `'unknown'` until the Rust `get_os_type` round trip returns, and in that startup window `!== 'macos'` resolves to **fire the close branch** — on a Mac. `=== 'windows'` resolves the same window to **do not fire**. It fails closed, which is the only acceptable direction for a branch that throws a document away.

`singleImplementationConvention.test.ts` needs no entry: its marker matches a platform test used as a **ternary**, and its own comment says a bare comparison guarding an `&&` is deliberately not matched — *"asking whether this is a Mac is fine, deciding again what follows from it is the duplicate."* Confirmed at 0 marker hits rather than assumed.

### The requirement doc is gone, so the test holds the intent now

`docs/requirements/157-ctrl-f4-close-tab.md` is not in the working tree — `d69c181`, *"chore: delete unused docs dir"*, swept it. It survives only in `git show 4670743:…`.

That deletion is part of the story rather than a footnote: it is **how the intent stopped being checkable**. A scope written only in prose, then deleted, cannot fail. The new test names the requirement in its failure message, so the scope now lives somewhere that breaks when contradicted.

### Falsification

```
✖ Mod+F4 closes a document on Windows, the one platform it was scoped to
  AssertionError: Linux: Ctrl+F4 still runs closeFile — requirement 157 puts this platform out of scope
  + [ 'closeFile' ]
  - []
```

| answered chords | before | after |
|---|---|---|
| macOS | 51 | **49** |
| Linux | 53 | **51** |
| Windows | 53 | 53 |

Two spellings drop per gated platform, not one: `cmdOrCtrl` is `ctrlKey || metaKey` everywhere, so `Ctrl+F4` and `Meta+F4` both died. Neither existing count assertion needed touching — both are floors against empty iteration, not snapshots.

### A trap found on the way, worth knowing about

An intermediate revision fed the real `platformOf` into the extracted handler's scope in `keymapHarness.ts`. Reverting it (a bare comparison calls no helper) produced a baseline of **610 answered chords per platform** instead of ~51: with no real helper in scope, `platformOf` resolved to the harness's recording stub, and merely *calling* it registered a fired action for every chord in the fuzz set.

Caught because the number was absurd. Any future branch that calls a helper inside `handleKeyDown` without teaching the harness will silently report as firing everywhere — which reads as a catastrophic regression rather than a harness gap.

`npm test` 845 → **846** · `vitest` 351 · `check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
