### PR TITLE
fix(editor): the format buttons see the markers just outside the selection

### DIFF
--- a/scripts/editorToolbar.test.ts
+++ b/scripts/editorToolbar.test.ts
@@ -11,6 +11,7 @@ import {
 	getVisibleEditorToolbarTools,
 	normalizeEditorToolbarHidden,
 	normalizeEditorToolbarOrder,
+	inlineWrapEdit,
 	toggleInlineWrap,
 	toggleLineMarker,
 	type InlineWrapToolId,
@@ -388,4 +389,73 @@ test('the italic button never turns bold text into italic text', () => {
 		const result = toggleInlineWrap('fmt-italic', bold);
 		assert.ok(result.includes(bold), `italic on ${bold} produced ${result}, which no longer contains it`);
 	}
+});
+
+/**
+ * The whole gesture: a buffer, the part of it the user selected, and one click.
+ * Spelled this way because the defects below are only visible from outside the
+ * selection — asserting on the selected text alone is what missed them.
+ */
+function clickWith(id: InlineWrapToolId, buffer: string, selected: string): string {
+	const start = buffer.indexOf(selected);
+	assert.notEqual(start, -1, `${JSON.stringify(selected)} is not in ${JSON.stringify(buffer)}`);
+	const end = start + selected.length;
+	const { reach, text } = inlineWrapEdit(id, buffer.slice(0, start), selected, buffer.slice(end));
+	return buffer.slice(0, start - reach) + text + buffer.slice(end + reach);
+}
+
+test('double-clicking a word and clicking the button again removes the format', () => {
+	// Double-click selects the word, not the markers around it. Reading only the
+	// selection, every one of these answered "there is no format here" and wrote
+	// a second pair.
+	const cases: [InlineWrapToolId, string][] = [
+		['fmt-strikethrough', '~~word~~'],
+		['fmt-strikethrough', '~word~'],
+		['fmt-bold', '**word**'],
+		['fmt-bold', '__word__'],
+		['fmt-italic', '*word*'],
+		['fmt-italic', '_word_'],
+		['fmt-inline-code', '`word`'],
+	];
+	for (const [id, buffer] of cases) {
+		assert.equal(clickWith(id, buffer, 'word'), 'word', `${id} on ${buffer}`);
+	}
+});
+
+test('a word struck through at the start of a line never becomes a code fence', () => {
+	// Why this one is worse than the others. Four tildes open a fenced code block
+	// whose info string is `word~~~~`, and nothing in the document closes it, so
+	// everything after the click renders as code. Verified against the renderer:
+	//   convert_markdown("~~~~word~~~~\n\nSecond paragraph.\n")
+	//     -> <pre><code class="language-word~~~~">\nSecond paragraph.\n</code></pre>
+	const after = clickWith('fmt-strikethrough', '~~word~~ and the rest of the line', 'word');
+	assert.ok(!/~~~/.test(after), `three or more tildes in a row: ${JSON.stringify(after)}`);
+});
+
+test('reaching outside the selection never breaks a neighbouring pair', () => {
+	// The reason this measures the whole run instead of matching one character.
+	// Italic sees an asterisk outside the selection either way; taking one from
+	// each end of bold's pair would have unbolded the word to italicise it.
+	assert.equal(clickWith('fmt-italic', '**word**', 'word'), '***word***');
+	assert.equal(clickWith('fmt-bold', '*word*', 'word'), '***word***');
+	assert.equal(clickWith('fmt-strikethrough', '**word**', 'word'), '**~~word~~**');
+
+	// Only one side has the marker, so this is not a pair to undo. Growing the
+	// range would delete a tilde the user typed and leave the other behind.
+	assert.equal(clickWith('fmt-strikethrough', '~~word and more', 'word'), '~~~~word~~ and more');
+
+	// Selecting the markers still works, and still gives the same answer as
+	// selecting only the word — the two paths must not disagree.
+	assert.equal(clickWith('fmt-strikethrough', '~~word~~', '~~word~~'), 'word');
+});
+
+test('a selection with nothing before it reaches nowhere', () => {
+	// `Editor.svelte` subtracts the reach from the selection's column, so a
+	// selection at the head of the line has to answer 0 rather than send the
+	// range off the front of it.
+	assert.deepEqual(inlineWrapEdit('fmt-strikethrough', '', 'word', '~~'), {
+		reach: 0,
+		text: '~~word~~',
+	});
+	assert.deepEqual(inlineWrapEdit('fmt-bold', '', 'word', ''), { reach: 0, text: '**word**' });
 });

--- a/scripts/editorToolbar.test.ts
+++ b/scripts/editorToolbar.test.ts
@@ -12,6 +12,7 @@ import {
 	normalizeEditorToolbarHidden,
 	normalizeEditorToolbarOrder,
 	inlineWrapEdit,
+	inlineWrapSelectionEnd,
 	toggleInlineWrap,
 	toggleLineMarker,
 	type InlineWrapToolId,
@@ -447,6 +448,61 @@ test('reaching outside the selection never breaks a neighbouring pair', () => {
 	// Selecting the markers still works, and still gives the same answer as
 	// selecting only the word — the two paths must not disagree.
 	assert.equal(clickWith('fmt-strikethrough', '~~word~~', '~~word~~'), 'word');
+});
+
+/**
+ * The whole gesture again, but carrying the selection forward the way the
+ * editor does: the edit says what it wrote, and that is what stays selected.
+ */
+function clickTwice(id: InlineWrapToolId, buffer: string, selected: string): string {
+	let start = buffer.indexOf(selected);
+	assert.notEqual(start, -1, `${JSON.stringify(selected)} is not in ${JSON.stringify(buffer)}`);
+	let end = start + selected.length;
+	let text = buffer;
+
+	for (let click = 0; click < 2; click += 1) {
+		const edit = inlineWrapEdit(id, text.slice(0, start), text.slice(start, end), text.slice(end));
+		const from = start - edit.reach;
+		text = text.slice(0, from) + edit.text + text.slice(end + edit.reach);
+		// What the edit wrote is what is selected when the next click arrives.
+		start = from;
+		end = from + edit.text.length;
+	}
+	return text;
+}
+
+test('clicking the same button twice puts the line back', () => {
+	// Reported from a build: `~~word~~`, double-click `word`, press S — and the
+	// second press wrote `wo~~rd~~`. The edit had said nothing about where the
+	// selection goes, so Monaco clamped columns 3-7 against the shorter line and
+	// left `rd` selected. Nothing here could have caught it while the selection
+	// lived only in the editor.
+	const cases: [InlineWrapToolId, string, string][] = [
+		['fmt-strikethrough', '~~word~~', 'word'],
+		['fmt-bold', '**word**', 'word'],
+		['fmt-italic', '*word*', 'word'],
+		['fmt-inline-code', '`word`', 'word'],
+		// And from the other direction: wrap, then unwrap.
+		['fmt-strikethrough', 'word', 'word'],
+		['fmt-bold', 'word', 'word'],
+		// With neighbours, so a mistake in the column arithmetic shows up as
+		// text landing in the wrong place rather than a no-op.
+		['fmt-strikethrough', 'a ~~word~~ b', 'word'],
+		['fmt-bold', 'a word b', 'word'],
+	];
+	for (const [id, buffer, selected] of cases) {
+		assert.equal(clickTwice(id, buffer, selected), buffer, `${id} on ${JSON.stringify(buffer)}`);
+	}
+});
+
+test('the edit reports the end of what it wrote', () => {
+	// Single line: the column after the text. Columns are 1-based.
+	assert.deepEqual(inlineWrapSelectionEnd(3, 'word'), { lineOffset: 0, column: 7 });
+	assert.deepEqual(inlineWrapSelectionEnd(1, ''), { lineOffset: 0, column: 1 });
+
+	// A selection can span lines, and then the end column belongs to the last
+	// line of the replacement, not to the column the edit started at.
+	assert.deepEqual(inlineWrapSelectionEnd(5, '**one\ntwo**'), { lineOffset: 1, column: 6 });
 });
 
 test('a selection with nothing before it reaches nowhere', () => {

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -7,6 +7,7 @@
 	import {
 		INLINE_WRAP_LOOKAROUND,
 		inlineWrapEdit,
+		inlineWrapSelectionEnd,
 		toggleLineMarker,
 		type InlineWrapToolId,
 		type LineMarkerToolId,
@@ -914,17 +915,36 @@
 			}),
 		);
 
-		editor.executeEdits("toggle-format", [
-			{
-				range: {
-					startLineNumber: selection.startLineNumber,
-					startColumn: selection.startColumn - reach,
-					endLineNumber: selection.endLineNumber,
-					endColumn: selection.endColumn + reach,
+		// The edit has to say where the selection goes. Left to Monaco, the old
+		// selection is adjusted against the new text, and that is wrong as soon
+		// as the range is wider than the selection was: `~~word~~` -> `word`
+		// clamps columns 3-7 to 3-5, leaving `rd` selected, and a second click
+		// wraps that instead — `wo~~rd~~`.
+		const startColumn = selection.startColumn - reach;
+		const end = inlineWrapSelectionEnd(startColumn, text);
+
+		editor.executeEdits(
+			"toggle-format",
+			[
+				{
+					range: {
+						startLineNumber: selection.startLineNumber,
+						startColumn,
+						endLineNumber: selection.endLineNumber,
+						endColumn: selection.endColumn + reach,
+					},
+					text,
 				},
-				text,
-			},
-		]);
+			],
+			[
+				new monaco.Selection(
+					selection.startLineNumber,
+					startColumn,
+					selection.startLineNumber + end.lineOffset,
+					end.column,
+				),
+			],
+		);
 	};
 
 	// Underline is an HTML tag rather than a Markdown marker, and its two ends

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -5,7 +5,8 @@
 	import { t, type LanguageCode } from '../utils/i18n.js';
 	import { MARKDOWN_LANGUAGE_ID, shouldLinkifyPastedUrl } from '../utils/pasteContext.js';
 	import {
-		toggleInlineWrap,
+		INLINE_WRAP_LOOKAROUND,
+		inlineWrapEdit,
 		toggleLineMarker,
 		type InlineWrapToolId,
 		type LineMarkerToolId,
@@ -892,10 +893,36 @@
 		const model = editor.getModel();
 		if (!selection || !model) return;
 
+		// Markers the user did not select are still the user's markers: double
+		// clicking a word inside `~~word~~` selects `word`. `inlineWrapEdit` reads
+		// the few characters on either side and says how far the edit has to grow
+		// to reach them — 0 whenever growing would break a neighbouring pair.
+		const { reach, text } = inlineWrapEdit(
+			id,
+			model.getValueInRange({
+				startLineNumber: selection.startLineNumber,
+				startColumn: Math.max(1, selection.startColumn - INLINE_WRAP_LOOKAROUND),
+				endLineNumber: selection.startLineNumber,
+				endColumn: selection.startColumn,
+			}),
+			model.getValueInRange(selection),
+			model.getValueInRange({
+				startLineNumber: selection.endLineNumber,
+				startColumn: selection.endColumn,
+				endLineNumber: selection.endLineNumber,
+				endColumn: selection.endColumn + INLINE_WRAP_LOOKAROUND,
+			}),
+		);
+
 		editor.executeEdits("toggle-format", [
 			{
-				range: selection,
-				text: toggleInlineWrap(id, model.getValueInRange(selection)),
+				range: {
+					startLineNumber: selection.startLineNumber,
+					startColumn: selection.startColumn - reach,
+					endLineNumber: selection.endLineNumber,
+					endColumn: selection.endColumn + reach,
+				},
+				text,
 			},
 		]);
 	};

--- a/src/lib/utils/editorToolbar.ts
+++ b/src/lib/utils/editorToolbar.ts
@@ -352,6 +352,37 @@ export function inlineWrapEdit(
 	return { reach, text };
 }
 
+/**
+ * Where `text` ends when it is written starting at `startColumn`, as a line
+ * offset from the start and a column — what the caller needs to leave exactly
+ * the written text selected.
+ *
+ * WHY THE EDIT HAS TO SAY. An `executeEdits` with no end-cursor state leaves
+ * the old selection to be adjusted against the new text, and once the replaced
+ * range is wider than the selection was, that adjustment is nonsense: taking
+ * `~~word~~` down to `word` clamps a selection of columns 3-7 to columns 3-5,
+ * which is `rd`. The next click on the same button then wraps `rd` and writes
+ * `wo~~rd~~`. Reported from a build, not caught here: the toggle itself is a
+ * pure function and cannot see a selection, which is the half of this feature
+ * only the editor holds.
+ *
+ * Selecting what was written keeps the two directions symmetric — strip and
+ * the word stays selected, wrap and the marked-up word does — so a second
+ * click on the same button is always the inverse of the first.
+ */
+export function inlineWrapSelectionEnd(
+	startColumn: number,
+	text: string,
+): { lineOffset: number; column: number } {
+	const lines = text.split('\n');
+	const lineOffset = lines.length - 1;
+	return {
+		lineOffset,
+		// Columns are 1-based, so the column after a line of length n is n + 1.
+		column: lineOffset === 0 ? startColumn + text.length : lines[lineOffset].length + 1,
+	};
+}
+
 const knownToolbarIds = new Set(DEFAULT_EDITOR_TOOLBAR_ORDER);
 
 export function normalizeEditorToolbarOrder(order: readonly string[] | null | undefined): string[] {

--- a/src/lib/utils/editorToolbar.ts
+++ b/src/lib/utils/editorToolbar.ts
@@ -278,6 +278,80 @@ export function toggleInlineWrap(id: InlineWrapToolId, text: string): string {
 	return `${write}${text}${write}`;
 }
 
+/** The longest run of `ch` at the end of `text`. */
+function trailingRun(text: string, ch: string): number {
+	let n = 0;
+	while (n < text.length && text[text.length - 1 - n] === ch) n += 1;
+	return n;
+}
+
+/** The longest run of `ch` at the start of `text`. */
+function leadingRun(text: string, ch: string): number {
+	let n = 0;
+	while (n < text.length && text[n] === ch) n += 1;
+	return n;
+}
+
+/**
+ * How far outside the selection this tool's own pair sits, or 0 for none.
+ *
+ * WHY IT MEASURES THE WHOLE RUN RATHER THAN MATCHING THE MARKER. Asking only
+ * "is the character outside the selection mine" says yes for Italic on
+ * `**word**` — that run does end in an asterisk — and taking one from each side
+ * would break bold's pair in half. Requiring the run to be exactly this marker's
+ * length is the same protection the longer-marker rule above gives, expressed on
+ * text the toggle cannot see: a run of two is bold's, so Italic leaves it alone
+ * and falls through to wrapping, which is `***word***` — asking for italic on
+ * bold text means both, exactly as it does when the markers are selected.
+ *
+ * Both sides must match, so a half-written `~~word~` is left alone rather than
+ * half unwrapped.
+ */
+function ownMarkerReach(id: InlineWrapToolId, before: string, after: string): number {
+	for (const marker of INLINE_WRAPS[id].strip) {
+		const ch = marker[0];
+		if (trailingRun(before, ch) !== marker.length) continue;
+		if (leadingRun(after, ch) !== marker.length) continue;
+		return marker.length;
+	}
+	return 0;
+}
+
+/** How far outside a selection any marker can reach — how much context a caller must read. */
+export const INLINE_WRAP_LOOKAROUND = Math.max(...ALL_WRAP_MARKERS.map((marker) => marker.length));
+
+/**
+ * One toolbar inline format applied to a selection *and its surroundings*: the
+ * replacement text, and how far the edit range has to grow on each side to
+ * cover markers the selection left out.
+ *
+ * WHY THE SELECTION ALONE IS NOT ENOUGH. `toggleInlineWrap` decides from the
+ * selected text, and the most ordinary way to undo a format does not select the
+ * markers: double-click the word. On `~~word~~` that selects `word`, the toggle
+ * sees no tildes, and wrapping is all it can do — leaving `~~~~word~~~~`, which
+ * at the start of a line is a four-tilde code fence whose info string is
+ * `word~~~~`. Nothing closes it, so the rest of the document renders as code.
+ * The same gesture answered `*word*` with `**word**`: the user asked to stop
+ * italicising and the text turned bold instead.
+ *
+ * The decision lives here rather than in the editor component so that it is
+ * reachable from a test that can spell the whole gesture — buffer, selection,
+ * click — instead of asserting on how the component is written.
+ */
+export function inlineWrapEdit(
+	id: InlineWrapToolId,
+	before: string,
+	selected: string,
+	after: string,
+): { reach: number; text: string } {
+	const reach = ownMarkerReach(id, before, after);
+	const text = toggleInlineWrap(
+		id,
+		before.slice(before.length - reach) + selected + after.slice(0, reach),
+	);
+	return { reach, text };
+}
+
 const knownToolbarIds = new Set(DEFAULT_EDITOR_TOOLBAR_ORDER);
 
 export function normalizeEditorToolbarOrder(order: readonly string[] | null | undefined): string[] {


### PR DESCRIPTION
## What this is

The four inline-format buttons — Bold, Italic, Strikethrough, Inline Code —
read only the text inside the selection, so the markers immediately outside it
were invisible to them. Double-clicking a word selects the word and not the
markers, which makes "double-click, click the button again" — the ordinary way
to take a format off — add a second pair instead of removing the first.

For Strikethrough that is a data-visibility bug, not a formatting annoyance:

```
~~word~~   double-click "word", press S   ->   ~~~~word~~~~
```

At the start of a line four tildes are a fenced code block whose info string is
`word~~~~`, and nothing in the document closes it. Verified against this repo's
own renderer:

```
convert_markdown("~~~~word~~~~\n\nA second paragraph.\n")

<pre data-sourcepos="1:1-3:37"><code class="language-word~~~~">
A second paragraph.
</code></pre>
```

Everything after the click renders as one grey code block. The user asked to
un-strike a word and the rest of their document disappeared.

The same gesture on the other three:

| buffer | double-click `word`, press | before | after |
|---|---|---|---|
| `~~word~~` | S | `~~~~word~~~~` | `word` |
| `~word~` | S | `~~~word~~~` | `word` |
| `**word**` | B | `****word****` | `word` |
| `*word*` | I | `**word**` | `word` |
| `` `word` `` | ` | ` ``word`` ` | `word` |

The italic row is worth calling out separately: asking to stop italicising
turned the text bold, silently.

Not reported by anyone. Found while reading `editorToolbar.ts` for something
else.

### The second commit

The first version of this shipped a regression, found by hand on a build and
not by anything here: after `~~word~~` was taken down to `word`, pressing the
same button again wrote `wo~~rd~~`.

Widening the replaced range past the selection is what exposed it. An
`executeEdits` with no end-cursor state leaves the old selection to be adjusted
against the new text, and that adjustment is only sane while the range *is* the
selection. Taking `~~word~~` (columns 1-9) down to `word` clamped a selection of
columns 3-7 to columns 3-5, which is `rd`, and the next click wrapped that.

The edit now states its own end — exactly the text it wrote. Strip and the word
stays selected; wrap and the marked-up word does; so a second click on the same
button is always the inverse of the first.

Worth recording because it says where the seam is: the toggle is a pure
function and cannot see a selection, and the selection is the half of this
feature only the editor holds. `inlineWrapSelectionEnd` is the arithmetic that
was wrong, so it lives beside the toggle where a test can reach it, and the
test that now covers it runs the gesture twice, carrying the selection forward
the way the editor does.

## Mechanism

`toggleInlineWrap` decides from the selected text alone, which is right — it is
where the marker-ownership rules live, including the one that keeps Italic off
Bold's asterisks. The gap is one level up, in `Editor.svelte`:

```ts
editor.executeEdits("toggle-format", [
    { range: selection, text: toggleInlineWrap(id, model.getValueInRange(selection)) },
]);
```

`getValueInRange(selection)` is the whole input. On `~~word~~` with `word`
selected it is `"word"`, the toggle correctly reports no strikethrough there,
and wrapping is the only thing left to do.

`inlineWrapEdit` now reads up to `INLINE_WRAP_LOOKAROUND` characters on either
side of the selection and returns both the replacement text and how far the
edit range has to grow to include a pair this tool wrote.

It compares **the whole run** of marker characters against the marker's length
rather than asking "is the character outside the selection one of mine". The
weaker test says yes for Italic on `**word**` — that run does end in an
asterisk — and taking one from each end would have unbolded the word in order
to italicise it. Requiring the run to be exactly two for `**` and exactly one
for `*` is the same protection `toggleInlineWrap` already gets from its
longer-marker rule, applied to text it cannot see, so both paths give the same
answer: Italic on bold text is `***word***`, whether or not the markers were
selected.

Both sides must match, so a half-written `~~word` is left alone rather than
half unwrapped.

## Scope

- **The decision moved into `editorToolbar.ts`, the component kept the
  arithmetic.** `inlineWrapEdit` returns a reach and the component turns it
  into columns. That split is what lets the test below spell a whole gesture —
  buffer, selection, click — instead of asserting on how `Editor.svelte` reads.
- **Underline is untouched.** `toggleTagFormat` writes `<u>`/`</u>`, two
  different strings, so none of the run reasoning applies to it. It has the
  same shape of bug and it wants a different fix; it is not in this PR.
- **Shortcuts and the context menu needed no change** — all four route through
  `toggleInlineWrapTool`, so the guard sits where every caller already passes.
- **Not fixed here, noticed while working:** `.github/PULL_REQUEST_TEMPLATE.md`
  lists the CI commands as `npm audit`, `npm run check`, `npm test`, `cargo
  test`. `test.yml` also runs `npm run test:vitest` — 41 files, 365 tests — so
  a contributor following the template can push something that CI fails on.

## Tests

`scripts/editorToolbar.test.ts`, four tests, all through a `clickWith` helper
that takes a buffer and the substring the user selected, so each case reads as
the gesture rather than as a call.

**Reverting the fix, keeping the tests** (`ownMarkerReach` returning 0, which
is exactly the old behaviour):

```
✖ double-clicking a word and clicking the button again removes the format
✖ a word struck through at the start of a line never becomes a code fence
✔ reaching outside the selection never breaks a neighbouring pair
   pass 86  fail 2
```

The third one stays green on that revert, on purpose — it guards the opposite
direction, the over-reach this change could introduce. So it was reverted
separately, by relaxing the run comparison from `!==` to `<` (i.e. "match one
character of mine"):

```
✖ reaching outside the selection never breaks a neighbouring pair
   pass 87  fail 1
```

Both directions fail on their own defect and no other test moves, which is the
part I would not have trusted without running it.

The fourth test pins `reach === 0` when there is nothing before the selection,
because the component subtracts the reach from a column number.

No source-text assertions were added.

## Verification

```
npm audit            0 vulnerabilities
npm run check        796 files, 0 errors, 0 warnings
npm test             910 pass, 0 fail
npm run test:vitest  41 files, 365 pass
cargo test           148 pass, 0 fail
```

The renderer output quoted above came from a throwaway `#[test]` calling
`convert_markdown`, run once and removed — it asserts comrak's behaviour, not
this repo's, so it did not belong in the suite.

**Not verified:** anything outside macOS. The change is Monaco range
arithmetic with no platform-specific paths, but I have not run it on Windows or
Linux.

**Not covered by a test:** the component wiring itself — that it reads the
right slices either side of the selection and applies `reach` to the columns.
That path needs a real Monaco model, and mounting one to guard four lines of
arithmetic did not seem worth it, so it was checked by hand against a local
build. That pass is what found the regression the second commit fixes, and it
was repeated after it:

- the seven marked-up words, double-clicked and toggled — each comes back to
  the bare word, none gains a marker
- `~~word~~` at the head of a line, which is the case that used to swallow the
  rest of the document
- the over-reach cases: Italic on `**word**` still answers `***word***`, Bold
  on `*word*` the same, Strikethrough on `**word**` gives `**~~word~~**`
- click the same button twice without touching the selection — back to the
  line it started from, which is what regressed and now does not

Two things fell out of that pass worth writing down:

**Two of the seven behave differently on the way in, and correctly on the way
out.** Monaco's default `wordSeparators` contain `*`, `~` and a backtick but
not `_`, so double-clicking inside `_word_` or `__word__` selects the
underscores too. Those two arrive as "the markers were selected" rather than as
"reach outside the selection", and the toggle answers them the same way, which
is the property the last test in the file pins.

**Underline does not have this defect**, though it looked like it should:
`toggleTagFormat` also passes no end-cursor state. It is fine because its range
*is* the selection, so Monaco expands the selection over the replacement — a
click on `plain` in `a plain b` leaves all twelve characters of `<u>plain</u>`
selected, and the next click strips them. That is the same measurement from the
other side: what broke here was widening the range, not the missing cursor
state on its own.

The one thing in that path I convinced myself of by reading rather than
running: `startColumn - reach` cannot go below 1, because a selection at the
head of a line has an empty string before it, an empty string has no run, and
so the reach is 0 — which is what the fourth test pins.

