### PR TITLE
feat(shortcuts): Mod+K inserts a link, and the table verbs move off the chord

### DIFF
--- a/scripts/editorToolbar.test.ts
+++ b/scripts/editorToolbar.test.ts
@@ -66,7 +66,15 @@ test('each tool carries the label, name and shortcut the toolbar renders', () =>
 	assert.equal(byId.get('fmt-strikethrough')?.shortcut?.('Cmd'), 'Cmd+Shift+X');
 	assert.equal(byId.get('fmt-strikethrough')?.label, 'S');
 	assert.equal(byId.get('fmt-strikethrough')?.name, 'Strikethrough');
-	assert.equal(byId.get('insert-table-simple')?.shortcut?.('Cmd'), 'Cmd+K T');
+	assert.equal(byId.get('insert-table-simple')?.shortcut?.('Cmd'), 'Cmd+Alt+T');
+
+	// The four buttons that gained a hint when the keymap was reworked. Three list
+	// buttons had actions and no key at all, and Link — the chord four independent
+	// editors agree on — had none either, so the tooltip had nothing to print.
+	assert.equal(byId.get('fmt-link')?.shortcut?.('Cmd'), 'Cmd+K');
+	assert.equal(byId.get('fmt-numbered-list')?.shortcut?.('Ctrl'), 'Ctrl+Shift+7');
+	assert.equal(byId.get('fmt-bullet-list')?.shortcut?.('Ctrl'), 'Ctrl+Shift+8');
+	assert.equal(byId.get('fmt-checklist')?.shortcut?.('Cmd'), 'Cmd+Shift+9');
 });
 
 test('normalizeEditorToolbarOrder drops unknown ids, deduplicates, and appends new defaults', () => {

--- a/scripts/editorToolbar.test.ts
+++ b/scripts/editorToolbar.test.ts
@@ -66,7 +66,7 @@ test('each tool carries the label, name and shortcut the toolbar renders', () =>
 	assert.equal(byId.get('fmt-strikethrough')?.shortcut?.('Cmd'), 'Cmd+Shift+X');
 	assert.equal(byId.get('fmt-strikethrough')?.label, 'S');
 	assert.equal(byId.get('fmt-strikethrough')?.name, 'Strikethrough');
-	assert.equal(byId.get('insert-table-simple')?.shortcut?.('Cmd'), 'Cmd+Alt+T');
+	assert.equal(byId.get('insert-table-simple')?.shortcut?.('Cmd'), 'Cmd+Opt+T');
 
 	// The four buttons that gained a hint when the keymap was reworked. Three list
 	// buttons had actions and no key at all, and Link — the chord four independent

--- a/scripts/formatShortcutKeymap.test.ts
+++ b/scripts/formatShortcutKeymap.test.ts
@@ -101,7 +101,16 @@ test('the toolbar tooltip prints the shortcut the editor actually registered', (
 			chords[0].replace(/\bMeta\b/g, 'Ctrl'),
 			`${id}: toolbar hint and registered keybinding disagree`,
 		);
-		assert.equal(tool.shortcut('Cmd'), tool.shortcut('Ctrl').replace('Ctrl', 'Cmd'));
+		// Both renderings come from the same registry row through `formatChord`, so
+		// they name the same key and the same number of modifiers — but NOT the same
+		// WORDS: `Alt` is `Opt` on macOS (#651). Asserting a string substitution here
+		// would be a second copy of that word map, which is the defect #651 removed;
+		// `shortcutRegistry.test.ts` owns the per-platform naming and this only has to
+		// prove the two renderings are still the same chord.
+		const asCmd = tool.shortcut('Cmd').split('+');
+		const asCtrl = tool.shortcut('Ctrl').split('+');
+		assert.equal(asCmd.length, asCtrl.length, `${id}: the two renderings are not the same chord`);
+		assert.equal(asCmd.at(-1), asCtrl.at(-1), `${id}: the two renderings end on different keys`);
 	}
 
 	// The rows this change adds, spelled out, so that deleting one of them from

--- a/scripts/formatShortcutKeymap.test.ts
+++ b/scripts/formatShortcutKeymap.test.ts
@@ -1,16 +1,21 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { KeyCode } from 'monaco-editor/esm/vs/editor/common/standalone/standaloneEnums.js';
+import { KeyMod } from 'monaco-editor/esm/vs/editor/common/services/editorBaseApi.js';
+
 import { getEditorToolbarTools } from '../src/lib/utils/editorToolbar.js';
 import {
 	OperatingSystem,
 	PLATFORMS,
+	bareCommands,
+	chordOf,
 	documentKeymap,
 	editorKeymap,
 	registeredActions,
 	type Chord,
 } from './keymapHarness.js';
-import { readRustBackend, readSource } from './sourceTree.js';
+import { readRustBackend, readSource, sliceBetween, sliceFrom } from './sourceTree.js';
 
 /*
  * Issues #121 (six formatting commands with no shortcut) and #392 (Ctrl+T means
@@ -254,4 +259,84 @@ test('a chord that both layers answer means the same thing in both', () => {
  * so the check is against ALL of Monaco's chords rather than a remembered
  * eleven — including Quote's deliberate `inPlaceReplace.down` override, which
  * is now argued in that file's allow-list instead of asserted by absence here.
+ *
+ * What is left in this file is the other direction, below: a Monaco default the
+ * app takes OFF the keymap rather than takes over. Nothing of ours claims that
+ * key, so it is not a chord-ownership question and does not belong in the
+ * ownership file; both ends of it are read out of the installed Monaco.
  */
+
+// ------------------------------------- a core Monaco binding, taken back off
+
+/**
+ * The `-`-prefixed rules `Editor.svelte` hands `monaco.editor.addKeybindingRules`,
+ * evaluated with Monaco's own `KeyMod`/`KeyCode`.
+ *
+ * The same trick as the rest of this harness: the numbers come from the real
+ * enums, so a rule that names the wrong chord cannot look right here.
+ */
+function removedKeybindings(): Array<{ keybinding: number; command: string }> {
+	const marker = 'monaco.editor.addKeybindingRules(';
+	const literal = sliceBetween(readSource('src/lib/components/Editor.svelte'), marker, ');').slice(marker.length);
+	return new Function('monaco', `return ${literal};`)({ KeyMod, KeyCode });
+}
+
+test('Mod+Shift+K deletes no line here, and Delete Line keeps its palette entry', () => {
+	// WHY THE KEY GOES. `editor.action.deleteLines` is VS Code's convention,
+	// inherited by standalone Monaco and inherited again by this app, where it
+	// silently destroys the line the caret is on. None of the mainstream Markdown
+	// editors — Typora, Obsidian, iA Writer, Bear — binds it: it is a code-editor
+	// key that leaked into a prose editor, and it was being mis-fired.
+	//
+	// WHY IT IS A REMOVAL RULE. Binding the chord to a no-op `addCommand` would
+	// make the key dead AND leave a fake command sitting in front of Monaco's;
+	// a rule whose command id starts with `-` is what Monaco itself reads as
+	// "drop this default", which is the shape a core binding has to be undone in.
+
+	// 1. That mechanism, read out of the installed Monaco rather than assumed.
+	const resolver = readSource(
+		new URL('../node_modules/monaco-editor/esm/vs/platform/keybinding/common/keybindingResolver.js', import.meta.url),
+	);
+	assert.match(
+		sliceFrom(resolver, 'static handleRemovals('),
+		/rule\.command\.charAt\(0\) === '-'/,
+		"Monaco no longer drops defaults by a '-'-prefixed command id",
+	);
+
+	// 2. The default being removed, likewise: both the id and the chord come from
+	//    Monaco's source, so a rename or a re-chord upstream fails here instead of
+	//    leaving behind a rule that quietly matches nothing.
+	const linesOperations = readSource(
+		new URL('../node_modules/monaco-editor/esm/vs/editor/contrib/linesOperations/browser/linesOperations.js', import.meta.url),
+	);
+	assert.match(
+		sliceBetween(linesOperations, "id: 'editor.action.deleteLines'", 'run(_accessor'),
+		/primary: 2048 \/\* KeyMod\.CtrlCmd \*\/ \| 1024 \/\* KeyMod\.Shift \*\/ \| 41 \/\* KeyCode\.KeyK \*\//,
+		'Monaco binds Delete Line to some other chord now',
+	);
+
+	// 3. The rule the app registers, and nothing else: this is a keymap subtraction
+	//    with one entry, and a second one arriving unremarked is a decision nobody
+	//    wrote down.
+	assert.deepEqual(removedKeybindings(), [
+		{ keybinding: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyK, command: '-editor.action.deleteLines' },
+	]);
+
+	// 4. And nothing of the app's took the chord instead. The command stays in the
+	//    command palette — dropping a KEY is not dropping a command, the same rule
+	//    the table delete verbs live under — but the keystroke now does nothing.
+	for (const platform of PLATFORMS) {
+		const chord = platform.mac ? 'Shift+Meta+K' : 'Ctrl+Shift+K';
+		assert.equal(chordOf(removedKeybindings()[0].keybinding, platform.os), chord);
+		for (const [id, chords] of editorKeymap(platform.mac, platform.os)) {
+			assert.ok(!chords.includes(chord), `${platform.name}: ${id} binds ${chord}, the chord just unbound`);
+		}
+		for (const command of bareCommands()) {
+			assert.notEqual(
+				chordOf(command.binding, platform.os),
+				chord,
+				`${platform.name}: ${command.handler} binds ${chord}, the chord just unbound`,
+			);
+		}
+	}
+});

--- a/scripts/monacoChordOwnership.spec.ts
+++ b/scripts/monacoChordOwnership.spec.ts
@@ -200,13 +200,57 @@ type Override = {
 	/** The app registration: a Monaco action id, or `addCommand(fn)` for a bare command. */
 	action: string;
 	chords: PerPlatform;
-	/** The Monaco command that loses the key. */
+	/**
+	 * The Monaco command that loses the key. For a `namespace` row it is one
+	 * command from BEHIND the prefix, named so the row fails if the prefix stops
+	 * meaning what the argument says it means.
+	 */
 	monaco: string;
+	/**
+	 * The chord is a PREFIX of Monaco chord sequences rather than a chord Monaco
+	 * binds outright, so what the app takes is a whole namespace.
+	 *
+	 * This exists because the first rule below could not see that case at all.
+	 * `Mod+K` is not a key in Monaco's map — every `Mod+K …` entry is keyed by the
+	 * full two-part chord — so an app action claiming plain `Mod+K` matched
+	 * nothing, and the rule waved through the single largest keymap change this
+	 * app has ever made. A guard that only notices exact collisions is blind
+	 * exactly where the loss is biggest.
+	 */
+	namespace?: true;
 	/** Why losing it is acceptable. */
 	why: string;
 };
 
 const DELIBERATE_OVERRIDES: readonly Override[] = [
+	{
+		action: 'fmt-link',
+		chords: { macOS: 'Meta+K', Windows: 'Ctrl+K', Linux: 'Ctrl+K' },
+		namespace: true,
+		monaco: 'editor.foldAll',
+		why:
+			"THE LARGEST THING THIS APP TAKES OFF MONACO, and the cost is enumerated rather than " +
+			'summarised because a reader arriving later deserves the actual bill. Monaco binds no complete ' +
+			'keybinding on Ctrl/Cmd+K; it binds 31 chord SEQUENCES behind it, carrying 30 commands, ' +
+			'identically on all three platforms. Twenty are folding (foldAll, unfoldAll, foldLevel1-7, ' +
+			'foldRecursively, unfoldRecursively, foldAllExcept, unfoldAllExcept, toggleFold, ' +
+			'toggleFoldRecursively, foldAllBlockComments, foldAllMarkerRegions, unfoldAllMarkerRegions, ' +
+			'createFoldingRangeFromSelection, removeManualFoldingRanges). The other ten are addCommentLine, ' +
+			'removeCommentLine, formatSelection, revealDefinitionAside, togglePeekWidgetFocus, ' +
+			'setSelectionAnchor, selectFromAnchorToCursor, moveSelectionToNextFindMatch, showHover and ' +
+			'trimTrailingWhitespace. All 30 remain in the command palette (Mod+P); what goes is the key. ' +
+			'WHY THE FOLDING BULK IS NOT THE LOSS IT LOOKS LIKE: editor folding barely works in this app to ' +
+			'begin with. Nothing in src/ registers a folding-range provider — grep registerFoldingRangeProvider ' +
+			"— and Monaco's own basic-languages/markdown/markdown.js declares folding only through region " +
+			'markers (<!-- #region --> / <!-- #endregion -->), which nobody writes in Markdown. What those ' +
+			"twenty commands actually operate on is indentation folding. The folding a user of this app has " +
+			'and wants is the preview-side system in src/lib/utils/foldState.ts, which is click-driven and ' +
+			'untouched by any of this. No replacement fold chords are added, deliberately. ' +
+			'WHAT IS BOUGHT: Ctrl/Cmd+K is Insert Link in Typora, Bear, iA Writer and GitHub — the only ' +
+			'command in the whole survey where four independent sources agree exactly — and the link button ' +
+			'had no keyboard shortcut at all. A prose editor spending its single most agreed-on chord on a ' +
+			'code-folding namespace nobody can reach was the trade being made silently in the other direction.',
+	},
 	{
 		action: 'fmt-italic',
 		chords: { macOS: 'Meta+I', Windows: 'Ctrl+I', Linux: 'Ctrl+I' },
@@ -379,6 +423,54 @@ test('every chord the app takes off Monaco is one it says out loud it is taking'
 	);
 });
 
+/** The Monaco chord SEQUENCES that begin with `chord`, on one platform. */
+function sequencesUnder(monaco: MonacoKeymap, chord: Chord): Array<[Chord, string[]]> {
+	return [...monaco].filter(([candidate]) => candidate.startsWith(`${chord} `));
+}
+
+test('a chord taken off a Monaco chord NAMESPACE is one the app says out loud it is taking', () => {
+	// The blind spot in the rule above, and the reason this file grew a second
+	// one. Monaco keys its map by the FULL chord, so `Meta+K` — the prefix of 31
+	// sequences — is not in it, and `monaco.get('Meta+K')` is undefined. An app
+	// action registering plain `Mod+K` therefore reported no conflict at all,
+	// while ending every `Mod+K …` command in the editor: once the first key
+	// resolves to a complete keybinding there is no second key to press.
+	//
+	// Losing a namespace is a bigger decision than losing one command, so it needs
+	// a louder rule rather than a quieter one.
+	const unexplained: string[] = [];
+
+	for (const platform of PLATFORMS) {
+		const monaco = defaultsFor(platform.name);
+		for (const [chord, owners] of appEditorChords(platform.mac, platform.os)) {
+			if (chord.includes(' ')) continue; // a sequence shadows no prefix
+			const shadowed = sequencesUnder(monaco, chord);
+			if (!shadowed.length) continue;
+
+			const allowed = DELIBERATE_OVERRIDES.some(
+				(o) => o.namespace && o.chords[platform.name] === chord && owners.includes(o.action),
+			);
+			if (allowed) continue;
+
+			const commands = new Set(shadowed.flatMap(([, ids]) => ids));
+			unexplained.push(
+				`${platform.name}: ${owners.join('/')} takes ${chord} as a whole key, ending ` +
+					`${shadowed.length} Monaco chord sequences behind it (${commands.size} commands)`,
+			);
+		}
+	}
+
+	assert.deepEqual(
+		unexplained,
+		[],
+		'Claiming a chord that Monaco uses as a chord PREFIX does not collide with one command, it\n' +
+			'ends a namespace: the first key now resolves and there is no second key to press.\n' +
+			'Move the binding, or add a DELIBERATE_OVERRIDES row with `namespace: true` whose `why`\n' +
+			'enumerates what is behind the prefix rather than eliding it:\n  ' +
+			unexplained.join('\n  '),
+	);
+});
+
 test('no row in the allow-list has gone stale', async () => {
 	// Without this the table only ever grows: a row left behind after its binding
 	// moved reads as a live justification for a conflict that no longer exists,
@@ -388,9 +480,15 @@ test('no row in the allow-list has gone stale', async () => {
 		const owners = appEditorChords(platform.mac, platform.os).get(chord);
 
 		assert.ok(owners?.includes(row.action), `${platform.name}: ${row.action} no longer binds ${chord}`);
+
+		// A namespace row's Monaco side is behind the prefix, not on it — looking the
+		// chord up directly would find nothing and delete a live justification.
+		const claimants = row.namespace
+			? sequencesUnder(monaco, chord).flatMap(([, ids]) => ids)
+			: (monaco.get(chord) ?? []);
 		assert.ok(
-			monaco.get(chord)?.includes(row.monaco),
-			`${platform.name}: Monaco no longer binds ${chord} to ${row.monaco}; delete the override`,
+			claimants.includes(row.monaco),
+			`${platform.name}: Monaco no longer binds ${row.monaco} ${row.namespace ? 'behind' : 'to'} ${chord}; delete the override`,
 		);
 		assert.ok(row.why.length > 80, `${row.action} on ${chord} carries no real justification`);
 	}
@@ -438,7 +536,7 @@ test('zen mode is off redo, and on a chord nothing else wants', async () => {
 	// left implicit in the rules above. Confirmed by hand on a debug build
 	// first: Cmd+Shift+Z entered zen mode and nothing redid.
 	for (const platform of PLATFORMS) {
-		const chord = platform.mac ? 'Shift+Meta+D' : 'Ctrl+Shift+D';
+		const chord = platform.mac ? 'Alt+Meta+Z' : 'Ctrl+Alt+Z';
 		expect(editorKeymap(platform.mac, platform.os).get('toggle-zen-mode'), platform.name).toEqual([chord]);
 		expect(defaultsFor(platform.name).get(chord), platform.name).toBeUndefined();
 	}

--- a/scripts/shortcutRegistry.test.ts
+++ b/scripts/shortcutRegistry.test.ts
@@ -113,9 +113,11 @@ test('the chord translator agrees with the harness on chords both already know',
 	assert.equal(toMonacoLabel('Alt+Left', false), 'Alt+LeftArrow');
 
 	assert.deepEqual(mac.get('fmt-inline-code'), ['Shift+Meta+E']);
-	// Two keybindings, one action: the second is the same chord with the modifier
-	// still held for the second key. See the modifier-held test further down.
-	assert.deepEqual(win.get('insert-table-simple'), ['Ctrl+K T', 'Ctrl+K Ctrl+T']);
+	// `Mod+K T` above is still translated correctly; nothing BINDS a sequence any
+	// more, which is the rule asserted further down. Insert Table is the action
+	// that used to hold the two-part chord and is the single stroke `Mod+Alt+T`
+	// now, so this is the row that would have to change if the sequence came back.
+	assert.deepEqual(win.get('insert-table-simple'), ['Ctrl+Alt+T']);
 });
 
 // ------------------------------------------------------------- sanity guards
@@ -662,55 +664,65 @@ test('every keybinding the editor registers is either advertised or consciously 
 	}
 });
 
-// ---------------------------------------- the Mod+K chords, with Mod held down
+// ------------------------------------------- every chord is one keystroke
+//
+// The rule that replaced the `Mod+K` namespace. Insert Table and Insert Column
+// used to be `Mod+K T` and `Mod+K C`, and Insert Table had to be registered
+// TWICE — once released, once with the modifier still held — because "Cmd+K T"
+// reads as one gesture and `Cmd+K` then `Cmd+T` otherwise fell through to
+// `file-new`: asking for a table opened a tab. That was the cheaper half of the
+// problem. The expensive half was that people found the two-key gesture awkward
+// enough to stop using it, which is what this whole rework came out of.
+//
+// So there is no namespace to keep consistent any more, and the invariant worth
+// holding is the stronger one: nothing the app binds is a sequence at all.
 
-/**
- * `Mod+K <key>` chords that deliberately do NOT also take `Mod+K Mod+<key>`.
- *
- * The exemption is a collision, not a preference: `addAction` registers at
- * weight 1000, above every Monaco default, so taking one of these would not fill
- * an empty slot — it would silently delete a command that works today.
- */
-const MODIFIER_HELD_EXEMPT: Record<string, string> = {
-	'table-insert-column':
-		"Mod+K Mod+C is Monaco's own editor.action.addCommentLine " +
-		'(contrib/comment/browser/comment.js), and it is not a dead binding in Markdown: with no ' +
-		'line-comment token the command falls back to wrapping the line in <!-- -->. Mod+K C, ' +
-		'released, is unclaimed and stays the chord for Insert Column.',
-};
-
-test('every Mod+K chord also answers with the modifier still held', () => {
-	// HOW PEOPLE ACTUALLY PRESS THESE. "Cmd+K T" reads as one gesture, so the Cmd
-	// stays down for the T — and `Cmd+K` then `Cmd+T` matched nothing here, fell
-	// through, and reached the app's own new-tab chord: asking for Insert Table
-	// opened a tab. VS Code registers both forms of every Mod+K chord it ships for
-	// exactly this reason.
+test('the app binds no chord sequence anywhere, in either keyboard layer', () => {
+	// `Mod+K` is Insert Link now, so a sequence beginning with it could not be
+	// typed even if something declared one — the first key would fire the link.
+	// This is the rule that would catch a new sequence being introduced on some
+	// other prefix, which is the shape the ergonomics complaint was about rather
+	// than anything specific to K.
 	let checked = 0;
 	for (const platform of PLATFORMS) {
-		const modifier = platform.mac ? 'Meta' : 'Ctrl';
 		for (const [id, chords] of editorKeymap(platform.mac, platform.os)) {
-			if (id in MODIFIER_HELD_EXEMPT) continue;
 			for (const chord of chords) {
-				const [first, second] = chord.split(' ');
-				if (!second || first !== `${modifier}+K` || second.startsWith(`${modifier}+`)) continue;
 				assert.ok(
-					chords.includes(`${first} ${modifier}+${second}`),
-					`${platform.name}: ${id} answers ${chord}, but not the same chord with ${modifier} ` +
-						'still held for the second key — which is how the chord is pressed',
+					!chord.includes(' '),
+					`${platform.name}: ${id} is bound to the sequence ${chord}; every binding here is one keystroke`,
 				);
 				checked++;
 			}
 		}
+		for (const command of bareCommands()) {
+			const chord = chordOf(command.binding, platform.os);
+			assert.ok(!chord.includes(' '), `${platform.name}: ${command.handler} is bound to the sequence ${chord}`);
+			checked++;
+		}
 	}
-	assert.ok(checked >= 3, `only ${checked} Mod+K chords were checked`);
+	assert.ok(checked > 90, `only ${checked} bindings were checked`);
 
-	// The exemption list must not rot either: an id that stopped binding a Mod+K
-	// chord has no collision left to be excused from.
-	const bound = editorKeymap(false, OperatingSystem.Windows);
-	for (const id of Object.keys(MODIFIER_HELD_EXEMPT)) {
-		assert.ok(
-			bound.get(id)?.some((chord) => chord.startsWith('Ctrl+K ')),
-			`${id} no longer binds a Mod+K chord — drop it from MODIFIER_HELD_EXEMPT`,
+	// And the registry says the same thing, which is the half a user sees: the
+	// panel cannot advertise a gesture the editor no longer answers.
+	for (const entry of SHORTCUTS) {
+		for (const chord of entry.chords) {
+			assert.ok(!chord.includes(' '), `${entry.id} advertises the sequence ${chord}`);
+		}
+	}
+});
+
+test('Mod+K belongs to Insert Link, on every platform', () => {
+	// The decision itself, asserted where a reader will look for it. Typora, Bear,
+	// iA Writer and GitHub all document this chord for Insert Link — four
+	// independent sources agreeing exactly, which no other command in the survey
+	// managed — and the link button carried no shortcut at all before this.
+	for (const platform of PLATFORMS) {
+		const chord = platform.mac ? 'Meta+K' : 'Ctrl+K';
+		assert.deepEqual(editorKeymap(platform.mac, platform.os).get('fmt-link'), [chord], platform.name);
+		assert.equal(
+			SHORTCUTS.find((entry) => entry.id === 'fmt-link')?.chords[0],
+			'Mod+K',
+			'the panel advertises it too',
 		);
 	}
 });
@@ -730,6 +742,12 @@ const TABLE_VERBS_WITHOUT_A_CHORD: Record<string, string> = {
 		'Mod+K Shift+R sat one slip from what was then Monaco\'s Mod+Shift+K (delete line, unbound ' +
 		'here now), and a mis-fired destructive table edit is much worse than a mis-fired insert',
 	'table-delete-column': 'the same, one key over',
+	'table-insert-column':
+		'it was on Mod+K C, and Mod+K is Insert Link now, so the sequence cannot be typed. Mod+Alt+C ' +
+		"was the intended replacement and is not available: on macOS it is Monaco's toggleFindCaseSensitive, " +
+		'live whenever the editor has focus and registered with registerEditorCommand rather than ' +
+		'registerEditorAction — so it has no command palette entry to fall back on, and taking it would ' +
+		'leave find-case-sensitivity reachable only by mouse. Palette-only until a chord is chosen',
 };
 
 test('the table verbs with no chord are still commands, and advertise nothing', () => {

--- a/scripts/shortcutRegistry.test.ts
+++ b/scripts/shortcutRegistry.test.ts
@@ -727,8 +727,8 @@ const TABLE_VERBS_WITHOUT_A_CHORD: Record<string, string> = {
 	'table-insert-row':
 		'Mod+Enter owns it now — inside a table, "insert a line below" already means "insert a row below"',
 	'table-delete-row':
-		"Mod+K Shift+R sat one slip from Monaco's own Mod+Shift+K (delete line), and a mis-fired " +
-		'destructive table edit is much worse than a mis-fired insert',
+		'Mod+K Shift+R sat one slip from what was then Monaco\'s Mod+Shift+K (delete line, unbound ' +
+		'here now), and a mis-fired destructive table edit is much worse than a mis-fired insert',
 	'table-delete-column': 'the same, one key over',
 };
 

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -1280,18 +1280,23 @@
 			editor.addAction({
 				id: "toggle-zen-mode",
 				label: t('settings.zenMode', lang),
-				// NOT Ctrl/Cmd+Shift+Z, which this used to be. That chord is REDO,
-				// and on macOS it is redo's only one: Monaco's mac override replaces
-				// the default rule rather than adding to it, so Cmd+Y — the escape
-				// hatch Windows and Linux keep — does not exist there. `addAction`
-				// registers at weight 1000, so zen mode did not share the key, it
-				// took it, and a mac user had no way to redo from the keyboard at
-				// all. D is for distraction-free; it is unclaimed in Monaco on all
-				// three platforms and joins the app's own Ctrl/Cmd+Shift row
-				// (B, E, F, M, R, S, T, X). `monacoChordOwnership.spec.ts` reads
-				// Monaco's real keymap and is what refuses the next such landing.
+				// THE THIRD ADDRESS THIS COMMAND HAS HAD, and the first two are why
+				// the note is this long. It was Ctrl/Cmd+Shift+Z, which is REDO — on
+				// macOS redo's ONLY key, because Monaco's mac override replaces the
+				// default rule rather than adding to it, so Cmd+Y (the escape hatch
+				// Windows and Linux keep) does not exist there. `addAction` registers
+				// at weight 1000, so zen mode did not share that key, it took it, and
+				// a mac user had no way to redo from the keyboard at all.
+				//
+				// Then Ctrl/Cmd+Shift+D, which was free — but the Ctrl/Cmd+Shift row
+				// is where the formatting verbs live (B, E, F, X and now the digits),
+				// and a view mode is not one of them. Ctrl/Cmd+Alt+Z is unclaimed in
+				// Monaco on all three platforms, Z is for zen, and it sits with the
+				// other Alt-modified commands rather than among the formatters.
+				// `monacoChordOwnership.spec.ts` reads Monaco's real keymap and is
+				// what refuses the next such landing.
 				keybindings: [
-					monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyD,
+					monaco.KeyMod.CtrlCmd | monaco.KeyMod.Alt | monaco.KeyCode.KeyZ,
 				],
 				run: () => {
 					settings.toggleZenMode();
@@ -1412,47 +1417,72 @@
 				run: () => toggleLineMarkerTool("fmt-heading-3"),
 			}),
 
+			// The three list buttons, which had actions and no keys at all.
+			// Ctrl/Cmd+Shift+7 and +8 are GitHub's documented chords, the same on
+			// both its platforms, and Monaco leaves the whole Ctrl/Cmd+Shift digit
+			// row alone except for `1` (replaceOne). Numbered is 7 and bulleted is
+			// 8 because that is the way round GitHub has them.
 			editor.addAction({
 				id: "fmt-bullet-list",
 				label: t('menu.bulletList', lang),
+				keybindings: [
+					monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Digit8,
+				],
 				run: () => toggleLineMarkerTool("fmt-bullet-list"),
 			}),
 
 			editor.addAction({
 				id: "fmt-numbered-list",
 				label: t('menu.numberedList', lang),
+				keybindings: [
+					monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Digit7,
+				],
 				run: () => toggleLineMarkerTool("fmt-numbered-list"),
 			}),
 
+			// 9 HAS NO PRECEDENT, and this says so rather than implying one:
+			// GitHub documents no task-list chord, nor do Typora and Obsidian, and
+			// the two editors that do bind one disagree and are both occupied here
+			// (Bear's Cmd+T is New File; iA Writer's Opt+Cmd+L is Monaco's
+			// `toggleFindInSelection` on macOS). So the third list button takes the
+			// digit next to the two above it.
 			editor.addAction({
 				id: "fmt-checklist",
 				label: t('menu.checklist', lang),
+				keybindings: [
+					monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Digit9,
+				],
 				run: () => toggleLineMarkerTool("fmt-checklist"),
 			}),
 
 			editor.addAction({
 				id: "fmt-link",
 				label: t('menu.link', lang),
+				// ⌘K / Ctrl+K. Typora, Bear, iA Writer and GitHub all document this
+				// for Insert Link — the only command in the survey where four
+				// independent sources agree exactly — and the button had no key at
+				// all.
+				//
+				// Monaco binds no COMPLETE keybinding on Ctrl/Cmd+K; what it binds is
+				// 31 chord SEQUENCES behind it. Claiming the key as a whole chord
+				// ends that namespace, which is deliberate and argued in
+				// monacoChordOwnership.spec.ts rather than here, because the loss is
+				// keymap-wide rather than one command's.
+				keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyK],
 				run: () => insertLink(),
 			}),
 
 			editor.addAction({
 				id: "insert-table-simple",
 				label: t('menu.insertTable', lang),
-				// BOTH FORMS OF THE CHORD, which is what VS Code registers for every
-				// one of its own `Mod+K` chords and for the same reason: "Cmd+K T"
-				// reads as one gesture, so the Cmd stays down for the T. Without the
-				// second entry `Cmd+K` then `Cmd+T` matched nothing, fell through, and
-				// reached `file-new` — asking for a table opened a tab.
+				// ONE STROKE, not a sequence. This was `Mod+K T` (in both its
+				// released and modifier-held forms, the way VS Code registers its own
+				// Mod+K chords); Mod+K is Insert Link now, and a two-key gesture was
+				// awkward enough to press that it is what started this rework.
+				// Ctrl+Alt+T / ⌥⌘T is Typora's and Bear's chord for the same command,
+				// and Monaco binds nothing on it on any of the three platforms.
 				keybindings: [
-					monaco.KeyMod.chord(
-						monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyK,
-						monaco.KeyCode.KeyT,
-					),
-					monaco.KeyMod.chord(
-						monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyK,
-						monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyT,
-					),
+					monaco.KeyMod.CtrlCmd | monaco.KeyMod.Alt | monaco.KeyCode.KeyT,
 				],
 				run: () => {
 					const selection = editor.getSelection();
@@ -1481,9 +1511,9 @@
 			// The rest of the table verbs. They are actions rather than bare
 			// commands because a user has to be able to FIND them — in the command
 			// palette, in the shortcuts panel — which a nameless `addCommand`
-			// cannot be. Three of the four carry no keybinding at all, and an
-			// action with no keybinding is still a command palette entry, which is
-			// where a verb you reach for twice a year belongs.
+			// cannot be. NONE of the four carries a keybinding now, and an action
+			// with no keybinding is still a command palette entry, which is where a
+			// verb you reach for twice a year belongs.
 			//
 			// WHY THE DESTRUCTIVE PAIR HAS NO CHORD. They were on `Mod+K Shift+R`
 			// and `Mod+K Shift+C`, one slip from what was then Monaco's own
@@ -1511,22 +1541,18 @@
 				},
 			}),
 
-			// The one table verb still on the chord, in the namespace `Mod+K`
-			// already opened for Insert Table. `C` for column, and only the
-			// released form: `Mod+K Mod+C` is Monaco's own
-			// `editor.action.addCommentLine`, which is live in Markdown — with no
-			// line-comment token it falls back to wrapping the line in `<!-- -->`.
-			// `addAction` registers at weight 1000 and would win, so claiming it
-			// would delete a working command rather than fill an empty slot.
 			editor.addAction({
 				id: "table-insert-column",
 				label: t('menu.insertTableColumn', lang),
-				keybindings: [
-					monaco.KeyMod.chord(
-						monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyK,
-						monaco.KeyCode.KeyC,
-					),
-				],
+				// NO CHORD, for now. It was on `Mod+K C`, which cannot be typed any
+				// more: `Mod+K` is Insert Link and is no longer a prefix. The intended
+				// replacement, `Mod+Alt+C`, is not available — on macOS that is
+				// Monaco's `toggleFindCaseSensitive`, live whenever the editor has
+				// focus, and registered with `registerEditorCommand` rather than
+				// `registerEditorAction`, so it has no command palette entry to fall
+				// back on. Taking it would leave a user no way to toggle case in find
+				// except the mouse, which is the one thing no override in
+				// monacoChordOwnership.spec.ts is allowed to do.
 				run: () => {
 					editTable("insert-column");
 				},

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -784,6 +784,28 @@
 			EDITING_KEY_CONTEXT,
 		);
 
+		// ⌘⇧K / Ctrl+Shift+K, TAKEN BACK. It is `editor.action.deleteLines`, VS
+		// Code's convention inherited by standalone Monaco and inherited again by
+		// this app — a chord that silently destroys the line the caret is on. This
+		// is a Markdown editor: Typora, Obsidian, iA Writer and Bear all leave that
+		// chord alone, and it was being mis-fired here.
+		//
+		// A REMOVAL RULE, not a no-op command on the same chord. A `-`-prefixed
+		// command id is what Monaco's own resolver reads as "drop this default"
+		// (`KeybindingResolver.handleRemovals`); binding a do-nothing command
+		// instead would leave the key dead AND leave a fake command sitting in
+		// front of Monaco's, which is worse than either.
+		//
+		// The COMMAND stays: an action with no key is still a command palette
+		// entry (`Mod+P`), which is where the table delete verbs live for exactly
+		// the same reason. The key goes, the verb does not.
+		const removedKeybindings = monaco.editor.addKeybindingRules([
+			{
+				keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyK,
+				command: "-editor.action.deleteLines",
+			},
+		]);
+
 		editorReady = true;
 
 		// After the view-state / anchor-line restore above, deliberately: an
@@ -800,6 +822,11 @@
 			mediaQuery.removeEventListener("change", updateTheme);
 			container.removeEventListener("wheel", wheelListener, { capture: true });
 			completionProvider.dispose();
+			// The keybinding rules are global to the Monaco module, not to this
+			// editor, so they are disposed with it rather than left to pile up one
+			// copy per mount — this component is rebuilt every time a tab goes to
+			// reading mode and back.
+			removedKeybindings.dispose();
 
 			if (editor && currentTabId) {
 				const state = editor.saveViewState();
@@ -1459,10 +1486,12 @@
 			// where a verb you reach for twice a year belongs.
 			//
 			// WHY THE DESTRUCTIVE PAIR HAS NO CHORD. They were on `Mod+K Shift+R`
-			// and `Mod+K Shift+C`, one slip from Monaco's own `Mod+Shift+K` —
-			// delete line. A mis-fired insert is an undo; a mis-fired delete of the
-			// row you were reading is the kind of thing that gets noticed three
-			// edits later. Insert keeps a chord; delete does not get one.
+			// and `Mod+K Shift+C`, one slip from what was then Monaco's own
+			// `Mod+Shift+K` — delete line. That neighbour is unbound now (see the
+			// removal rule in `createEditor`), and the verbs still get no chord: the
+			// hazard was never only the neighbour. A mis-fired insert is an undo; a
+			// mis-fired delete of the row you were reading is the kind of thing that
+			// gets noticed three edits later.
 			//
 			// WHY INSERT ROW HAS NO CHORD EITHER: `Mod+Enter` owns it now, one
 			// keystroke instead of two, and Tab at the end of the table appends one.

--- a/src/lib/utils/shortcuts.ts
+++ b/src/lib/utils/shortcuts.ts
@@ -196,20 +196,53 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 	{ id: 'fmt-heading-1', labelKey: 'menu.heading1', chords: ['Mod+1'], group: 'edit', editorAction: true },
 	{ id: 'fmt-heading-2', labelKey: 'menu.heading2', chords: ['Mod+2'], group: 'edit', editorAction: true },
 	{ id: 'fmt-heading-3', labelKey: 'menu.heading3', chords: ['Mod+3'], group: 'edit', editorAction: true },
+	// GitHub's documented ordered/unordered list chords, identical on both
+	// platforms ("Inserts Markdown formatting for an ordered list" / "…an
+	// unordered list"). Numbered is 7 and bulleted is 8 because that is the way
+	// round GitHub has them, not because either digit resembles a list.
+	{ id: 'fmt-numbered-list', labelKey: 'menu.numberedList', chords: ['Mod+Shift+7'], group: 'edit', editorAction: true },
+	{ id: 'fmt-bullet-list', labelKey: 'menu.bulletList', chords: ['Mod+Shift+8'], group: 'edit', editorAction: true },
+	// 9 IS ARBITRARY, and deliberately not dressed up as a convention: GitHub
+	// documents no task-list chord at all, and neither does Typora or Obsidian.
+	// The two that do disagree and are both taken here — Bear's `Cmd+T` is New
+	// File, iA Writer's `Opt+Cmd+L` is Monaco's `toggleFindInSelection` on macOS
+	// — so the tie-break is adjacency: the third list button gets the digit next
+	// to the two the first two took.
+	{ id: 'fmt-checklist', labelKey: 'menu.checklist', chords: ['Mod+Shift+9'], group: 'edit', editorAction: true },
 	{
-		id: 'insert-table-simple',
-		labelKey: 'menu.insertTable',
-		// A chord SEQUENCE, not a combination: Mod+K, release, then T.
-		chords: ['Mod+K T'],
+		id: 'fmt-link',
+		labelKey: 'menu.link',
+		// The strongest competitor signal in the whole keymap: Typora, Bear, iA
+		// Writer and GitHub all document Mod+K for Insert Link, and it is the only
+		// command where four independent sources agree exactly. The link button had
+		// no shortcut at all until now.
+		//
+		// Taking it means Mod+K stops being a chord PREFIX, which is what
+		// `insert-table-simple` and `table-insert-column` used to hang off. What
+		// that costs on Monaco's side is argued in monacoChordOwnership.spec.ts.
+		chords: ['Mod+K'],
 		group: 'edit',
 		editorAction: true,
 	},
-	// Columns are the one table verb still on a chord: rarer than rows, and no
-	// unmodified key means "insert a column" anywhere. Rows are on `Mod+Enter` and
-	// on Tab at the end of the table, both in the `keys` group below, and the two
-	// DELETE verbs have no chord at all — they are palette-only, because
-	// `Mod+K Shift+R` sat one slip from Monaco's `Mod+Shift+K` (delete line).
-	{ id: 'table-insert-column', labelKey: 'menu.insertTableColumn', chords: ['Mod+K C'], group: 'edit', editorAction: true },
+	{
+		id: 'insert-table-simple',
+		labelKey: 'menu.insertTable',
+		// Typora's and Bear's macOS chord for the same command, and a single stroke
+		// rather than the `Mod+K T` sequence it replaces: the sequence was awkward
+		// enough to press that it is what started this rework.
+		chords: ['Mod+Alt+T'],
+		group: 'edit',
+		editorAction: true,
+	},
+	// INSERT COLUMN IS NOT HERE ANY MORE. It was on `Mod+K C`, and `Mod+K` is
+	// Insert Link now, so the sequence cannot be typed. `Mod+Alt+C` was the
+	// intended replacement and is not available: on macOS it is Monaco's
+	// `toggleFindCaseSensitive`, bound whenever the editor has focus, and
+	// registered as an editor COMMAND rather than an action — so it has no
+	// command palette entry to fall back on, which is the one thing every
+	// override in monacoChordOwnership.spec.ts requires. Insert Column is
+	// palette-only until a chord is chosen for it; see
+	// TABLE_VERBS_WITHOUT_A_CHORD in shortcutRegistry.test.ts.
 
 	// ---------------------------------------------------------------- keys
 	//
@@ -287,10 +320,12 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 	{
 		id: 'toggle-zen-mode',
 		labelKey: 'menu.zenMode',
-		// D for distraction-free. This was Mod+Shift+Z until it turned out that
-		// chord is redo's only binding on macOS — see the note at the keybinding
+		// Z for zen, at the third address this command has had. Mod+Shift+Z was
+		// redo's only binding on macOS; Mod+Shift+D was free but sat in the same
+		// Mod+Shift row the six formatting commands live in, and moving it out
+		// leaves that row to the formatting verbs. See the note at the keybinding
 		// in Editor.svelte.
-		chords: ['Mod+Shift+D'],
+		chords: ['Mod+Alt+Z'],
 		group: 'view',
 		editorAction: true,
 	},


### PR DESCRIPTION
`Mod+K` was a chord prefix holding two table verbs, and the Link button — the single function four independent editors document the same chord for — had no keyboard shortcut at all. Hand-testing settled it: the chord was too awkward to press, which is what started this.

| command | from | to | source |
|---|---|---|---|
| Insert Link | *(none)* | `Mod+K` | Typora, Bear, iA Writer, GitHub |
| Insert Table | `Mod+K T` | `Mod+Alt+T` | Typora and Bear's macOS chord |
| Zen Mode | `Mod+Shift+D` | `Mod+Alt+Z` | — |
| Numbered List | *(none)* | `Mod+Shift+7` | GitHub |
| Bullet List | *(none)* | `Mod+Shift+8` | GitHub |
| Checklist | *(none)* | `Mod+Shift+9` | **none — arbitrary, and labelled as such** |

The registry holds `Alt`; #651's `formatChord` renders it `Opt` on macOS, so the panel shows `Cmd+Opt+T` there and `Ctrl+Alt+T` elsewhere. The panel, the native menu and the toolbar tooltips all read `shortcutLabel()`, so they picked up every change without being touched.

`Mod+Shift+9` has no precedent anywhere — GitHub documents no task-list chord, and neither do Typora or Obsidian. Both the comment and the registry label it arbitrary-but-adjacent rather than implying a source it does not have.

### Insert Column did not get a chord

`Mod+Alt+C` is occupied. On macOS `Alt+Meta+C` is Monaco's `toggleFindCaseSensitive`, `kbExpr: EditorContextKeys.focus` — live whenever the editor has focus, not gated on the find widget being open.

What rules it out is not the collision but the recovery: it is a `registerEditorCommand`, **not** a `registerEditorAction`, so it has **no command palette entry**. Taking it would leave find-case-sensitivity reachable only by clicking the `Aa` button, which breaks the contract every `DELIBERATE_OVERRIDES` row in this repo rests on — *the displaced command is still reachable*.

Insert Column is therefore palette-only, recorded in `TABLE_VERBS_WITHOUT_A_CHORD` with that reasoning, alongside the delete verbs that are palette-only for their own reason. Free `Mod+Alt` letters on all three platforms, for whoever picks this up: **A B D E G H I J K M N O Q S U V X Y**.

### The guardrail could not see the largest change in the file

`monacoChordOwnership.spec.ts` keys Monaco's defaults by the **full** chord. Monaco has no bare `Meta+K` — it has `Meta+K Meta+C`, `Meta+K Meta+0` and so on — so `monaco.get('Meta+K')` was `undefined` and the ownership rule `continue`d.

**It waved the biggest keymap change in the app straight through.** A rule that only compares whole chords cannot see a chord being claimed as a complete key when Monaco uses it as a *prefix*, which is precisely the shape of this change.

Added a second rule for exactly that, plus a `namespace: true` row whose staleness check looks *behind* the prefix — so the row goes stale if Monaco stops using `Mod+K` as a prefix, not merely if it stops binding `Mod+K` itself.

### The cost, enumerated rather than summarised

Taking plain `Mod+K` ends Monaco's `Mod+K …` namespace: **31 chord sequences carrying 30 commands, 20 of them folding**, identical on all three platforms. The `DELIBERATE_OVERRIDES` row names all thirty.

That is larger than the audit that proposed this change estimated (22 commands, 14 folding), and the row says so.

**Why it is still acceptable, verified rather than assumed:** editor folding does almost nothing for Markdown here. There is no `registerFoldingRangeProvider` anywhere in `src/`, and Monaco's `basic-languages/markdown/markdown.js` declares folding only through `<!-- #region -->` markers, which nobody writes in Markdown. What remains is indentation folding. The app's useful folding is its own preview-side system (`foldState.ts`) — click-driven, untouched by any of this, and reached through the fold icons rather than a key. Every displaced command remains in the command palette.

### Also carried: `Mod+Shift+K` no longer deletes a line

A commit that was verified, then never pushed, so it missed #645 and is not in master — `Mod+Shift+K` still deletes a line there today. It is Monaco's `deleteLines`, and it was reported mis-firing.

Refolding it conflicted: #648 deleted `MONACO_DEFAULTS`, and the conflict region swallowed the new test with it. Resolved by keeping master's comment and re-adding the test intact; its only dependency on the deleted table was prose. Delete Line keeps its palette entry.

### Falsification

Four red-first failures, one per change, each quoted in the commit that fixes it. Two more after rebasing onto #651: a literal `Cmd+Alt+T`, and an assertion that the Cmd rendering *is* the Ctrl rendering with one word swapped — itself a copy of the assumption #651 removed. The second now proves only that the two renderings are the same chord, and leaves per-platform naming to the test that owns it.

`npm test` 900 → **903** · `vitest` 356 → **357** · `check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
