### PR TITLE
fix(anchor): one numbering for the tab's anchor line

### DIFF
--- a/scripts/tabAnchorAcrossPanes.spec.ts
+++ b/scripts/tabAnchorAcrossPanes.spec.ts
@@ -1,0 +1,263 @@
+/**
+ * One tab, two panes, one anchor line — and a document with front matter, which
+ * is the only kind of document that can tell whether the two panes agree about
+ * what a line number means.
+ *
+ * `tab.anchorLine` is where the reader was. The preview writes it off
+ * `data-sourcepos`, which counts from the first line of the BODY; the editor
+ * writes it off Monaco, which counts from the first line of the FILE. Each pane
+ * read its own writes back the way it made them, so each looked correct on its
+ * own, and every switch between them landed the height of the front matter
+ * away. Without front matter the two numberings coincide and the defect is
+ * invisible — which is what every earlier fixture was, and why this one is not.
+ *
+ * So both directions are driven end to end here, and what is asserted is where
+ * the READER ends up, not the number in the field:
+ *
+ *   preview scroll offset -> anchor -> editor's reveal line -> the text there
+ *   editor top line       -> anchor -> preview's anchor element -> its text
+ *
+ * The pieces are the real ones on both sides — `processMarkdownHtml`'s output,
+ * `getSourceLineAtPreviewOffset`, `findAnchorElement`, `getAnchorScrollTop`,
+ * the real `TabManager` — and the crossing itself is imported rather than
+ * re-implemented, because a test that re-derives the shift cannot notice the
+ * component forgetting it.
+ *
+ * What is injected is layout: jsdom has none, and `measure` is a parameter of
+ * the mapping for exactly this reason. The numbers below are not a claim about
+ * how a browser lays a paragraph out; the property under test only needs blocks
+ * to be somewhere, in order.
+ */
+
+import assert from 'node:assert/strict';
+
+import { test } from 'vitest';
+
+(window as any).__TAURI_INTERNALS__ = {
+	metadata: { currentWindow: { label: 'main' }, currentWebview: { windowLabel: 'main', label: 'main' } },
+	invoke: (cmd: string) => Promise.resolve(cmd === 'get_os_type' ? 'macos' : null),
+};
+
+const { tabManager } = await import('../src/lib/stores/tabs.svelte.js');
+const { processMarkdownHtml } = await import('../src/lib/utils/markdown.js');
+const { findAnchorElement, getAnchorScrollTop, getSourceLineAtPreviewOffset, PREVIEW_ANCHOR_OFFSET } = await import(
+	'../src/lib/utils/previewAnchor.js'
+);
+const {
+	asBufferLine,
+	asRendererLine,
+	editorTopLineForTabAnchor,
+	lineCoordinates,
+	tabAnchorForEditorTopLine,
+	EDITOR_ANCHOR_LINE_OFFSET,
+} = await import('../src/lib/utils/lineCoordinates.js');
+
+/* ------------------------------------------------------------------ */
+/* one document, written twice: as a file and as its render            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * comrak's shape, as the render-protocol fixtures record it: a `data-sourcepos`
+ * range on every block, counted from the first line of the BODY. The file the
+ * user edits is built line for line beside it, front matter included, so the
+ * two differ by exactly the thing under test.
+ */
+class Fixture {
+	readonly bodyLines: string[] = [];
+	private readonly parts: string[] = [];
+	private readonly lines = new Map<string, number>();
+
+	private push(source: string, html: (line: number) => string) {
+		this.bodyLines.push(source, '');
+		const line = this.bodyLines.length - 1;
+		this.lines.set(source, line);
+		this.parts.push(html(line));
+	}
+
+	heading(text: string, slug: string) {
+		this.push(
+			`## ${text}`,
+			(line) =>
+				`<h2 data-sourcepos="${line}:1-${line}:${text.length + 3}">` +
+				`<a href="#${slug}" aria-hidden="true" class="anchor" id="${slug}"></a>${text}</h2>`,
+		);
+	}
+
+	paragraph(text: string) {
+		this.push(text, (line) => `<p data-sourcepos="${line}:1-${line}:${text.length}">${text}</p>`);
+	}
+
+	html() {
+		return this.parts.join('\n') + '\n';
+	}
+}
+
+/** Five lines of YAML and the blank line after it: the body starts at file line 7. */
+const FRONT_MATTER = ['---', 'title: Anchored', 'tags:', '  - front matter', '---', ''];
+
+const DOC = new Fixture();
+for (const section of ['alpha', 'beta', 'gamma', 'delta']) {
+	DOC.heading(`${section} section`, `${section}-section`);
+	for (let p = 1; p <= 4; p += 1) {
+		DOC.paragraph(`${section} paragraph ${p}, a sentence of prose.`);
+	}
+}
+
+const FILE_LINES = [...FRONT_MATTER, ...DOC.bodyLines];
+const RAW = FILE_LINES.join('\n');
+const COORDS = lineCoordinates(RAW);
+const PATH = '/notes/anchored.md';
+
+/** The line of the FILE a block sits on: 1-based, front matter counted. */
+function fileLine(text: string): number {
+	const index = FILE_LINES.indexOf(text);
+	assert.notEqual(index, -1, `${text} is not a line of the fixture`);
+	return index + 1;
+}
+
+/** The document the preview walks: `.markdown-body`, holding the real pipeline's output. */
+const BODY = (() => {
+	const body = document.createElement('div');
+	body.className = 'markdown-body';
+	body.innerHTML = processMarkdownHtml(DOC.html(), PATH, new Set<string>());
+	return body;
+})();
+
+/* ------------------------------------------------------------------ */
+/* the layout jsdom does not have                                      */
+/* ------------------------------------------------------------------ */
+
+const BLOCK_HEIGHT = 100;
+
+/** Does anything in here carry a source range? Anything else gets no box. */
+function isAnnotated(element: Element): boolean {
+	return element.hasAttribute('data-sourcepos') || Array.from(element.children).some(isAnnotated);
+}
+
+/**
+ * Every annotated block gets a top and a height, children stacked inside their
+ * parent in document order — bottom-up, so a container's box really does
+ * contain its children's, which is the one property the descent relies on.
+ */
+const BOXES = (() => {
+	const boxes = new Map<Element, { top: number; height: number }>();
+
+	const place = (element: Element, top: number): number => {
+		const children = Array.from(element.children).filter(isAnnotated);
+		if (children.length === 0) {
+			boxes.set(element, { top, height: BLOCK_HEIGHT });
+			return BLOCK_HEIGHT;
+		}
+
+		let cursor = top;
+		for (const child of children) cursor += place(child, cursor);
+		boxes.set(element, { top, height: cursor - top });
+		return cursor - top;
+	};
+
+	place(BODY, 0);
+	return boxes;
+})();
+
+const measure = (node: unknown) => BOXES.get(node as Element) ?? { top: 0, height: 0 };
+
+function blockAt(text: string): Element {
+	const element = Array.from(BODY.querySelectorAll('[data-sourcepos]')).find((node) => node.textContent === text);
+	assert.ok(element, `${text} was not rendered as a block of its own`);
+	return element;
+}
+
+function openTab() {
+	tabManager.closeAll();
+	localStorage.clear();
+	tabManager.addTab(PATH, RAW);
+	return tabManager.tabs.find((item) => item.path === PATH)!;
+}
+
+/** Not the first paragraph of its section, so the two lines above it are prose. */
+const READING = 'gamma paragraph 3, a sentence of prose.';
+
+test('the fixture is a document whose two numberings differ', () => {
+	assert.equal(COORDS.frontMatterLines, FRONT_MATTER.length);
+	assert.equal(fileLine(READING), COORDS.toBufferLine(asRendererLine(fileLine(READING) - FRONT_MATTER.length)));
+});
+
+/* ------------------------------------------------------------------ */
+/* preview -> editor                                                   */
+/* ------------------------------------------------------------------ */
+
+test('a tab scrolled in the preview opens the editor on the line the reader was reading', () => {
+	const tab = openTab();
+
+	// What the reader did: scrolled the preview until READING sat at the offset
+	// the anchor is measured at. `getPreviewScrollAnchor` rounds what the
+	// mapping answers and hands it straight over.
+	const anchor = getSourceLineAtPreviewOffset(BODY, measure(blockAt(READING)).top, measure);
+	assert.ok(anchor !== null, 'the preview must resolve a source line for a block it laid out');
+	tabManager.updateTabAnchorLine(tab.id, asRendererLine(Math.round(anchor)));
+
+	// What the editor does with it: reveals a line near the top of its viewport.
+	const top = editorTopLineForTabAnchor(COORDS, tab.anchorLine);
+
+	assert.equal(
+		FILE_LINES[top - 1],
+		'gamma paragraph 2, a sentence of prose.',
+		'the editor opens with the paragraph before the reader at the top of the viewport',
+	);
+	assert.equal(
+		FILE_LINES[top - 1 + EDITOR_ANCHOR_LINE_OFFSET],
+		READING,
+		'and the paragraph the reader was on where the anchor puts it',
+	);
+});
+
+/* ------------------------------------------------------------------ */
+/* editor -> preview                                                   */
+/* ------------------------------------------------------------------ */
+
+test('a tab scrolled in the editor opens the preview on the block the reader was reading', () => {
+	const tab = openTab();
+
+	// What Monaco reports on the way out: the buffer line at the top of the
+	// viewport, with READING the anchor's distance below it.
+	const topLine = asBufferLine(fileLine(READING) - EDITOR_ANCHOR_LINE_OFFSET);
+	tabManager.updateTabAnchorLine(tab.id, tabAnchorForEditorTopLine(COORDS, topLine));
+
+	const match = findAnchorElement(BODY, tab.anchorLine);
+	assert.ok(match, 'the recorded anchor must resolve to a rendered block');
+	assert.equal(
+		(match.element as unknown as Element).textContent,
+		READING,
+		'the preview restores to the block the reader left the editor on',
+	);
+
+	// And it puts that block where the capture side measures from, so a reader
+	// bouncing between the panes stays put rather than creeping down the page.
+	const box = measure(match.element);
+	assert.equal(
+		getAnchorScrollTop(box.top, box.height, match, tab.anchorLine, PREVIEW_ANCHOR_OFFSET),
+		Math.max(0, box.top - PREVIEW_ANCHOR_OFFSET),
+	);
+});
+
+/* ------------------------------------------------------------------ */
+/* that the brand is still there                                       */
+/* ------------------------------------------------------------------ */
+//
+// The brand has no run-time representation, so this cannot be an `assert`. It
+// is the `@ts-expect-error` directives below, which invert into the failure
+// wanted: if `updateTabAnchorLine` ever goes back to taking a plain `number`,
+// these lines compile and `npm run check` fails them as UNUSED directives.
+
+test('the anchor cannot be written in the editor’s numbering by accident', () => {
+	const tab = openTab();
+	tabManager.updateTabAnchorLine(tab.id, asRendererLine(12));
+
+	// A Monaco line, which is what this call used to be handed.
+	// @ts-expect-error `updateTabAnchorLine` takes a RendererLine; this is a BufferLine
+	tabManager.updateTabAnchorLine(tab.id, COORDS.toBufferLine(tab.anchorLine));
+
+	// And a bare number, which does not say which of the two it is.
+	// @ts-expect-error a plain `number` no longer claims a numbering
+	tabManager.updateTabAnchorLine(tab.id, 812);
+});

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -27,7 +27,13 @@
 		getVerticalOffsetForLine,
 		type ScrollSyncPosition,
 	} from '../utils/scrollSync.js';
-	import { asBufferLine, type BufferLine } from '../utils/lineCoordinates.js';
+	import {
+		asBufferLine,
+		editorTopLineForTabAnchor,
+		lineCoordinates,
+		tabAnchorForEditorTopLine,
+		type BufferLine,
+	} from '../utils/lineCoordinates.js';
 	import {
 		DEFAULT_IMAGE_DIRECTORY,
 		documentParentDir,
@@ -485,8 +491,13 @@
 		} else if (tabManager.activeTab) {
 			let scrolled = false;
 			if (tabManager.activeTab.anchorLine > 0) {
+				// The anchor is a RENDERER line, whoever recorded it — this pane
+				// or the preview — and Monaco can only be aimed with a buffer
+				// line. The conversion is the whole point of the crossing: a tab
+				// last scrolled in the preview used to open here the height of
+				// its front matter too far up the document.
 				editor.revealLineNearTop(
-					Math.max(1, tabManager.activeTab.anchorLine - 2),
+					editorTopLineForTabAnchor(lineCoordinates(value), tabManager.activeTab.anchorLine),
 					monaco.editor.ScrollType.Immediate,
 				);
 				scrolled = true;
@@ -841,10 +852,19 @@
 				}
 
 				const ranges = editor.getVisibleRanges();
-				if (ranges.length > 0) {
-					const startLine = ranges[0].startLineNumber;
-					const anchorLine = startLine + 2;
-					tabManager.updateTabAnchorLine(currentTabId, anchorLine);
+				const model = editor.getModel();
+				if (ranges.length > 0 && model) {
+					// Monaco counts from the first line of the FILE and the tab's
+					// anchor counts from the first line of the body, so this is a
+					// crossing; `EDITOR_ANCHOR_LINE_OFFSET` is the old `+ 2`,
+					// which is a separate decision and is documented as one.
+					tabManager.updateTabAnchorLine(
+						currentTabId,
+						tabAnchorForEditorTopLine(
+							lineCoordinates(model.getValue()),
+							asBufferLine(ranges[0].startLineNumber),
+						),
+					);
 				}
 			}
 

--- a/src/lib/stores/tabs.svelte.ts
+++ b/src/lib/stores/tabs.svelte.ts
@@ -141,6 +141,11 @@ export interface Tab {
 	 * makes forgetting that a type error instead of a document that opens the
 	 * height of its own front matter off (#607).
 	 *
+	 * The editor writes it too, and pays that toll in both directions:
+	 * `tabAnchorForEditorTopLine` on the way in, `editorTopLineForTabAnchor` on
+	 * the way out. It used to write a raw Monaco line here, which is why the
+	 * paragraph above is worth reading twice.
+	 *
 	 * `scrollPercentage` is a 0-1 fraction of the scrollable range. It survives
 	 * a container of some other height, but it drifts with the content: the
 	 * "rough percentage of the document instead of where you left off" that
@@ -870,27 +875,26 @@ class TabManager {
 	}
 
 	/**
-	 * The one place a bare number becomes this tab's anchor.
+	 * The one place this tab's anchor is written, in the one numbering it is in.
 	 *
-	 * `line` is a plain `number` and not a `RendererLine`, which is the ONE
-	 * unbranded claim left on this field, and it is deliberate rather than an
-	 * oversight. Two components write here and they do not agree on what they
-	 * are writing: `MarkdownViewer.svelte` hands over `getPreviewScrollAnchor`,
-	 * a renderer line off `data-sourcepos`; `components/Editor.svelte` hands
-	 * over `ranges[0].startLineNumber + 2`, a MONACO line, which is a buffer
-	 * line. Branding this parameter turns that second call into the type error
-	 * it deserves to be — and there is no conversion to write there without
-	 * settling which of the two numberings the field is (it is the renderer's:
-	 * `findAnchorElement` reads it back against `data-sourcepos`).
+	 * `line` is a `RendererLine` because that is what the field is — the restore
+	 * reads it back with `findAnchorElement` against `data-sourcepos`, which
+	 * counts from the first line of the body. Two components write here and they
+	 * used to disagree: `MarkdownViewer.svelte` hands over
+	 * `getPreviewScrollAnchor`, already a renderer line, while
+	 * `components/Editor.svelte` handed over a MONACO line, which counts from
+	 * the first line of the file. Both round-tripped their own writes, so
+	 * neither pane looked broken alone and every cross-pane switch landed the
+	 * height of the front matter away.
 	 *
-	 * So the assertion sits here, where it is visible, instead of at four call
-	 * sites where it would not be. Whoever fixes the editor's half takes this
-	 * parameter to `RendererLine` and deletes this comment.
+	 * The brand is what stops that being writable: the editor now converts at
+	 * its own edge (`tabAnchorForEditorTopLine`), and a caller that forgets is a
+	 * type error rather than a document that opens in the wrong place.
 	 */
-	updateTabAnchorLine(id: string, line: number) {
+	updateTabAnchorLine(id: string, line: RendererLine) {
 		const tab = this.tabs.find((t) => t.id === id);
 		if (tab) {
-			tab.anchorLine = asRendererLine(line);
+			tab.anchorLine = line;
 		}
 	}
 

--- a/src/lib/utils/lineCoordinates.ts
+++ b/src/lib/utils/lineCoordinates.ts
@@ -123,3 +123,37 @@ export function lineCoordinates(rawContent: string): LineCoordinates {
 			getPreviewOffsetForSourceLine(root, toRendererLine(line), measure),
 	};
 }
+
+/**
+ * How far below the top of the editor's viewport the tab's anchor line sits.
+ *
+ * The editor's counterpart to `PREVIEW_ANCHOR_OFFSET`, and there for the same
+ * reason: what a reader is returned to is the line they were READING, not
+ * whichever line the viewport happened to cut in half. The preview says that in
+ * pixels because it is laid out in pixels; the editor says it in lines because
+ * Monaco is aimed with one. It was written out as a bare `+ 2` at the capture
+ * and a bare `- 2` at the restore, under the comment "Anchor to 3rd line".
+ *
+ * It is NOT the front-matter shift wearing a disguise, which is the reading the
+ * `+ 2` invites: this is a constant and that shift is a property of the
+ * document, and the two crossings below apply both.
+ */
+export const EDITOR_ANCHOR_LINE_OFFSET = 2;
+
+/**
+ * The editor's crossing into the tab's numbering: `topLine` is the buffer line
+ * at the top of its viewport, the answer is what the tab records.
+ *
+ * Non-positive when the reader is parked in the front matter, which has no
+ * renderer line at all — it renders as a panel, not as body. Both restore
+ * cascades are guarded on `anchorLine > 0`, so that answer falls through to
+ * `scrollPercentage` rather than aiming the other pane at the top.
+ */
+export function tabAnchorForEditorTopLine(coords: LineCoordinates, topLine: BufferLine): RendererLine {
+	return coords.toRendererLine(asBufferLine(topLine + EDITOR_ANCHOR_LINE_OFFSET));
+}
+
+/** The way back: the buffer line to reveal near the top for a recorded anchor. */
+export function editorTopLineForTabAnchor(coords: LineCoordinates, anchor: RendererLine): BufferLine {
+	return asBufferLine(Math.max(1, coords.toBufferLine(anchor) - EDITOR_ANCHOR_LINE_OFFSET));
+}


### PR DESCRIPTION
`tab.anchorLine` was written by two panes in **two different line numberings**.

```
MarkdownViewer.svelte   getPreviewScrollAnchor(…)        → a RENDERER line ✅
Editor.svelte           ranges[0].startLineNumber + 2    → a BUFFER line   ❌
Editor.svelte           read back into revealLineNearTop → wants a BUFFER line
```

Each pane round-tripped its own writes consistently, which is why nothing looked broken in isolation. The **cross-pane** path was wrong in both directions, off by the height of the front matter: scroll the preview, switch to the editor, and the caret lands somewhere else — and the reverse.

This is the defect class #607 introduced `BufferLine` / `RendererLine` for. #641 branded the field itself and that is what surfaced this, but the **parameter** had to stay a plain `number` because branding it turns `Editor.svelte` into a compile error, and that file was owned by another branch at the time. It left an assertion and a comment naming the site.

### The brand does the finding

`updateTabAnchorLine(id, line: RendererLine)`, and the `asRendererLine(line)` laundering inside it is gone. The brand turned up **exactly the one caller its comment named** and no others; `MarkdownViewer`'s call already passed a `RendererLine`.

**Converted, not cast** — there is no `as RendererLine` anywhere in the fix. `lineCoordinates.ts` gained the editor's crossing in both directions, so `Editor.svelte` never touches the shift by hand:

- `tabAnchorForEditorTopLine(coords, topLine)` — Monaco's top visible buffer line → the renderer line the tab records
- `editorTopLineForTabAnchor(coords, anchor)` — the recorded renderer line → the buffer line to reveal

### The `+ 2` stays, and now says why

Traced to `edfb555` (*"roughly match viewer-editor scroll location"*), written with the comment `// Anchor to 3rd line`; the `- 2` at the restore landed in the same commit.

**It is not a front-matter fudge.** It is a constant, and the front-matter shift is a property of the document — a constant 2 could never have been standing in for it. It is the editor's counterpart to `PREVIEW_ANCHOR_OFFSET = 60`: both panes record the line the reader was *reading*, not the one the viewport cut in half. One says it in pixels because it is laid out in pixels; the other in lines because Monaco is aimed with one. It survives as `EDITOR_ANCHOR_LINE_OFFSET` with that written down.

So the read side was **correct already** and was not compensating for the bad write. The `- 2` is the exact inverse of the `+ 2` within the editor's own pane; what was missing beside it was the buffer↔renderer conversion, which is variable (6 lines in the fixture).

### One behaviour change worth naming

An editor parked **inside the front matter** now yields a non-positive anchor — front matter renders as a panel and has no renderer line at all. Both restore cascades are already guarded on `anchorLine > 0`, so it falls through to `scrollPercentage`. Previously it stored a plausible-looking wrong line.

### Tests

`scripts/tabAnchorAcrossPanes.spec.ts`, 4 tests, driving **both crossings end to end** over a document with front matter (6 buffer lines above the body): real `processMarkdownHtml` output, real `getSourceLineAtPreviewOffset` / `findAnchorElement` / `getAnchorScrollTop`, the real `TabManager`, layout injected through `measure` as `scrollSyncBlockMapping.test.ts` does. **Assertions are on the text the reader lands on**, not the number stored.

Both halves fail against the old arithmetic:

```
FAIL > a tab scrolled in the preview opens the editor on the line the reader was reading
  + 'beta paragraph 4, a sentence of prose.'
  - 'gamma paragraph 2, a sentence of prose.'

FAIL > a tab scrolled in the editor opens the preview on the block the reader was reading
  + 'delta paragraph 1, a sentence of prose.'
  - 'gamma paragraph 3, a sentence of prose.'
```

Brand liveness is asserted with `@ts-expect-error` — an *unused* directive is itself an error, so a green `npm run check` is the assertion. Unbranding the parameter reports both directives unused.

`npm test` 903 · `vitest` 357 → **361** · `check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
