### PR TITLE
fix(toc): the floating toggle clears the editor toolbar instead of covering Bold

### DIFF
--- a/scripts/issue261EditorPdf.test.ts
+++ b/scripts/issue261EditorPdf.test.ts
@@ -119,6 +119,42 @@ test('floating toc toggle keeps a visible translucent surface outside edit mode'
 	assert.doesNotMatch(viewer, /\.toc-toggle-floating\.in-edit-mode:not\(\.expanded\)/);
 });
 
+test('the floating toc toggle clears whatever chrome the pane puts above the document', () => {
+	// The toggle is positioned against `.layout-container`, whose top is the top
+	// of the window, so its `top` has to account for everything above the
+	// document. It used to be the literal 48px — title bar plus inset — which is
+	// only the whole story in preview. In edit mode the editor toolbar occupies
+	// that strip and the toggle sat on its first button, Bold.
+	//
+	// Both halves of `--pane-top-chrome` are pinned because neither side fails
+	// loudly on its own: a custom property nobody sets falls back to the `0px`
+	// in the `var()`, and a custom property nobody reads is just an unused
+	// declaration. Renaming one side would put the toggle back on top of Bold
+	// with every test still green.
+	assert.match(
+		viewer,
+		/--pane-top-chrome:\s*\{paneTopChrome\}px;/,
+		'the layout container publishes the measured height',
+	);
+	assert.match(
+		viewer,
+		/\.toc-toggle-floating\s*\{[\s\S]*?top:\s*calc\(48px \+ var\(--pane-top-chrome, 0px\)\);/,
+		'the toggle reads it',
+	);
+
+	// Measured, not assumed: a second copy of the toolbar's height would go
+	// stale the next time its padding or border changed, and nothing would say so.
+	assert.match(viewer, /bind:clientHeight=\{editorToolbarHeight\}/);
+
+	// And reset when there is no toolbar to measure — a `clientHeight` binding
+	// keeps its last value once the element is gone, which would leave the
+	// toggle pushed down in preview.
+	assert.match(
+		viewer,
+		/paneTopChrome = \$derived\([\s\S]*?showEditorToolbar \? editorToolbarHeight : 0,?\s*\)/,
+	);
+});
+
 test('print layout gives document content paper-specific rhythm and boundaries', () => {
 	const printStyles = sliceFrom(styles, '@media print {');
 

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -345,6 +345,31 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	let isTocResizing = $state(false);
 	let tocWrapperEl = $state<HTMLElement | null>(null);
 	let tocToggleEl = $state<HTMLElement | null>(null);
+
+	/*
+	 * How tall the editor toolbar currently is, measured rather than assumed.
+	 *
+	 * The floating table-of-contents toggle is absolutely positioned against
+	 * `.layout-container`, and its `top` used to be the literal 48px — the 36px
+	 * title bar plus a 12px inset. That is the right answer only in preview,
+	 * where the title bar is the whole of the chrome above the document. In edit
+	 * mode the toolbar occupies exactly that strip, so the toggle landed on top
+	 * of its first button.
+	 *
+	 * Reading the height keeps one answer to "where does the chrome end": the
+	 * toolbar's own layout. A second literal here would have to be re-derived
+	 * every time its padding, border or font changed, and nothing would fail
+	 * when it was not — the toggle would just start overlapping again.
+	 *
+	 * The `{#if}` around the toolbar is mirrored rather than the height: a
+	 * `clientHeight` binding keeps its last value when the element it measured
+	 * goes away, so the toggle would stay pushed down after the toolbar was
+	 * hidden or the tab returned to preview.
+	 */
+	let editorToolbarHeight = $state(0);
+	let paneTopChrome = $derived(
+		(isEditing || isSplit) && settings.showEditorToolbar ? editorToolbarHeight : 0,
+	);
 	let previewContentWidth = $derived(getPreviewContentWidth(settings.previewMaxWidth, settings.previewFullWidth));
 	let isOverhanging = $derived(
 		isTocOverhanging({
@@ -3524,12 +3549,12 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 					class:toc-on-left={isMarkdown && settings.tocSide === 'left'}
 					class:toc-on-right={isMarkdown && settings.tocSide === 'right'}
 					class:toc-resizing={isTocResizing}
-					style="--toc-width: {settings.tocWidth}px;">
+					style="--toc-width: {settings.tocWidth}px; --pane-top-chrome: {paneTopChrome}px;">
 					<!-- Editor Pane -->
 					<div bind:this={editorPaneEl} class="pane editor-pane" class:active={isEditing || isSplit} style="flex: {isSplit ? tabManager.activeTab.splitRatio : isEditing ? 1 : 0}">
 						{#if isEditing || isSplit}
 							{#if settings.showEditorToolbar}
-								<div transition:slide={{ duration: 150 }}>
+								<div bind:clientHeight={editorToolbarHeight} transition:slide={{ duration: 150 }}>
 									<EditorToolbar
 										modifier={modifierFor(settings.osType)}
 										toolbarOrder={settings.editorToolbarOrder}
@@ -3731,8 +3756,7 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 							bind:this={tocToggleEl}
 							class="toc-toggle-floating {settings.showToc ? 'expanded' : ''}"
 							class:on-right={settings.tocSide === 'right'}
-							class:in-edit-mode={isEditing && !settings.showToc}
-							onclick={() => settings.toggleToc()}
+								onclick={() => settings.toggleToc()}
 							aria-label={settings.showToc ? t('tooltip.hideTableOfContents', settings.language) : t('tooltip.showTableOfContents', settings.language)}
 							onmouseenter={(e) => {
 								const rect = e.currentTarget.getBoundingClientRect();
@@ -4525,7 +4549,13 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 
 	.toc-toggle-floating {
 		position: absolute;
-		top: 48px;
+		/*
+		 * 36px of title bar, a 12px inset, and however tall the editor toolbar
+		 * is right now — 0 when there isn't one. See `paneTopChrome`: the last
+		 * term is measured because the toolbar's height is the toolbar's to
+		 * decide, and a copy of it here would silently go stale.
+		 */
+		top: calc(48px + var(--pane-top-chrome, 0px));
 		left: 8px;
 		width: 28px;
 		height: 28px;


### PR DESCRIPTION
## What this is

In edit mode the floating table-of-contents toggle sits on top of the editor
toolbar's first button. Bold is unreachable, and the toggle is drawn over a
control that is not it.

Reported by a user of a local build.

## Mechanism

The toggle is absolutely positioned against `.layout-container`. That container
is `position: absolute; top: 0`, so `top` is measured from the top of the
window, not from below the title bar — the 36px is `padding-top`, which
absolute positioning does not see. Hence the literal:

```css
.toc-toggle-floating { top: 48px; }   /* 36px title bar + 12px inset */
```

48px is the correct answer in preview, where the title bar is the whole of the
chrome above the document. In edit mode it is not:

```
y=0    ┌──────────────────────────────┐
       │ title bar             36px   │
y=36   ├──────────────────────────────┤
       │ .editor-toolbar              │  min-height 34 + 1px border  →  36..71
y=48   │    ┌──────┐                  │
       │    │ toc  │                  │  top 48, height 28           →  48..76
y=71   ├────│      │──────────────────┤
y=76   │    └──────┘                  │
```

`left: 8px` then lands it on the first tool in the bar, which is Bold.

The literal is the whole bug: it answers "where does the chrome above the
document end" a second time, and the first answer — the toolbar's own layout —
is free to change without it.

So the toolbar's height is now measured and published to the toggle:

```svelte
<div class="layout-container" style="… --pane-top-chrome: {paneTopChrome}px;">
    <div bind:clientHeight={editorToolbarHeight}> <EditorToolbar … /> </div>
```
```css
top: calc(48px + var(--pane-top-chrome, 0px));
```

The `{#if}` around the toolbar is mirrored in `paneTopChrome`, not its height:
a `clientHeight` binding keeps its last value once the element it measured is
gone, so without that reset the toggle would stay pushed down after the toolbar
was hidden from the title bar, or when the tab went back to preview.

One nice consequence of measuring rather than switching: the toolbar mounts
under `transition:slide`, so `clientHeight` reports its animating height and
the toggle rides down with it. No `transition: top` is needed, and adding one
would make it lag.

## Scope

- **`in-edit-mode` is removed.** It was applied in the markup and had no rule
  anywhere in the repo. Its rule was the earlier attempt at this same defect,
  reverted in #261 for stripping the toggle's surface — making it invisible in
  edit mode rather than moving it — and
  `scripts/issue261EditorPdf.test.ts` has forbidden that selector ever since.
  The attribute outlived the rule as a hook to something the suite rejects, so
  it goes. The guard stays exactly as it was: this fix moves the toggle and
  leaves its translucent surface alone, which is what that test asks for.
- **The toggle stays where it is otherwise.** Same corner, same 12px inset,
  same left/right behaviour, same expanded offsets. In preview nothing moves at
  all — `--pane-top-chrome` is 0 and the computed `top` is still 48px.
- **Noticed, not fixed here:** "show or hide the table of contents" has two
  entry points. `titlebarToolbar.ts` already registers a `toc` tool sharing this
  toggle's `tooltip.showTableOfContents` key, and it is the only view toggle
  whose `defaultPlacement` is `'menu'` — `fullWidth`, `live`, `sync`, `split`,
  `edit` and `editorToolbar` all default to `'bar'`. Whether the floating
  control should exist alongside it, and whether `toc` should join its siblings
  on the bar, is a design call rather than a fix — and not one this PR needs to
  settle, since the collision is gone either way. Recording it here rather than
  acting on it. Worth knowing if you do look at it later: changing that default
  reaches only users with no stored placement, because the setting persists the
  whole normalised map, so anyone who has ever saved settings already has
  `toc: 'menu'` written down.

## Tests

One test in `scripts/issue261EditorPdf.test.ts`, beside the existing toggle
assertions. It matches source text, so: the anchor is `--pane-top-chrome`, a
contract between a `style` attribute and a stylesheet with no compiler and no
runtime error between them. A custom property nobody sets falls back to the
`0px` in the `var()`; a custom property nobody reads is an unused declaration.
Either way the toggle goes back on top of Bold with every other test green,
which is why both ends are pinned rather than one.

Reverted three ways, each on its own:

| revert | result |
|---|---|
| `top` back to the literal `48px` | fails |
| rename the property on the publishing side only | fails |
| drop the reset, so the height survives the toolbar | fails |

`pass 12 / fail 1` in each case — the same single test, and nothing else moves.

## Verification

```
npm audit            0 vulnerabilities
npm run check        796 files, 0 errors, 0 warnings
npm test             905 pass, 0 fail
npm run test:vitest  41 files, 365 pass
cargo test           148 pass, 0 fail
```

The geometry above is computed from the CSS — `min-height: 34px` with
`box-sizing: border-box` plus a 1px `border-bottom`, against `top: 48px` and
`height: 28px`. It matches what the reporter saw. A local build is going
through a hand pass across the four cases that differ (preview, edit, split,
and the toolbar hidden from the title bar); I will report back here rather than
leave that implied.

**Not verified:** Windows and Linux. This is layout with no platform-specific
paths, but the title bar is drawn differently per platform and 36px is a
constant this file already assumed before the change.
