### PR TITLE
fix(menu): the editor's context menu gets the entries that are about the document

### DIFF
--- a/scripts/contextMenuParity.test.ts
+++ b/scripts/contextMenuParity.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { functionSource, readSource } from './sourceTree.js';
+
+/*
+ * Issue #97: in split view the two context menus are different lists.
+ *
+ * Some of that is the panes being different — Cut and Paste need somewhere to
+ * type, the two Monaco entries need Monaco, and the viewer's own entries each
+ * need a rendered element to have been clicked. What is not is the three
+ * actions that have nothing to do with where the click landed: Select All acts
+ * on the text either pane is showing, and the two file actions act on the
+ * document that both of them are. Those were in the viewer's menu only.
+ *
+ * The maintainer's note on the issue — that the editor menu is Monaco's
+ * built-in and therefore different — was true when it was written and is not
+ * now: #207 replaced it with one this app draws, because Monaco's Paste reads
+ * the clipboard through the webview and cannot work here. Parity is reachable
+ * because both menus are ours.
+ *
+ * Both menus are built inside a 4,700-line component, so this asserts against
+ * the source. What it establishes is that each shared label appears in both
+ * builders — not what happens when it is clicked.
+ */
+
+const viewer = readSource('src/lib/MarkdownViewer.svelte');
+const editorMenu = functionSource(viewer, 'showEditorContextMenu');
+const documentMenu = functionSource(viewer, 'handleContextMenu');
+
+test('the actions that are about the document are in both menus', () => {
+	for (const key of ['menu.selectAll', 'menu.openLocation', 'menu.closeFile']) {
+		assert.match(editorMenu, new RegExp(key.replace('.', '\\.')), `${key} is missing from the editor menu`);
+		assert.match(documentMenu, new RegExp(key.replace('.', '\\.')), `${key} is missing from the viewer menu`);
+	}
+});
+
+test('the actions that are about the pane stay in one menu', () => {
+	// Asserted so that "make them consistent" does not turn into "make them
+	// identical" later: an editor entry in the viewer would be dead, and the
+	// viewer's entries need a rendered element that the editor does not have.
+	for (const key of ['menu.cut', 'menu.paste', 'menu.commandPalette', 'menu.changeAllOccurrences']) {
+		assert.doesNotMatch(documentMenu, new RegExp(key.replace('.', '\\.')), `${key} reached the viewer menu`);
+	}
+	for (const key of ['menu.openInNewTab', 'menu.copyReference', 'menu.saveImageAs', 'menu.edit']) {
+		assert.doesNotMatch(editorMenu, new RegExp(key.replace('.', '\\.')), `${key} reached the editor menu`);
+	}
+});
+
+test('Select All does not go through the id resolver that would drop it', () => {
+	// `runEditorAction` resolves with `editor.getAction(id)?.run()`, and
+	// `editor.action.selectAll` is registered by `registerCommand` as a
+	// MultiCommand — it is not in the map `getAction` reads
+	// (`codeEditorWidget.js`: `getAction(id) { return this._actions.get(id) }`,
+	// filled only from the editor-action registry). The optional call would have
+	// made the menu entry appear and silently do nothing.
+	assert.doesNotMatch(
+		editorMenu,
+		/runEditorAction\(['"]editor\.action\.selectAll['"]\)/,
+		'Select All was sent through getAction, which cannot resolve a command',
+	);
+	assert.match(editorMenu, /editorPane\?\.selectAll\(\)/);
+
+	const editor = readSource('src/lib/components/Editor.svelte');
+	assert.match(
+		functionSource(editor, 'selectAll'),
+		/setSelection\(model\.getFullModelRange\(\)\)/,
+		'selectAll selects the whole model',
+	);
+});

--- a/src/lib/MarkdownViewer.svelte
+++ b/src/lib/MarkdownViewer.svelte
@@ -180,6 +180,8 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 		cutToClipboard: () => Promise<void>;
 		copyToClipboard: () => Promise<void>;
 		pasteFromClipboard: () => Promise<void>;
+		/** Also the editor's menu, since #97 gave it the shared items. */
+		selectAll: () => void;
 	} | null>(null);
 	let liveMode = $state(false);
 
@@ -2439,6 +2441,23 @@ import { createDocumentSession, type LoadMarkdownOptions } from './sessions/docu
 					shortcut: chord('Mod+F2'),
 					onClick: () => editorPane?.runEditorAction('editor.action.changeAll'),
 				},
+				// #97: in split view the two menus were different lists, and the
+				// three below were the difference that had nothing to do with
+				// which pane the click landed in. Select All acts on the text
+				// either pane is showing; the file ones act on the document that
+				// both of them are.
+				//
+				// The rest stays different on purpose. Cut and Paste need
+				// somewhere to type; the two Monaco entries above need Monaco;
+				// and the viewer's own — Open in New Tab, Copy Reference, Save
+				// Image As, Edit — each need a rendered element to have been
+				// clicked, which is not a thing that exists in the editor. Parity
+				// of the shared items, not of the lists.
+				{ separator: true },
+				{ label: t('menu.selectAll', settings.language), onClick: () => editorPane?.selectAll() },
+				{ separator: true },
+				{ label: t('menu.openLocation', settings.language), onClick: openFileLocation, disabled: !currentFile },
+				{ label: t('menu.closeFile', settings.language), onClick: closeFile },
 			],
 		};
 	}

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -2434,6 +2434,23 @@
 		editor.getAction(actionId)?.run();
 	}
 
+	/**
+	 * Select the whole document.
+	 *
+	 * Spelled out rather than sent through `runEditorAction`, which resolves an
+	 * id with `getAction(id)?.run()` — and `editor.action.selectAll` is a
+	 * `registerCommand` MultiCommand, not an editor action, so it is not in the
+	 * map `getAction` reads. The optional call would have made the menu entry
+	 * appear and do nothing. `editor.trigger` would reach it, by falling through
+	 * to the command service, but this is three lines that cannot miss.
+	 */
+	export function selectAll() {
+		const model = editor?.getModel();
+		if (!editor || !model) return;
+		editor.focus();
+		editor.setSelection(model.getFullModelRange());
+	}
+
 	export const getValue = () => editor?.getValue() || "";
 	export const setValue = (val: string) => editor?.setValue(val);
 	export const focus = () => editor?.focus();


### PR DESCRIPTION
## What this is

Closes #97, reported against 2.6.4.

In split view the editor's context menu and the viewer's are different lists.
This adds the three entries that were different for no reason to do with where
the click landed.

## Mechanism

The two menus, as they were:

```
editor                       viewer
──────────────────────       ────────────────────────────────
Cut / Copy / Paste           Open in New Tab   (on a link)
─                            Copy Reference    (on a heading)
Command Palette      F1      Save Image As     (on media)
Change All Occurrences ⌘F2   Copy             (with a selection)
                             Select All
                             ─
                             Open File Location
                             Edit
                             ─
                             Close File
```

Most of that difference is the panes being different. Three entries are not:
**Select All** acts on the text either pane is showing, and **Open File
Location** and **Close File** act on the document that both of them are. Those
three are now in both.

**The note on the issue is out of date, which is what makes this fixable.** It
says the editor menu is Monaco's built-in and therefore different — true in
April. #207 replaced it with one this app draws, because Monaco's Paste reads
the clipboard through the webview and cannot work here. Both menus are ours now,
so the scope proposed in the thread (sync Monaco's UI language, add some viewer
actions) is no longer what the problem needs.

**Select All is a new export on the editor, not an id through
`runEditorAction`.** That resolver is:

```ts
editor.getAction(actionId)?.run();
```

and `getAction` is `this._actions.get(id)`, a map `codeEditorWidget` fills from
the editor-action registry alone. `editor.action.selectAll` is not in it — it is
registered by `registerCommand` as a `MultiCommand` (`editorExtensions.js`), and
`editor.trigger` reaches that kind only by falling through to the command
service. So the id resolves to `undefined`, the `?.` swallows it, and the menu
entry would have appeared and done nothing.

## Scope

- **Not identical lists, and there is a test saying so.** Cut and Paste need
  somewhere to type; the two Monaco entries need Monaco; Open in New Tab, Copy
  Reference, Save Image As and Edit each need a rendered element to have been
  clicked. An assertion holds each of those to one menu, so that "make them
  consistent" does not become "make them the same" in a later pass.
- **Copy is in both already** and is left alone — the editor's copies the
  selection through the editor, the viewer's through the DOM selection.
- **`runEditorAction` is unchanged**, and its silent miss is worth knowing
  about: any future menu entry given a command id rather than an action id will
  appear and do nothing, with nothing to say so. Making it fall through to
  `editor.trigger` would fix the class — `trigger` tries `getAction` first, so
  existing callers would not change — but that is fifteen call sites' worth of
  dispatch change for one menu entry, so it is recorded rather than done.
- **`editorPane`'s type is a hand-written mirror** of the editor's exports, so
  it needed the new member. `svelte-check` caught that, which is the mirror
  working.

## Tests

`scripts/contextMenuParity.test.ts`. Both menus are built inside a 4,700-line
component, so these assert against the source; what they establish is that each
label appears in the right builder, not what happens when it is clicked.

Reverted three ways:

| revert | result |
|---|---|
| drop Select All from the editor menu | 1 pass / 2 fail |
| send Select All through `runEditorAction` | 2 pass / 1 fail |
| drop Close File from the editor menu | 2 pass / 1 fail |

## Verification

```
npm audit            0 vulnerabilities
npm run check        798 files, 0 errors, 0 warnings
npm test             918 pass, 0 fail
npm run test:vitest  41 files, 365 pass
```

No new strings: `menu.selectAll`, `menu.openLocation` and `menu.closeFile` are
already in all 26 locales, which is what made this three lines of menu.

**Not checked by hand yet** — that the three entries appear in the editor's menu
in split view and each does what it says, Select All included, since that is the
one whose failure mode was silence. I will report it here rather than leave the
gap implied.
