### PR TITLE
test: delete two proven-redundant assertions, and unpin three from their formatting

### DIFF
--- a/scripts/menuModalGuards.test.ts
+++ b/scripts/menuModalGuards.test.ts
@@ -1,17 +1,34 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { readSource } from './sourceTree.js';
+import { functionSource, readSource, sliceBetween } from './sourceTree.js';
 
 const viewer = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
 const titleBar = readSource(new URL('../src/lib/components/TitleBar.svelte', import.meta.url));
 const modal = readSource(new URL('../src/lib/components/Modal.svelte', import.meta.url));
 
+// Three of the four assertions below used to spell `\n\t\t` and `\n\t\t\t` into
+// the pattern, so they pinned the indentation of the code as much as its order.
+// A single `prettier` run — or wrapping one condition across two lines — turned
+// all three red without changing a thing the user can see. What actually has to
+// hold is which function the statement lives in and what it comes BEFORE, so
+// that is what is asserted now: the scope comes from `functionSource`, and the
+// ordering from offsets within that scope.
+
+/** The document-level right-click handler, braces included. */
+const contextMenuHandler = functionSource(viewer, 'handleContextMenu');
+
+/** Where `needle` sits inside `scope`, asserted to be present at all. */
+function offsetIn(scope: string, needle: string, what: string): number {
+	const at = scope.indexOf(needle);
+	assert.notEqual(at, -1, `${what} is gone from the handler`);
+	return at;
+}
+
 test('document context menus do not open while a modal is active', () => {
-	assert.match(
-		viewer,
-		/function handleContextMenu\(e: MouseEvent\) \{\n\t\tif \(modalState\.show\) return;/,
-	);
+	// First statement, not merely present: every branch below it either opens a
+	// menu or returns, so a modal guard placed after any of them is not a guard.
+	assert.match(contextMenuHandler, /^function handleContextMenu\([^)]*\)\s*\{\s*if \(modalState\.show\)\s*return;/);
 });
 
 test('titlebar menus close before a document context menu opens', () => {
@@ -20,15 +37,25 @@ test('titlebar menus close before a document context menu opens', () => {
 });
 
 test('modal backdrop consumes context-menu events outside text fields', () => {
-	assert.match(
-		modal,
-		/if \(\(e\.target as HTMLElement\)\.closest\('input, textarea'\)\) return;\n\t\t\te\.preventDefault\(\);\n\t\t\te\.stopPropagation\(\);/,
-	);
+	// Scoped to the backdrop's own `oncontextmenu`, so a `preventDefault` that
+	// belongs to some other handler in this component cannot satisfy it.
+	const backdrop = sliceBetween(modal, 'oncontextmenu={', 'role="presentation"');
+	const carveOut = offsetIn(backdrop, "closest('input, textarea')", 'the text-field carve-out');
+	const prevent = offsetIn(backdrop, 'e.preventDefault();', 'the native-menu suppression');
+	const stop = offsetIn(backdrop, 'e.stopPropagation();', 'the propagation guard');
+
+	// The carve-out returns, so anything that suppresses the native menu has to
+	// come after it or the prompt input loses Cut/Copy/Paste.
+	assert.ok(prevent > carveOut && stop > carveOut, 'the backdrop suppresses the menu before letting text fields out');
 });
 
 test('text fields keep the webview edit menu so paste stays reachable', () => {
-	assert.match(
-		viewer,
-		/if \(\(e\.target as HTMLElement\)\.closest\('input, textarea, \[contenteditable="true"\]'\)\) return;\n\t\te\.preventDefault\(\);/,
+	const carveOut = offsetIn(
+		contextMenuHandler,
+		'closest(\'input, textarea, [contenteditable="true"]\')',
+		'the text-field carve-out',
 	);
+	const prevent = offsetIn(contextMenuHandler, 'e.preventDefault();', 'the native-menu suppression');
+
+	assert.ok(prevent > carveOut, 'preventDefault runs before the text-field carve-out, so paste is unreachable');
 });

--- a/scripts/settingsPersistence.spec.ts
+++ b/scripts/settingsPersistence.spec.ts
@@ -208,18 +208,13 @@ test('changing one setting rewrites only that setting key', () => {
 	assert.deepEqual(written(() => {}), []);
 });
 
-test('the store installs a storage listener that survives on the real window', () => {
-	// The other half of the multi-window fix, through jsdom's real event
-	// dispatch: `addEventListener('storage', …)` runs inside an `$effect`, so it
-	// is only wired up once the effects flush.
-	resetStorage();
-	const store = createStore();
-	flushSync();
-
-	localStorage.setItem('editor.fontSize', '30');
-	dispatchStorage('editor.fontSize', '30');
-	assert.equal(store.editorFontSize, 30);
-});
+// `the store installs a storage listener that survives on the real window` stood
+// here. Its body was the first half of `storage events fold another window
+// changes into this instance` below, verbatim — same reset, same store, same
+// flush, same `editor.fontSize` write and dispatch, same assertion — and that
+// test then goes on to do the language key as well. Deleting
+// `window.addEventListener('storage', …)` from the store turns eight tests in
+// this file red, that superset among them.
 
 test('a second window no longer clobbers what the first window just changed', () => {
 	// Window A and window B are separate webviews with separate store instances
@@ -889,10 +884,13 @@ test('the zen fallback is each setting own default', () => {
  * ---------------------------------------------------------------------------
  */
 
-test('the store listens for cross-window storage events', () => {
-	assert.match(storeSource, /addEventListener\('storage', onStorage\)/);
-	assert.match(storeSource, /removeEventListener\('storage', onStorage\)/);
-});
+// `the store listens for cross-window storage events` stood here, matching
+// `addEventListener('storage', onStorage)` and its `removeEventListener` in the
+// source text. Both halves are already run rather than read, in this same file:
+// neutering the `addEventListener` reddens eight tests, and replacing the
+// effect's disposer with `() => {}` reddens `a disposed store stops writing and
+// stops listening`. The text match added a way to fail that a rename of the
+// private `onStorage` handler would trigger on its own.
 
 test('the store has no single effect that writes every key', () => {
 	const setItemCalls = storeSource.match(/localStorage\.setItem\(/g) ?? [];

--- a/scripts/windowStartupHandle.test.ts
+++ b/scripts/windowStartupHandle.test.ts
@@ -6,6 +6,19 @@ import { readRustBackend, readSource } from './sourceTree.js';
 const backend = readRustBackend();
 
 test('startup reuses the window handle returned by the builder', () => {
-	assert.match(backend, /let window = window_builder\.build\(\)\?;/);
-	assert.doesNotMatch(backend, /app\.get_webview_window\(label\)\.unwrap\(\)/);
+	// Not vacuous: the build call the rule below is about still exists, so
+	// "nobody re-finds the window" cannot pass by the builder having gone away.
+	assert.match(backend, /window_builder\s*\.\s*build\(\)/);
+
+	// The defect (#318): building the window, then throwing the handle away and
+	// looking it back up by label — an `Option` that startup unwrapped, which is
+	// a panic on the one path where the lookup misses.
+	//
+	// The binding's spelling is deliberately NOT pinned. This used to also
+	// assert `/let window = window_builder\.build\(\)\?;/`, which is a claim
+	// about what the local is CALLED: renaming it to `win`, or letting rustfmt
+	// wrap the line, turned this red with the behaviour untouched. The pattern
+	// below is widened for the same reason — it no longer requires the receiver
+	// to be spelled `app`, so the lookup cannot come back through an alias.
+	assert.doesNotMatch(backend, /get_webview_window\([^)]*\)\s*\.\s*unwrap\(\)/);
 });


### PR DESCRIPTION
An audit proposed deleting ~60 tests as redundant. **Six of its six cross-file claims were wrong**, and the requirement to prove each deletion by breaking the guarded code is what caught them. Two deletions survived.

The finding is worth more than the diff.

### What the proof caught

Each of these was going to be deleted as a duplicate. Each stays:

| claimed duplicate | what breaking the code showed |
|---|---|
| `tabTransfer`'s 6 reject tests | The table-driven case deletes 12 **cosmetic** fields; the six cover `rawContent` / `history` and *type* mismatches. Dropping `rawContent` from `STRING_FIELDS` reddens exactly the two nobody thought mattered. |
| `foldStatePerDocument` ↔ `tabReadingPosition` | Same six scenarios over **two different fields** — folds vs reading position. |
| `scrollSync` ↔ `scrollSyncBlockMapping` | Ratio mapping vs the block mapping that replaced it in #474: one property, **two implementations**, both still live. |
| `jumpToSelectedFragment` ↔ `lineCoordinates` | `frontMatterLineOffset` vs `lineCoordinates` — **the primitive and the composition over it**. |
| `settingsPersistence`'s 4 flex tests | Called a style audit; they are the only guard for the theme-row defect they name. |
| `exportSanitize` CSP pair | The overlap is two assertions inside a composite test, not a test. |

**The pattern the audit missed:** this codebase deliberately tests the primitive *and* the composition over it, so similar names describe the same property at different layers. Matching on names finds "duplicates" that are nothing of the kind. Suite-wide, only two test *names* repeat, and both are legitimate.

### What shipped

**Two deletions, each proven.** Both in `settingsPersistence.spec.ts`:

- One was verbatim the first half of its own superset. Neutering `addEventListener('storage')` reddens 8 tests including that superset.
- One was a text match on both listener calls. The `addEventListener` half is covered by those 8; the `removeEventListener` half by *a disposed store stops writing and stops listening*, which reddens on its own when the disposer becomes `() => {}`.

**Four assertions unpinned from formatting**, which is where the real debt was:

- `menuModalGuards` hard-coded `\n\t\t` in three patterns. Reformatting the guarded code — multi-line signature, split `return`, blank lines — turned 3 of 4 red **for nothing**. Now scoped through `functionSource` / `sliceBetween` with offset ordering: survives the reformat, still reddens on all three defect mutations.
- `windowStartupHandle` pinned a Rust local's *name*, and its absence pattern **had a real hole**: it only matched `app.get_webview_window(...)`, so reintroducing the defect through any other receiver passed silently. Widened; the alias mutation now fails.

That second one is the shape worth noticing — a test proposed for deletion as redundant turned out to be **too weak**, not surplus.

### Left standing, deliberately

The ~101 source-shape assertions across 35 test files that all point at `MarkdownViewer.svelte` (4,822 lines). They are not 35 bad tests; they are 35 shadows of one missing seam, and the fix is to move the logic out — the same surgery #644 did for the fold drivers — not to delete the tests or to mount the component under jsdom, which `AGENTS.md` correctly rejects.

That is a refactor of production code and belongs on its own branch. **Do not read this PR as having finished the job**; the commit message says so too.

`npm test` 904 (unchanged — the rest were rewrites, not deletions) · `vitest` 361 → **359** · `cargo` 148 · `check` 0 errors. Only `scripts/` touched; production files were mutated during the proofs and each restored, with `git status` verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
