### PR TITLE
refactor(viewer): lift the key dispatcher out, so its tests can call it

### DIFF
--- a/scripts/formatShortcutKeymap.test.ts
+++ b/scripts/formatShortcutKeymap.test.ts
@@ -13,8 +13,10 @@ import {
 	documentKeymap,
 	editorKeymap,
 	registeredActions,
+	viewerCommandTable,
 	type Chord,
 } from './keymapHarness.js';
+import type { ViewerCommand } from '../src/lib/utils/viewerKeymap.js';
 import { readRustBackend, readSource, sliceBetween, sliceFrom } from './sourceTree.js';
 
 /*
@@ -158,9 +160,9 @@ test('Ctrl/Cmd+T means new file outside the editor too, on every platform', () =
 	for (const platform of PLATFORMS) {
 		const keymap = documentKeymap(platform.osType);
 		for (const chord of platform.mac ? ['Meta+T', 'Meta+N'] : ['Ctrl+T', 'Ctrl+N']) {
-			assert.deepEqual(
+			assert.equal(
 				keymap.get(chord),
-				['handleNewFile'],
+				'new-file',
 				`${chord} on ${platform.name} opens a new file and nothing else`,
 			);
 		}
@@ -168,14 +170,13 @@ test('Ctrl/Cmd+T means new file outside the editor too, on every platform', () =
 });
 
 test('no path anywhere still opens a Home tab from a keystroke', () => {
-	for (const platform of PLATFORMS) {
-		for (const [chord, fired] of documentKeymap(platform.osType)) {
-			assert.ok(
-				!fired.some((call) => call.includes('addHomeTab')),
-				`${chord} on ${platform.name} still reaches addHomeTab`,
-			);
-		}
-	}
+	// The #392 defect in its original spelling: the document branch for Ctrl+T
+	// called `tabManager.addHomeTab`. There is no `ViewerCommand` for that any
+	// more, so the checkable end is the other one — the component's command table
+	// has no route to `addHomeTab`, from any chord. `viewerCommandTable()` reads
+	// that table out of the component; see its note in `keymapHarness.ts`.
+	const routes = Object.entries(viewerCommandTable()).filter(([, body]) => body.includes('addHomeTab'));
+	assert.deepEqual(routes.map(([command]) => command), [], 'a keyboard command still reaches addHomeTab');
 });
 
 test('the native macOS menu claims exactly two accelerators, and T is not one', () => {
@@ -223,30 +224,30 @@ const KNOWN_LAYER_DIVERGENCES: Record<Chord, string> = {
 test('a chord that both layers answer means the same thing in both', () => {
 	// The pairs the app deliberately mirrors: the editor action and the
 	// window-level branch that stands in for it when the caret is elsewhere.
-	const MIRROR: Record<string, string> = {
-		'file-new': 'handleNewFile',
-		'file-open': 'selectFile',
-		'file-save': 'saveContent',
-		'file-close': 'closeFile',
-		'view-toggle-edit': 'toggleEditView',
-		'view-toggle-split': 'toggleSplitView',
-		'tab-undo-close': 'handleUndoCloseTab',
+	const MIRROR: Record<string, ViewerCommand> = {
+		'file-new': 'new-file',
+		'file-open': 'open-file',
+		'file-save': 'save',
+		'file-close': 'close-file',
+		'view-toggle-edit': 'toggle-edit-view',
+		'view-toggle-split': 'toggle-split-view',
+		'tab-undo-close': 'undo-close-tab',
 	};
 
 	for (const platform of PLATFORMS) {
 		const editorSide = editorKeymap(platform.mac, platform.os);
 		const documentSide = documentKeymap(platform.osType);
 
-		for (const [id, expectedCall] of Object.entries(MIRROR)) {
+		for (const [id, expectedCommand] of Object.entries(MIRROR)) {
 			const chords = editorSide.get(id);
 			assert.ok(chords?.length, `${id} is bound in the editor on ${platform.name}`);
 			for (const chord of chords) {
 				if (chord in KNOWN_LAYER_DIVERGENCES) continue;
-				const fired = documentSide.get(chord);
-				assert.ok(fired, `${platform.name}: ${chord} runs ${id} in the editor but nothing outside it`);
-				assert.ok(
-					fired.some((call) => call.startsWith(expectedCall)),
-					`${platform.name}: ${chord} runs ${id} in the editor but ${fired.join(', ')} outside it`,
+				assert.ok(documentSide.has(chord), `${platform.name}: ${chord} runs ${id} in the editor but nothing outside it`);
+				assert.equal(
+					documentSide.get(chord),
+					expectedCommand,
+					`${platform.name}: ${chord} runs ${id} in the editor but ${documentSide.get(chord)} outside it`,
 				);
 			}
 		}

--- a/scripts/jumpToSelectedFragment.test.ts
+++ b/scripts/jumpToSelectedFragment.test.ts
@@ -49,6 +49,8 @@ import {
 	type ShimElement,
 	type ShimNode,
 } from './renderProtocolDom.ts';
+import { viewerCommandFor } from '../src/lib/utils/viewerKeymap.js';
+import { viewerCommandTable } from './keymapHarness.js';
 import { functionSource, readSource, sliceFrom } from './sourceTree.js';
 
 installShimDom();
@@ -440,7 +442,17 @@ test('one function owns what ⌘E means, and every entry point uses it', () => {
 	// here, so the chord cannot mean one thing with the caret in the editor and
 	// another with it in the preview — which is what
 	// `formatShortcutKeymap.test.ts` pins from the other side.
-	assert.match(viewerSource, /if \(mod && key === 'e'\) \{[\s\S]{0,600}?toggleEditView\(\)/);
+	// The chord is a call now, not a pattern: the branch structure moved to
+	// `viewerKeymap.ts` and #647 had already shown what the old spelling cost —
+	// five assertions of this shape went red for a renamed local.
+	assert.equal(
+		viewerCommandFor(
+			{ key: 'e', code: 'KeyE', ctrlKey: true, metaKey: false, shiftKey: false, altKey: false },
+			{ mode: 'app', osType: 'windows', isSplit: false, overlayOpen: false, isEditing: false, editorHasFocus: false },
+		),
+		'toggle-edit-view',
+	);
+	assert.match(viewerCommandTable()['toggle-edit-view'], /toggleEditView\(\)/);
 	assert.equal(
 		(viewerSource.match(/ontoggleEdit=\{\(\) => toggleEditView\(\)\}/g) ?? []).length,
 		3,

--- a/scripts/keymapHarness.ts
+++ b/scripts/keymapHarness.ts
@@ -8,6 +8,7 @@ import ts from 'typescript';
 
 import { listEnter, parseListItem } from '../src/lib/utils/listEditing.js';
 import { tableOperation, tableStep } from '../src/lib/utils/tableEditing.js';
+import { viewerCommandFor, type KeyContext, type ViewerCommand } from '../src/lib/utils/viewerKeymap.js';
 import { readSource, functionSource } from './sourceTree.js';
 
 /*
@@ -19,12 +20,13 @@ import { readSource, functionSource } from './sourceTree.js';
  * same extraction, so there is no way for one of them to be checked against a
  * more forgiving model of the app than the other.
  *
- * `registerLocalizedActions` and `handleKeyDown` are lifted out of their Svelte
- * components and RUN. Keybinding numbers come from Monaco's real `KeyMod` and
- * `KeyCode` and are turned back into chords by Monaco's real `decodeKeybinding`,
- * once per operating system. Nothing here matches the components as text, so
- * renaming a local, reordering the actions or rewriting the branch structure
- * changes nothing; changing a KEY does.
+ * `registerLocalizedActions` is lifted out of Editor.svelte and RUN; the
+ * document-level dispatcher is simply imported, having been moved to
+ * `src/lib/utils/viewerKeymap.ts` for that reason. Keybinding numbers come from
+ * Monaco's real `KeyMod` and `KeyCode` and are turned back into chords by
+ * Monaco's real `decodeKeybinding`, once per operating system. Nothing here
+ * matches the components as text, so renaming a local, reordering the actions or
+ * rewriting the branch structure changes nothing; changing a KEY does.
  *
  * WHAT IT DOES NOT ESTABLISH
  *
@@ -211,110 +213,50 @@ const FUZZ_KEYS: Array<{ keyCode: number; key: string; code: string }> = [
 ];
 
 /**
- * Which app functions the document-level handler runs for each chord.
+ * Reading the document, not editing it, with nothing in front of it — the state
+ * every caller of `documentKeymap` is asking about.
  *
- * The handler is extracted and evaluated the same way as the editor's action
- * list, then fired once per chord. Everything it can reach — `tabManager`,
- * `saveContent`, `handleNewFile` — is a recording stub, so what comes back is
- * the handler's real branch structure rather than a description of it.
- *
- * ASSIGNMENTS ARE RECORDED TOO, as `name=value`. Several branches do their work
- * by writing a variable rather than by calling anything — `showSettings = true`
- * for Mod+`,` and `settings.previewFullWidth = false` for the preview-width
- * chords — and a call-only recorder reported those chords as dead. They were
- * not; the harness simply could not see them, which is the empty-iteration
- * failure mode one level down. `set` on the scope proxy used to return `true`
- * and discard the write.
+ * `editorHasFocus: false` is the reporter's scenario in #153 (preview mode) and
+ * the one in which the app's own chords, rather than Monaco's, are supposed to
+ * answer.
  */
-export function documentKeymap(osType: string): Map<Chord, string[]> {
-	const source = functionSource(readSource('src/lib/MarkdownViewer.svelte'), 'handleKeyDown');
-	const js = ts.transpileModule(source, {
-		compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ESNext },
-	}).outputText;
-
-	let fired: string[] = [];
-	/**
-	 * A stub that is callable, indexable and self-similar, so
-	 * `getCurrentWindow().close()` and `tabManager.cycleTab('next')` both work
-	 * without the harness having to know they exist. Every call is recorded under
-	 * its full path, which is what the assertions read.
-	 */
-	const record = (name: string): never => {
-		const fn = (...args: unknown[]) => {
-			fired.push(args.length && typeof args[0] === 'string' ? `${name}:${args[0]}` : name);
-			return record(`${name}()`);
-		};
-		return new Proxy(fn, {
-			get: (target, key) =>
-				typeof key === 'string' && !(key in target) ? record(`${name}.${key}`) : (target as never)[key as never],
-		}) as never;
-	};
-
-	const known: Record<string, unknown> = {
-		// `has: () => true` below means the scope claims EVERY identifier, globals
-		// included, so `Math` has to be handed back deliberately rather than
-		// answered with a recording stub.
-		Math,
+function readingContext(osType: string): KeyContext {
+	return {
 		mode: 'app',
-		// Writes to the store are recorded as well as calls: several branches do
-		// their work by assigning a settings field (`settings.previewFullWidth =
-		// false` for the preview-width chords), and without the `set` trap those
-		// chords come back as firing nothing at all — the same blind spot the
-		// scope proxy's own `set` trap fixed one level up. The trap does not write
-		// through: `get` keeps answering with a fresh stub, so nothing a chord
-		// assigns can leak into the next chord's starting state.
-		settings: new Proxy(
-			{ osType },
-			{
-				get: (t, k) => (k === 'osType' ? osType : record(`settings.${String(k)}`)),
-				set: (t, k, value) => {
-					fired.push(`settings.${String(k)}=${typeof value === 'object' ? '{…}' : String(value)}`);
-					return true;
-				},
-			},
-		),
-		showSettings: false,
-		showHome: false,
+		osType: osType as KeyContext['osType'],
+		isSplit: false,
+		overlayOpen: false,
 		isEditing: false,
-		modalState: { show: false },
-		promptModal: { show: false },
-		editorPaneEl: null,
-		document: { activeElement: null },
-		tabManager: new Proxy(
-			{ activeTab: { isSplit: false, isDirty: true, path: '/x.md' }, activeTabId: 'tab-1' },
-			{ get: (t, k) => (k in t ? (t as Record<string, unknown>)[k as string] : record(`tabManager.${String(k)}`)) },
-		),
-		canUsePreviewWidthShortcut: () => true,
-		adjustPreviewMaxWidth: () => 800,
+		editorHasFocus: false,
 	};
+}
 
-	// Written per fire so an assignment made by one chord cannot leak into the
-	// next one's starting state — `zoomLevel` in particular is read as well as
-	// written, and a leaked 110 would make the next zoom-in look like a no-op.
-	const initial = { ...known };
+/**
+ * Which command the document-level dispatcher means by each chord.
+ *
+ * The dispatcher is IMPORTED and called — `viewerCommandFor` is a plain
+ * function of the keystroke and a six-field context, so there is nothing to
+ * extract, transpile or stand in for. It used to be the body of
+ * `handleKeyDown` inside MarkdownViewer.svelte, and getting at it meant slicing
+ * the function out of the component by name, running it through
+ * `ts.transpileModule`, and evaluating it inside a `with` block whose scope
+ * object answered EVERY free identifier with a recording stub.
+ *
+ * That last part is why the extraction was worth doing. A stub is indexable,
+ * callable and self-similar, which makes it a plausible answer to a question the
+ * harness has never heard of — and its result compares false to everything. #649
+ * hit exactly that: `platformOf(...)` inside the handler resolved to a stub,
+ * every `=== 'macos'` test against it was false, and the harness cheerfully
+ * reported 610 answered chords where the app answers 51. The failure was silent
+ * in both directions, because a stub neither throws nor refuses.
+ *
+ * Nothing here can go that way again. `viewerCommandFor` closes over nothing, so
+ * a dependency it grows is a compile error at this call site rather than a stub.
+ */
+export function documentKeymap(osType: string): Map<Chord, ViewerCommand> {
+	const context = readingContext(osType);
+	const map = new Map<Chord, ViewerCommand>();
 
-	const scope = new Proxy(known, {
-		has: () => true,
-		get: (target, property) => {
-			if (typeof property !== 'string') return undefined;
-			if (property in target) return target[property];
-			return record(property);
-		},
-		set: (target, property, value) => {
-			if (typeof property === 'string') {
-				fired.push(`${property}=${typeof value === 'object' ? '{…}' : String(value)}`);
-				target[property] = value;
-			}
-			return true;
-		},
-	});
-
-	const build = new Function('scope', `with (scope) { ${js}\nreturn handleKeyDown; }`) as (
-		s: unknown,
-	) => (e: unknown) => void;
-	const handler = build(scope);
-
-	const map = new Map<Chord, string[]>();
 	for (const primary of [
 		{ ctrlKey: false, metaKey: false },
 		{ ctrlKey: true, metaKey: false },
@@ -323,28 +265,75 @@ export function documentKeymap(osType: string): Map<Chord, string[]> {
 		for (const shiftKey of [false, true]) {
 			for (const altKey of [false, true]) {
 				for (const entry of FUZZ_KEYS) {
-					fired = [];
-					Object.assign(known, initial);
-					handler({
-						...primary,
-						shiftKey,
-						altKey,
-						key: entry.key,
-						code: entry.code,
-						target: null,
-						preventDefault: () => {},
-					});
-					if (fired.length === 0) continue;
-					map.set(label({ ...primary, shiftKey, altKey, keyCode: entry.keyCode }), [...new Set(fired)]);
+					const command = viewerCommandFor(
+						{ ...primary, shiftKey, altKey, key: entry.key, code: entry.code, target: null },
+						context,
+					);
+					if (command) map.set(label({ ...primary, shiftKey, altKey, keyCode: entry.keyCode }), command);
 				}
 			}
 		}
 	}
 	assert.ok(
 		map.size > 15,
-		`the document handler answered ${map.size} chords; the harness is not running the real function`,
+		`the document dispatcher answered ${map.size} chords; the harness is not running the real function`,
 	);
 	return map;
+}
+
+/**
+ * The component's command table: each `ViewerCommand`, and the code
+ * `MarkdownViewer.svelte` runs for it.
+ *
+ * THE ONE THING THE SEAM COULD NOT MOVE, and the only text-matching in this
+ * file. Deciding WHICH command a chord means is now a pure function that tests
+ * import; deciding what `'new-file'` DOES is a switch over the component's own
+ * closures — `handleNewFile`, `saveContent`, `getCurrentWindow().close()` — and
+ * a closure over component state is the thing that cannot leave a component.
+ *
+ * The alternative was to pass those eleven functions in as a host object, so
+ * that a test could hand over eleven spies. That is the shape #644 rejected for
+ * three members and it does not improve at eleven: every caller has to build
+ * one, and the test that builds one is describing the component rather than
+ * running it. So the seam stops at the command name, and this reads the last
+ * inch as text — deliberately, and in one place instead of thirty.
+ *
+ * What it is NOT is the old `handleKeyDown` extraction. There is no
+ * `transpileModule`, no `with`, no scope proxy and therefore no stub that can
+ * answer a question nobody asked: the parse yields case labels and body text,
+ * every command the dispatcher can reach must have exactly one case, and a
+ * command that lost its case is a missing key rather than a silent no-op.
+ */
+export function viewerCommandTable(): Record<ViewerCommand, string> {
+	const source = functionSource(readSource('src/lib/MarkdownViewer.svelte'), 'runViewerCommand');
+	const table: Record<string, string> = {};
+
+	// `case 'a':` runs of one or more labels, then everything up to the next
+	// `case` or the end of the switch. Stacked labels fall through to one body —
+	// that is how `preview-width-narrower` and `preview-width-wider` share theirs
+	// — so a label with nothing of its own is given the next label's, walking
+	// backwards. Without that the first of a pair maps to the empty string, which
+	// any `doesNotMatch` would pass against.
+	const labels = [...source.matchAll(/\n\t*case '([a-z-]+)':/g)];
+	let shared = '';
+	for (let index = labels.length - 1; index >= 0; index--) {
+		const match = labels[index];
+		const body = source.slice(match.index + match[0].length, labels[index + 1]?.index ?? source.length);
+		shared = body.trim() ? body : shared;
+		table[match[1]] = shared;
+	}
+
+	const reachable = new Set<ViewerCommand>();
+	for (const platform of PLATFORMS) for (const command of documentKeymap(platform.osType).values()) reachable.add(command);
+	for (const command of reachable) {
+		assert.ok(command in table, `runViewerCommand has no case for ${command}, which the keyboard reaches`);
+	}
+	assert.equal(
+		Object.keys(table).length,
+		reachable.size,
+		`runViewerCommand handles ${Object.keys(table).length} commands, ${reachable.size} are reachable`,
+	);
+	return table as Record<ViewerCommand, string>;
 }
 
 // ------------------------------------- the nameless commands, and their handlers

--- a/scripts/openShortcutInPreview.test.ts
+++ b/scripts/openShortcutInPreview.test.ts
@@ -1,9 +1,9 @@
 /**
  * #153: "While in Preview Mode - Ctrl+O doesn't work on windows."
  *
- * It works now — the branch is in `handleKeyDown`, which is attached to
- * `<svelte:document>` rather than to the editor, and it carries no mode
- * condition. What it never had is anything holding it there. The comment on
+ * It works now — the branch is in the document-level dispatcher, which is
+ * attached to `<svelte:document>` rather than to the editor, and it carries no
+ * editing condition. What it never had is anything holding it there. The comment on
  * the fix cited a test file that does not exist, and grepping the suite for
  * `selectFile` returned nothing, so the report's own scenario was resting on
  * the absence of a guard nobody had written down.
@@ -15,8 +15,9 @@
  * makes it correct rather than a second #392 is that both call the same
  * function, and that is what the second test holds.
  *
- * `documentKeymap` fires real chords at the real transpiled handler with
- * `isEditing: false` — the reporter's preview mode — and reports what ran.
+ * `documentKeymap` fires real chords at the real imported dispatcher with
+ * `isEditing: false` — the reporter's preview mode — and reports what each one
+ * means.
  */
 
 import assert from 'node:assert/strict';
@@ -31,9 +32,9 @@ const viewerSource = readSource(new URL('../src/lib/MarkdownViewer.svelte', impo
 test('Ctrl/Cmd+O opens the file dialog while reading, on every platform', () => {
 	for (const platform of PLATFORMS) {
 		const chord = platform.mac ? 'Meta+O' : 'Ctrl+O';
-		assert.deepEqual(
+		assert.equal(
 			documentKeymap(platform.osType).get(chord),
-			['selectFile'],
+			'open-file',
 			`${platform.name}: ${chord} must open a file from preview mode`,
 		);
 	}

--- a/scripts/previewWidth.test.ts
+++ b/scripts/previewWidth.test.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { viewerCommandFor, type KeyContext } from '../src/lib/utils/viewerKeymap.js';
+import { viewerCommandTable } from './keymapHarness.js';
 import { readSource } from './sourceTree.js';
 
 import {
@@ -85,14 +87,50 @@ test('Settings exposes a bounded preview-width input and reset action', () => {
 });
 
 test('preview width keyboard shortcuts avoid editable controls and app modals', () => {
-	assert.match(viewerSource, /function canUsePreviewWidthShortcut\(target: EventTarget \| null, isSplit: boolean\)/);
-	assert.match(viewerSource, /showSettings \|\| modalState\.show \|\| promptModal\.show \|\| showHome/);
-	assert.match(viewerSource, /closest\('input, textarea, select, \[contenteditable="true"\], \[role="textbox"\]'\)/);
-	// `modAlt` is the handler's name for "the platform modifier and Alt, and
-	// nothing else" — the chord these two keys are advertised under.
-	assert.match(viewerSource, /modAlt && \(code === 'BracketLeft' \|\| code === 'BracketRight'\)/);
-	assert.match(viewerSource, /settings\.previewFullWidth = false/);
-	assert.match(viewerSource, /settings\.previewMaxWidth = adjustPreviewMaxWidth\(settings\.previewMaxWidth, code === 'BracketLeft' \? -40 : 40\)/);
+	// Six source-shape assertions until the dispatcher got its own module: two
+	// about a chord condition, three about a function signature and its body,
+	// one about the width arithmetic. Four of them are questions the imported
+	// functions can be asked directly.
+	const reading: KeyContext = {
+		mode: 'app',
+		osType: 'windows',
+		isSplit: false,
+		overlayOpen: false,
+		isEditing: false,
+		editorHasFocus: false,
+	};
+	const chord = (code: string) => ({ key: code === 'BracketLeft' ? '[' : ']', code, ctrlKey: true, metaKey: false, shiftKey: false, altKey: true });
+
+	// The chord, and which way round the two keys go — never checked before,
+	// because both keys matched the same line of text.
+	assert.equal(viewerCommandFor(chord('BracketLeft'), reading), 'preview-width-narrower');
+	assert.equal(viewerCommandFor(chord('BracketRight'), reading), 'preview-width-wider');
+	// And nothing else on that chord: no Alt, or an extra Shift, is a different
+	// gesture and must not resize the preview.
+	assert.equal(viewerCommandFor({ ...chord('BracketLeft'), altKey: false }, reading), null);
+	assert.equal(viewerCommandFor({ ...chord('BracketLeft'), shiftKey: true }, reading), null);
+
+	// An overlay in front, or the editor alone on screen, and the chord is not
+	// the preview's to answer.
+	assert.equal(viewerCommandFor(chord('BracketLeft'), { ...reading, overlayOpen: true }), null);
+	assert.equal(viewerCommandFor(chord('BracketLeft'), { ...reading, isEditing: true }), null);
+	// …but split view puts the preview back on screen, so it applies again.
+	assert.equal(
+		viewerCommandFor(chord('BracketLeft'), { ...reading, isEditing: true, isSplit: true }),
+		'preview-width-narrower',
+	);
+
+	// The text-field carve-out needs a real DOM and a real selector match, so it
+	// is asserted in `viewerKeymap.spec.ts` under jsdom rather than faked here.
+
+	// What the command DOES stays in the component — the seam ends at the name.
+	// See the note on `viewerCommandTable` in `keymapHarness.ts`.
+	const narrower = viewerCommandTable()['preview-width-narrower'];
+	assert.match(narrower, /settings\.previewFullWidth = false/);
+	assert.match(
+		narrower,
+		/settings\.previewMaxWidth = adjustPreviewMaxWidth\(\s*settings\.previewMaxWidth,\s*command === 'preview-width-narrower' \? -40 : 40,?\s*\)/,
+	);
 });
 
 test('preview full-width state migrates from the legacy localStorage key', () => {

--- a/scripts/saveFromReadingMode.test.ts
+++ b/scripts/saveFromReadingMode.test.ts
@@ -1,59 +1,97 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { offsetOf, readSource, sliceBetween } from './sourceTree.js';
+import { viewerCommandFor, type KeyContext } from '../src/lib/utils/viewerKeymap.js';
+import { viewerCommandTable } from './keymapHarness.js';
+import { functionSource, readSource } from './sourceTree.js';
 
-const viewer = readSource(new URL('../src/lib/MarkdownViewer.svelte', import.meta.url));
+/*
+ * #168, reported by @dayeggpi: with a document that was never saved, Ctrl+S in
+ * reading mode did nothing at all. `toggleEdit` only runs its save/confirm flow
+ * for tabs that already have a path, so an untitled buffer switches to reading
+ * mode still dirty — and then the one shortcut that could rescue it was
+ * suppressed.
+ *
+ * Every assertion here used to read the component's source through
+ * `sliceBetween(viewer, "if (mod && key === 's') {", "if (modShift && key ===
+ * 't')")` — a slice whose start anchor was the branch condition itself and
+ * whose end anchor was the NEXT branch, so it moved when either was rewritten
+ * and said nothing about what Ctrl+S does. Lifting the dispatcher out split the
+ * two halves apart, and each is now checked where it lives: which chord means
+ * `'save'` is a function call, and what `'save'` does is the component's, read
+ * from its command table.
+ */
 
-// The guard gained `!e.shiftKey` when Save As was finally bound to Mod+Shift+S:
-// the branch used to match on the modifier and the letter alone, so the chord
-// the app menu advertised for Save As fell through to a plain Save. It later
-// gained `!e.altKey` too, and both now come from `mod` — the handler's name for
-// "the platform modifier and nothing else". The Save As branch (`modShift`)
-// sits above this one, so slicing from here still captures exactly the
-// plain-save body every assertion below is about.
-function keydownSaveBranch(): string {
-	return sliceBetween(viewer, "if (mod && key === 's') {", "if (modShift && key === 't')");
-}
+/** Reading a saved document, the state the report was made in. */
+const READING: KeyContext = {
+	mode: 'app',
+	osType: 'windows',
+	isSplit: false,
+	overlayOpen: false,
+	isEditing: false,
+	editorHasFocus: false,
+};
 
-// Reported in #168 by @dayeggpi: with a document that was never saved,
-// Ctrl+S in reading mode did nothing at all. `toggleEdit` only runs its
-// save/confirm flow for tabs that already have a path, so an untitled buffer
-// switches to reading mode still dirty — and then the one shortcut that could
-// rescue it was suppressed.
+/** Mod+S, with no other modifier. */
+const MOD_S = { key: 's', code: 'KeyS', ctrlKey: true, metaKey: false, shiftKey: false, altKey: false };
+
 test('Ctrl+S is not gated on the editor being visible', () => {
-	const branch = keydownSaveBranch();
-	assert.doesNotMatch(branch, /if \(isEditing \|\| isSplit\)/);
-	assert.match(branch, /saveContent\(\)/);
+	// The defect was a `if (isEditing || isSplit)` around the branch. Asked as a
+	// question rather than matched as text: all four combinations of the two
+	// flags must answer `'save'`, so no guard over either of them can come back
+	// without failing here.
+	for (const isEditing of [false, true]) {
+		for (const isSplit of [false, true]) {
+			assert.equal(
+				viewerCommandFor(MOD_S, { ...READING, isEditing, isSplit }),
+				'save',
+				`isEditing=${isEditing} isSplit=${isSplit}`,
+			);
+		}
+	}
 });
 
+test('the browser save dialog is always suppressed', () => {
+	// preventDefault has to run for every mode, including the no-op case, or
+	// reading mode would surface the webview's own Save Page dialog. It is one
+	// unconditional call on the command rather than one per branch now, so this
+	// reads the six-line handler rather than the branch it used to sit in — and
+	// covers all twenty-two commands instead of Save alone.
+	const handler = functionSource(readSource('src/lib/MarkdownViewer.svelte'), 'handleKeyDown');
+	assert.match(
+		handler,
+		/if \(!command\) return;\s*\n\s*e\.preventDefault\(\);/,
+		'a command that runs must have had the keystroke prevented first',
+	);
+});
+
+/*
+ * The three below are the residue of this seam, and they say so.
+ *
+ * What Ctrl+S DOES is a closure over `tabManager.activeTab` inside the
+ * component, which is the one thing that could not move: see the note on
+ * `viewerCommandTable` in `keymapHarness.ts`. They are still text assertions —
+ * but text anchored on a `case 'save':` label rather than on a chord condition,
+ * so the rename that reddened five of these in #647 no longer reaches them.
+ */
+const saveCommand = () => viewerCommandTable()['save'];
+
 test('an untitled buffer can be saved from reading mode', () => {
-	const branch = keydownSaveBranch();
 	// `path === ''` is the untitled case; documentSession.saveContent opens
 	// the Save dialog for it, so no extra plumbing is needed here.
-	assert.match(branch, /saveTarget\.path === ''/);
+	assert.match(saveCommand(), /saveTarget\.path === ''/);
 });
 
 test('a saved, unmodified document does not write on Ctrl+S', () => {
 	// Writing unconditionally would touch mtime and wake the file watcher,
 	// which in live mode reloads the tab -- a keystroke that reads as a no-op
 	// to the user should not move the document underneath them.
-	const branch = keydownSaveBranch();
-	assert.match(branch, /saveTarget\.isDirty \|\| saveTarget\.path === ''/);
-});
-
-test('the browser save dialog is always suppressed', () => {
-	// preventDefault has to run for every mode, including the no-op case,
-	// or reading mode would surface the webview's own Save Page dialog.
-	const branch = keydownSaveBranch();
-	const beforeGuard = branch.slice(0, offsetOf(branch, 'const saveTarget'));
-	assert.match(beforeGuard, /e\.preventDefault\(\);/);
+	assert.match(saveCommand(), /saveTarget\.isDirty \|\| saveTarget\.path === ''/);
 });
 
 test('the HOME tab is not savable', () => {
 	// HOME carries the sentinel path 'HOME' and is never dirty, so the guard
 	// excludes it without naming it. This pins that reasoning: if the guard
 	// ever becomes unconditional, HOME would start opening a Save dialog.
-	const branch = keydownSaveBranch();
-	assert.doesNotMatch(branch, /^\s*saveContent\(\);\s*$/m);
+	assert.doesNotMatch(saveCommand(), /^\s*saveContent\(\);\s*$/m);
 });

--- a/scripts/shortcutRegistry.test.ts
+++ b/scripts/shortcutRegistry.test.ts
@@ -16,6 +16,7 @@ import {
 	type ShortcutEntry,
 } from '../src/lib/utils/shortcuts.js';
 import { getTabFileActions, hasRealFilePath } from '../src/lib/utils/tabFileActions.js';
+import type { ViewerCommand } from '../src/lib/utils/viewerKeymap.js';
 import {
 	OperatingSystem,
 	PLATFORMS,
@@ -148,7 +149,7 @@ test('no registry entry is unverifiable', () => {
 	// that implements it, or it cannot be checked and must not be advertised.
 	for (const entry of SHORTCUTS) {
 		assert.ok(
-			entry.editorAction || entry.editorCommand || entry.documentCall || entry.nativeMenuAccelerator,
+			entry.editorAction || entry.editorCommand || entry.documentCommands || entry.nativeMenuAccelerator,
 			`${entry.id} names no implementation, so nothing here can confirm its chord fires`,
 		);
 	}
@@ -202,18 +203,25 @@ test('every chord the registry advertises runs the command it names, outside the
 	for (const platform of PLATFORMS) {
 		const keymap = documentKeymap(platform.osType);
 		for (const entry of SHORTCUTS) {
-			if (!entry.documentCall) continue;
+			if (!entry.documentCommands) continue;
 			if (entry.documentExempt?.includes(platform.osType)) continue;
-			for (const chord of entry.chords) {
+			for (const [index, chord] of entry.chords.entries()) {
+				// One command for the whole row, or one per chord in `chords` order.
+				// `assert.equal` rather than the old prefix match: the registry names a
+				// `ViewerCommand` now, so there is an exact answer to compare against
+				// and `tab-next` can no longer be satisfied by `tab-prev`'s branch.
+				const command: ViewerCommand | undefined =
+					entry.documentCommands[entry.documentCommands.length === 1 ? 0 : index];
+				assert.ok(command, `${entry.id} lists ${entry.documentCommands.length} commands for ${entry.chords.length} chords`);
 				const want = toMonacoLabel(chord, platform.mac);
-				const fired = keymap.get(want);
 				assert.ok(
-					fired,
+					keymap.has(want),
 					`${platform.name}: the panel would show ${formatChord(chord, platform.mac ? 'Cmd' : 'Ctrl')} for ${entry.id}, but that chord does nothing outside the editor`,
 				);
-				assert.ok(
-					fired.some((call) => call.startsWith(entry.documentCall!)),
-					`${platform.name}: ${want} is advertised as ${entry.id} (${entry.documentCall}) but runs ${fired.join(', ')}`,
+				assert.equal(
+					keymap.get(want),
+					command,
+					`${platform.name}: ${want} is advertised as ${entry.id} (${command}) but means ${keymap.get(want)}`,
 				);
 				checked++;
 			}
@@ -243,40 +251,34 @@ test('the native accelerator the registry defers to is the one the Rust menu cla
 });
 
 test('each zoom chord reaches its own zoom operation, not just the zoom code', () => {
-	// All three zoom chords land in the same three lines of `handleKeyDown`, so
-	// the contract test above can only prove they reach the zoom code — not that
-	// + and − are the right way round. What tells them apart is which store
-	// method each one calls.
+	// The contract test above compares each chord against the command its
+	// registry row names, so it cannot catch a registry that names the same
+	// command twice — three rows all saying `zoom-in` would agree with a
+	// dispatcher that answers `zoom-in` to all three, and + and − would be the
+	// same key. What is left for this test is that the three are DISTINCT.
 	//
-	// This used to read the number the chord assigned to a local `zoomLevel`,
+	// It used to read the number the chord assigned to a local `zoomLevel`,
 	// because the arithmetic lived in the handler. It lives in the store now, so
 	// the two halves of the claim are checked where each one is: that zoomIn
 	// really raises the level and resetZoom really returns to ZOOM_LEVEL_RANGE's
 	// default is asserted against the real store in settingsPersistence.test.ts,
 	// and what is left here — which chord asks for which — is the half only the
 	// keymap can answer.
-	const operations: Array<[string, string]> = [
-		['view-zoom-in', 'settings.zoomIn'],
-		['view-zoom-out', 'settings.zoomOut'],
-		['view-zoom-reset', 'settings.resetZoom'],
+	const expected: Array<[string, ViewerCommand]> = [
+		['view-zoom-in', 'zoom-in'],
+		['view-zoom-out', 'zoom-out'],
+		['view-zoom-reset', 'zoom-reset'],
 	];
 
 	for (const platform of PLATFORMS) {
 		const keymap = documentKeymap(platform.osType);
-		for (const [id, operation] of operations) {
+		const seen = new Map<ViewerCommand, string>();
+		for (const [id, command] of expected) {
 			const entry = SHORTCUTS.find((e) => e.id === id)!;
-			const fired = keymap.get(toMonacoLabel(entry.chords[0], platform.mac));
-			assert.ok(fired, `${id} answers on ${platform.name}`);
-			assert.ok(
-				fired.includes(operation),
-				`${id} must run ${operation}() on ${platform.name}; recorded ${fired.join(', ')}`,
-			);
-			// And nothing else: a chord that called two of the three would satisfy
-			// its own row above while quietly undoing another one.
-			for (const [, other] of operations) {
-				if (other === operation) continue;
-				assert.ok(!fired.includes(other), `${id} also runs ${other}() on ${platform.name}`);
-			}
+			const answered = keymap.get(toMonacoLabel(entry.chords[0], platform.mac));
+			assert.equal(answered, command, `${id} must mean ${command} on ${platform.name}, not ${answered}`);
+			assert.equal(seen.get(command), undefined, `${platform.name}: ${id} and ${seen.get(command)} both mean ${command}`);
+			seen.set(command, id);
 		}
 	}
 });
@@ -537,15 +539,10 @@ test('Save As runs Save As, and not a plain Save', () => {
 	for (const platform of PLATFORMS) {
 		const keymap = documentKeymap(platform.osType);
 		const shiftS = platform.mac ? 'Shift+Meta+S' : 'Ctrl+Shift+S';
-		const fired = keymap.get(shiftS);
-		assert.ok(fired, `${shiftS} does nothing on ${platform.name}`);
-		assert.ok(
-			fired.some((call) => call.startsWith('saveContentAs')),
-			`${platform.name}: ${shiftS} runs ${fired.join(', ')} instead of saveContentAs`,
-		);
-		assert.ok(
-			!fired.some((call) => call === 'saveContent'),
-			`${platform.name}: ${shiftS} still falls through to a plain Save`,
+		assert.equal(
+			keymap.get(shiftS),
+			'save-as',
+			`${platform.name}: ${shiftS} means ${keymap.get(shiftS) ?? 'nothing'} instead of save-as`,
 		);
 	}
 });
@@ -561,20 +558,19 @@ test('a close chord wearing an extra modifier destroys nothing', () => {
 	// Not "these three chords do nothing" but "nothing destructive answers to a
 	// modifier it does not name": a fourth spelling nobody thought of fails here
 	// too, and so does a future destructive branch that forgets its guard.
-	const DESTRUCTIVE = ['closeFile', 'getCurrentWindow'];
+	const DESTRUCTIVE: ViewerCommand[] = ['close-file', 'close-window'];
 	let plainClosesFound = 0;
 
 	for (const platform of PLATFORMS) {
 		const keymap = documentKeymap(platform.osType);
-		for (const [chord, calls] of keymap) {
-			const damage = calls.filter((call) => DESTRUCTIVE.some((command) => call.startsWith(command)));
-			if (damage.length === 0) continue;
+		for (const [chord, command] of keymap) {
+			if (!DESTRUCTIVE.includes(command)) continue;
 			if (!/\b(Shift|Alt)\b/.test(chord)) {
 				plainClosesFound++;
 				continue;
 			}
 			assert.fail(
-				`${platform.name}: ${chord} runs ${damage.join(', ')} — a chord reached for a window-level or ` +
+				`${platform.name}: ${chord} means ${command} — a chord reached for a window-level or ` +
 					'"close all" gesture must not close the document',
 			);
 		}
@@ -613,17 +609,18 @@ test('Mod+F4 closes a document on Windows, the one platform it was scoped to', (
 		// Both spellings on every platform: `cmdOrCtrl` is `ctrlKey || metaKey`
 		// everywhere, so a Mac or a Linux box answering EITHER one is the defect.
 		for (const spelling of documentSpellings('Mod+F4', platform.mac)) {
-			const fired = keymap.get(spelling) ?? [];
+			const command = keymap.get(spelling);
 			if (platform.osType === 'windows') {
-				assert.ok(
-					fired.includes('closeFile'),
-					`${platform.name}: ${spelling} runs ${fired.join(', ') || 'nothing'} instead of closeFile`,
+				assert.equal(
+					command,
+					'close-file',
+					`${platform.name}: ${spelling} means ${command ?? 'nothing'} instead of close-file`,
 				);
 			} else {
-				assert.deepEqual(
-					fired,
-					[],
-					`${platform.name}: ${spelling} still runs ${fired.join(', ')} — requirement 157 puts this platform out of scope`,
+				assert.equal(
+					command,
+					undefined,
+					`${platform.name}: ${spelling} still means ${command} — requirement 157 puts this platform out of scope`,
 				);
 			}
 		}
@@ -1084,59 +1081,45 @@ test('the panel’s groups are visibly separated, not run together', () => {
 // The editor layer's half of this is `every keybinding the editor registers is
 // either advertised or consciously not`, above.
 
-/** A recorded call, reduced to the command it names: drop the argument and the assigned value. */
-function commandOf(call: string): string {
-	return call.split(':')[0].replace(/=.*$/, '=');
-}
-
-/**
- * Commands the document handler can reach that are deliberately not advertised.
- *
- * One entry, and it is a second write inside a branch that IS advertised rather
- * than a chord of its own: everything the keyboard can *reach* is in the panel.
- * A new branch has to be listed here with a reason, or shown.
- */
-const DOCUMENT_NOT_ADVERTISED: Record<string, string> = {
-	'settings.previewFullWidth=':
-		'The preview-width chords (view-preview-width) turn full-width off before they narrow or widen ' +
-		'the preview, so this write is half of that one shortcut. No chord toggles full width on its own; ' +
-		'the title bar button does.',
-};
-
 /** Native menu accelerators deliberately not advertised. Also empty today. */
 const NATIVE_NOT_ADVERTISED: Record<string, string> = {};
 
-test('every command the document handler can reach is advertised, or consciously not', () => {
-	const advertised = SHORTCUTS.map((entry) => entry.documentCall).filter(Boolean) as string[];
-	assert.ok(advertised.length > 10, `${advertised.length} rows name a document command`);
+test('every command the document dispatcher can reach is advertised', () => {
+	const advertised = new Set(SHORTCUTS.flatMap((entry) => entry.documentCommands ?? []));
+	assert.ok(advertised.size > 10, `${advertised.size} commands are named by a registry row`);
 
-	const reachable = new Set<string>();
-	for (const platform of PLATFORMS) {
-		for (const calls of documentKeymap(platform.osType).values()) for (const call of calls) reachable.add(commandOf(call));
-	}
+	const reachable = new Set<ViewerCommand>();
+	for (const platform of PLATFORMS) for (const command of documentKeymap(platform.osType).values()) reachable.add(command);
 	// Without this the whole test passes vacuously if the harness stops running.
-	assert.ok(reachable.size > 10, `the document handler reached ${reachable.size} commands`);
+	assert.ok(reachable.size > 10, `the dispatcher reached ${reachable.size} commands`);
 
-	// Prefix either way: a row may name `getCurrentWindow` for a chord recorded as
-	// `getCurrentWindow().close`, or `showSettings=true` for one recorded as
-	// `showSettings=`. This direction is a coverage question — is the command
-	// mentioned at all — and the exact chord-by-chord contract is asserted above.
-	const unexplained = [...reachable].filter(
-		(command) =>
-			!advertised.some((call) => command.startsWith(call) || call.startsWith(command)) &&
-			!(command in DOCUMENT_NOT_ADVERTISED),
-	);
 	assert.deepEqual(
-		unexplained.sort(),
+		[...reachable].filter((command) => !advertised.has(command)).sort(),
 		[],
 		'these commands are reachable from the keyboard but the shortcuts panel never mentions them; ' +
-			'add a row to SHORTCUTS or a reason to DOCUMENT_NOT_ADVERTISED',
+			'add a row to SHORTCUTS',
 	);
 
-	for (const command of Object.keys(DOCUMENT_NOT_ADVERTISED)) {
-		assert.ok(reachable.has(command), `${command} is no longer reachable — drop it from DOCUMENT_NOT_ADVERTISED`);
-	}
+	// And the other direction: a row naming a command no chord answers is a
+	// panel entry that does nothing.
+	assert.deepEqual(
+		[...advertised].filter((command) => !reachable.has(command)).sort(),
+		[],
+		'the panel advertises these commands but no chord reaches them',
+	);
 });
+
+/*
+ * WHERE `DOCUMENT_NOT_ADVERTISED` WENT.
+ *
+ * It had one entry, `settings.previewFullWidth=`, and the entry existed only
+ * because the harness recorded WRITES: the preview-width branch turns full
+ * width off before it adjusts the width, so one shortcut looked like two
+ * commands and the second one had to be excused in prose. A `ViewerCommand` is
+ * the shortcut, not its side effects — `preview-width-narrower` covers both
+ * writes — so there is nothing left to excuse, and the test above can assert
+ * both directions instead of one.
+ */
 
 /**
  * Every harness label one registry chord is answered by.
@@ -1192,7 +1175,7 @@ const DOCUMENT_CHORDS_NOT_ADVERTISED: Record<string, string> = {
 test('every chord the document handler answers is advertised, or consciously not', () => {
 	for (const platform of PLATFORMS) {
 		const advertised = new Set(
-			SHORTCUTS.filter((entry) => entry.documentCall)
+			SHORTCUTS.filter((entry) => entry.documentCommands)
 				.flatMap((entry) => entry.chords)
 				.flatMap((chord) => documentSpellings(chord, platform.mac)),
 		);

--- a/scripts/viewerKeymap.spec.ts
+++ b/scripts/viewerKeymap.spec.ts
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+
+import {
+	canUsePreviewWidthShortcut,
+	viewerCommandFor,
+	type KeyContext,
+	type KeyStroke,
+	type ViewerCommand,
+} from '../src/lib/utils/viewerKeymap.js';
+import { PLATFORMS, viewerCommandTable } from './keymapHarness.js';
+
+/*
+ * The document-level dispatcher, called rather than read.
+ *
+ * `shortcutRegistry.test.ts` and `formatShortcutKeymap.test.ts` already sweep
+ * the whole keymap chord by chord and hold it against the shortcuts panel; what
+ * is here is the handful of claims that a sweep cannot make — the ones about
+ * the CONTEXT rather than the chord, which the sweep fires with one fixed
+ * context, and the two that need a real DOM.
+ *
+ * A `.spec.ts` for the DOM: `canUsePreviewWidthShortcut` matches a selector
+ * against a real element, and a hand-made object with a `closest` method would
+ * be asserting against the test's own idea of the selector rather than the
+ * browser's. See AGENTS.md on which runner a test belongs to.
+ */
+
+const READING: KeyContext = {
+	mode: 'app',
+	osType: 'windows',
+	isSplit: false,
+	overlayOpen: false,
+	isEditing: false,
+	editorHasFocus: false,
+};
+
+const chord = (key: string, code: string, mods: Partial<KeyStroke> = {}): KeyStroke => ({
+	key,
+	code,
+	ctrlKey: false,
+	metaKey: false,
+	shiftKey: false,
+	altKey: false,
+	...mods,
+});
+
+test('nothing is dispatched before the app has loaded', () => {
+	// `mode !== 'app'` was the handler's first line and the only branch condition
+	// that could not be reached by firing a chord at it, because the harness
+	// pinned `mode: 'app'` to get any answer at all.
+	const modS = chord('s', 'KeyS', { ctrlKey: true });
+	assert.equal(viewerCommandFor(modS, READING), 'save');
+	assert.equal(viewerCommandFor(modS, { ...READING, mode: 'loading' }), null);
+
+	// And it is the whole keymap, not just Save: a splash screen answers nothing.
+	for (const platform of PLATFORMS) {
+		for (const key of ['w', 'q', 'e', 'o', 't', 'n', ',', '0']) {
+			assert.equal(
+				viewerCommandFor(chord(key, `Key${key.toUpperCase()}`, { ctrlKey: true }), {
+					...READING,
+					osType: platform.osType as KeyContext['osType'],
+					mode: 'loading',
+				}),
+				null,
+				`${platform.name}: Mod+${key} while loading`,
+			);
+		}
+	}
+});
+
+test('Mod+F is Monaco’s while the caret is in the editor, and the app’s otherwise', () => {
+	// The one branch whose condition is where FOCUS is, which is why it is the
+	// one chord the app deliberately answers with nothing some of the time: a
+	// null means the caller does not preventDefault, and Monaco's own Find
+	// keybinding gets the keystroke.
+	const modF = chord('f', 'KeyF', { ctrlKey: true });
+	assert.equal(viewerCommandFor(modF, READING), 'find');
+	assert.equal(viewerCommandFor(modF, { ...READING, editorHasFocus: true }), null);
+});
+
+test('macOS leaves ⌘Q to the application menu, and the other two do not', () => {
+	// The early return, asked per platform. It is scoped by `osType` rather than
+	// by `platformOf`, which folds Linux into Windows and could not express it.
+	const modQ = chord('q', 'KeyQ', { metaKey: true });
+	assert.equal(viewerCommandFor(modQ, { ...READING, osType: 'macos' }), null);
+	assert.equal(viewerCommandFor(modQ, { ...READING, osType: 'windows' }), 'close-window');
+	assert.equal(viewerCommandFor(modQ, { ...READING, osType: 'linux' }), 'close-window');
+	// `osType` is `'unknown'` until the Rust command answers. Quit is not the
+	// destructive branch that has to fail closed — Ctrl+F4 is, and it does — but
+	// an unknown platform must still behave like the majority of them rather
+	// than like a fourth case nobody wrote.
+	assert.equal(viewerCommandFor(modQ, { ...READING, osType: 'unknown' }), 'close-window');
+});
+
+test('the zoom-in chord answers both spellings of “Mod plus”', () => {
+	// `+` IS the shifted `=` on the layouts that have both, so this branch cannot
+	// demand Shift be up. The keymap sweep only ever fires unshifted characters,
+	// so it sees the `=` half and never the `+` half; this is the other half.
+	assert.equal(viewerCommandFor(chord('=', 'Equal', { ctrlKey: true }), READING), 'zoom-in');
+	assert.equal(viewerCommandFor(chord('+', 'Equal', { ctrlKey: true, shiftKey: true }), READING), 'zoom-in');
+	// And the shifted `=` spelling that is NOT `+` stays unbound: on a layout
+	// where Shift+= is something else, the app has not claimed it.
+	assert.equal(viewerCommandFor(chord('=', 'Equal', { ctrlKey: true, shiftKey: true }), READING), null);
+	// Alt is up in every spelling — Mod+Alt+= is not zoom.
+	assert.equal(viewerCommandFor(chord('+', 'Equal', { ctrlKey: true, shiftKey: true, altKey: true }), READING), null);
+});
+
+test('the preview-width chords keep out of a text field', () => {
+	// The one condition that reads the DOM. jsdom rather than a stub with a
+	// `closest` method, so the selector is matched by the browser's own engine:
+	// a stub would only prove the test and the code agree about a string.
+	const bracket = chord('[', 'BracketLeft', { ctrlKey: true, altKey: true });
+
+	document.body.innerHTML = `
+		<div id="preview"><p id="prose">text</p></div>
+		<input id="field" />
+		<div id="editable" contenteditable="true"><span id="inside">text</span></div>
+		<div id="box" role="textbox"><span id="in-box">text</span></div>
+	`;
+	const at = (id: string) => document.getElementById(id)!;
+
+	assert.equal(viewerCommandFor({ ...bracket, target: at('prose') }, READING), 'preview-width-narrower');
+	for (const id of ['field', 'editable', 'inside', 'box', 'in-box']) {
+		assert.equal(viewerCommandFor({ ...bracket, target: at(id) }, READING), null, `#${id} owns its own keys`);
+	}
+
+	// A target that is not an element at all — `document`, or null — is not a
+	// text field, so the chord applies. This is the case the old
+	// `target instanceof Element` spelling answered by accident and the current
+	// one answers on purpose.
+	assert.equal(canUsePreviewWidthShortcut(null, READING), true);
+	assert.equal(canUsePreviewWidthShortcut(document, READING), true);
+});
+
+test('every command the dispatcher can name is one the component can run', () => {
+	// The seam's own contract, and the reason `runViewerCommand` is a switch over
+	// a union rather than a lookup in a map: the compiler rejects a case for a
+	// command that does not exist, and this rejects a command with no case.
+	const table = viewerCommandTable();
+	const reachable = new Set<ViewerCommand>();
+	for (const platform of PLATFORMS) {
+		for (const key of 'abcdefghijklmnopqrstuvwxyz0123456789'.split('')) {
+			for (const ctrlKey of [false, true]) {
+				for (const shiftKey of [false, true]) {
+					const command = viewerCommandFor(chord(key, `Key${key.toUpperCase()}`, { ctrlKey, shiftKey }), {
+						...READING,
+						osType: platform.osType as KeyContext['osType'],
+					});
+					if (command) reachable.add(command);
+				}
+			}
+		}
+	}
+	assert.ok(reachable.size >= 10, `only ${reachable.size} commands were reached; the sweep is not running`);
+	for (const command of reachable) assert.ok(table[command], `runViewerCommand has no case for ${command}`);
+});

--- a/scripts/windowOrganization.test.ts
+++ b/scripts/windowOrganization.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { viewerCommandFor } from '../src/lib/utils/viewerKeymap.js';
 import { readRustBackend, readSource, sliceBetween } from './sourceTree.js';
 
 const runtime = readSource('src-tauri/src/window_runtime.rs');
@@ -59,6 +60,15 @@ test('window organization exposes move, merge, and carry actions', () => {
 	assert.match(tab, /menu-tab-move/);
 	assert.match(viewer, /async function mergeAllWindowsHere/);
 	assert.match(viewer, /async function carryActiveTabToNextWindow/);
-	assert.match(viewer, /modShift && key === 'm'/);
+	// The chord itself moved to `viewerKeymap.ts`, so it is asked rather
+	// than matched — and the answer names the command, not the local variable the
+	// branch happened to be written with.
+	assert.equal(
+		viewerCommandFor(
+			{ key: 'm', code: 'KeyM', ctrlKey: true, metaKey: false, shiftKey: true, altKey: false },
+			{ mode: 'app', osType: 'windows', isSplit: false, overlayOpen: false, isEditing: false, editorHasFocus: false },
+		),
+		'move-tab-to-next-window',
+	);
 	assert.match(titleBar, /onmergeAllWindows/);
 });

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -105,6 +105,7 @@ import { tabManager, type Tab } from './stores/tabs.svelte.js';
 import { snapshotTab } from './utils/tabTransfer.js';
 import { adjustPreviewMaxWidth, getPreviewContentWidth } from './utils/previewWidth.js';
 import { isTocOverhanging } from './utils/tocOverlay.js';
+import { viewerCommandFor, type KeyContext, type ViewerCommand } from './utils/viewerKeymap.js';
 import {
 	getScrollSyncPositionFromPixels,
 	getScrollTopForSyncPosition,
@@ -2754,254 +2755,111 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		}
 	}
 
-	function canUsePreviewWidthShortcut(target: EventTarget | null, isSplit: boolean) {
-		if (showSettings || modalState.show || promptModal.show || showHome || (isEditing && !isSplit)) return false;
-		const element = target instanceof Element ? target : null;
-		return !element?.closest('input, textarea, select, [contenteditable="true"], [role="textbox"]');
+	/*
+	 * WHICH command a keystroke means is decided by `viewerKeymap.ts`; what is
+	 * left here is which of this component's functions each command runs.
+	 *
+	 * The split is #644's, applied to the other end of the file: the branch
+	 * structure was unreachable from a test while it lived in a `.svelte` file,
+	 * so fourteen assertions across four files read it as TEXT instead, and #647
+	 * turned five of them red on a rename that changed no behaviour. The chord
+	 * logic imports now; the table below is the residue, and
+	 * `keymapHarness.viewerCommandTable()` is the one reader of it left.
+	 *
+	 * Every command preventDefaults, which is why the call does it once rather
+	 * than twenty-two times. A chord the app does not bind — and the two it
+	 * deliberately leaves to someone else, macOS's ⌘Q and Mod+F inside Monaco —
+	 * comes back null and is not prevented.
+	 */
+	function keyContext(): KeyContext {
+		const active = document.activeElement as Node | null;
+		return {
+			mode,
+			osType: settings.osType,
+			isSplit: !!tabManager.activeTab?.isSplit,
+			overlayOpen: showSettings || modalState.show || promptModal.show || showHome,
+			isEditing,
+			editorHasFocus: !!editorPaneEl && !!active && editorPaneEl.contains(active),
+		};
+	}
+
+	function runViewerCommand(command: ViewerCommand) {
+		switch (command) {
+			case 'preview-width-narrower':
+			case 'preview-width-wider':
+				settings.previewFullWidth = false;
+				settings.previewMaxWidth = adjustPreviewMaxWidth(
+					settings.previewMaxWidth,
+					command === 'preview-width-narrower' ? -40 : 40,
+				);
+				return;
+			case 'reload-from-disk':
+				return void reloadFromDisk();
+			case 'move-tab-to-next-window':
+				return void carryActiveTabToNextWindow();
+			case 'close-file':
+				return void closeFile();
+			case 'new-file':
+				return void handleNewFile();
+			case 'open-file':
+				return void selectFile();
+			case 'close-window':
+				return void getCurrentWindow().close();
+			case 'toggle-split-view':
+				if (tabManager.activeTabId) toggleSplitView(tabManager.activeTabId);
+				return;
+			case 'toggle-edit-view':
+				// The `silentSave` argument this used to pass meant "suppress the
+				// unsaved-changes modal on the hotkey path". There is no modal on a
+				// view toggle any more, and a keystroke that says "show me the other
+				// pane" is not a request to write the file: whether a dirty tab is
+				// flushed is now decided by the user's auto-save setting alone,
+				// identically for the hotkey and the toolbar button.
+				return void toggleEditView();
+			case 'save-as':
+				return void saveContentAs();
+			case 'save': {
+				// Reading mode used to swallow the shortcut entirely. An untitled
+				// buffer reaches it with content still unsaved — `toggleEdit` only
+				// runs its save flow for tabs that already have a path — so the only
+				// way to keep that text was to switch back to the editor first.
+				// Saving is never mode-specific; the guard asks whether there is
+				// anything to write, not which pane is visible. A saved, unmodified
+				// document stays a no-op so the shortcut cannot churn its mtime and
+				// wake the file watcher.
+				const saveTarget = tabManager.activeTab;
+				if (saveTarget && (saveTarget.isDirty || saveTarget.path === '')) saveContent();
+				return;
+			}
+			case 'undo-close-tab':
+				return void handleUndoCloseTab();
+			case 'next-tab':
+				return tabManager.cycleTab('next');
+			case 'previous-tab':
+				return tabManager.cycleTab('prev');
+			case 'history-back':
+				return void navigateFileHistory('back');
+			case 'history-forward':
+				return void navigateFileHistory('forward');
+			case 'zoom-in':
+				return settings.zoomIn();
+			case 'zoom-out':
+				return settings.zoomOut();
+			case 'zoom-reset':
+				return settings.resetZoom();
+			case 'open-settings':
+				showSettings = true;
+				return;
+			case 'find':
+				return triggerFindAction();
+		}
 	}
 
 	function handleKeyDown(e: KeyboardEvent) {
-		if (mode !== 'app') return;
-
-		const cmdOrCtrl = e.ctrlKey || e.metaKey;
-		const key = e.key.toLowerCase();
-		const code = e.code;
-
-		/*
-		 * The three modifier shapes almost every branch below wants, named once.
-		 *
-		 * A chord means the modifiers it names AND the absence of the ones it does
-		 * not. Half the branches here used to say only `cmdOrCtrl && key === …`,
-		 * which is not `Mod+X` — it is `Mod+X` plus its whole Shift/Alt cross
-		 * product. `Mod+W` was the expensive case: Shift+Cmd+W and Alt+Cmd+W are
-		 * what a user reaches for when they mean "close the window" or "close
-		 * everything", and both silently closed one document instead. `Mod+Q`,
-		 * `Mod+E`, `Mod+S`, `Mod+,` and the zoom chords all had the same hole, and
-		 * on macOS Shift+Cmd+Q — Log Out — reached the window-close branch.
-		 *
-		 * The guard is here rather than repeated in fourteen branches so that a
-		 * branch added later INHERITS it by reaching for `mod`, instead of having
-		 * to remember three negations. `shortcutRegistry.test.ts` closes the other
-		 * half: any chord this handler answers that the registry does not advertise
-		 * fails there, so a new branch cannot quietly grow a cross product again.
-		 *
-		 * Three branches are deliberately not written in these terms, each with its
-		 * reason at the branch: tab cycling (Shift picks the direction), zoom in
-		 * (`+` is the shifted `=`), and the Alt-only navigation chords.
-		 */
-		const mod = cmdOrCtrl && !e.shiftKey && !e.altKey;
-		const modShift = cmdOrCtrl && e.shiftKey && !e.altKey;
-		const modAlt = cmdOrCtrl && !e.shiftKey && e.altKey;
-
-		// The macOS application menu owns ⌘Q. Document shortcuts remain in the
-		// in-window controls, so they continue to act on the current webview.
-		if (settings.osType === 'macos' && mod && key === 'q') return; // → menu-app-quit
-
-		const isSplit = tabManager.activeTab?.isSplit;
-
-		if (modAlt && (code === 'BracketLeft' || code === 'BracketRight')) {
-			if (!canUsePreviewWidthShortcut(e.target, !!isSplit)) return;
-			e.preventDefault();
-			settings.previewFullWidth = false;
-			settings.previewMaxWidth = adjustPreviewMaxWidth(settings.previewMaxWidth, code === 'BracketLeft' ? -40 : 40);
-			return;
-		}
-
-		if (!cmdOrCtrl && !e.shiftKey && !e.altKey && code === 'F5') {
-			e.preventDefault();
-			reloadFromDisk();
-			return;
-		}
-		if (modShift && key === 'm') {
-			e.preventDefault();
-			carryActiveTabToNextWindow();
-			return;
-		}
-		// Nothing catches the Shift and Alt variants on the way past: they are not
-		// another command in disguise, they are a user asking the WINDOW manager
-		// for something. Leaving them unhandled — and unprevented — is what lets
-		// the OS answer them, which is strictly better than answering with the one
-		// irreversible thing the app can do.
-		if (mod && key === 'w') {
-			e.preventDefault();
-			closeFile();
-		}
-		// Windows only, which is the scope this binding was written to and then
-		// exceeded. `docs/requirements/157-ctrl-f4-close-tab.md`, added by the
-		// same commit as the branch itself (4670743, "add Ctrl+F4 shortcut to
-		// close active tab on Windows"), puts "macOS / Linux (dort ist Ctrl+F4
-		// kein Standard)" under "Out of scope"; the handler bound all three
-		// anyway. So this is not a new product decision, it is the documented one
-		// finally being implemented. The doc went away with the rest of docs/ in
-		// d69c181, which is how the intent stopped being checkable —
-		// `shortcutRegistry.test.ts` now holds it instead.
-		//
-		// The convention argument is why the requirement says that: Ctrl+F4
-		// closes a document window on Windows, still live in Office and the IDEs.
-		// macOS has no equivalent — Cmd+F4 means nothing, and with "Use F1, F2,
-		// etc. as standard function keys" off, which is the default, F4 runs a
-		// system function and the app never receives the event at all
-		// (hand-tested on a Mac: it did nothing). A Mac was therefore offered a
-		// THIRD route to an irreversible action that was at once non-conventional
-		// and nearly unpressable.
-		//
-		// Not a rule about odd-looking chords: `Cmd+Shift+=` stays on every
-		// platform. That one is not a platform convention, it is how "Cmd plus"
-		// is typed — `+` is the shifted `=` on every layout — so Mac users press
-		// it as much as anyone. The question is "does anyone on this platform
-		// actually press this?", not "does it carry a Shift?".
-		//
-		// A bare `settings.osType` comparison next to #646's `platformOf` is
-		// deliberate, not an oversight. `platformOf` answers `'macos' | 'windows'`
-		// and folds Linux INTO `'windows'` — correct for the two questions it was
-		// built for (which modifier to print, which window chrome to draw) and
-		// unable to express this one, which needs all three apart. And the reason
-		// to avoid a bare comparison does not apply to this spelling: `osType` is
-		// `'unknown'` until the Rust command answers, and `=== 'windows'` resolves
-		// that window to DO NOT FIRE. It fails closed, which is the only
-		// acceptable direction for a branch that throws a document away.
-		if (settings.osType === 'windows' && mod && code === 'F4') {
-			e.preventDefault();
-			closeFile();
-		}
-		// New file, both keys, whether or not the editor has focus (#392).
-		//
-		// Monaco resolves its own keybindings on the editor container and calls
-		// stopPropagation() when it consumes one, so this handler only ever runs
-		// for keystrokes the editor did not claim. That is how Ctrl+T came to
-		// mean two things: inside Monaco the `file-new` action answered it and
-		// opened an Untitled buffer, outside it this branch opened a Home tab.
-		// Both of the app's own labels already promised the first one — the tab
-		// strip's + button is titled "New Tab (Ctrl+T)" and the app menu prints
-		// Ctrl/Cmd+T beside "New File" — so the branch, not the labels, was the
-		// odd one out.
-		//
-		// `file-new` binds Ctrl/Cmd+N as well, and this handler used to know
-		// about only one of the two, which left Ctrl+N doing nothing at all
-		// outside the editor. Both are listed here so the two paths cannot
-		// drift again; `formatShortcutKeymap.test.ts` holds them equal.
-		if (mod && (key === 't' || key === 'n')) {
-			e.preventDefault();
-			handleNewFile();
-		}
-		if (mod && key === 'o') {
-			e.preventDefault();
-			selectFile();
-		}
-		if (mod && key === 'q') {
-			e.preventDefault();
-			getCurrentWindow().close();
-		}
-		if (mod && (code === 'Backslash' || code === 'IntlBackslash')) {
-			e.preventDefault();
-			if (tabManager.activeTabId) toggleSplitView(tabManager.activeTabId);
-		}
-		if (mod && key === 'e') {
-			e.preventDefault();
-			// The `silentSave` argument these two used to pass meant "suppress
-			// the unsaved-changes modal on the hotkey path". There is no modal
-			// on a view toggle any more, and a keystroke that says "show me the
-			// other pane" is not a request to write the file: whether a dirty
-			// tab is flushed is now decided by the user's auto-save setting
-			// alone, identically for the hotkey and the toolbar button.
-			//
-			toggleEditView();
-		}
-		if (modShift && key === 's') {
-			// Save As. The app menu advertised this chord for as long as the menu has
-			// existed, but nothing ever bound it: the branch below matched on
-			// `cmdOrCtrl && key === 's'` with no Shift guard, so the advertised
-			// keystroke fell through to a plain Save and silently overwrote the file
-			// the user was asking to write somewhere else. `saveContentAs` had no
-			// keyboard path at all — its only caller was the menu button.
-			e.preventDefault();
-			saveContentAs();
-			return;
-		}
-		if (mod && key === 's') {
-			// Reading mode used to swallow the shortcut entirely. An untitled
-			// buffer reaches it with content still unsaved — `toggleEdit`
-			// only runs its save flow for tabs that already have a path — so
-			// the only way to keep that text was to switch back to the
-			// editor first. Saving is never mode-specific; the guard now
-			// asks whether there is anything to write, not which pane is
-			// visible. A saved, unmodified document stays a no-op so the
-			// shortcut cannot churn its mtime and wake the file watcher.
-			e.preventDefault();
-			const saveTarget = tabManager.activeTab;
-			if (saveTarget && (saveTarget.isDirty || saveTarget.path === '')) saveContent();
-		}
-
-		if (modShift && key === 't') {
-			e.preventDefault();
-			handleUndoCloseTab();
-		}
-		// Not `mod`/`modShift`: Shift is the ARGUMENT here, not part of the chord's
-		// identity — it picks the direction. Alt still has to be up.
-		if (cmdOrCtrl && !e.altKey && code === 'Tab') {
-			e.preventDefault();
-			tabManager.cycleTab(e.shiftKey ? 'prev' : 'next');
-		}
-		if (mod && code === 'PageUp') {
-			e.preventDefault();
-			tabManager.cycleTab('prev');
-		}
-		if (mod && code === 'PageDown') {
-			e.preventDefault();
-			tabManager.cycleTab('next');
-		}
-		// Alt-based chords, so they say what they need by hand: `mod` would demand
-		// Alt be up, which is the opposite of what these two bind.
-		if (e.metaKey && !e.ctrlKey && e.altKey && !e.shiftKey && code === 'ArrowLeft') {
-			e.preventDefault();
-			tabManager.cycleTab('prev');
-		}
-		if (e.metaKey && !e.ctrlKey && e.altKey && !e.shiftKey && code === 'ArrowRight') {
-			e.preventDefault();
-			tabManager.cycleTab('next');
-		}
-		if (e.altKey && !e.shiftKey && !cmdOrCtrl && code === 'ArrowLeft') {
-			e.preventDefault();
-			navigateFileHistory('back');
-		}
-		if (e.altKey && !e.shiftKey && !cmdOrCtrl && code === 'ArrowRight') {
-			e.preventDefault();
-			navigateFileHistory('forward');
-		}
-		// The one chord that cannot demand Shift be up. `+` IS the shifted `=` on
-		// the layouts that have both, so `mod` would delete the `+` spelling
-		// outright and leave Cmd+Shift+= — how a lot of people zoom in — dead. The
-		// guard is per-spelling instead: bare `=` wants no Shift, `+` brings its
-		// own. (The keymap harness only ever fires unshifted characters, so it sees
-		// the `=` half of this and never the `+` half.)
-		if (cmdOrCtrl && !e.altKey && (key === '+' || (key === '=' && !e.shiftKey))) {
-			e.preventDefault();
-			settings.zoomIn();
-		}
-		if (mod && key === '-') {
-			e.preventDefault();
-			settings.zoomOut();
-		}
-		if (mod && key === '0') {
-			e.preventDefault();
-			settings.resetZoom();
-		}
-		if (mod && key === ',') {
-			e.preventDefault();
-			showSettings = true;
-		}
-		// Ctrl/Cmd+F: route to either Monaco's built-in find or the preview
-		// FindBar depending on focus and which panes are visible. We only
-		// preventDefault when we actually take the action ourselves —
-		// otherwise we let Monaco's own keybinding fire.
-		if (mod && key === 'f') {
-			const active = document.activeElement as Node | null;
-			const editorHasFocus = !!editorPaneEl && !!active && editorPaneEl.contains(active);
-			if (!editorHasFocus) {
-				e.preventDefault();
-				triggerFindAction();
-			}
-		}
+		const command = viewerCommandFor(e, keyContext());
+		if (!command) return;
+		e.preventDefault();
+		runViewerCommand(command);
 	}
 
 	async function navigateFileHistory(direction: 'back' | 'forward') {

--- a/src/lib/utils/shortcuts.ts
+++ b/src/lib/utils/shortcuts.ts
@@ -36,6 +36,8 @@
  * It was invisible in the app until this group existed: #636 shipped list
  * continuation and nothing anywhere told a user it was there.
  */
+import type { ViewerCommand } from './viewerKeymap.js';
+
 type ShortcutGroup = 'file' | 'edit' | 'keys' | 'view' | 'window';
 
 /** Display order of the groups, and the i18n key that titles each one. */
@@ -91,11 +93,22 @@ export type ShortcutEntry = {
 	 */
 	readonly editorCommand?: string;
 	/**
-	 * The app function `MarkdownViewer.svelte`'s document-level handler runs for
-	 * this chord when the editor does not have focus. Recorded as a call path, so
-	 * `tabManager.cycleTab` matches `tabManager.cycleTab:next`.
+	 * The command the document-level dispatcher means by this row's chords when
+	 * the editor does not have focus.
+	 *
+	 * One entry means every chord in the row runs it (`file-new` binds both
+	 * `Mod+T` and `Mod+N`); otherwise there is one per chord, in `chords` order,
+	 * which is how `view-preview-width`'s `[` and `]` say which way each goes.
+	 *
+	 * A `ViewerCommand` rather than a function name, now that the dispatcher has
+	 * a module of its own: the compiler now rejects a row naming a
+	 * command that does not exist, where the old free-text spellings
+	 * (`showSettings=true`, `settings.previewMaxWidth=`, `toggleEdit` for a
+	 * function called `toggleEditView`) were matched by prefix and could only be
+	 * checked at runtime — and `tab-next` and `tab-prev` both said
+	 * `tabManager.cycleTab`, so nothing could tell them apart.
 	 */
-	readonly documentCall?: string;
+	readonly documentCommands?: readonly ViewerCommand[];
 	/**
 	 * Platforms where the document handler deliberately stays out of the way.
 	 * Only Quit uses this: on macOS the native Tauri menu owns `Cmd+Q` and the
@@ -123,7 +136,7 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 		chords: ['Mod+T', 'Mod+N'],
 		group: 'file',
 		editorAction: true,
-		documentCall: 'handleNewFile',
+		documentCommands: ['new-file'],
 	},
 	{
 		id: 'file-open',
@@ -131,7 +144,7 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 		chords: ['Mod+O'],
 		group: 'file',
 		editorAction: true,
-		documentCall: 'selectFile',
+		documentCommands: ['open-file'],
 	},
 	{
 		id: 'file-save',
@@ -139,7 +152,7 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 		chords: ['Mod+S'],
 		group: 'file',
 		editorAction: true,
-		documentCall: 'saveContent',
+		documentCommands: ['save'],
 	},
 	{
 		id: 'file-save-as',
@@ -149,14 +162,14 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 		// with no Shift guard, so the advertised keystroke ran a plain Save.
 		chords: ['Mod+Shift+S'],
 		group: 'file',
-		documentCall: 'saveContentAs',
+		documentCommands: ['save-as'],
 	},
 	{
 		id: 'file-reload',
 		labelKey: 'menu.reloadFromDisk',
 		chords: ['F5'],
 		group: 'file',
-		documentCall: 'reloadFromDisk',
+		documentCommands: ['reload-from-disk'],
 	},
 	{
 		id: 'file-close',
@@ -164,7 +177,7 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 		chords: ['Mod+W'],
 		group: 'file',
 		editorAction: true,
-		documentCall: 'closeFile',
+		documentCommands: ['close-file'],
 	},
 	{
 		id: 'file-reveal',
@@ -178,7 +191,7 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 		labelKey: 'menu.exit',
 		chords: ['Mod+Q'],
 		group: 'file',
-		documentCall: 'getCurrentWindow',
+		documentCommands: ['close-window'],
 		// On macOS the document handler returns before this branch; the native
 		// menu's CmdOrCtrl+Q is what answers, and #281 left exactly two entries.
 		documentExempt: ['macos'],
@@ -315,7 +328,7 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 		chords: ['Mod+E'],
 		group: 'view',
 		editorAction: true,
-		documentCall: 'toggleEdit',
+		documentCommands: ['toggle-edit-view'],
 	},
 	{
 		id: 'view-toggle-live',
@@ -333,7 +346,7 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 		chords: ['Mod+\\'],
 		group: 'view',
 		editorAction: true,
-		documentCall: 'toggleSplitView',
+		documentCommands: ['toggle-split-view'],
 	},
 	{
 		id: 'toggle-zen-mode',
@@ -359,16 +372,14 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 		labelKey: 'menu.find',
 		chords: ['Mod+F'],
 		group: 'view',
-		documentCall: 'triggerFindAction',
+		documentCommands: ['find'],
 	},
 	{
 		id: 'app-settings',
 		labelKey: 'menu.settings',
 		chords: ['Mod+,'],
 		group: 'view',
-		// The branch opens Settings by assigning, not by calling; the harness
-		// records the write.
-		documentCall: 'showSettings=true',
+		documentCommands: ['open-settings'],
 		nativeMenuAccelerator: 'CmdOrCtrl+,',
 	},
 	{
@@ -376,16 +387,15 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 		labelKey: 'settings.previewMaxWidth',
 		// One row, two chords: `[` narrows and `]` widens, the same pair the
 		// settings stepper offers. Both run the same branch, which turns full-width
-		// off before it adjusts the width; the width write is the one this row
-		// names, and the full-width write is accounted for in
-		// DOCUMENT_NOT_ADVERTISED as part of this same shortcut.
+		// off before it adjusts the width — one shortcut, two directions, which is
+		// why this is the one row whose commands are listed per chord.
 		chords: ['Mod+Alt+[', 'Mod+Alt+]'],
 		group: 'view',
-		documentCall: 'settings.previewMaxWidth=',
+		documentCommands: ['preview-width-narrower', 'preview-width-wider'],
 	},
-	{ id: 'view-zoom-in', labelKey: 'menu.zoomIn', chords: ['Mod+='], group: 'view', documentCall: 'settings.zoomIn' },
-	{ id: 'view-zoom-out', labelKey: 'menu.zoomOut', chords: ['Mod+-'], group: 'view', documentCall: 'settings.zoomOut' },
-	{ id: 'view-zoom-reset', labelKey: 'menu.resetZoom', chords: ['Mod+0'], group: 'view', documentCall: 'settings.resetZoom' },
+	{ id: 'view-zoom-in', labelKey: 'menu.zoomIn', chords: ['Mod+='], group: 'view', documentCommands: ['zoom-in'] },
+	{ id: 'view-zoom-out', labelKey: 'menu.zoomOut', chords: ['Mod+-'], group: 'view', documentCommands: ['zoom-out'] },
+	{ id: 'view-zoom-reset', labelKey: 'menu.resetZoom', chords: ['Mod+0'], group: 'view', documentCommands: ['zoom-reset'] },
 
 	// -------------------------------------------------------------- window
 	{
@@ -396,7 +406,7 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 		chords: ['Ctrl+Tab'],
 		group: 'window',
 		editorAction: true,
-		documentCall: 'tabManager.cycleTab',
+		documentCommands: ['next-tab'],
 	},
 	{
 		id: 'tab-prev',
@@ -404,7 +414,7 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 		chords: ['Ctrl+Shift+Tab'],
 		group: 'window',
 		editorAction: true,
-		documentCall: 'tabManager.cycleTab',
+		documentCommands: ['previous-tab'],
 	},
 	{
 		id: 'tab-undo-close',
@@ -412,28 +422,28 @@ export const SHORTCUTS: readonly ShortcutEntry[] = [
 		chords: ['Mod+Shift+T'],
 		group: 'window',
 		editorAction: true,
-		documentCall: 'handleUndoCloseTab',
+		documentCommands: ['undo-close-tab'],
 	},
 	{
 		id: 'tab-move-window',
 		labelKey: 'menu.moveToWindow',
 		chords: ['Mod+Shift+M'],
 		group: 'window',
-		documentCall: 'carryActiveTabToNextWindow',
+		documentCommands: ['move-tab-to-next-window'],
 	},
 	{
 		id: 'nav-back',
 		labelKey: 'menu.back',
 		chords: ['Alt+Left'],
 		group: 'window',
-		documentCall: 'navigateFileHistory',
+		documentCommands: ['history-back'],
 	},
 	{
 		id: 'nav-forward',
 		labelKey: 'menu.forward',
 		chords: ['Alt+Right'],
 		group: 'window',
-		documentCall: 'navigateFileHistory',
+		documentCommands: ['history-forward'],
 	},
 	{
 		id: 'app-command-palette',

--- a/src/lib/utils/viewerKeymap.ts
+++ b/src/lib/utils/viewerKeymap.ts
@@ -1,0 +1,285 @@
+import type { OSType } from '../stores/settings.svelte.js';
+
+/*
+ * WHICH COMMAND a document-level keystroke means — the whole of it, and nothing
+ * else.
+ *
+ * This was the body of `handleKeyDown` in MarkdownViewer.svelte, where it could
+ * not be imported and therefore could not be run by a test. What tests did
+ * instead was read it: fourteen assertions across four files matched the
+ * component's source text for `if (mod && key === 'e')` and its neighbours, and
+ * #647 turned five of them red by renaming a local. A source-shape assertion
+ * cannot tell a rename from a regression, because it never asks what the code
+ * DOES.
+ *
+ * The same argument as #644's fold drivers, and the same shape of answer: the
+ * logic moves out, the wiring stays in. What moves is the part that is a
+ * function of the keystroke — the branch structure, every modifier guard, the
+ * per-platform scoping. What stays is the part that is genuinely the
+ * component's: which of its own functions each command runs.
+ *
+ * WHY A COMMAND NAME RATHER THAN A HOST OBJECT. The obvious extraction hands
+ * the dispatcher the eleven callbacks it used to close over (`closeFile`,
+ * `saveContent`, `handleNewFile`, …) as a host argument, the way `FoldHost`
+ * carries the fold drivers' three. Eleven is not three: a host that large is
+ * the component with its name changed, every caller has to build one, and the
+ * test that builds one is back to describing the component rather than running
+ * it. So the seam is cut one step earlier, at the question that is actually
+ * hard — WHICH command — and the answer is a string the caller switches on.
+ * The component's switch is the residue, and it is checked where it lives.
+ *
+ * WHY IT TAKES NO STORES. Nothing here imports `settings` or `tabManager`;
+ * every fact about the app arrives in `KeyContext` as a plain value. That is
+ * partly #644's constraint (a store import drags its runes behind every
+ * importer) and mostly this one: with no free identifiers there is nothing for
+ * a test harness to stub, which is the failure #649 hit — a helper the harness
+ * did not know about resolved to a recording stub whose result compared false
+ * to everything, so a Windows-only branch reported as firing on all three
+ * platforms and the measured chord count went from 51 to 610. A function whose
+ * every input is an argument cannot be run against a more agreeable copy of the
+ * app, because there is no copy to make.
+ */
+
+/**
+ * One command the document-level keyboard reaches, named rather than called.
+ *
+ * The direction is part of the name — `next-tab` and `previous-tab` rather than
+ * one `cycle-tab` — because the registry rows that advertise these chords used
+ * to name `tabManager.cycleTab` for both and could not tell them apart.
+ */
+export type ViewerCommand =
+	| 'preview-width-narrower'
+	| 'preview-width-wider'
+	| 'reload-from-disk'
+	| 'move-tab-to-next-window'
+	| 'close-file'
+	| 'new-file'
+	| 'open-file'
+	| 'close-window'
+	| 'toggle-split-view'
+	| 'toggle-edit-view'
+	| 'save-as'
+	| 'save'
+	| 'undo-close-tab'
+	| 'next-tab'
+	| 'previous-tab'
+	| 'history-back'
+	| 'history-forward'
+	| 'zoom-in'
+	| 'zoom-out'
+	| 'zoom-reset'
+	| 'open-settings'
+	| 'find';
+
+/**
+ * The keystroke, as much of it as any branch reads.
+ *
+ * A structural subset of `KeyboardEvent` rather than the event itself, so a
+ * test can hand over an object literal without a DOM. `target` is here because
+ * the preview-width branch walks up from it; every other branch reads only
+ * `key`, `code` and the four modifiers.
+ */
+export type KeyStroke = {
+	readonly key: string;
+	readonly code: string;
+	readonly ctrlKey: boolean;
+	readonly metaKey: boolean;
+	readonly shiftKey: boolean;
+	readonly altKey: boolean;
+	readonly target?: EventTarget | null;
+};
+
+/**
+ * Everything about the app a branch below is allowed to know.
+ *
+ * Six plain values, all of them read-only. Anything a command needs in order to
+ * RUN — the active tab, the settings store, the window — is deliberately absent:
+ * this decides which command, and the caller runs it.
+ */
+export type KeyContext = {
+	/** The app is still loading its first document; nothing is dispatched. */
+	readonly mode: 'loading' | 'app';
+	readonly osType: OSType;
+	/** The active tab shows both panes, which keeps the preview reachable. */
+	readonly isSplit: boolean;
+	/** Settings, the modal, the prompt or the home screen is in front. */
+	readonly overlayOpen: boolean;
+	readonly isEditing: boolean;
+	/** The caret is inside the Monaco pane, so Monaco's own Find should answer. */
+	readonly editorHasFocus: boolean;
+};
+
+/**
+ * Whether the preview-width chords apply, given what the keystroke landed on.
+ *
+ * Exported because it is the one branch condition that reads the DOM, and the
+ * only one a test cannot state as a boolean: `Mod+Alt+[` inside a text field is
+ * the field's business.
+ */
+export function canUsePreviewWidthShortcut(target: EventTarget | null | undefined, context: KeyContext): boolean {
+	if (context.overlayOpen || (context.isEditing && !context.isSplit)) return false;
+	// `typeof target.closest === 'function'` rather than `target instanceof
+	// Element`, which is what this said while it lived in the component. The
+	// module is imported by `node --test` files that have no DOM at all, where
+	// the bare global is a ReferenceError rather than a false — and `instanceof`
+	// against a DOM constructor is the wrong test anyway for a node from another
+	// realm. The method being called is the thing worth asking about.
+	const element = target as Element | null | undefined;
+	if (typeof element?.closest !== 'function') return true;
+	return !element.closest('input, textarea, select, [contenteditable="true"], [role="textbox"]');
+}
+
+/**
+ * The command this keystroke means, or null for one the app does not bind.
+ *
+ * Null is also the answer for a chord that is *deliberately* left to something
+ * else — macOS's ⌘Q, which the native menu owns, and Mod+F while the editor has
+ * focus, which is Monaco's. The caller preventDefaults exactly when this
+ * returns a command, which is what the handler did branch by branch before.
+ */
+export function viewerCommandFor(e: KeyStroke, context: KeyContext): ViewerCommand | null {
+	if (context.mode !== 'app') return null;
+
+	const cmdOrCtrl = e.ctrlKey || e.metaKey;
+	const key = e.key.toLowerCase();
+	const code = e.code;
+
+	/*
+	 * The three modifier shapes almost every branch below wants, named once.
+	 *
+	 * A chord means the modifiers it names AND the absence of the ones it does
+	 * not. Half the branches here used to say only `cmdOrCtrl && key === …`,
+	 * which is not `Mod+X` — it is `Mod+X` plus its whole Shift/Alt cross
+	 * product. `Mod+W` was the expensive case: Shift+Cmd+W and Alt+Cmd+W are
+	 * what a user reaches for when they mean "close the window" or "close
+	 * everything", and both silently closed one document instead. `Mod+Q`,
+	 * `Mod+E`, `Mod+S`, `Mod+,` and the zoom chords all had the same hole, and
+	 * on macOS Shift+Cmd+Q — Log Out — reached the window-close branch.
+	 *
+	 * The guard is here rather than repeated in fourteen branches so that a
+	 * branch added later INHERITS it by reaching for `mod`, instead of having
+	 * to remember three negations. `shortcutRegistry.test.ts` closes the other
+	 * half: any chord this function answers that the registry does not advertise
+	 * fails there, so a new branch cannot quietly grow a cross product again.
+	 *
+	 * Three branches are deliberately not written in these terms, each with its
+	 * reason at the branch: tab cycling (Shift picks the direction), zoom in
+	 * (`+` is the shifted `=`), and the Alt-only navigation chords.
+	 */
+	const mod = cmdOrCtrl && !e.shiftKey && !e.altKey;
+	const modShift = cmdOrCtrl && e.shiftKey && !e.altKey;
+	const modAlt = cmdOrCtrl && !e.shiftKey && e.altKey;
+
+	// The macOS application menu owns ⌘Q. Document shortcuts remain in the
+	// in-window controls, so they continue to act on the current webview.
+	if (context.osType === 'macos' && mod && key === 'q') return null; // → menu-app-quit
+
+	if (modAlt && (code === 'BracketLeft' || code === 'BracketRight')) {
+		if (!canUsePreviewWidthShortcut(e.target, context)) return null;
+		return code === 'BracketLeft' ? 'preview-width-narrower' : 'preview-width-wider';
+	}
+
+	if (!cmdOrCtrl && !e.shiftKey && !e.altKey && code === 'F5') return 'reload-from-disk';
+	if (modShift && key === 'm') return 'move-tab-to-next-window';
+	// Nothing catches the Shift and Alt variants on the way past: they are not
+	// another command in disguise, they are a user asking the WINDOW manager
+	// for something. Leaving them unhandled — and unprevented — is what lets
+	// the OS answer them, which is strictly better than answering with the one
+	// irreversible thing the app can do.
+	if (mod && key === 'w') return 'close-file';
+	// Windows only, which is the scope this binding was written to and then
+	// exceeded. `docs/requirements/157-ctrl-f4-close-tab.md`, added by the
+	// same commit as the branch itself (4670743, "add Ctrl+F4 shortcut to
+	// close active tab on Windows"), puts "macOS / Linux (dort ist Ctrl+F4
+	// kein Standard)" under "Out of scope"; the handler bound all three
+	// anyway. So this is not a new product decision, it is the documented one
+	// finally being implemented. The doc went away with the rest of docs/ in
+	// d69c181, which is how the intent stopped being checkable —
+	// `shortcutRegistry.test.ts` now holds it instead.
+	//
+	// The convention argument is why the requirement says that: Ctrl+F4
+	// closes a document window on Windows, still live in Office and the IDEs.
+	// macOS has no equivalent — Cmd+F4 means nothing, and with "Use F1, F2,
+	// etc. as standard function keys" off, which is the default, F4 runs a
+	// system function and the app never receives the event at all
+	// (hand-tested on a Mac: it did nothing). A Mac was therefore offered a
+	// THIRD route to an irreversible action that was at once non-conventional
+	// and nearly unpressable.
+	//
+	// Not a rule about odd-looking chords: `Cmd+Shift+=` stays on every
+	// platform. That one is not a platform convention, it is how "Cmd plus"
+	// is typed — `+` is the shifted `=` on every layout — so Mac users press
+	// it as much as anyone. The question is "does anyone on this platform
+	// actually press this?", not "does it carry a Shift?".
+	//
+	// A bare `osType` comparison next to #646's `platformOf` is deliberate,
+	// not an oversight. `platformOf` answers `'macos' | 'windows'` and folds
+	// Linux INTO `'windows'` — correct for the two questions it was built for
+	// (which modifier to print, which window chrome to draw) and unable to
+	// express this one, which needs all three apart. And the reason to avoid a
+	// bare comparison does not apply to this spelling: `osType` is `'unknown'`
+	// until the Rust command answers, and `=== 'windows'` resolves that window
+	// to DO NOT FIRE. It fails closed, which is the only acceptable direction
+	// for a branch that throws a document away.
+	if (context.osType === 'windows' && mod && code === 'F4') return 'close-file';
+	// New file, both keys, whether or not the editor has focus (#392).
+	//
+	// Monaco resolves its own keybindings on the editor container and calls
+	// stopPropagation() when it consumes one, so this handler only ever runs
+	// for keystrokes the editor did not claim. That is how Ctrl+T came to
+	// mean two things: inside Monaco the `file-new` action answered it and
+	// opened an Untitled buffer, outside it this branch opened a Home tab.
+	// Both of the app's own labels already promised the first one — the tab
+	// strip's + button is titled "New Tab (Ctrl+T)" and the app menu prints
+	// Ctrl/Cmd+T beside "New File" — so the branch, not the labels, was the
+	// odd one out.
+	//
+	// `file-new` binds Ctrl/Cmd+N as well, and this handler used to know
+	// about only one of the two, which left Ctrl+N doing nothing at all
+	// outside the editor. Both are listed here so the two paths cannot
+	// drift again; `formatShortcutKeymap.test.ts` holds them equal.
+	if (mod && (key === 't' || key === 'n')) return 'new-file';
+	if (mod && key === 'o') return 'open-file';
+	if (mod && key === 'q') return 'close-window';
+	if (mod && (code === 'Backslash' || code === 'IntlBackslash')) return 'toggle-split-view';
+	if (mod && key === 'e') return 'toggle-edit-view';
+	// Save As. The app menu advertised this chord for as long as the menu has
+	// existed, but nothing ever bound it: the branch below matched on
+	// `cmdOrCtrl && key === 's'` with no Shift guard, so the advertised
+	// keystroke fell through to a plain Save and silently overwrote the file
+	// the user was asking to write somewhere else. `saveContentAs` had no
+	// keyboard path at all — its only caller was the menu button.
+	if (modShift && key === 's') return 'save-as';
+	if (mod && key === 's') return 'save';
+	if (modShift && key === 't') return 'undo-close-tab';
+	// Not `mod`/`modShift`: Shift is the ARGUMENT here, not part of the chord's
+	// identity — it picks the direction. Alt still has to be up.
+	if (cmdOrCtrl && !e.altKey && code === 'Tab') return e.shiftKey ? 'previous-tab' : 'next-tab';
+	if (mod && code === 'PageUp') return 'previous-tab';
+	if (mod && code === 'PageDown') return 'next-tab';
+	// Alt-based chords, so they say what they need by hand: `mod` would demand
+	// Alt be up, which is the opposite of what these two bind.
+	if (e.metaKey && !e.ctrlKey && e.altKey && !e.shiftKey && code === 'ArrowLeft') return 'previous-tab';
+	if (e.metaKey && !e.ctrlKey && e.altKey && !e.shiftKey && code === 'ArrowRight') return 'next-tab';
+	if (e.altKey && !e.shiftKey && !cmdOrCtrl && code === 'ArrowLeft') return 'history-back';
+	if (e.altKey && !e.shiftKey && !cmdOrCtrl && code === 'ArrowRight') return 'history-forward';
+	// The one chord that cannot demand Shift be up. `+` IS the shifted `=` on
+	// the layouts that have both, so `mod` would delete the `+` spelling
+	// outright and leave Cmd+Shift+= — how a lot of people zoom in — dead. The
+	// guard is per-spelling instead: bare `=` wants no Shift, `+` brings its
+	// own. (The keymap harness only ever fires unshifted characters, so it sees
+	// the `=` half of this and never the `+` half; `viewerKeymap.test.ts` fires
+	// the `+` half directly.)
+	if (cmdOrCtrl && !e.altKey && (key === '+' || (key === '=' && !e.shiftKey))) return 'zoom-in';
+	if (mod && key === '-') return 'zoom-out';
+	if (mod && key === '0') return 'zoom-reset';
+	if (mod && key === ',') return 'open-settings';
+	// Ctrl/Cmd+F: route to either Monaco's built-in find or the preview
+	// FindBar depending on focus and which panes are visible. The caller only
+	// preventDefaults when it takes the action itself — otherwise Monaco's own
+	// keybinding fires — which is why focus is a condition here rather than a
+	// branch inside the command.
+	if (mod && key === 'f' && !context.editorHasFocus) return 'find';
+
+	return null;
+}


### PR DESCRIPTION
Tests read `MarkdownViewer.svelte`'s **source text** because its logic is unreachable any other way. That is why #647 had five assertions like `assert.match(viewerSource, /if \(mod && key === 'e'\)/)` go red when a local variable was renamed, with no behaviour change at all.

This makes the keyboard half reachable. Same surgery #644 did for the fold drivers — moving logic **out**, not mounting the component under jsdom, which `AGENTS.md` rejects for good reasons.

### The cut, and why not a host object

`viewerCommandFor(stroke, context) → ViewerCommand | null` in `src/lib/utils/viewerKeymap.ts`. The chord logic moves; the component keeps `runViewerCommand`, a switch from command name to its own closures.

The obvious extraction fails: the dispatcher closes over **eleven** of the component's functions (`closeFile`, `saveContent`, `handleNewFile`, …). A `KeyHost` of eleven is the component under a new name — every caller builds one, and a test that builds one is describing the component again.

So the seam is cut one step earlier, at the hard question — *which command* — and the answer is a string. What it takes instead is a six-field `KeyContext` of plain read-only values: `mode`, `osType`, `isSplit`, `overlayOpen`, `isEditing`, `editorHasFocus`. **No stores, no callbacks.**

**#649's trap is structurally gone.** That bug — a helper called inside the dispatcher resolving to the harness's recording stub, silently reporting every chord as firing on every platform, measured as 610 answered chords instead of 51 — was possible because the harness answered free identifiers. The new module imports nothing but a type, so there are no free identifiers to answer. `documentKeymap` imports and calls the function: no `transpileModule`, no `with`, no scope proxy. A dependency the dispatcher grows is now a **compile error at the call site**.

### The seam landed, measured both directions

Renaming `mod`, `modShift`, `modAlt`, `cmdOrCtrl`, `key`, `code` and the context parameter:

| | result |
|---|---|
| inside `viewerKeymap.ts` | **0 red** |
| the same rename on `handleKeyDown` at master | **7 red** |

That is the whole point of the change, stated as a measurement rather than an argument.

An aside that matters: a sloppy first rename clobbered the string literal `'e'`, silently unbinding Mod+E. The new suite caught it immediately — *"runViewerCommand handles 22 commands, 21 are reachable"*. The replacement tests do fail when behaviour changes.

### Behaviour is identical

Per-platform answered chords, before → after: **macOS 49 → 49, Windows 53 → 53, Linux 51 → 51**, with a 1:1 correspondence diffed from every old recorded call to every new command name. The only refinement is `settings.previewMaxWidth=` splitting into `preview-width-narrower` / `-wider`, which the old tests could not tell apart.

### Correcting the premise this was dispatched on

I said ~101 shape assertions across 35 files. Measured: **245 across 45 files**, and **exactly 14 are about the dispatcher** (11 inside `handleKeyDown`, 3 on `canUsePreviewWidthShortcut`), in 4 files.

So the keyboard cluster was the densest *usable* slice, but it is **6% of the viewer's shape assertions**. The other 231 are rendering, export, tabs, sanitising, window state. Worth knowing before anyone assumes this scales linearly.

**14 → 5.** Nine became real calls. The five that remain describe what a command *does* — the Save guard's `isDirty || path === ''`, the preview-width arithmetic — closures over `tabManager.activeTab` inside the component, which is the part that cannot move. They now anchor on `case 'save':` rather than on a chord condition, so #647's failure mode no longer reaches them.

### A side benefit that closed two real gaps

`shortcuts.ts` rows carry `documentCommands: ViewerCommand[]` instead of `documentCall: string`, so the registry is compiler-checked and the per-chord assertion is `assert.equal` rather than a prefix match. That surfaced two things the prefix match could not see: `tab-next` and `tab-prev` both said `tabManager.cycleTab` and were indistinguishable, and the `[` / `]` direction was never tested at all. `DOCUMENT_NOT_ADVERTISED` and its prose excuse are gone — it existed only because the harness recorded writes.

`MarkdownViewer.svelte` **4,822 → 4,680**. `npm test` 904 · `vitest` 361 → **365** · `cargo` 148 · `check` 0 errors.

### On further slices

Hold off. The next-densest clusters (`viewModeWithoutSaving.spec.ts`'s 32 assertions behind a pluck-and-transpile harness, `previewSanitize`, `renderPipelineConvention`) contain many genuine single-implementation **absence claims**, which `AGENTS.md` is right to keep as text. That needs an inventory pass before committing to another extraction, not an assumption that the same trick works twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
