### PR TITLE
fix(preview): the link hover box names the link, and goes when you click it

### DIFF
--- a/scripts/linkHoverPreview.test.ts
+++ b/scripts/linkHoverPreview.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { functionSource, offsetOf, readSource } from './sourceTree.js';
+
+/*
+ * The box that names a link while the cursor is on it had two faults, both
+ * reported from a build.
+ *
+ * It said `tauri://localhost/3.md` for `[3.md](./3.md)`. That is the DOM
+ * resolving `href` against the webview's own origin — the same resolution
+ * `resolveLocalFileLinkPath` exists to undo on the click side, and the same
+ * origin `localFileLinks.test.ts` documents. `handleMouseOver` had already
+ * read `getAttribute('href')` into `rawHref` for its other two branches; the
+ * one that prints the address was the one that did not use it.
+ *
+ * And it stayed on screen after the click. `mouseout` is the only thing that
+ * takes it down, and a click that replaces the document removes the anchor
+ * while the cursor is still on it — removing a node dispatches no `mouseout`,
+ * so nothing ever fired.
+ *
+ * Neither half has a seam a Node test can reach: both are branches inside a
+ * 4,700-line component, and what they do is set component state. So these
+ * assert against the source, and what they establish is narrow — that the
+ * resolved href is not read where the address is printed, and that the click
+ * handler drops the box before it does anything else. Whether the box is then
+ * painted or not is checked by hand.
+ */
+
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
+
+test('the hover preview never prints the webview origin', () => {
+	const hover = functionSource(viewer, 'handleMouseOver');
+
+	// Stated as the thing that must not come back rather than as today's
+	// spelling of what replaced it: the resolved property is what put a
+	// `tauri://` URL in front of the user, so this function may not read it.
+	//
+	// The whole function, comments included — deliberately. The first version of
+	// this test went red on the comment explaining the fix, and that is the rule
+	// working: a comment naming the property is how the next person is talked
+	// into writing it again. Describe it, do not spell it.
+	assert.doesNotMatch(
+		hover,
+		/anchor\.href/,
+		'the hover preview reads the resolved href, which is the webview origin plus a path that is not the file',
+	);
+	assert.match(hover, /getAttribute\('href'\)/);
+});
+
+test('a click takes the hover preview down before it does anything else', () => {
+	const click = functionSource(viewer, 'handleLinkClick');
+
+	// Before the branches, because every one of them can be the one that
+	// replaces the document — a fold, an anchor, a relative link, a new tab.
+	const hide = offsetOf(click, 'tooltip.show = false');
+	const firstBranch = offsetOf(click, 'toggleFoldFromClick');
+
+	assert.ok(hide >= 0, 'the click handler never drops the hover preview');
+	assert.ok(
+		hide < firstBranch,
+		'the hover preview is dropped after a branch that can already have replaced the document',
+	);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -1548,6 +1548,15 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 	async function handleLinkClick(e: MouseEvent) {
 		const target = e.target as HTMLElement;
 
+		// The hover preview describes the element under the cursor, and only
+		// `mouseout` takes it down. A click that replaces the document removes
+		// that element while the cursor is still on it, and removing a node
+		// dispatches no `mouseout` — so the box was left on screen until the
+		// pointer happened to cross another link. Dropping it here, before any
+		// branch, is the same thing a browser does with its own link preview:
+		// the click is the moment the description stops being about anything.
+		tooltip.show = false;
+
 		// Fold toggle: the heading's chevron, or a foldable callout's whole title
 		// bar. One branch for both, because they are one feature — the callout's
 		// own branch used to toggle the classes and stop there, so a folded
@@ -2608,9 +2617,16 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 				}
 			}
 
-			if (anchor.href) {
+			// `rawHref`, which the two branches above already use, rather than the
+			// anchor's resolved property. The DOM resolves that against the
+			// webview's own origin, so `[3.md](./3.md)` previewed as
+			// `tauri://localhost/3.md` — a scheme that is an implementation detail
+			// of the shell the app runs in, and a path that is not where the file
+			// is. Undoing the same resolution is what `resolveLocalFileLinkPath`
+			// exists for on the click side.
+			if (rawHref) {
 				const rect = anchor.getBoundingClientRect();
-				tooltip = { show: true, text: anchor.href, shortcut: '', html: '', isFootnote: false, x: rect.left + rect.width / 2, y: rect.top - 8, align: 'top' };
+				tooltip = { show: true, text: rawHref, shortcut: '', html: '', isFootnote: false, x: rect.left + rect.width / 2, y: rect.top - 8, align: 'top' };
 			}
 		}
 	}


### PR DESCRIPTION
## What this is

Two faults in the box that names a link while the cursor is on it, both
reported from a local build.

It printed `tauri://localhost/3.md` for `[3.md](./3.md)`, and it stayed on
screen after the click.

## Mechanism

**The address.** `handleMouseOver` reads `getAttribute('href')` into `rawHref`
and uses it for its anchor-link and footnote branches. The branch that prints an
address read the anchor's resolved property instead, which the DOM has already
resolved against the webview's own origin. That is the same resolution
`resolveLocalFileLinkPath` exists to undo on the click side, and the same origin
`localFileLinks.test.ts` documents for the defect that handed local file links
to the browser. So the user was shown a scheme that is an implementation detail
of the shell the app runs in, and a path that is not where the file is.

**The box that would not go.** `mouseout` is the only thing that takes it down:

```svelte
<svelte:document onmouseover={handleMouseOver} onmouseout={handleMouseOut} />
```
```ts
if (target?.tagName === 'A') tooltip.show = false;
```

A click that replaces the document removes the anchor while the cursor is still
on it, and removing a node dispatches no `mouseout` — so the document-level
listener never heard anything and the box sat there until the pointer happened
to cross another link. Which is what "sometimes clicking something else makes it
go away" was.

Dropping it at the top of `handleLinkClick`, before any branch, is what a
browser does with its own link preview: the click is the moment the description
stops being about anything. Every branch in that handler — a fold, an anchor, a
relative link — can be the one that replaces the document, so it goes before all
of them rather than into each.

## Scope

- **Only the click path.** Switching tabs while hovering a link should strand
  the box the same way, and a live-mode reload should too. Neither is
  reproduced, so neither is changed here.
- **Not fixed in the render path, though it would cover all of them.** The
  effect that patches preview DOM is "the one place a rendered document becomes
  preview DOM" — but it also renders documents that are *not* on screen (a
  window restore renders every restored tab, a cross-window arrival renders
  itself), so hiding something the user is looking at from there would fire for
  tabs they are not looking at.
- **The footnote and anchor-link previews are untouched.** They already read
  `rawHref`.

## Tests

`scripts/linkHoverPreview.test.ts`. Both halves are branches inside a
4,700-line component that set component state — there is no seam a Node test
can reach, so these assert against the source, the way `localFileLinks.test.ts`
does for the click wiring of the same defect class. What they establish is
narrow and stated in the file: that the resolved property is not read where the
address is printed, and that the click handler drops the box before it does
anything else. Whether the box is then painted is checked by hand.

The first assertion is deliberately the whole function, comments included. Its
first version went red on the comment explaining the fix — which is the rule
working rather than a false positive: a comment naming the property is how the
next person is talked into writing it again. The comment now describes it
instead of spelling it.

Reverted separately:

| revert | result |
|---|---|
| print the resolved property again | 1 pass / 1 fail |
| stop dropping the box on click | 1 pass / 1 fail |

## Verification

```
npm audit            0 vulnerabilities
npm run check        797 files, 0 errors, 0 warnings
npm test             907 pass, 0 fail
npm run test:vitest  41 files, 365 pass
```

**Not checked by hand yet.** The reporter's case — hover a relative link, read
the address, click it, watch the box go — is what the two assertions above
cannot establish, and it has not been run against a build. I will report it here
rather than leave the gap implied.

**Not verified:** Windows and Linux. The origin differs there
(`http://tauri.localhost`), which is exactly why the resolved property is the
wrong thing to print, but I have not hovered a link on either.
